### PR TITLE
Add sbt-errors-summary to bloop

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -1,7 +1,7 @@
 package bloop
 
 import xsbti.compile._
-import xsbti.T2
+import xsbti.{Reporter, T2}
 import java.util.Optional
 import java.io.File
 
@@ -19,6 +19,7 @@ case class CompileInputs(
     scalacOptions: Array[String],
     javacOptions: Array[String],
     previousResult: PreviousResult,
+    reporter: Reporter,
     logger: Logger
 )
 
@@ -60,7 +61,7 @@ object Compiler {
       val skip = false
       val empty = Array.empty[T2[String, String]]
       val lookup = new ZincClasspathEntryLookup(compileInputs.previousResult)
-      val reporter = new LoggedReporter(100, compileInputs.logger)
+      val reporter = compileInputs.reporter
       val compilerCache = new FreshCompilerCache
       val cacheFile = compileInputs.baseDirectory.resolve("cache").toFile
       val incOptions = IncOptions.create()

--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -4,6 +4,7 @@ import bloop.engine.ExecutionContext.threadPool
 import bloop.io.{AbsolutePath, Paths}
 import bloop.io.Timer.timed
 import bloop.logging.Logger
+import bloop.reporter.ReporterConfig
 import bloop.tasks.{CompilationTasks, TestTasks}
 import sbt.internal.inc.bloop.ZincInternals
 
@@ -47,7 +48,7 @@ object Bloop {
         val newProjects = timed(logger) {
           val project = projects(projectName)
           val tasks = new CompilationTasks(projects, compilerCache, logger)
-          tasks.parallelCompile(project)
+          tasks.parallelCompile(project, ReporterConfig.defaultFormat)
         }
         run(newProjects, compilerCache)
 

--- a/frontend/src/main/scala/bloop/Project.scala
+++ b/frontend/src/main/scala/bloop/Project.scala
@@ -12,6 +12,7 @@ import sbt.internal.inc.FileAnalysisStore
 import xsbti.compile.{CompileAnalysis, MiniSetup, PreviousResult}
 
 case class Project(name: String,
+                   baseDirectory: AbsolutePath,
                    dependencies: Array[String],
                    scalaInstance: ScalaInstance,
                    classpath: Array[AbsolutePath],
@@ -26,6 +27,7 @@ case class Project(name: String,
   def toProperties(): Properties = {
     val properties = new Properties()
     properties.setProperty("name", name)
+    properties.setProperty("baseDirectory", baseDirectory.syntax)
     properties.setProperty("dependencies", dependencies.mkString(","))
     properties.setProperty("scalaOrg", scalaInstance.organization)
     properties.setProperty("scalaName", scalaInstance.name)
@@ -110,6 +112,7 @@ object Project {
   def fromProperties(properties: Properties): Project = {
     def toPaths(line: String) = line.split(",").map(NioPaths.get(_)).map(AbsolutePath.apply)
     val name = properties.getProperty("name")
+    val baseDirectory = AbsolutePath(NioPaths.get(properties.getProperty("baseDirectory")))
     val dependencies =
       properties.getProperty("dependencies").split(",").filterNot(_.isEmpty)
     val scalaOrganization = properties.getProperty("scalaOrganization")
@@ -133,17 +136,20 @@ object Project {
     val testFrameworks =
       properties.getProperty("testFrameworks").split(";").map(_.split(",").filterNot(_.isEmpty))
     val tmp = AbsolutePath(NioPaths.get(properties.getProperty("tmp")))
-    Project(name,
-            dependencies,
-            scalaInstance,
-            classpath,
-            classesDir,
-            scalacOptions,
-            javacOptions,
-            sourceDirectories,
-            previousResult,
-            testFrameworks,
-            tmp,
-            None)
+    Project(
+      name,
+      baseDirectory,
+      dependencies,
+      scalaInstance,
+      classpath,
+      classesDir,
+      scalacOptions,
+      javacOptions,
+      sourceDirectories,
+      previousResult,
+      testFrameworks,
+      tmp,
+      None
+    )
   }
 }

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -16,6 +16,9 @@ object Commands {
       project: String,
       @HelpMessage("If set, it compiles incrementally. By default, true.")
       incremental: Boolean = true,
+      @HelpMessage(
+        "If set, displays compilation message following scalac's style. Defaults to false.")
+      scalacstyle: Boolean = false,
       @Recurse cliOptions: CliOptions = CliOptions.default,
   ) extends Command
 
@@ -26,6 +29,9 @@ object Commands {
       @ExtraName("all")
       @HelpMessage("If set, also runs the tests in dependencies. Defaults to true.")
       aggregate: Boolean = false,
+      @HelpMessage(
+        "If set, displays compilation message following scalac's style. Defaults to false.")
+      scalacstyle: Boolean = false,
       @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends Command
 

--- a/frontend/src/main/scala/bloop/reporter/ClassicFormat.scala
+++ b/frontend/src/main/scala/bloop/reporter/ClassicFormat.scala
@@ -1,0 +1,28 @@
+package bloop.reporter
+
+import scala.compat.Platform.EOL
+
+object ClassicFormat extends (ConfigurableReporter => ReporterFormat) {
+  override def apply(reporter: ConfigurableReporter): ClassicFormat =
+    new ClassicFormat(reporter)
+}
+
+class ClassicFormat(reporter: ConfigurableReporter) extends DefaultReporterFormat(reporter) {
+  override def formatProblem(problem: Problem): String = {
+    val line = toOption(problem.position.line).map(_ + ":").getOrElse("")
+    val col = problem.position.lineOffset match {
+      case Some(offset) if reporter.config.columnNumbers => (offset + 1) + ":"
+      case _ => ""
+    }
+
+    val sourcePath =
+      formatSourcePath(problem).map(_ + ":" + colored(colorFor(problem), s"$line$col"))
+
+    val text =
+      List(sourcePath, formatMessage(problem), formatSource(problem)).flatten
+        .mkString(EOL)
+
+    val prefix = s"${extraSpace(problem.severity)}[E${problem.id}] "
+    prefixed(reporter.config.errorIdColor, prefix, text)
+  }
+}

--- a/frontend/src/main/scala/bloop/reporter/ConfigurableReporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/ConfigurableReporter.scala
@@ -1,0 +1,28 @@
+package bloop.reporter
+
+import bloop.logging.Logger
+
+/**
+ * Interface for a reporter that has a configuration.
+ * This is the API visible from a `ReporterFormat`.
+ */
+trait ConfigurableReporter {
+
+  /** Where to log the message */
+  def logger: Logger
+
+  /** The base directory of this reporter. */
+  def base: String
+
+  /** The configuration for this reporter. */
+  def config: ReporterConfig
+
+  /** All the `Problems` seen by this reporter. */
+  def allProblems: Seq[Problem]
+
+  /** `true` if this reporter has received errors, `false` otherwise. */
+  def hasErrors(): Boolean
+
+  /** `true` if this reporter has received warnings, `false` otherwise. */
+  def hasWarnings(): Boolean
+}

--- a/frontend/src/main/scala/bloop/reporter/DefaultReporterFormat.scala
+++ b/frontend/src/main/scala/bloop/reporter/DefaultReporterFormat.scala
@@ -1,0 +1,100 @@
+package bloop.reporter
+
+import scala.compat.Platform.EOL
+
+/**
+ * Helper object for easy configuration.
+ */
+object DefaultReporterFormat extends (ConfigurableReporter => ReporterFormat) {
+  override def apply(reporter: ConfigurableReporter): DefaultReporterFormat =
+    new DefaultReporterFormat(reporter)
+}
+
+/**
+ * Default format for reporter.
+ *
+ * @param reporter The reporter that uses this format.
+ */
+class DefaultReporterFormat(reporter: ConfigurableReporter) extends ReporterFormat(reporter) {
+
+  protected def formatSourcePath(problem: Problem): Option[String] =
+    problem.position.pfile.map { f =>
+      colored(reporter.config.sourcePathColor, f)
+    }
+
+  protected def formatSource(problem: Problem): Option[String] =
+    for {
+      line <- Option(problem.position.lineContent).filter(_.nonEmpty)
+      sp <- toOption(problem.position.pointerSpace)
+    } yield {
+      s"""$line
+         |$sp^""".stripMargin
+    }
+
+  protected def formatMessage(problem: Problem): Option[String] =
+    Some(problem.message)
+
+  override def formatProblem(problem: Problem): String = {
+    val line = toOption(problem.position.line).map("L" + _).getOrElse("")
+    val col = toOption(problem.position.pointer) match {
+      case Some(offset) if reporter.config.columnNumbers => "C" + (offset + 1)
+      case _ => ""
+    }
+
+    val sourceCode =
+      formatSource(problem).map { s =>
+        val prefix = line + col
+        prefixed(colorFor(problem), if (prefix.nonEmpty) prefix + ": " else "", s)
+      }
+
+    val text =
+      List(formatSourcePath(problem), formatMessage(problem), sourceCode).flatten
+        .mkString(EOL)
+
+    val prefix = s"${extraSpace(problem.severity)}[E${problem.id}] "
+    prefixed(reporter.config.errorIdColor, prefix, text)
+  }
+
+  override def printSummary(): Unit = {
+    val log: String => Unit =
+      (line: String) =>
+        if (reporter.hasErrors()) reporter.logger.error(line)
+        else if (reporter.hasWarnings()) reporter.logger.warn(line)
+        else reporter.logger.info(line)
+
+    reporter.allProblems
+      .groupBy(_.position.pfile)
+      .foreach {
+        case (None, _) =>
+          ()
+        case (Some(file), inFile) =>
+          val sorted =
+            inFile
+              .sortBy(_.position.pline)
+              .flatMap(showProblemLine)
+
+          if (sorted.nonEmpty) {
+            val line = s"""$file: ${sorted.mkString(", ")}"""
+            log(line)
+          }
+      }
+
+    if (reporter.config.showLegend && reporter.allProblems.nonEmpty)
+      reporter.logger.info("Legend: Ln = line n, Cn = column n, En = error n")
+  }
+
+  /**
+   * Shows the line at which `problem` occured and the id of the problem.
+   *
+   * @param problem The problem to show
+   * @return A formatted string that shows the line of the problem and its id.
+   */
+  private def showProblemLine(problem: Problem): Option[String] =
+    problem.position.pline.map { line =>
+      val color = colorFor(problem)
+
+      colored(color, "L" + line) +
+        colored(reporter.config.errorIdColor, s" [E${problem.id}]")
+    }
+
+}

--- a/frontend/src/main/scala/bloop/reporter/Problem.scala
+++ b/frontend/src/main/scala/bloop/reporter/Problem.scala
@@ -1,0 +1,15 @@
+package bloop.reporter
+
+/** Describes a problem (error, warning, message, etc.) given to the reporter. */
+final case class Problem private (
+                                  /** A unique (per compilation run) number for this message. */
+                                  id: Int,
+                                  /** The severity of this message. */
+                                  severity: xsbti.Severity,
+                                  /** The actual content of the message */
+                                  message: String,
+                                  /** Position in the source code where the message was triggered */
+                                  position: xsbti.Position,
+                                  /** The category of this problem. */
+                                  category: String)
+    extends xsbti.Problem

--- a/frontend/src/main/scala/bloop/reporter/Reporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/Reporter.scala
@@ -1,0 +1,95 @@
+package bloop.reporter
+
+import bloop.logging.Logger
+import xsbti.{Position, Severity}
+
+/**
+ * A flexible reporter whose configuration is provided by a `ReporterConfig`.
+ * This configuration indicated whether to use colors, how to format messages,
+ * etc.
+ *
+ * @param logger The logger that will receive the output of the reporter.
+ * @param base   The base prefix to remove from paths.
+ * @param sourcePositionMapper A function that transforms positions.
+ * @param config The configuration for this reporter.
+ */
+final class Reporter(val logger: Logger,
+                     val base: String,
+                     sourcePositionMapper: Position => Position,
+                     val config: ReporterConfig)
+    extends xsbti.Reporter
+    with ConfigurableReporter {
+
+  private val format = config.format(this)
+  private val _problems = collection.mutable.ArrayBuffer.empty[Problem]
+  private var _nextID = 1
+
+  override def reset(): Unit = {
+    _problems.clear()
+    _nextID = 1
+  }
+
+  override def hasErrors(): Boolean =
+    hasErrors(_problems)
+
+  override def hasWarnings(): Boolean =
+    hasWarnings(_problems)
+
+  override def printSummary(): Unit = {
+    if (config.reverseOrder) {
+      _problems.reverse.foreach(logFull)
+    }
+
+    format.printSummary()
+
+  }
+
+  override def allProblems: Seq[Problem] =
+    _problems
+
+  override def problems(): Array[xsbti.Problem] =
+    _problems.toArray
+
+  override def log(prob: xsbti.Problem): Unit = {
+    val mappedPos = sourcePositionMapper(prob.position)
+    val problemID = if (prob.position.sourceFile.isPresent) nextID() else -1
+    val problem =
+      Problem(problemID, prob.severity, prob.message, mappedPos, prob.category)
+    _problems += problem
+
+    // If we show errors in reverse order, they'll all be shown
+    // in `printSummary`.
+    if (!config.reverseOrder) {
+      logFull(problem)
+    }
+  }
+
+  override def comment(pos: Position, msg: String): Unit = ()
+
+  /**
+   * Log the full error message for `problem`.
+   *
+   * @param problem The problem to log.
+   */
+  private def logFull(problem: Problem): Unit = {
+    val text = format.formatProblem(problem)
+    problem.severity match {
+      case Severity.Error => logger.error(text)
+      case Severity.Warn => logger.warn(text)
+      case Severity.Info => logger.info(text)
+    }
+  }
+
+  private def hasErrors(problems: Seq[Problem]): Boolean =
+    problems.exists(_.severity == Severity.Error)
+
+  private def hasWarnings(problems: Seq[Problem]): Boolean =
+    problems.exists(_.severity == Severity.Warn)
+
+  private def nextID(): Int = {
+    val id = _nextID
+    _nextID += 1
+    id
+  }
+
+}

--- a/frontend/src/main/scala/bloop/reporter/ReporterConfig.scala
+++ b/frontend/src/main/scala/bloop/reporter/ReporterConfig.scala
@@ -1,0 +1,67 @@
+package bloop.reporter
+
+/**
+ * General configuration for the formats.
+ * Formats are supposed to be opinionated, and they are free to ignore any
+ * of those settings.
+ */
+final case class ReporterConfig(
+                                /** `true` to enable colors, `false` to disable them. */
+                                colors: Boolean,
+                                /** `true` to strip the base directory, `false` to show the full path. */
+                                shortenPaths: Boolean,
+                                /** `true` to show the column number, `false` to hide it. */
+                                columnNumbers: Boolean,
+                                /** `true` to show the errors in reverse order, `false` to show them in FIFO order. */
+                                reverseOrder: Boolean,
+                                /** `true` to show a legend explaining the output of the reporter, `false` to hide it. */
+                                showLegend: Boolean,
+                                /** The color to use to show errors. */
+                                errorColor: String,
+                                /** The color to use to show warnings. */
+                                warningColor: String,
+                                /** The color to use to show information messages. */
+                                infoColor: String,
+                                /** The color to use to show debug messages. */
+                                debugColor: String,
+                                /** The color to use to highlight the path where a message was triggered. */
+                                sourcePathColor: String,
+                                /** The color to use to show an error ID. */
+                                errorIdColor: String,
+                                /** The format to use. */
+                                format: ConfigurableReporter => ReporterFormat)
+
+object ReporterConfig {
+
+  lazy val defaultFormat =
+    new ReporterConfig(
+      true,
+      true,
+      false,
+      true,
+      false,
+      scala.Console.RED,
+      scala.Console.YELLOW,
+      scala.Console.CYAN,
+      scala.Console.WHITE,
+      scala.Console.UNDERLINED,
+      scala.Console.BLUE,
+      DefaultReporterFormat
+    )
+
+  lazy val scalacFormat =
+    new ReporterConfig(
+      true,
+      true,
+      false,
+      false,
+      true,
+      scala.Console.RED,
+      scala.Console.YELLOW,
+      scala.Console.CYAN,
+      scala.Console.WHITE,
+      scala.Console.UNDERLINED,
+      scala.Console.BLUE,
+      ScalacFormat
+    )
+}

--- a/frontend/src/main/scala/bloop/reporter/ReporterFormat.scala
+++ b/frontend/src/main/scala/bloop/reporter/ReporterFormat.scala
@@ -1,0 +1,100 @@
+package bloop.reporter
+
+import xsbti.{Position, Severity}
+import scala.Console.RESET
+import scala.compat.Platform.EOL
+
+import java.io.File
+import java.util.Optional
+
+/**
+ * Describes how messages should be formatted by a `ConfigurableReporter`.
+ *
+ * @param reporter The reporter that will use this format.
+ */
+abstract class ReporterFormat(reporter: ConfigurableReporter) {
+
+  /**
+   * Returns a string representation of `Problem`, as it should be shown by
+   * the reporter.
+   *
+   * @param problem The problem to format.
+   * @return A string representation of the problem.
+   */
+  def formatProblem(problem: Problem): String
+
+  /**
+   * Prints a summary of all the errors reporter to the logger.
+   */
+  def printSummary(): Unit
+
+  /**
+   * Shows `str` with color `color` if the reporter is configured with
+   * `colors = true`.
+   *
+   * @param color The color to use
+   * @param str   The string to color.
+   * @return The colored string if `colors = true`, `str` otherwise.
+   */
+  protected def colored(color: String, str: String): String =
+    if (reporter.config.colors) s"${RESET}${color}${str}${RESET}"
+    else str
+
+  /**
+   * Put a prefix `prefix` at the beginning of `paragraph`, indents all lines.
+   *
+   * @param prefix    The prefix to insert.
+   * @param paragraph The block of text to prefix and indent.
+   * @return The prefixed and indented paragraph.
+   */
+  protected def prefixed(prefixColor: String, prefix: String, paragraph: String): String =
+    paragraph.lines
+      .mkString(colored(prefixColor, prefix), EOL + " " * prefix.length, "")
+
+  /**
+   * Retrieves the right color to use for `problem` based on Severity.
+   *
+   * @param problem The problem to show.
+   * @return The ANSI string to set the right color.
+   */
+  protected def colorFor(problem: Problem): String =
+    problem.severity match {
+      case Severity.Info => reporter.config.infoColor
+      case Severity.Error => reporter.config.errorColor
+      case Severity.Warn => reporter.config.warningColor
+    }
+
+  /**
+   * Returns the absolute path of `file` with `base` stripped, if the reporter
+   * if configured with `shortenPaths = true`.
+   *
+   * @param file The file whose path to show.
+   * @return The absolute path of `file` with `base` stripped if `shortenPaths = true`,
+   *         or the original path otherwise.
+   */
+  protected def showPath(file: File): Option[String] = {
+    val absolutePath = Option(file).map(_.getAbsolutePath)
+    if (reporter.config.shortenPaths)
+      absolutePath.map(_.stripPrefix(reporter.base))
+    else absolutePath
+  }
+
+  /**
+   * Returns spaces to fix alignment given the `severity`.
+   */
+  protected def extraSpace(severity: Severity): String =
+    severity match {
+      case Severity.Warn => " "
+      case Severity.Info => " "
+      case _ => ""
+    }
+
+  protected implicit class MyPosition(position: Position) {
+    def pfile: Option[String] = toOption(position.sourceFile).flatMap(showPath)
+    def pline: Option[Int] = toOption(position.line).map(_.toInt)
+    def lineOffset: Option[Int] = toOption(position.pointerSpace).map(_.length)
+  }
+
+  protected def toOption[T](m: Optional[T]): Option[T] =
+    if (m.isPresent) Some(m.get) else None
+}

--- a/frontend/src/main/scala/bloop/reporter/ScalacFormat.scala
+++ b/frontend/src/main/scala/bloop/reporter/ScalacFormat.scala
@@ -1,0 +1,69 @@
+package bloop.reporter
+
+import xsbti.{Position, Severity}
+import scala.compat.Platform.EOL
+
+import java.util.Optional
+
+object ScalacFormat extends (ConfigurableReporter => ReporterFormat) {
+  override def apply(reporter: ConfigurableReporter): ReporterFormat =
+    new ScalacFormat(reporter)
+}
+
+/**
+ * A format that mimics that of scalac.
+ * Adapted from `sbt.LoggerReporter`
+ * Copyright 2002-2009 LAMP/EPFL
+ * see LICENSE_Scala
+ * Original author: Martin Odersky
+ */
+class ScalacFormat(reporter: ConfigurableReporter) extends ReporterFormat(reporter) {
+
+  override def formatProblem(problem: Problem): String =
+    format(problem.position, problem.message)
+
+  override def printSummary(): Unit = {
+    val warnings = reporter.allProblems.count(_.severity == Severity.Warn)
+    if (warnings > 0)
+      reporter.logger.warn(countElementsAsString(warnings, "warning") + " found")
+    val errors = reporter.allProblems.count(_.severity == Severity.Error)
+    if (errors > 0)
+      reporter.logger.error(countElementsAsString(errors, "error") + " found")
+  }
+
+  private def format(pos: Position, msg: String): String = {
+    if (!(pos.sourcePath.isPresent || pos.line.isPresent))
+      msg
+    else {
+      val out = new StringBuilder
+      val sourcePrefix = jo2o(pos.sourcePath).getOrElse("")
+      val columnNumber = jo2o(pos.pointer).map(_.toInt + 1).getOrElse(1)
+      val lineNumberString = jo2o(pos.line)
+        .map(":" + _ + ":" + columnNumber + ":")
+        .getOrElse(":") + " "
+      out.append(sourcePrefix + lineNumberString + msg + EOL)
+      val lineContent = pos.lineContent
+      if (!lineContent.isEmpty) {
+        out.append(lineContent + EOL)
+        for (space <- jo2o(pos.pointerSpace))
+          out.append(space + "^") // pointer to the column position of the error/warning
+      }
+      out.toString
+    }
+  }
+
+  private def countElementsAsString(n: Int, elements: String): String = {
+    n match {
+      case 0 => "no " + elements + "s"
+      case 1 => "one " + elements
+      case 2 => "two " + elements + "s"
+      case 3 => "three " + elements + "s"
+      case 4 => "four " + elements + "s"
+      case _ => "" + n + " " + elements + "s"
+    }
+  }
+
+  private def jo2o[T](m: Optional[T]): Option[T] =
+    if (m.isPresent) Some(m.get) else None
+
+}

--- a/frontend/src/test/scala/bloop/tasks/CompilationTaskTest.scala
+++ b/frontend/src/test/scala/bloop/tasks/CompilationTaskTest.scala
@@ -6,6 +6,7 @@ import bloop.{Project, ScalaInstance}
 import bloop.engine.ExecutionContext.threadPool
 import ProjectHelpers._
 import bloop.logging.Logger
+import bloop.reporter.ReporterConfig
 
 object CompilationTaskTest extends TestSuite {
   private val logger = Logger.get
@@ -19,17 +20,17 @@ object CompilationTaskTest extends TestSuite {
     val `C2.scala` = "package p2\nimport p0.A\nobject C extends A"
   }
 
-  def checkAfterCleanCompilation(structures: Map[String, Map[String, String]],
-                                 dependencies: Map[String, Set[String]],
-                                 scalaInstance: ScalaInstance = CompilationHelpers.scalaInstance,
-                                 logger: Logger)(
-      afterCompile: Map[String, Project] => Unit = (_ => ())) = {
+  def checkAfterCleanCompilation(
+      structures: Map[String, Map[String, String]],
+      dependencies: Map[String, Set[String]],
+      scalaInstance: ScalaInstance = CompilationHelpers.scalaInstance,
+      logger: Logger)(afterCompile: Map[String, Project] => Unit = (_ => ())) = {
     withProjects(structures, dependencies, scalaInstance = scalaInstance) { projects =>
       // Check that this is a clean compile!
       assert(projects.forall { case (_, prj) => noPreviousResult(prj) })
       val project = projects(ProjectNameToCompile)
       val tasks = new CompilationTasks(projects, CompilationHelpers.compilerCache, logger)
-      val newProjects = tasks.parallelCompile(project)
+      val newProjects = tasks.parallelCompile(project, ReporterConfig.defaultFormat)
       afterCompile(newProjects)
     }
   }

--- a/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
+++ b/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
@@ -7,6 +7,7 @@ import bloop.engine.ExecutionContext.threadPool
 import bloop.io.AbsolutePath
 import bloop.logging.Logger
 import bloop.util.TopologicalSort
+import bloop.reporter.ReporterConfig
 
 object IntegrationTestSuite extends DynTest {
   val logger = Logger.get
@@ -28,6 +29,7 @@ object IntegrationTestSuite extends DynTest {
       val projects = ProjectHelpers.loadTestProject(testDirectory.getFileName.toString, logger)
       val rootProject = Project(
         name = rootProjectName,
+        baseDirectory = AbsolutePath(testDirectory),
         dependencies = projects.keys.toArray,
         scalaInstance = projects.head._2.scalaInstance,
         classpath = Array.empty,
@@ -55,7 +57,7 @@ object IntegrationTestSuite extends DynTest {
 
     assert(projects.forall { case (_, p) => ProjectHelpers.noPreviousResult(p) })
     val tasks = new CompilationTasks(projects, CompilationHelpers.compilerCache, logger)
-    val newProjects = tasks.parallelCompile(projects(rootProjectName))
+    val newProjects = tasks.parallelCompile(projects(rootProjectName), ReporterConfig.defaultFormat)
     val reachableProjects = TopologicalSort.reachable(newProjects(rootProjectName), newProjects)
     assert(reachableProjects.forall { case (_, p) => ProjectHelpers.hasPreviousResult(p) })
   }

--- a/frontend/src/test/scala/bloop/tasks/ProjectHelpers.scala
+++ b/frontend/src/test/scala/bloop/tasks/ProjectHelpers.scala
@@ -90,8 +90,9 @@ object ProjectHelpers {
                   sources: Map[String, String],
                   dependencies: Set[String],
                   scalaInstance: ScalaInstance): Project = {
+    val baseDirectory = projectDir(baseDir, name)
     val (srcs, classes) = makeProjectStructure(baseDir, name)
-    val tempDir = projectDir(baseDir, name).resolve("tmp")
+    val tempDir = baseDirectory.resolve("tmp")
     Files.createDirectories(tempDir)
 
     val target = classesDir(baseDir, name)
@@ -101,6 +102,7 @@ object ProjectHelpers {
     writeSources(srcs, sources)
     Project(
       name = name,
+      baseDirectory = AbsolutePath(baseDirectory),
       dependencies = dependencies.toArray,
       scalaInstance = scalaInstance,
       classpath = classpath,

--- a/frontend/src/test/scala/bloop/tasks/TestTaskTest.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestTaskTest.scala
@@ -2,6 +2,7 @@ package bloop.tasks
 
 import bloop.DynTest
 import bloop.logging.Logger
+import bloop.reporter.ReporterConfig
 import sbt.testing.{Runner, TaskDef}
 
 import bloop.engine.ExecutionContext.threadPool
@@ -48,7 +49,7 @@ object TestTaskTest extends DynTest {
     val testProject = {
       val projects = ProjectHelpers.loadTestProject(projectName, logger)
       val tasks = CompilationTasks(projects, CompilationHelpers.compilerCache, logger)
-      tasks.parallelCompile(projects(moduleName))
+      tasks.parallelCompile(projects(moduleName), ReporterConfig.defaultFormat)
     }
 
     new TestTasks(testProject, logger)

--- a/sbt-bloop/src/main/scala/bloop/SbtBloop.scala
+++ b/sbt-bloop/src/main/scala/bloop/SbtBloop.scala
@@ -38,6 +38,7 @@ object PluginImplementation {
 
   case class Config(
       name: String,
+      baseDirectory: File,
       dependencies: Seq[String],
       scalaOrganization: String,
       scalaName: String,
@@ -56,6 +57,7 @@ object PluginImplementation {
     def toProperties: java.util.Properties = {
       val properties = new java.util.Properties()
       properties.setProperty("name", name)
+      properties.setProperty("baseDirectory", baseDirectory.getAbsolutePath)
       properties.setProperty("dependencies", seqToString(dependencies))
       properties.setProperty("scalaOrganization", scalaOrganization)
       properties.setProperty("scalaName", scalaName)
@@ -85,6 +87,7 @@ object PluginImplementation {
       val project = Keys.thisProject.value
       val configuration = Keys.configuration.value
       val projectName = makeName(project.id, configuration)
+      val baseDirectory = Keys.baseDirectory.value.getAbsoluteFile
 
       // In the test configuration, add a dependency on the base project
       val baseProjectDependency = if (configuration == Test) List(project.id) else Nil
@@ -116,7 +119,7 @@ object PluginImplementation {
       (Keys.sourceGenerators.value ++ Keys.resourceGenerators.value).join.map(_.flatten)
 
       // format: OFF
-      val config = Config(projectName, dependenciesAndAggregates, scalaOrg, scalaName,scalaVersion,
+      val config = Config(projectName, baseDirectory, dependenciesAndAggregates, scalaOrg, scalaName,scalaVersion,
         classpath, classesDir, scalacOptions, javacOptions, sourceDirs, testFrameworks, allScalaJars, tmp)
       sbt.IO.createDirectory(bloopConfigDir)
       val stream = new FileOutputStream(outFile)


### PR DESCRIPTION
It is still possible to revert to scalac-style reporting by using the
`--scalacstyle` when doing compile