### PR TITLE
Allow to specify where `BloopLogger` should write

### DIFF
--- a/frontend/src/main/resources/log4j2.properties
+++ b/frontend/src/main/resources/log4j2.properties
@@ -1,11 +1,1 @@
-name = PropertiesConfig
-
-appender.console.type = Console
-appender.console.name = STDOUT
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %highlight{%equals{[%-0.-1level] }{[I] }{}}{FATAL=white, ERROR=bright red, WARN=yellow, INFO=dim blue, DEBUG=green, TRACE=blue}%msg%n
-appender.console.filter.threshold.type = ThresholdFilter
-appender.console.filter.threshold.level = info
-
-rootLogger.level = info
-rootLogger.appenderRef.stdout.ref = STDOUT
+rootLogger.level = all

--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -15,7 +15,7 @@ object Bloop {
   def main(args: Array[String]): Unit = {
     val baseDirectory = AbsolutePath(args.lift(0).getOrElse(".."))
     val configDirectory = baseDirectory.resolve(".bloop-config")
-    val logger = BloopLogger(configDirectory.syntax)
+    val logger = BloopLogger.default("bloop-logger")
     val projects = Project.fromDir(configDirectory, logger)
     val build: Build = Build(configDirectory, projects)
     val state = State(build, logger)

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -153,7 +153,8 @@ object Cli {
     }
 
     val configDirectory = getConfigDir(cliOptions)
-    val logger = BloopLogger(configDirectory.syntax)
+    val logger =
+      BloopLogger.at(configDirectory.toString, cliOptions.common.out, cliOptions.common.err)
     val state = loadStateFor(configDirectory, logger)
     val newState = Interpreter.execute(action, state)
     State.stateCache.updateBuild(newState)

--- a/frontend/src/main/scala/bloop/engine/State.scala
+++ b/frontend/src/main/scala/bloop/engine/State.scala
@@ -67,13 +67,6 @@ object State {
     State(build, results, compilerCache, options, ExitStatus.Ok, logger)
   }
 
-  def updateLogger(logger: Logger, commonOptions: CommonOptions): Unit = {
-    logger match {
-      case bloopLogger: BloopLogger => BloopLogger.update(bloopLogger, commonOptions.out)
-      case _ => logger.warn(s"Logger $logger is not of type `bloop.logging.BloopLogger`.")
-    }
-  }
-
   def setUpShutdownHoook(): Unit = {
     Runtime
       .getRuntime()

--- a/frontend/src/test/scala/bloop/engine/FileWatchingSpec.scala
+++ b/frontend/src/test/scala/bloop/engine/FileWatchingSpec.scala
@@ -2,9 +2,11 @@ package bloop.engine
 
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.nio.file.Files
+import java.util.UUID
 
 import bloop.Project
 import bloop.cli.{CliOptions, Commands}
+import bloop.logging.BloopLogger
 import bloop.tasks.{CompilationHelpers, ProjectHelpers}
 import bloop.tasks.ProjectHelpers.{RootProject, noPreviousResult, withState}
 import org.junit.Test
@@ -62,10 +64,13 @@ class FileWatchingSpec {
       case (state, project, bloopOut) =>
         val cliOptions0 = CliOptions.default
         val newOut = new PrintStream(bloopOut)
+        val loggerName = UUID.randomUUID().toString
+        val newLogger = BloopLogger.at(loggerName, newOut, newOut)
+        val newState = state.copy(logger = newLogger)
         val commonOptions = cliOptions0.common.copy(out = newOut)
         val cliOptions = cliOptions0.copy(common = commonOptions)
         val cmd = Commands.Compile(project.name, watch = true, cliOptions = cliOptions)
-        Interpreter.execute(Run(cmd), state)
+        Interpreter.execute(Run(cmd), newState)
         ()
     }
 
@@ -104,10 +109,13 @@ class FileWatchingSpec {
       case (state, project, bloopOut) =>
         val cliOptions0 = CliOptions.default
         val newOut = new PrintStream(bloopOut)
+        val loggerName = UUID.randomUUID().toString
+        val newLogger = BloopLogger.at(loggerName, newOut, newOut)
+        val newState = state.copy(logger = newLogger)
         val commonOptions = cliOptions0.common.copy(out = newOut)
         val cliOptions = cliOptions0.copy(common = commonOptions, verbose = true)
         val cmd = Commands.Test(project.name, watch = true, cliOptions = cliOptions)
-        Interpreter.execute(Run(cmd), state)
+        Interpreter.execute(Run(cmd), newState)
         ()
     }
 

--- a/frontend/src/test/scala/bloop/logging/BloopLoggerSpec.scala
+++ b/frontend/src/test/scala/bloop/logging/BloopLoggerSpec.scala
@@ -1,0 +1,155 @@
+package bloop.logging
+
+import java.io.{
+  BufferedReader,
+  ByteArrayOutputStream,
+  ByteArrayInputStream,
+  InputStreamReader,
+  PrintStream
+}
+import java.util.UUID
+
+import scala.collection.mutable
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class BloopLoggerSpec {
+  @Test
+  def infoAndWarnMessagesGoToOut =
+    runAndCheck { logger =>
+      logger.info("info")
+      logger.warn("warn")
+    } { (outMsgs, errMsgs) =>
+      assertEquals(2, outMsgs.length.toLong)
+      assertEquals(0, errMsgs.length.toLong)
+
+      assert(isInfo(outMsgs.head))
+      assert(isWarn(outMsgs.last))
+    }
+
+  @Test
+  def errorMessagesGoToErr =
+    runAndCheck { logger =>
+      logger.error("error")
+    } { (outMsgs, errMsgs) =>
+      assertEquals(0, outMsgs.length.toLong)
+      assertEquals(1, errMsgs.length.toLong)
+
+      assert(isError(errMsgs.head))
+    }
+
+  @Test
+  def debugAndTraceMessagesAreIgnoredByDefault =
+    runAndCheck { logger =>
+      logger.debug("debug")
+      logger.trace(new Exception)
+    } { (outMsgs, errMsgs) =>
+      assertEquals(0, outMsgs.length.toLong)
+      assertEquals(0, errMsgs.length.toLong)
+    }
+
+  @Test
+  def debugAndTraceMessagesGoToErrInVerboseMode =
+    runAndCheck { logger =>
+      logger.error("error0")
+      logger.warn("warn0")
+      logger.info("info0")
+      logger.debug("debug0")
+      logger.trace(new Exception("trace0"))
+
+      logger.verbose {
+        logger.error("error1")
+        logger.warn("warn1")
+        logger.info("info1")
+        logger.debug("debug1")
+        logger.trace(new Exception("trace1"))
+      }
+
+      logger.error("error2")
+      logger.warn("warn2")
+      logger.info("info2")
+      logger.debug("debug2")
+      logger.trace(new Exception("trace2"))
+
+    } { (outMsgs, errMsgs) =>
+      assertEquals(6, outMsgs.length.toLong)
+      assertEquals(5, errMsgs.length.toLong)
+
+      assert(isWarn(outMsgs(0)) && outMsgs(0).endsWith("warn0"))
+      assert(isInfo(outMsgs(1)) && outMsgs(1).endsWith("info0"))
+      assert(isWarn(outMsgs(2)) && outMsgs(2).endsWith("warn1"))
+      assert(isInfo(outMsgs(3)) && outMsgs(3).endsWith("info1"))
+      assert(isWarn(outMsgs(4)) && outMsgs(4).endsWith("warn2"))
+      assert(isInfo(outMsgs(5)) && outMsgs(5).endsWith("info2"))
+
+      assert(isError(errMsgs(0)) && errMsgs(0).endsWith("error0"))
+      assert(isError(errMsgs(1)) && errMsgs(1).endsWith("error1"))
+      assert(isDebug(errMsgs(2)) && errMsgs(2).endsWith("debug1"))
+      assert(isTrace(errMsgs(3)) && errMsgs(3).endsWith("java.lang.Exception: trace1"))
+      assert(isError(errMsgs(4)) && errMsgs(4).endsWith("error2"))
+    }
+
+  @Test
+  def multipleLoggersDontStepOnEachOtherToes = {
+    val bos0 = new ByteArrayOutputStream
+    val ps0 = new PrintStream(bos0)
+
+    val bos1 = new ByteArrayOutputStream
+    val ps1 = new PrintStream(bos1)
+
+    val l0 = BloopLogger.at("l0", ps0, ps0)
+    val l1 = BloopLogger.at("l1", ps1, ps1)
+
+    l0.info("info0")
+    l1.info("info1")
+
+    val msgs0 = convertAndReadAllFrom(bos0)
+    val msgs1 = convertAndReadAllFrom(bos1)
+
+    assertEquals(1, msgs0.length.toLong)
+    assertEquals(1, msgs1.length.toLong)
+    assertEquals("info0", msgs0.head)
+    assertEquals("info1", msgs1.head)
+  }
+
+  private def isWarn(msg: String): Boolean = msg.contains("[W]")
+  private def isError(msg: String): Boolean = msg.contains("[E]")
+  private def isDebug(msg: String): Boolean = msg.contains("[D]")
+  private def isTrace(msg: String): Boolean = msg.contains("[T]")
+  private def isInfo(msg: String): Boolean = {
+    !(isWarn(msg) || isError(msg) || isDebug(msg) || isTrace(msg))
+  }
+
+  private def runAndCheck(op: BloopLogger => Unit)(
+      check: (Seq[String], Seq[String]) => Unit): Unit = {
+    val outStream = new ByteArrayOutputStream
+    val errStream = new ByteArrayOutputStream
+
+    val out = new PrintStream(outStream)
+    val err = new PrintStream(errStream)
+
+    val loggerName = UUID.randomUUID().toString
+    val logger = BloopLogger.at(loggerName, out, err)
+    op(logger)
+
+    val outMessages = convertAndReadAllFrom(outStream)
+    val errMessages = convertAndReadAllFrom(errStream)
+
+    check(outMessages, errMessages)
+
+  }
+
+  private def convertAndReadAllFrom(stream: ByteArrayOutputStream): Seq[String] = {
+    val inStream = new ByteArrayInputStream(stream.toByteArray)
+    val reader = new BufferedReader(new InputStreamReader(inStream))
+
+    val buffer = mutable.Buffer.empty[String]
+    var current = ""
+    while ({ current = reader.readLine(); current } != null) {
+      buffer += current
+    }
+
+    buffer
+  }
+}

--- a/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
+++ b/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
@@ -30,7 +30,7 @@ object IntegrationTestSuite extends DynTest {
   private def testProject(testDirectory: Path): Unit = {
     val rootProjectName = "bloop-test-root"
     val fakeConfigDir = AbsolutePath(testDirectory.resolve(s"rootProjectName"))
-    val logger = BloopLogger(fakeConfigDir.toString)
+    val logger = BloopLogger.default(fakeConfigDir.toString)
     val classesDir = AbsolutePath(testDirectory)
     val state0 = ProjectHelpers.loadTestProject(testDirectory.getFileName.toString)
     val previousProjects = state0.build.projects

--- a/frontend/src/test/scala/bloop/tasks/ProjectHelpers.scala
+++ b/frontend/src/test/scala/bloop/tasks/ProjectHelpers.scala
@@ -70,7 +70,7 @@ object ProjectHelpers {
   def loadTestProject(projectsBase: Path, name: String): State = {
     val base = projectsBase.resolve(name)
     val configDir = base.resolve("bloop-config")
-    val logger = BloopLogger(configDir.toString())
+    val logger = BloopLogger.default(configDir.toString())
     val baseDirectoryFile = configDir.resolve("base-directory")
     assert(Files.exists(configDir) && Files.exists(baseDirectoryFile))
     val testBaseDirectory = {
@@ -111,7 +111,7 @@ object ProjectHelpers {
         case (name, sources) =>
           makeProject(temp, name, sources, dependencies.getOrElse(name, Set.empty), scalaInstance)
       }
-      val logger = BloopLogger(temp.toString)
+      val logger = BloopLogger.default(temp.toString)
       val build = Build(AbsolutePath(temp), projects.toList)
       val state = State.forTests(build, CompilationHelpers.getCompilerCache(logger), logger)
       op(state)


### PR DESCRIPTION
This commit makes us define the streams that should be used by an
instance of `BloopLogger` when constructing the logger. As a result, we
have a clearer relation between each CLI invocation and the assigned
logger, making it easier to have output be written to the correct
stream.

It also solves issues that we had with repeated output (output would be
written to the console as many times as we had loggers created).