### PR TITLE
Don't crash with empty `allJars` in ScalaInstance

### DIFF
--- a/backend/src/main/scala/bloop/ScalaInstance.scala
+++ b/backend/src/main/scala/bloop/ScalaInstance.scala
@@ -76,7 +76,7 @@ object ScalaInstance {
             scalaName: String,
             scalaVersion: String,
             allJars: Array[AbsolutePath]): ScalaInstance = {
-    if (allJars.forall(j => Files.exists(j.underlying)))
+    if (allJars.nonEmpty && allJars.forall(j => Files.exists(j.underlying)))
       new ScalaInstance(scalaOrg, scalaName, scalaVersion, allJars.map(_.toFile))
     else resolve(scalaOrg, scalaName, scalaVersion)
   }


### PR DESCRIPTION
When creating a `ScalaInstance`, we check that the JARs that we're given
all exist. However, we don't handle the case where the array may be
empty. In this case, they all exist, but we'll create a `ScalaInstance`
with no JARs, which will crash the compiler down the road.

This commit fixes this issue by making us resolve the `ScalaInstance` if
we're given no JARs.