### PR TITLE
Fix #75: Add configure command to set up global state

### DIFF
--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -56,7 +56,7 @@ object Commands {
   case class Configure(
       @ExtraName("parallelism")
       @HelpMessage("Set the number of threads used for parallel compilation and test execution.")
-      threads: Int = ExecutionContext.nCPUs,
+      threads: Int = ExecutionContext.executor.getCorePoolSize,
       @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends Command
 

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -1,5 +1,6 @@
 package bloop.cli
 
+import bloop.engine.ExecutionContext
 import caseapp.{ExtraName, HelpMessage, Hidden, Recurse}
 
 object Commands {
@@ -49,6 +50,13 @@ object Commands {
       @ExtraName("w")
       @HelpMessage("If set, run the command whenever projects' source files change.")
       watch: Boolean = false,
+      @Recurse cliOptions: CliOptions = CliOptions.default
+  ) extends Command
+
+  case class Configure(
+      @ExtraName("parallelism")
+      @HelpMessage("Set the number of threads used for parallel compilation and test execution.")
+      threads: Int = ExecutionContext.nCPUs,
       @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends Command
 

--- a/frontend/src/main/scala/bloop/cli/CommonOptions.scala
+++ b/frontend/src/main/scala/bloop/cli/CommonOptions.scala
@@ -2,6 +2,7 @@ package bloop.cli
 
 import java.io.{InputStream, PrintStream}
 
+import bloop.engine.ExecutionContext
 import bloop.io.AbsolutePath
 import caseapp.Hidden
 
@@ -19,6 +20,7 @@ case class CommonOptions(
     @Hidden out: PrintStream = System.out,
     @Hidden in: InputStream = System.in,
     @Hidden err: PrintStream = System.err,
+    threads: Int = ExecutionContext.nCPUs
 ) {
   def workingPath: AbsolutePath = AbsolutePath(workingDirectory)
 }

--- a/frontend/src/main/scala/bloop/engine/ExecutionContext.scala
+++ b/frontend/src/main/scala/bloop/engine/ExecutionContext.scala
@@ -1,10 +1,15 @@
 package bloop.engine
 
-import java.util.concurrent.Executors
+import java.util.concurrent.{LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
 
 object ExecutionContext {
-  private val nCPUs = Runtime.getRuntime.availableProcessors()
-  private val executor = Executors.newFixedThreadPool(nCPUs)
+  private[bloop] val nCPUs = Runtime.getRuntime.availableProcessors()
+
+  // This inlines the implementation of `Executors.newFixedThreadPool` to avoid losing the type
+  private[bloop] val executor: ThreadPoolExecutor =
+    new ThreadPoolExecutor(nCPUs, nCPUs, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue());
+
+  // If you change the backing of this thread pool, please make sure you modify users of `executor`
   implicit val threadPool: scala.concurrent.ExecutionContext =
     scala.concurrent.ExecutionContext.fromExecutorService(executor)
 }

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -41,6 +41,9 @@ object Interpreter {
       case Run(cmd: Commands.Test, next) =>
         val state = updateState(state0, cmd.cliOptions.common)
         execute(next, logAndTime(state, cmd.cliOptions, test(cmd, state)))
+      case Run(cmd: Commands.Configure, next) =>
+        val state = updateState(state0, cmd.cliOptions.common)
+        execute(next, logAndTime(state, cmd.cliOptions, configure(cmd, state)))
     }
   }
 
@@ -149,6 +152,12 @@ object Interpreter {
           case None => projects -> (name :: missing)
         }
     }
+  }
+
+  private def configure(cmd: Commands.Configure, state: State): State = {
+    if (cmd.threads != ExecutionContext.executor.getCorePoolSize)
+      State.setCores(state, cmd.threads)
+    else state
   }
 
   private def clean(cmd: Commands.Clean, state: State): State = {

--- a/frontend/src/main/scala/bloop/engine/State.scala
+++ b/frontend/src/main/scala/bloop/engine/State.scala
@@ -83,4 +83,25 @@ object State {
           State.stateCache.allStates.foreach(s => CompileTasks.persist(s))
       })
   }
+
+  /**
+   * Sets up the cores for the execution context to be used for compiling and testing the project.
+   *
+   * The execution context is for now global and it's reused across different states.
+   * When the number of threads that can be used is changed by the user, all the states
+   * of the builds are affected. This is the most reasonable way to do it since, I believe,
+   * having a thread pool per build state can end up being too expensive (this, however,
+   * must be tested and benchmarked in order to be truth, and that's left for the future).
+   *
+   * The following implementation relies that the thread pool we get is backed up by the
+   * executor in `ExecutionContext`. If this invariant changes, this implementation must
+   * change, as explained in `ExecutionContext`.
+   *
+   * The implementation of this method is forcibly mutable.
+   */
+  def setCores(state: State, threads: Int): State = {
+    state.logger.info(s"Reconfiguring the number of bloop threads to $threads.")
+    ExecutionContext.executor.setCorePoolSize(threads)
+    state
+  }
 }

--- a/frontend/src/test/scala/bloop/engine/InterpreterSpec.scala
+++ b/frontend/src/test/scala/bloop/engine/InterpreterSpec.scala
@@ -47,4 +47,24 @@ class InterpreterSpec {
     assert(output.contains("maintained by"))
     assert(output.contains("Scala Center"))
   }
+
+  @Test def SupportDynamicCoreSetup(): Unit = {
+    val (cliOptions, outStream) = changeOut(state)
+    val action1 = Run(Commands.Configure(cliOptions = cliOptions))
+    val state1 = Interpreter.execute(action1, state)
+    val output1 = outStream.toString("UTF-8")
+    // Make sure that threads are set to 6.
+    assert(!output1.contains("Reconfiguring the number of bloop threads to 4."))
+
+    val action2 = Run(Commands.Configure(threads = 6, cliOptions = cliOptions))
+    val state2 = Interpreter.execute(action2, state1)
+    val action3 = Run(Commands.Configure(threads = 4, cliOptions = cliOptions))
+    val _ = Interpreter.execute(action3, state2)
+    val output23 = outStream.toString("UTF-8")
+
+    // Make sure that threads are set to 6.
+    assert(output23.contains("Reconfiguring the number of bloop threads to 6."))
+    // Make sure that threads are set to 4.
+    assert(output23.contains("Reconfiguring the number of bloop threads to 4."))
+  }
 }


### PR DESCRIPTION
The `Configure` command is supposed to allow you to set up the global state
of the bloop server, variables like, say, the number of threads.

In the future, I expect this command to grow bigger and support other
global parameters that are similar to the one supported now.