### PR TITLE
fix cloning part at installation section at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Bloop is not released yet. To publish bloop locally, you'll need to clone this r
 sbt:
 
 ```sh
-$ git clone --recursive -j8 https://github.com/scalacenter/bloop.git
+$ git clone --recursive https://github.com/scalacenter/bloop.git
 $ cd bloop
 $ sbt
 > install

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Bloop is not released yet. To publish bloop locally, you'll need to clone this r
 sbt:
 
 ```sh
-$ git clone https://github.com/scalacenter/bloop.git
+$ git clone --recursive -j8 https://github.com/scalacenter/bloop.git
 $ cd bloop
 $ sbt
 > install


### PR DESCRIPTION
current clone instruction won't works because  git clone doesn't download submodules  like 'nailgun-server'
therefore it seems like 
'git clone --recursive -j8 https://github.com/scalacenter/bloop.git' should be used (for git >= 1.9)