### PR TITLE
Fix #94: Add projects + cleaned projects in clean

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -174,7 +174,7 @@ object Interpreter {
 
     if (notFoundProjects.isEmpty) {
       val tasks = compilationTasks(projects, logger)
-      val cleanProjects = tasks.clean(projectNames)
+      val cleanProjects = projects ++ tasks.clean(projectNames)
       Project.update(configDir, cleanProjects)
       ExitStatus.Ok
     } else {


### PR DESCRIPTION
Otherwise we were just returning the projects that have been cleaned,
completely discarding the projects that were untouched.

Fixes #94