### PR TITLE
Replace Zinc's default global lock

### DIFF
--- a/backend/src/main/scala/bloop/CompilerCache.scala
+++ b/backend/src/main/scala/bloop/CompilerCache.scala
@@ -1,6 +1,5 @@
 package bloop
 
-import java.nio.file.Path
 import java.util.concurrent.ConcurrentHashMap
 
 import bloop.io.{AbsolutePath, Paths}
@@ -12,7 +11,7 @@ import xsbti.compile.{ClasspathOptions, Compilers}
 class CompilerCache(componentProvider: ComponentProvider, retrieveDir: AbsolutePath) {
   import CompilerCache.CacheId
   private val logger = QuietLogger
-  private val cache  = new ConcurrentHashMap[CacheId, Compilers]()
+  private val cache = new ConcurrentHashMap[CacheId, Compilers]()
 
   def get(id: CacheId): Compilers = cache.computeIfAbsent(id, newCompilers)
 
@@ -28,14 +27,14 @@ class CompilerCache(componentProvider: ComponentProvider, retrieveDir: AbsoluteP
                        classpathOptions: ClasspathOptions,
                        componentProvider: ComponentProvider): AnalyzingCompiler = {
     val bridgeSources = ZincInternals.getModuleForBridgeSources(scalaInstance)
-    val bridgeId      = ZincInternals.getBridgeComponentId(bridgeSources, scalaInstance)
+    val bridgeId = ZincInternals.getBridgeComponentId(bridgeSources, scalaInstance)
     componentProvider.component(bridgeId) match {
       case Array(jar) => ZincUtil.scalaCompiler(scalaInstance, jar, classpathOptions)
       case _ =>
         ZincUtil.scalaCompiler(
           /* scalaInstance        = */ scalaInstance,
           /* classpathOptions     = */ classpathOptions,
-          /* globalLock           = */ ZincInternals.getGlobalLock,
+          /* globalLock           = */ Lock,
           /* componentProvider    = */ componentProvider,
           /* secondaryCacheDir    = */ Some(Paths.getCacheDirectory("bridge-cache").toFile),
           /* dependencyResolution = */ DependencyResolution.getEngine,

--- a/backend/src/main/scala/bloop/Lock.scala
+++ b/backend/src/main/scala/bloop/Lock.scala
@@ -1,0 +1,10 @@
+package bloop
+
+import java.io.File
+import java.util.concurrent.Callable
+
+import xsbti.GlobalLock
+
+object Lock extends GlobalLock {
+  override def apply[T](file: File, callable: Callable[T]): T = synchronized { callable.call() }
+}

--- a/backend/src/main/scala/sbt/internal/inc/bloop/ZincInternals.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/ZincInternals.scala
@@ -1,16 +1,15 @@
 package sbt.internal.inc.bloop
 
-import java.nio.file.{Files, Path}
+import java.nio.file.Files
 
-import bloop.{CompilerCache, ScalaInstance}
+import bloop.ScalaInstance
 import bloop.io.AbsolutePath
-import xsbti.{ComponentProvider, GlobalLock}
+import xsbti.ComponentProvider
 import sbt.internal.inc.ZincComponentCompiler
 import sbt.librarymanagement.{Configurations, ModuleID}
 
 object ZincInternals {
-  def latestVersion: String     = ZincComponentCompiler.incrementalVersion
-  def getGlobalLock: GlobalLock = ZincComponentCompiler.getDefaultLock
+  def latestVersion: String = ZincComponentCompiler.incrementalVersion
   def getComponentProvider(componentsDir: AbsolutePath): ComponentProvider = {
     val componentsPath = componentsDir.underlying
     if (!Files.exists(componentsPath)) Files.createDirectory(componentsPath)
@@ -50,7 +49,7 @@ object ZincInternals {
    */
   def getBridgeComponentId(sources: ModuleID, scalaInstance: ScalaInstance): String = {
     import ZincComponentCompiler.{binSeparator, javaClassVersion}
-    val id           = s"${sources.organization}-${sources.name}-${sources.revision}"
+    val id = s"${sources.organization}-${sources.name}-${sources.revision}"
     val scalaVersion = scalaInstance.actualVersion()
     s"$id$binSeparator${scalaVersion}__$javaClassVersion"
   }


### PR DESCRIPTION
It doesn't do any locking, so we end up compiling the compiler bridge
concurrently multiple time. This patch doesn't implement a real global
lock (as in locking across multiple JVMs), so it's not a fix for #45.