### PR TITLE
Return `EmptyResult` by default in `ResultsCache`

### DIFF
--- a/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
@@ -11,7 +11,7 @@ final class ResultsCache(cache: Map[Project, PreviousResult], logger: Logger) {
   private val EmptyResult: PreviousResult =
     PreviousResult.of(Optional.empty[CompileAnalysis], Optional.empty[MiniSetup])
 
-  def getResult(project: Project): Option[PreviousResult] = cache.get(project)
+  def getResult(project: Project): PreviousResult = cache.getOrElse(project, EmptyResult)
   def updateCache(project: Project, previousResult: PreviousResult): ResultsCache =
     new ResultsCache(cache + (project -> previousResult), logger)
   def iterator: Iterator[(Project, PreviousResult)] = cache.iterator

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTasks.scala
@@ -29,9 +29,7 @@ object CompileTasks {
 
     type Results = Map[Project, PreviousResult]
     def runCompilation(project: Project, rs: Results): Results = {
-      val previousResult = state.results
-        .getResult(project)
-        .getOrElse(sys.error("Results cache was not initialized"))
+      val previousResult = state.results.getResult(project)
       val inputs = toInputs(project, reporterConfig, previousResult)
       val result = Compiler.compile(inputs)
       rs + (project -> result)

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTasks.scala
@@ -53,7 +53,7 @@ object TestTasks {
       val frameworks = project.testFrameworks
         .flatMap(fname => TestInternals.getFramework(testLoader, fname.toList, logger))
       logger.debug(s"Found frameworks: ${frameworks.map(_.name).mkString(", ")}")
-      val analysis = state.results.getResult(project).flatMap(_.analysis().toOption).getOrElse {
+      val analysis = state.results.getResult(project).analysis().toOption.getOrElse {
         logger.warn(s"Test execution is triggered but no compilation detected for ${projectName}.")
         sbt.internal.inc.Analysis.empty
       }

--- a/frontend/src/test/scala/bloop/tasks/ProjectHelpers.scala
+++ b/frontend/src/test/scala/bloop/tasks/ProjectHelpers.scala
@@ -91,7 +91,7 @@ object ProjectHelpers {
   def noPreviousResult(project: Project, state: State): Boolean =
     !hasPreviousResult(project, state)
   def hasPreviousResult(project: Project, state: State): Boolean =
-    state.results.getResult(project).exists(_.analysis().isPresent)
+    state.results.getResult(project).analysis().isPresent
 
   def makeProject(baseDir: Path,
                   name: String,

--- a/frontend/src/test/scala/bloop/tasks/TestTaskTest.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestTaskTest.scala
@@ -18,7 +18,7 @@ object TestTaskTest extends DynTest {
     val state0 = ProjectHelpers.loadTestProject(TestProjectName, logger)
     val project = state0.build.getProjectFor(target).getOrElse(sys.error(s"Missing $target!"))
     val state = CompileTasks.compile(state0, project, ReporterConfig.defaultFormat)
-    val result = state.results.getResult(project).flatMap(_.analysis().toOption)
+    val result = state.results.getResult(project).analysis().toOption
     val analysis = result.getOrElse(sys.error(s"$target lacks analysis after compilation!?"))
     (state, project, analysis)
   }


### PR DESCRIPTION
This is more in-line with the result of doing `reset`, plus it fixes an
issue with compilation tasks complaining about the results cache being
un-initialized.