### PR TITLE
Improve logging abstraction, Hide L4J better

### DIFF
--- a/backend/src/main/scala/bloop/logging/AbstractLogger.scala
+++ b/backend/src/main/scala/bloop/logging/AbstractLogger.scala
@@ -1,0 +1,27 @@
+package bloop.logging
+import java.util.function.Supplier
+
+abstract class AbstractLogger extends Logger {
+
+  override def debug(msg: Supplier[String]): Unit = debug(msg.get())
+  override def error(msg: Supplier[String]): Unit = error(msg.get())
+  override def warn(msg: Supplier[String]): Unit = warn(msg.get())
+  override def info(msg: Supplier[String]): Unit = info(msg.get)
+  override def trace(exception: Supplier[Throwable]): Unit = trace(exception.get())
+
+  override def quietIfError[T](op: BufferedLogger => T): T = verbose {
+    val bufferedLogger = new BufferedLogger(this)
+    try op(bufferedLogger)
+    catch { case ex: Throwable => bufferedLogger.clear(); throw ex }
+  }
+
+  override def quietIfSuccess[T](op: BufferedLogger => T): T = verbose {
+    val bufferedLogger = new BufferedLogger(this)
+    try op(bufferedLogger)
+    catch { case ex: Throwable => bufferedLogger.flush(); throw ex }
+  }
+
+  override def verboseIf[T](cond: Boolean)(op: => T): T =
+    if (cond) verbose(op)
+    else op
+}

--- a/backend/src/main/scala/bloop/logging/BufferedLogger.scala
+++ b/backend/src/main/scala/bloop/logging/BufferedLogger.scala
@@ -1,30 +1,25 @@
 package bloop.logging
-import java.util.function.Supplier
+
 import java.util.concurrent.ConcurrentLinkedDeque
 
-class BufferedLogger(underlying: Logger) extends Logger(underlying) {
+class BufferedLogger(underlying: Logger) extends AbstractLogger {
 
   private[this] val buffer = new ConcurrentLinkedDeque[() => Unit]()
 
-  override def debug(msg: String) = buffer.addLast(() => underlying.debug(msg))
-  override def debug(msg: Supplier[String]) = buffer.addLast(() => underlying.debug(msg))
-
-  override def error(msg: String) = buffer.addLast(() => underlying.error(msg))
-  override def error(msg: Supplier[String]) = buffer.addLast(() => underlying.error(msg))
-
-  override def warn(msg: String) = buffer.addLast(() => underlying.warn(msg))
-  override def warn(msg: Supplier[String]) = buffer.addLast(() => underlying.warn(msg))
-
-  override def trace(exception: Throwable) = buffer.addLast(() => underlying.trace(exception))
-  override def trace(exception: Supplier[Throwable]) =
-    buffer.addLast(() => underlying.trace(exception))
-
-  override def info(msg: String) = buffer.addLast(() => underlying.info(msg))
-  override def info(msg: Supplier[String]) = buffer.addLast(() => underlying.info(msg.get))
+  override def name = underlying.name
+  override def ansiCodesSupported() = underlying.ansiCodesSupported()
 
   def clear(): Unit = buffer.clear()
   def flush(): Unit = {
     buffer.forEach(op => op.apply())
     buffer.clear()
   }
+
+  override def debug(msg: String) = buffer.addLast(() => underlying.debug(msg))
+  override def error(msg: String) = buffer.addLast(() => underlying.error(msg))
+  override def warn(msg: String) = buffer.addLast(() => underlying.warn(msg))
+  override def trace(exception: Throwable) = buffer.addLast(() => underlying.trace(exception))
+  override def info(msg: String) = buffer.addLast(() => underlying.info(msg))
+  override def verbose[T](op: => T) = op
+
 }

--- a/backend/src/main/scala/bloop/logging/Log4JLogger.scala
+++ b/backend/src/main/scala/bloop/logging/Log4JLogger.scala
@@ -1,0 +1,27 @@
+package bloop.logging
+
+import org.apache.logging.log4j
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
+
+class Log4JLogger(override val name: String) extends AbstractLogger {
+  def this(logger: Logger) = this(logger.name)
+
+  private val logger: log4j.Logger = LogManager.getLogger(name)
+
+  override def ansiCodesSupported() = true
+
+  override def debug(msg: String): Unit = msg.lines.foreach(logger.debug)
+  override def error(msg: String): Unit = msg.lines.foreach(logger.error)
+  override def warn(msg: String): Unit = msg.lines.foreach(logger.warn)
+  override def trace(exception: Throwable): Unit = logger.trace(exception)
+
+  override def info(msg: String): Unit = msg.lines.foreach(logger.info)
+
+  override def verbose[T](op: => T): T = {
+    val initialLevel = LogManager.getRootLogger.getLevel
+    Configurator.setRootLevel(Level.DEBUG)
+    try op
+    finally Configurator.setRootLevel(initialLevel)
+  }
+}

--- a/backend/src/main/scala/bloop/logging/Logger.scala
+++ b/backend/src/main/scala/bloop/logging/Logger.scala
@@ -1,60 +1,14 @@
 package bloop.logging
 
-import java.util.function.Supplier
-
-import org.apache.logging.log4j
-import org.apache.logging.log4j.{Level, LogManager}
-import org.apache.logging.log4j.core.config.Configurator
+trait Logger extends xsbti.Logger with sbt.testing.Logger {
+  def name: String
+  def quietIfError[T](op: BufferedLogger => T): T
+  def quietIfSuccess[T](op: BufferedLogger => T): T
+  def verboseIf[T](cond: Boolean)(op: => T): T
+  def verbose[T](op: => T): T
+}
 
 object Logger {
   val name = "bloop"
-  def get = new Logger
-}
-class Logger private (private val logger: log4j.Logger)
-    extends xsbti.Logger
-    with sbt.testing.Logger {
-  private def this() = this(LogManager.getLogger(Logger.name))
-  def this(logger: Logger) = this(logger.logger)
-
-  def name: String = logger.getName()
-  override def ansiCodesSupported() = true
-
-  def debug(msg: String): Unit = msg.lines.foreach(logger.debug)
-  override def debug(msg: Supplier[String]): Unit = debug(msg.get())
-
-  def error(msg: String): Unit = msg.lines.foreach(logger.error)
-  override def error(msg: Supplier[String]): Unit = error(msg.get())
-
-  def warn(msg: String): Unit = msg.lines.foreach(logger.warn)
-  override def warn(msg: Supplier[String]): Unit = warn(msg.get())
-
-  def trace(exception: Throwable): Unit = logger.trace(exception)
-  override def trace(exception: Supplier[Throwable]): Unit =
-    logger.trace(exception.get())
-
-  def info(msg: String): Unit = msg.lines.foreach(logger.info)
-  override def info(msg: Supplier[String]): Unit = info(msg.get)
-
-  def quietIfError[T](op: BufferedLogger => T): T = verbose {
-    val bufferedLogger = new BufferedLogger(this)
-    try op(bufferedLogger)
-    catch { case ex: Throwable => bufferedLogger.clear(); throw ex }
-  }
-
-  def quietIfSuccess[T](op: BufferedLogger => T): T = verbose {
-    val bufferedLogger = new BufferedLogger(this)
-    try op(bufferedLogger)
-    catch { case ex: Throwable => bufferedLogger.flush(); throw ex }
-  }
-
-  def verboseIf[T](cond: Boolean)(op: => T): T =
-    if (cond) verbose(op)
-    else op
-
-  def verbose[T](op: => T): T = {
-    val initialLevel = LogManager.getRootLogger.getLevel
-    Configurator.setRootLevel(Level.DEBUG)
-    try op
-    finally Configurator.setRootLevel(initialLevel)
-  }
+  def get = new Log4JLogger(name)
 }


### PR DESCRIPTION
It was very tedious to define new subclasses of `Logger`. We now have a
`Logger` base trait, and an `AbstractLogger` that defines all the
basic functionalities, making it much easier to add a new subclass of
`Logger`.

The old `Logger` is renamed to `Log4JLogger`.