### PR TITLE
Make build load more efficient: cache Scala instances

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -69,8 +69,7 @@ object Compiler {
     }
 
     val scalaInstance = compileInputs.scalaInstance
-    val cacheId = CompilerCache.CacheId.fromInstance(scalaInstance)
-    val compilers = compileInputs.compilerCache.get(cacheId)
+    val compilers = compileInputs.compilerCache.get(scalaInstance)
     val inputs = getInputs(compilers)
     val incrementalCompiler = ZincUtil.defaultIncrementalCompiler
     incrementalCompiler.compile(inputs, logger)

--- a/backend/src/main/scala/bloop/CompilerCache.scala
+++ b/backend/src/main/scala/bloop/CompilerCache.scala
@@ -12,15 +12,13 @@ import xsbti.compile.{ClasspathOptions, Compilers}
 class CompilerCache(componentProvider: ComponentProvider,
                     retrieveDir: AbsolutePath,
                     userResolvers: List[Resolver] = Nil) {
-  import CompilerCache.CacheId
   private val logger = QuietLogger
-  private val cache = new ConcurrentHashMap[CacheId, Compilers]()
+  private val cache = new ConcurrentHashMap[ScalaInstance, Compilers]()
 
-  def get(id: CacheId): Compilers = cache.computeIfAbsent(id, newCompilers)
+  def get(scalaInstance: ScalaInstance): Compilers =
+    cache.computeIfAbsent(scalaInstance, newCompilers)
 
-  private def newCompilers(cacheId: CacheId): Compilers = {
-    val scalaInstance =
-      ScalaInstance(cacheId.scalaOrganization, cacheId.scalaName, cacheId.scalaVersion)
+  private def newCompilers(scalaInstance: ScalaInstance): Compilers = {
     val classpathOptions = ClasspathOptions.of(true, false, false, true, false)
     val compiler = getScalaCompiler(scalaInstance, classpathOptions, componentProvider)
     ZincUtil.compilers(scalaInstance, classpathOptions, None, compiler)
@@ -46,13 +44,5 @@ class CompilerCache(componentProvider: ComponentProvider,
           /* log                  = */ logger
         )
     }
-  }
-}
-
-object CompilerCache {
-  case class CacheId(scalaOrganization: String, scalaName: String, scalaVersion: String)
-  object CacheId {
-    def fromInstance(scalaInstance: ScalaInstance): CacheId =
-      CacheId(scalaInstance.organization, scalaInstance.name, scalaInstance.version)
   }
 }

--- a/backend/src/main/scala/bloop/ScalaInstance.scala
+++ b/backend/src/main/scala/bloop/ScalaInstance.scala
@@ -2,9 +2,11 @@ package bloop
 
 import java.io.File
 import java.net.URLClassLoader
+import java.nio.file.Files
 import java.util.Properties
 
 import coursier._
+
 import scalaz.\/
 import scalaz.concurrent.Task
 
@@ -46,12 +48,35 @@ class ScalaInstance(
 }
 
 object ScalaInstance {
+  import bloop.io.AbsolutePath
+
+  /**
+    * Reuses all jars to create an Scala instance if and only if all of them exist.
+    *
+    * This is done mainly by performance reasons, since dependency resolution is not
+    * in the scope of what bloop is supposed to do. All resolution should be done by the user.
+    *
+    * When this is not the case, we resolve the Scala jars from coursier. This is good
+    * because it means that if for some reason the scala jars do not exist, the user
+    * will get no matter what get the right instance. If the jars don't exist and they
+    * cannot be resolved, users will get a resolution error instead of a weird compilation
+    * error when compilation via Zinc starts.
+    */
+  def apply(scalaOrg: String,
+            scalaName: String,
+            scalaVersion: String,
+            allJars: Array[AbsolutePath]): ScalaInstance = {
+    if (allJars.forall(j => Files.exists(j.underlying)))
+      new ScalaInstance(scalaOrg, scalaName, scalaVersion, allJars.map(_.toFile))
+    else resolve(scalaOrg, scalaName, scalaVersion)
+  }
+
+
   // Cannot wait to use opaque types for this
   type InstanceId = (String, String, String)
   import java.util.concurrent.ConcurrentHashMap
   private val instances = new ConcurrentHashMap[InstanceId, ScalaInstance]
-
-  def apply(scalaOrg: String, scalaName: String, scalaVersion: String): ScalaInstance = {
+  def resolve(scalaOrg: String, scalaName: String, scalaVersion: String): ScalaInstance = {
     def resolveInstance: ScalaInstance = {
       val start = Resolution(Set(Dependency(Module(scalaOrg, scalaName), scalaVersion)))
       val repositories = Seq(Cache.ivy2Local, MavenRepository("https://repo1.maven.org/maven2"))

--- a/frontend/src/main/scala/bloop/Project.scala
+++ b/frontend/src/main/scala/bloop/Project.scala
@@ -32,6 +32,8 @@ case class Project(name: String,
     properties.setProperty("scalacOptions", scalacOptions.mkString(","))
     properties.setProperty("javacOptions", javacOptions.mkString(","))
     properties.setProperty("sourceDirectories", sourceDirectories.map(_.syntax).mkString(","))
+    properties.setProperty("allScalaJars",
+                           scalaInstance.allJars.map(_.getAbsolutePath).mkString(","))
     properties.setProperty("tmp", tmp.syntax)
     properties
   }
@@ -79,16 +81,16 @@ object Project {
   }
 
   def fromProperties(properties: Properties): Project = {
+    def toPaths(line: String) = line.split(",").map(NioPaths.get(_)).map(AbsolutePath.apply).toArray
     val name = properties.getProperty("name")
     val dependencies =
       properties.getProperty("dependencies").split(",").filterNot(_.isEmpty)
     val scalaOrganization = properties.getProperty("scalaOrganization")
+    val allScalaJars = toPaths(properties.getProperty("allScalaJars"))
     val scalaName = properties.getProperty("scalaName")
     val scalaVersion = properties.getProperty("scalaVersion")
-    val scalaInstance =
-      ScalaInstance(scalaOrganization, scalaName, scalaVersion)
-    val classpath =
-      properties.getProperty("classpath").split(",").map(NioPaths.get(_)).map(AbsolutePath.apply)
+    val scalaInstance = ScalaInstance(scalaOrganization, scalaName, scalaVersion, allScalaJars)
+    val classpath = toPaths(properties.getProperty("classpath"))
     val classesDir = AbsolutePath(NioPaths.get(properties.getProperty("classesDir")))
     val scalacOptions =
       properties.getProperty("scalacOptions").split(";").filterNot(_.isEmpty)

--- a/frontend/src/test/scala/bloop/tasks/CompilationHelpers.scala
+++ b/frontend/src/test/scala/bloop/tasks/CompilationHelpers.scala
@@ -29,6 +29,5 @@ object CompilationHelpers {
   }
 
   def scalaInstance: ScalaInstance =
-    ScalaInstance("org.scala-lang", "scala-compiler", Properties.versionNumberString)
-
+    ScalaInstance.resolve("org.scala-lang", "scala-compiler", Properties.versionNumberString)
 }

--- a/frontend/src/test/scala/bloop/tasks/CompilationTaskTest.scala
+++ b/frontend/src/test/scala/bloop/tasks/CompilationTaskTest.scala
@@ -30,17 +30,17 @@ object CompilationTaskTest extends TestSuite {
     }
 
     "Compile with scala 2.12.4" - {
-      val scalaInstance = ScalaInstance("org.scala-lang", "scala-compiler", "2.12.4")
+      val scalaInstance = ScalaInstance.resolve("org.scala-lang", "scala-compiler", "2.12.4")
       simpleProject(scalaInstance)
     }
 
     "Compile with Scala 2.12.3" - {
-      val scalaInstance = ScalaInstance("org.scala-lang", "scala-compiler", "2.12.3")
+      val scalaInstance = ScalaInstance.resolve("org.scala-lang", "scala-compiler", "2.12.3")
       simpleProject(scalaInstance)
     }
 
     "Compile with scala 2.11.11" - {
-      val scalaInstance = ScalaInstance("org.scala-lang", "scala-compiler", "2.11.11")
+      val scalaInstance = ScalaInstance.resolve("org.scala-lang", "scala-compiler", "2.11.11")
       simpleProject(scalaInstance)
     }
 
@@ -129,7 +129,7 @@ object CompilationTaskTest extends TestSuite {
 
     val dependencies = Map.empty[String, Set[String]]
 
-    val scalaInstance = ScalaInstance("org.scala-lang", "scala-compiler", "2.11.11")
+    val scalaInstance = ScalaInstance.resolve("org.scala-lang", "scala-compiler", "2.11.11")
     withProjects(projectStructures, dependencies, scalaInstance) { projects =>
       val project = projects("prj")
 

--- a/sbt-bloop/src/main/scala/bloop/SbtBloop.scala
+++ b/sbt-bloop/src/main/scala/bloop/SbtBloop.scala
@@ -8,7 +8,7 @@ import Keys._
 import sbt.plugins.JvmPlugin
 
 object SbtBloop extends AutoPlugin {
-  override def trigger  = allRequirements
+  override def trigger = allRequirements
   override def requires = JvmPlugin
 
   private val bloopInstall: TaskKey[Unit] =
@@ -49,12 +49,13 @@ object SbtBloop extends AutoPlugin {
             Keys.ivyScala.value
               .map(_.scalaOrganization)
               .getOrElse("org.scala-lang")
-          val scalaName  = "scala-compiler"
-          val classpath  = dependencyClasspath.value.map(_.data.getAbsoluteFile)
+          val scalaName = "scala-compiler"
+          val allScalaJars = Keys.scalaInstance.value.allJars.map(_.getAbsoluteFile)
+          val classpath = dependencyClasspath.value.map(_.data.getAbsoluteFile)
           val classesDir = classDirectory.value.getAbsoluteFile
           val sourceDirs = sourceDirectories.value
-          val tmp        = target.value / "tmp-bloop"
-          val outFile    = bloopConfigDir.value / (projectName + ".config")
+          val tmp = target.value / "tmp-bloop"
+          val outFile = bloopConfigDir.value / (projectName + ".config")
           val config =
             Config(
               projectName,
@@ -67,6 +68,7 @@ object SbtBloop extends AutoPlugin {
               scalacOptions.value,
               javacOptions.value,
               sourceDirs,
+              allScalaJars,
               tmp
             )
           val properties = config.toProperties
@@ -90,6 +92,7 @@ object SbtBloop extends AutoPlugin {
                             scalacOptions: Seq[String],
                             javacOptions: Seq[String],
                             sourceDirectories: Seq[File],
+                            allScalaJars: Seq[File],
                             tmp: File) {
     def toProperties: Properties = {
       val properties = new Properties()
@@ -104,6 +107,7 @@ object SbtBloop extends AutoPlugin {
       properties.setProperty("javacOptions", javacOptions.mkString(";"))
       properties.setProperty("sourceDirectories",
                              sourceDirectories.map(_.getAbsolutePath).mkString(","))
+      properties.setProperty("allScalaJars", allScalaJars.map(_.getAbsolutePath).mkString(","))
       properties.setProperty("tmp", tmp.getAbsolutePath)
       properties
     }


### PR DESCRIPTION
This PR caches scala instances that first need to be resolved to be
used. This avoids repeating lots of work that was happening when we were
loading the build.

Now, the build for scalac loads in 1300ms instead of 4300ms.