### PR TITLE
Fix logging with Nailgun

### DIFF
--- a/backend/src/main/scala/bloop/logging/BloopLogger.scala
+++ b/backend/src/main/scala/bloop/logging/BloopLogger.scala
@@ -42,12 +42,22 @@ class BloopLogger(override val name: String, out: PrintStream, err: PrintStream)
   }
 
   private[this] def initialize(): Unit = BloopLogger.synchronized {
+    removeAllAppenders()
+
     outAppender.start()
     errAppender.start()
 
     val coreLogger = logger.asInstanceOf[log4j.core.Logger]
     coreLogger.addAppender(outAppender)
     coreLogger.addAppender(errAppender)
+  }
+
+  private[this] def removeAllAppenders(): Unit = BloopLogger.synchronized {
+    val coreLogger = logger.asInstanceOf[log4j.core.Logger]
+    val appenders = coreLogger.getAppenders()
+    appenders.forEach {
+      case (_, appender) => coreLogger.removeAppender(appender)
+    }
   }
 
   /**

--- a/frontend/src/test/scala/bloop/logging/BloopLoggerSpec.scala
+++ b/frontend/src/test/scala/bloop/logging/BloopLoggerSpec.scala
@@ -113,6 +113,29 @@ class BloopLoggerSpec {
     assertEquals("info1", msgs1.head)
   }
 
+  @Test
+  def multipleLoggerSameNamesDifferentOutputs = {
+    val loggerName = "same-name-logger"
+
+    val bos0 = new ByteArrayOutputStream
+    val ps0 = new PrintStream(bos0)
+    val l0 = BloopLogger.at(loggerName, ps0, ps0)
+    l0.info("info0")
+
+    val bos1 = new ByteArrayOutputStream
+    val ps1 = new PrintStream(bos1)
+    val l1 = BloopLogger.at(loggerName, ps1, ps1)
+    l1.info("info1")
+
+    val msgs0 = convertAndReadAllFrom(bos0)
+    val msgs1 = convertAndReadAllFrom(bos1)
+
+    assertEquals(1, msgs0.length.toLong)
+    assertEquals(1, msgs1.length.toLong)
+    assertEquals("info0", msgs0.head)
+    assertEquals("info1", msgs1.head)
+  }
+
   private def isWarn(msg: String): Boolean = msg.contains("[W]")
   private def isError(msg: String): Boolean = msg.contains("[E]")
   private def isDebug(msg: String): Boolean = msg.contains("[D]")


### PR DESCRIPTION
Using Nailgun, we re-use loggers with the same name. This means that
between sessions, the old appenders will continue to exist for that
logger. Finally, Log4J will not add the appenders that we create if
appenders with the same name already exist for a given logger.

As a result, we were not adding the right appenders when re-using an
existing logger. This commit fixes that by removing all the current
appenders when creating a new instance of `BloopLogger`.