### PR TITLE
Replace `discoveredSbtPlugins` in sbt 0.13

### DIFF
--- a/sbt-bloop/src/main/scala-sbt-0.13/bloop/DiscoveredSbtPlugins.scala
+++ b/sbt-bloop/src/main/scala-sbt-0.13/bloop/DiscoveredSbtPlugins.scala
@@ -1,0 +1,16 @@
+package bloop
+
+import sbt.{Compile, Def, PluginDiscovery, Setting}
+import sbt.Keys.{compile, discoveredSbtPlugins, sbtPlugin}
+
+object DiscoveredSbtPlugins {
+  // Replace the implementation of `discoveredSbtPlugins` in sbt 0.13 by an implementation
+  // that uses a dynamic task. This way, we don't need to compile to generate the resources,
+  // except if the project is an sbt plugin.
+  val settings: Seq[Setting[_]] = Seq(
+    discoveredSbtPlugins in Compile := Def.taskDyn {
+      if (sbtPlugin.value) Def.task { PluginDiscovery.discoverSourceAll(compile.value) } else
+        Def.task { PluginDiscovery.emptyDiscoveredNames }
+    }.value
+  )
+}

--- a/sbt-bloop/src/main/scala-sbt-1.0/bloop/DiscoveredSbtPlugins.scala
+++ b/sbt-bloop/src/main/scala-sbt-1.0/bloop/DiscoveredSbtPlugins.scala
@@ -1,0 +1,9 @@
+package bloop
+
+import sbt.Setting
+
+object DiscoveredSbtPlugins {
+  // The implementation of `discoveredSbtPlugins` in sbt 1.0 is correct.
+  // We don't need to replace it.
+  val settings: Seq[Setting[_]] = Seq.empty
+}

--- a/sbt-bloop/src/main/scala/bloop/SbtBloop.scala
+++ b/sbt-bloop/src/main/scala/bloop/SbtBloop.scala
@@ -34,7 +34,7 @@ object PluginImplementation {
     sbt.taskKey[Unit]("Generate bloop configuration files for this project")
   val projectSettings: Seq[Def.Setting[_]] = List(Compile, Test).flatMap { conf =>
     inConfig(conf)(List(bloopGenerate := PluginDefaults.bloopGenerate.value))
-  }
+  } ++ DiscoveredSbtPlugins.settings // discoveredSbtPlugins triggers compilation in 0.13, we replace it.
 
   case class Config(
       name: String,


### PR DESCRIPTION
This task always triggers compilation, because it doesn't rely on a
dynamic task as it should. This commit replaces the implementation of
this task in sbt-bloop by the same implementation that is used in sbt
1.0 (which is correct and uses a dynamic task).

Because this task is used in a resource generator that is present by
default, we would always trigger compilation when inspecting the
generated resources. This is no longer the case (except if the project
is an sbt plugin).