### PR TITLE
Select test project with suffix when running tests

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -137,7 +137,8 @@ object Interpreter {
                    logger: Logger): ExitStatus = timed(logger) {
     val configDir = getConfigDir(cliOptions)
     val projects = Project.fromDir(configDir, logger)
-    projects.get(projectName) match {
+    val testProject = TestTasks.selectTestProject(projectName, projects)
+    testProject match {
       case Some(project) =>
         val compilation = compilationTasks(projects, logger)
         val compiledProjects = compilation.parallelCompile(project, reporterConfig)

--- a/frontend/src/main/scala/bloop/tasks/TestTasks.scala
+++ b/frontend/src/main/scala/bloop/tasks/TestTasks.scala
@@ -62,3 +62,8 @@ class TestTasks(projects: Map[String, Project], logger: Logger) {
   }
 
 }
+
+object TestTasks {
+  def selectTestProject(projectName: String, projects: Map[String, Project]): Option[Project] =
+    projects.get(projectName + "-test").orElse(projects.get(projectName))
+}

--- a/frontend/src/test/scala/bloop/tasks/TestTaskTest.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestTaskTest.scala
@@ -11,6 +11,16 @@ object TestTaskTest extends DynTest {
 
   private val logger = Logger.get
 
+  test("Test project can be selected with or without `-test` suffix") {
+    val projects = ProjectHelpers.loadTestProject("with-tests", logger)
+    val withoutSuffix = TestTasks.selectTestProject("with-tests", projects)
+    val withSuffix = TestTasks.selectTestProject("with-tests-test", projects)
+    assert(withoutSuffix.isDefined)
+    assert(withoutSuffix.get.name == "with-tests-test")
+    assert(withSuffix.isDefined)
+    assert(withSuffix.get.name == "with-tests-test")
+  }
+
   val frameworks = List("ScalaTest", "ScalaCheck", "Specs2", "UTest")
 
   frameworks.foreach { framework =>
@@ -27,7 +37,7 @@ object TestTaskTest extends DynTest {
       logger.quietIfSuccess { logger =>
         val projectName = "with-tests"
         val moduleName = projectName + "-test"
-        val tasks = getTestTasks("with-tests", "with-tests-test", logger)
+        val tasks = getTestTasks(projectName, moduleName, logger)
         val testClassLoader = tasks.getTestLoader(moduleName)
         val definedTests = tasks
           .definedTests(moduleName, testClassLoader)


### PR DESCRIPTION
This makes it more convenient to run the tests. It's still possible
to specify the `-test` suffix.