### PR TITLE
Fix `ExecutionContext` preventing exit

### DIFF
--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -1,6 +1,6 @@
 package bloop
 
-import bloop.engine.ExecutionContext.threadPool
+import bloop.engine.ExecutionContext
 import bloop.io.{AbsolutePath, Paths}
 import bloop.io.Timer.timed
 import bloop.logging.Logger
@@ -21,11 +21,12 @@ object Bloop {
     val provider = ZincInternals.getComponentProvider(Paths.getCacheDirectory("components"))
     val compilerCache = new CompilerCache(provider, Paths.getCacheDirectory("scala-jars"), logger)
     // TODO: Remove projects and pass in the compilation tasks to abstract over the boilerplate
-    run(projects, compilerCache)
+    ExecutionContext.withFixedThreadPool { run(projects, compilerCache)(_) }
   }
 
   @tailrec
-  def run(projects: Map[String, Project], compilerCache: CompilerCache): Unit = {
+  def run(projects: Map[String, Project], compilerCache: CompilerCache)(
+      implicit executionContext: ExecutionContext): Unit = {
     val input = scala.io.StdIn.readLine("> ")
     input.split(" ") match {
       case Array("projects") =>

--- a/frontend/src/main/scala/bloop/Server.scala
+++ b/frontend/src/main/scala/bloop/Server.scala
@@ -2,6 +2,7 @@ package bloop
 
 import java.net.InetAddress
 
+import bloop.engine.{ExecutionContext, FixedThreadPool}
 import bloop.logging.Logger
 import com.martiansoftware.nailgun.{Alias, NGContext, NGServer}
 
@@ -10,6 +11,7 @@ import scala.util.Try
 class Server
 object Server {
   private val defaultPort: Int = 2113
+  private[bloop] val executionContext: ExecutionContext = new FixedThreadPool()
 
   def main(args: Array[String]): Unit = {
     val port = Try { args(0).toInt }.getOrElse(Server.defaultPort)
@@ -44,6 +46,7 @@ object Server {
   private def shutDown(server: NGServer): Unit = {
     val logger = Logger.get
     Project.persistAllProjects(logger)
+    executionContext.shutdown()
     server.shutdown(true)
   }
 

--- a/frontend/src/main/scala/bloop/engine/FixedThreadPool.scala
+++ b/frontend/src/main/scala/bloop/engine/FixedThreadPool.scala
@@ -1,0 +1,16 @@
+package bloop.engine
+
+import java.util.concurrent.Executors
+import scala.concurrent.{ExecutionContext => ScalaExecutionContext}
+
+class FixedThreadPool(nThreads: Int) extends ExecutionContext {
+  def this() = this(Runtime.getRuntime.availableProcessors())
+  private val executor = Executors.newFixedThreadPool(nThreads)
+
+  override implicit val context: ScalaExecutionContext =
+    ScalaExecutionContext.fromExecutorService(executor)
+
+  override def shutdown(): Unit =
+    executor.shutdown()
+
+}

--- a/frontend/src/main/scala/bloop/tasks/CompilationTasks.scala
+++ b/frontend/src/main/scala/bloop/tasks/CompilationTasks.scala
@@ -2,10 +2,11 @@ package bloop.tasks
 
 import java.util.Optional
 
+import bloop.engine.ExecutionContext
 import bloop.{CompileInputs, Compiler, CompilerCache, Project}
 
 import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.Await
 import xsbti.compile.{CompileAnalysis, MiniSetup, PreviousResult}
 import bloop.logging.Logger
 import bloop.reporter.{Reporter, ReporterConfig}

--- a/frontend/src/test/scala/bloop/tasks/CompilationTaskTest.scala
+++ b/frontend/src/test/scala/bloop/tasks/CompilationTaskTest.scala
@@ -3,7 +3,7 @@ package bloop.tasks
 import utest._
 
 import bloop.{Project, ScalaInstance}
-import bloop.engine.ExecutionContext.threadPool
+import bloop.engine.ExecutionContext.global
 import ProjectHelpers._
 import bloop.logging.Logger
 import bloop.reporter.ReporterConfig

--- a/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
+++ b/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
@@ -3,7 +3,7 @@ package bloop.tasks
 import java.nio.file.{Files, Path, Paths}
 
 import bloop.{DynTest, Project}
-import bloop.engine.ExecutionContext.threadPool
+import bloop.engine.ExecutionContext.global
 import bloop.io.AbsolutePath
 import bloop.logging.Logger
 import bloop.util.TopologicalSort

--- a/frontend/src/test/scala/bloop/tasks/TaskTest.scala
+++ b/frontend/src/test/scala/bloop/tasks/TaskTest.scala
@@ -1,6 +1,6 @@
 package bloop.tasks
 
-import bloop.engine.ExecutionContext.threadPool
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import scala.collection.mutable.Buffer
 

--- a/frontend/src/test/scala/bloop/tasks/TestTaskTest.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestTaskTest.scala
@@ -5,7 +5,7 @@ import bloop.logging.Logger
 import bloop.reporter.ReporterConfig
 import sbt.testing.{Runner, TaskDef}
 
-import bloop.engine.ExecutionContext.threadPool
+import bloop.engine.ExecutionContext.global
 
 object TestTaskTest extends DynTest {
 


### PR DESCRIPTION
The `ExecutionContext` that we were using was preventing application
exit because the backing thread pool was never shutdown, thus preventing
the application from exiting.