### PR TITLE
Fix #50: Fix plugin switch command implementation

### DIFF
--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -24,7 +24,7 @@ object BuildKeys {
   import sbt.{Reference, RootProject, ProjectRef, BuildRef, file}
   import sbt.librarymanagement.syntax.stringToOrganization
   final val testDependencies = List(
-    "junit"        % "junit"           % "4.12" % "test",
+    "junit" % "junit" % "4.12" % "test",
     "com.novocode" % "junit-interface" % "0.11" % "test"
   )
 
@@ -41,15 +41,15 @@ object BuildKeys {
   final val AbsolutePath = file(".").getCanonicalFile.getAbsolutePath
 
   final val ZincProject = RootProject(file(s"$AbsolutePath/zinc"))
-  final val ZincBuild   = BuildRef(ZincProject.build)
-  final val Zinc        = ProjectRef(ZincProject.build, "zinc")
-  final val ZincRoot    = ProjectRef(ZincProject.build, "zincRoot")
-  final val ZincBridge  = ProjectRef(ZincProject.build, "compilerBridge")
+  final val ZincBuild = BuildRef(ZincProject.build)
+  final val Zinc = ProjectRef(ZincProject.build, "zinc")
+  final val ZincRoot = ProjectRef(ZincProject.build, "zincRoot")
+  final val ZincBridge = ProjectRef(ZincProject.build, "compilerBridge")
 
-  final val NailgunProject  = RootProject(file(s"$AbsolutePath/nailgun"))
-  final val NailgunBuild    = BuildRef(NailgunProject.build)
-  final val Nailgun         = ProjectRef(NailgunProject.build, "nailgun")
-  final val NailgunServer   = ProjectRef(NailgunProject.build, "nailgun-server")
+  final val NailgunProject = RootProject(file(s"$AbsolutePath/nailgun"))
+  final val NailgunBuild = BuildRef(NailgunProject.build)
+  final val Nailgun = ProjectRef(NailgunProject.build, "nailgun")
+  final val NailgunServer = ProjectRef(NailgunProject.build, "nailgun-server")
   final val NailgunExamples = ProjectRef(NailgunProject.build, "nailgun-examples")
 }
 
@@ -87,6 +87,7 @@ object BuildImplementation {
     Keys.testOptions in Test += sbt.Tests.Argument("-oD"),
     Keys.onLoadMessage := Header.intro,
     Keys.commands += Semanticdb.command(Keys.crossScalaVersions.value),
+    Keys.commands ~= BuildDefaults.fixPluginCross _,
     Keys.onLoad := BuildDefaults.onLoad.value,
   )
 
@@ -110,7 +111,7 @@ object BuildImplementation {
   )
 
   object BuildDefaults {
-    import sbt.State
+    import sbt.{State, Command}
 
     /* This rounds off the trickery to set up those projects whose `overridingProjectSettings` have
      * been overriden because sbt has decided to initialize the settings from the sourcedep after. */
@@ -138,6 +139,11 @@ object BuildImplementation {
         val allSessionSettings = currentSessionSettings ++ currentSession.rawAppend
         extracted.append(globalSettings ++ projectSettings ++ allSessionSettings, hijackedState)
       }
+    }
+
+    def fixPluginCross(commands: Seq[Command]): Seq[Command] = {
+      val pruned = commands.filterNot(p => p == sbt.WorkingPluginCross.oldPluginSwitch)
+      sbt.WorkingPluginCross.pluginSwitch +: pruned
     }
   }
 }

--- a/project/WorkingPluginCross.scala
+++ b/project/WorkingPluginCross.scala
@@ -1,0 +1,43 @@
+package sbt
+
+import sbt.internal.util.complete.{DefaultParsers, Parser}
+import DefaultParsers._
+import sbt.Keys._
+import sbt.internal.CommandStrings._
+import Cross.{requireSession, spacedFirst}
+import sbt.internal.SettingCompletions
+
+object WorkingPluginCross {
+  final val oldPluginSwitch = sbt.PluginCross.pluginSwitch
+  lazy val pluginSwitch: Command = {
+    def switchParser(state: State): Parser[(String, String)] = {
+      val knownVersions = Nil
+      lazy val switchArgs = token(NotSpace.examples(knownVersions: _*)) ~ (token(
+        Space ~> matched(state.combinedParser)) ?? "")
+      lazy val nextSpaced = spacedFirst(PluginSwitchCommand)
+      token(PluginSwitchCommand ~ OptSpace) flatMap { _ =>
+        switchArgs & nextSpaced
+      }
+    }
+
+    def crossExclude(s: Def.Setting[_]): Boolean =
+      s.key match {
+        case Def.ScopedKey(Scope(_, _, pluginCrossBuild.key, _), sbtVersion.key) => true
+        case _ => false
+      }
+
+    Command.arb(requireSession(switchParser), pluginSwitchHelp) {
+      case (state, (version, command)) =>
+        val x = Project.extract(state)
+        import x._
+        state.log.info(s"Setting `sbtVersion in pluginCrossBuild` to $version")
+        val add = List(sbtVersion in GlobalScope in pluginCrossBuild :== version) ++
+          List(scalaVersion := PluginCross.scalaVersionSetting.value) ++
+          inScope(GlobalScope.copy(project = Select(currentRef)))(
+            Seq(scalaVersion := PluginCross.scalaVersionSetting.value)
+          )
+        val session = SettingCompletions.setThis(state, x, add, "").session
+        BuiltinCommands.reapply(session, structure, command :: state)
+    }
+  }
+}


### PR DESCRIPTION
This should probably be reported and fixed upstream.

The implementation of `pluginSwitch` is wrong and does not correctly
reapply the setting when there are other modifications in the state,
produced in the build pipeline.

This commit hot swaps the implementation by the correct one, which uses
the underlying mechanism that the `set` command uses.

Another possible implementation would have been similar to the one we
already have in our default `onLoad`, but this one works so I haven't
tried the other one.