### PR TITLE
Use fixed size thread pool for task execution

### DIFF
--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -1,5 +1,6 @@
 package bloop
 
+import bloop.engine.ExecutionContext.threadPool
 import bloop.io.{AbsolutePath, Paths}
 import bloop.io.Timer.timed
 import bloop.logging.Logger
@@ -7,7 +8,6 @@ import bloop.tasks.{CompilationTasks, TestTasks}
 import sbt.internal.inc.bloop.ZincInternals
 
 import scala.annotation.tailrec
-import scala.concurrent.ExecutionContext.Implicits.global
 
 object Bloop {
 

--- a/frontend/src/main/scala/bloop/engine/ExecutionContext.scala
+++ b/frontend/src/main/scala/bloop/engine/ExecutionContext.scala
@@ -1,0 +1,10 @@
+package bloop.engine
+
+import java.util.concurrent.Executors
+
+object ExecutionContext {
+  private val nCPUs = Runtime.getRuntime.availableProcessors()
+  private val executor = Executors.newFixedThreadPool(nCPUs)
+
+  implicit val threadPool = scala.concurrent.ExecutionContext.fromExecutorService(executor)
+}

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -4,6 +4,7 @@ import bloop.cli.{CliOptions, Commands, CommonOptions, ExitStatus}
 import bloop.io.{AbsolutePath, Paths}
 import bloop.logging.Logger
 import bloop.tasks.{CompilationTasks, TestTasks}
+import ExecutionContext.threadPool
 import bloop.util.TopologicalSort
 import bloop.{CompilerCache, Project}
 import sbt.internal.inc.bloop.ZincInternals
@@ -86,7 +87,6 @@ object Interpreter {
                       incremental: Boolean,
                       cliOptions: CliOptions,
                       logger: Logger): ExitStatus = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     val configDir = getConfigDir(cliOptions)
     val projects = Project.fromDir(configDir, logger)
     val tasks = constructTasks(projects, logger)

--- a/frontend/src/test/scala/bloop/tasks/CompilationTaskTest.scala
+++ b/frontend/src/test/scala/bloop/tasks/CompilationTaskTest.scala
@@ -2,8 +2,8 @@ package bloop.tasks
 
 import utest._
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import bloop.{Project, ScalaInstance}
+import bloop.engine.ExecutionContext.threadPool
 import ProjectHelpers._
 import bloop.logging.Logger
 

--- a/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
+++ b/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
@@ -1,9 +1,9 @@
 package bloop.tasks
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import java.nio.file.{Files, Path, Paths}
 
 import bloop.{DynTest, Project}
+import bloop.engine.ExecutionContext.threadPool
 import bloop.io.AbsolutePath
 import bloop.logging.Logger
 import bloop.util.TopologicalSort

--- a/frontend/src/test/scala/bloop/tasks/TaskTest.scala
+++ b/frontend/src/test/scala/bloop/tasks/TaskTest.scala
@@ -1,6 +1,6 @@
 package bloop.tasks
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import bloop.engine.ExecutionContext.threadPool
 
 import scala.collection.mutable.Buffer
 

--- a/frontend/src/test/scala/bloop/tasks/TestTaskTest.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestTaskTest.scala
@@ -4,7 +4,7 @@ import bloop.DynTest
 import bloop.logging.Logger
 import sbt.testing.{Runner, TaskDef}
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import bloop.engine.ExecutionContext.threadPool
 
 object TestTaskTest extends DynTest {
 


### PR DESCRIPTION
There were many problems with the global execution context with nailgun.
I tried that, and it makes logging and task execution work again with
Nailgun.