### PR TITLE
Include only top level `ClassLike` as tests suites

### DIFF
--- a/frontend/src/main/scala/bloop/tasks/TestTasks.scala
+++ b/frontend/src/main/scala/bloop/tasks/TestTasks.scala
@@ -23,18 +23,20 @@ class TestTasks(projects: Map[String, Project], logger: Logger) {
     val (subclassPrints, annotatedPrints) = TestInternals.getFingerprints(frameworks)
 
     val analysis = project.previousResult.analysis().orElse(Analysis.empty)
-    val definitions = TestInternals.allDefs(analysis)
+    val definitions = TestInternals.potentialTests(analysis)
 
     val discovered = Discovery(subclassPrints.map(_._1), annotatedPrints.map(_._1))(definitions)
-    logger.debug("Discovered tests: " + discovered.map(_._1.name()).mkString(", "))
 
     val tasks = mutable.Map.empty[Framework, mutable.Buffer[TaskDef]]
     frameworks.foreach(tasks(_) = mutable.Buffer.empty)
+
+    logger.debug(s"Tests discovered in project '$projectName':")
     discovered.foreach {
       case (de, di) =>
         val printInfos = TestInternals.matchingFingerprints(subclassPrints, annotatedPrints, di)
         printInfos.foreach {
           case (_, _, framework, fingerprint) =>
+            logger.debug(s" * ${de.name}")
             val taskDef = new TaskDef(de.name, fingerprint, false, Array(new SuiteSelector))
             tasks(framework) += taskDef
         }


### PR DESCRIPTION
We were not sufficiently strict in our consideration of what may be a
test suite. This made us check the fingerprints against many more
objects than necessary.

Also, improve the logging to only show that as tests the definitions
that have been recognized as such by test frameworks.