### PR TITLE
Add support for resources in `run` and `test`

### DIFF
--- a/frontend/src/test/resources/projects/with-resources/build.sbt
+++ b/frontend/src/test/resources/projects/with-resources/build.sbt
@@ -2,16 +2,12 @@ name := "with-resources"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.4" % "test"
 
-resourceGenerators in Compile += Def.task {
-  val out = resourceManaged.in(Compile).value / "generated-compile-resource.txt"
-  IO.write(out, "Content of generated-compile-resource.txt")
-
-  Seq(out)
-}.taskValue
-
-resourceGenerators in Test += Def.task {
-  val out = resourceManaged.in(Test).value / "generated-test-resource.txt"
-  IO.write(out, "Content of generated-test-resource.txt")
-
-  Seq(out)
-}.taskValue
+List(Compile, Test).flatMap(inConfig(_) {
+  resourceGenerators += Def.task {
+    val configName = configuration.value.name
+    val fileName = s"generated-$configName-resource.txt"
+    val out = resourceManaged.value / fileName
+    IO.write(out, s"Content of $fileName")
+    Seq(out)
+  }.taskValue
+})

--- a/frontend/src/test/resources/projects/with-resources/build.sbt
+++ b/frontend/src/test/resources/projects/with-resources/build.sbt
@@ -1,0 +1,17 @@
+name := "with-resources"
+
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.4" % "test"
+
+resourceGenerators in Compile += Def.task {
+  val out = resourceManaged.in(Compile).value / "generated-compile-resource.txt"
+  IO.write(out, "Content of generated-compile-resource.txt")
+
+  Seq(out)
+}.taskValue
+
+resourceGenerators in Test += Def.task {
+  val out = resourceManaged.in(Test).value / "generated-test-resource.txt"
+  IO.write(out, "Content of generated-test-resource.txt")
+
+  Seq(out)
+}.taskValue

--- a/frontend/src/test/resources/projects/with-resources/project/build.properties
+++ b/frontend/src/test/resources/projects/with-resources/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.0.4

--- a/frontend/src/test/resources/projects/with-resources/src/main/resources/my-compile-resource.txt
+++ b/frontend/src/test/resources/projects/with-resources/src/main/resources/my-compile-resource.txt
@@ -1,0 +1,1 @@
+Content of my-compile-resource.txt

--- a/frontend/src/test/resources/projects/with-resources/src/main/scala/Main.scala
+++ b/frontend/src/test/resources/projects/with-resources/src/main/scala/Main.scala
@@ -1,0 +1,21 @@
+import java.io.{BufferedReader, InputStreamReader}
+
+object Main {
+
+  def resourceContent(name: String): Option[String] = {
+    Option(getClass.getClassLoader.getResourceAsStream(name)).map { stream =>
+      val reader = new BufferedReader(new InputStreamReader(stream))
+      reader.readLine()
+    }
+  }
+
+  def main(args: Array[String]): Unit = {
+    assert(resourceContent("my-compile-resource.txt") == Some("Content of my-compile-resource.txt"))
+    assert(
+      resourceContent("generated-compile-resource.txt") == Some(
+        "Content of generated-compile-resource.txt"))
+    assert(resourceContent("non-existent-resource.txt") == None)
+    println("OK")
+  }
+
+}

--- a/frontend/src/test/resources/projects/with-resources/src/test/resources/my-test-resource.txt
+++ b/frontend/src/test/resources/projects/with-resources/src/test/resources/my-test-resource.txt
@@ -1,0 +1,1 @@
+Content of my-test-resource.txt

--- a/frontend/src/test/resources/projects/with-resources/src/test/scala/Test.scala
+++ b/frontend/src/test/resources/projects/with-resources/src/test/scala/Test.scala
@@ -1,0 +1,19 @@
+import org.scalatest._
+
+import Main.resourceContent
+
+class Test extends FlatSpec with Matchers {
+  "Resources" should "be found" in {
+    assert(resourceContent("my-compile-resource.txt") == Some("Content of my-compile-resource.txt"))
+    assert(
+      resourceContent("generated-compile-resource.txt") == Some(
+        "Content of generated-compile-resource.txt"))
+
+    assert(resourceContent("my-test-resource.txt") == Some("Content of my-test-resource.txt"))
+    assert(
+      resourceContent("generated-test-resource.txt") == Some(
+        "Content of generated-test-resource.txt"))
+
+    assert(resourceContent("non-existent-resource.txt") == None)
+  }
+}

--- a/frontend/src/test/scala/bloop/tasks/CompilationTaskTest.scala
+++ b/frontend/src/test/scala/bloop/tasks/CompilationTaskTest.scala
@@ -105,6 +105,9 @@ object CompilationTaskTest extends TestSuite {
     val dependencies = Map.empty[String, Set[String]]
     val structures = Map(RootProject -> Map("A.scala" -> "object A"))
     // Scala bug to report: removing `(_ => ())` fails to compile.
-    checkAfterCleanCompilation(structures, dependencies, scalaInstance, quiet = true)(_ => ())
+    checkAfterCleanCompilation(structures,
+                               dependencies,
+                               scalaInstance = scalaInstance,
+                               quiet = true)(_ => ())
   }
 }

--- a/frontend/src/test/scala/bloop/tasks/RunTasksSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/RunTasksSpec.scala
@@ -134,13 +134,14 @@ class RunTasksSpec {
     val projectName = "with-resources"
     val mainClassName = "Main"
     val state0 = loadTestProject(projectName)
-    val state =
+    val state = {
       if (fork) {
         val newProjects = state0.build.projects.map(_.copy(javaEnv = JavaEnv.default(fork = true)))
         state0.copy(build = state0.build.copy(projects = newProjects))
       } else {
         state0
       }
+    }
 
     val command = Commands.Run(projectName, Some(mainClassName), args = List.empty)
     runAndCheck(state, command) { messages =>

--- a/frontend/src/test/scala/bloop/tasks/TestResourcesSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestResourcesSpec.scala
@@ -1,0 +1,38 @@
+package bloop.tasks
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+import sbt.internal.util.EscHelpers.removeEscapeSequences
+
+import bloop.cli.Commands
+import bloop.exec.JavaEnv
+import bloop.tasks.ProjectHelpers.{loadTestProject, runAndCheck}
+
+class TestResourcesSpec {
+
+  @Test
+  def testsCanSeeResourcesWithoutForking = testsCanSeeResources(fork = false)
+
+  @Test
+  def testsCanSeeResourcesWithForking = testsCanSeeResources(fork = true)
+
+  private def testsCanSeeResources(fork: Boolean): Unit = {
+    val projectName = "with-resources"
+    val state0 = loadTestProject(projectName)
+    val state =
+      if (fork) {
+        val newProjects = state0.build.projects.map(_.copy(javaEnv = JavaEnv.default(fork = true)))
+        state0.copy(build = state0.build.copy(projects = newProjects))
+      } else {
+        state0
+      }
+
+    val command = Commands.Test(projectName)
+    runAndCheck(state, command) { messages =>
+      val cleanMessages = messages.map { case (l, m) => (l, removeEscapeSequences(m)) }
+      assert(cleanMessages.contains(("info", "Resources")))
+      assert(cleanMessages.contains(("info", "- should be found")))
+    }
+  }
+}

--- a/frontend/src/test/scala/bloop/tasks/TestResourcesSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestResourcesSpec.scala
@@ -20,13 +20,13 @@ class TestResourcesSpec {
   private def testsCanSeeResources(fork: Boolean): Unit = {
     val projectName = "with-resources"
     val state0 = loadTestProject(projectName)
-    val state =
-      if (fork) {
+    val state = {
+      if (!fork) state0
+      else {
         val newProjects = state0.build.projects.map(_.copy(javaEnv = JavaEnv.default(fork = true)))
         state0.copy(build = state0.build.copy(projects = newProjects))
-      } else {
-        state0
       }
+    }
 
     val command = Commands.Test(projectName)
     runAndCheck(state, command) { messages =>

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -229,11 +229,63 @@ object BuildImplementation {
     """.stripMargin
     }
 
+    private val testPluginContents = {
+      """import sbt._
+        |import Keys._
+        |import bloop.SbtBloop.autoImport._
+        |
+        |object TestPlugin extends AutoPlugin {
+        |  override def requires = bloop.SbtBloop
+        |  override def trigger = allRequirements
+        |
+        |  object autoImport {
+        |    lazy val copyContentOutOfScripted =
+        |      taskKey[Unit]("Copy all generated sources and resources out of scripted")
+        |    lazy val copyContentOutOfScriptedIndividual =
+        |      taskKey[Unit]("Copy generated sources and resources out of scripted")
+        |  }
+        |  import autoImport._
+        |
+        |  override def globalSettings: Seq[Setting[_]] = Seq(
+        |    copyContentOutOfScripted := Def.taskDyn {
+        |      val filter = ScopeFilter(sbt.inAnyProject)
+        |      copyContentOutOfScriptedIndividual.all(filter).map(_ => ())
+        |    }.value
+        |  )
+        |
+        |  override def projectSettings: Seq[Setting[_]] = Seq(
+        |    copyContentOutOfScriptedIndividual := {
+        |      val outOfScriptedRoot = bloopConfigDir.value.getParentFile
+        |      val inScriptedRoot = baseDirectory.in(ThisBuild).value
+        |      def copy(toCopy: Seq[File]): Unit = {
+        |        for { src <- toCopy
+        |              toCopyPath <- IO.relativize(inScriptedRoot, src)
+        |              pathOutOfScripted = outOfScriptedRoot / toCopyPath } {
+        |          if (src.isDirectory) IO.copyDirectory(src, pathOutOfScripted)
+        |          else IO.copyFile(src, pathOutOfScripted)
+        |        }
+        |      }
+        |      val allManagedSources = (managedSources in Compile).value ++ (managedSources in Test).value
+        |      val allResources = {
+        |        val resources = (copyResources in Compile).value ++ (copyResources in Test).value
+        |        val (_, copied) = resources.unzip
+        |        copied
+        |      }
+        |      copy(allManagedSources ++ allResources)
+        |    }
+        |  )
+        |}""".stripMargin
+    }
+
     private val scriptedTestContents = {
       """> show bloopConfigDir
+        |# Some projects need to compile to generate resources. We do it now so that the configuration
+        |# that we generate doesn't appear too old.
+        |> resources
         |> registerDirectory
         |> installBloop
         |> checkInstall
+        |> copyContentOutOfScripted
       """.stripMargin
     }
 
@@ -249,6 +301,7 @@ object BuildImplementation {
         tests.foreach { testDir =>
           IO.createDirectory(testDir / "bloop-config")
           IO.write(testDir / "project" / "test-config.sbt", addSbtPlugin)
+          IO.write(testDir / "project" / "TestPlugin.scala", testPluginContents)
           IO.write(testDir / "test-config.sbt", createScriptedSetup(testDir))
           IO.write(testDir / "test", scriptedTestContents)
         }

--- a/project/TestPlugin.scala
+++ b/project/TestPlugin.scala
@@ -1,0 +1,47 @@
+import sbt._
+import Keys._
+import bloop.SbtBloop.autoImport.bloopConfigDir
+
+object TestPlugin extends AutoPlugin {
+  override def requires = bloop.SbtBloop
+  override def trigger = allRequirements
+
+  object autoImport {
+    lazy val copyContentOutOfScripted =
+      taskKey[Unit]("Copy all generated sources and resources out of scripted")
+    lazy val copyContentOutOfScriptedIndividual =
+      taskKey[Unit]("Copy generated sources and resources out of scripted")
+  }
+  import autoImport._
+
+  override def globalSettings: Seq[Setting[_]] = Seq(
+    copyContentOutOfScripted := Def.taskDyn {
+      val filter = ScopeFilter(sbt.inAnyProject)
+      copyContentOutOfScriptedIndividual.all(filter).map(_ => ())
+    }.value
+  )
+
+  override def projectSettings: Seq[Setting[_]] = Seq(
+    copyContentOutOfScriptedIndividual := {
+      val outOfScriptedRoot = bloopConfigDir.value.getParentFile
+      val inScriptedRoot = baseDirectory.in(ThisBuild).value
+      def copy(toCopy: Seq[File]): Unit = {
+        for {
+          src <- toCopy
+          toCopyPath <- IO.relativize(inScriptedRoot, src)
+          pathOutOfScripted = outOfScriptedRoot / toCopyPath
+        } {
+          if (src.isDirectory) IO.copyDirectory(src, pathOutOfScripted)
+          else IO.copyFile(src, pathOutOfScripted)
+        }
+      }
+      val allManagedSources = (managedSources in Compile).value ++ (managedSources in Test).value
+      val allResources = {
+        val resources = (copyResources in Compile).value ++ (copyResources in Test).value
+        val (_, copied) = resources.unzip
+        copied
+      }
+      copy(allManagedSources ++ allResources)
+    }
+  )
+}

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,0 +1,8 @@
+unmanagedSourceDirectories in Compile ++= {
+  val sbtBloopRoot = baseDirectory.value.getParentFile / "sbt-bloop" / "src" / "main"
+  val sbtBinVersion = sbtBinaryVersion.value
+  Seq(
+    sbtBloopRoot / s"scala-sbt-$sbtBinVersion",
+    sbtBloopRoot / "scala"
+  )
+}

--- a/sbt-bloop/src/main/scala-sbt-0.13/bloop/DiscoveredSbtPlugins.scala
+++ b/sbt-bloop/src/main/scala-sbt-0.13/bloop/DiscoveredSbtPlugins.scala
@@ -8,7 +8,7 @@ object DiscoveredSbtPlugins {
   // that uses a dynamic task. This way, we don't need to compile to generate the resources,
   // except if the project is an sbt plugin.
   val settings: Seq[Setting[_]] = Seq(
-    discoveredSbtPlugins in Compile := Def.taskDyn {
+    discoveredSbtPlugins := Def.taskDyn {
       if (sbtPlugin.value) Def.task { PluginDiscovery.discoverSourceAll(compile.value) } else
         Def.task { PluginDiscovery.emptyDiscoveredNames }
     }.value

--- a/sbt-bloop/src/main/scala/bloop/SbtBloop.scala
+++ b/sbt-bloop/src/main/scala/bloop/SbtBloop.scala
@@ -130,6 +130,9 @@ object PluginImplementation {
       // We cannot depend on `managedSources` and `managedResources` because they trigger compilation
       (Keys.sourceGenerators.value ++ Keys.resourceGenerators.value).join.map(_.flatten)
 
+      // Copy the resources, so that they're available when running and testing
+      val _ = Keys.copyResources.value
+
       // format: OFF
       val config = Config(projectName, baseDirectory, dependenciesAndAggregates, scalaOrg,
         scalaName,scalaVersion, classpath, classesDir, scalacOptions, javacOptions, sourceDirs,

--- a/sbt-bloop/src/main/scala/bloop/SbtBloop.scala
+++ b/sbt-bloop/src/main/scala/bloop/SbtBloop.scala
@@ -126,9 +126,9 @@ object PluginImplementation {
       val bloopConfigDir = AutoImportedKeys.bloopConfigDir.value
       val outFile = bloopConfigDir / s"$projectName.config"
 
-      // Force source and resource generators on this task manually
-      // We cannot depend on `managedSources` and `managedResources` because they trigger compilation
-      (Keys.sourceGenerators.value ++ Keys.resourceGenerators.value).join.map(_.flatten)
+      // Force source generators on this task manually
+      // We cannot depend on `managedSources` because it triggers compilation
+      Keys.sourceGenerators.value.join.map(_.flatten)
 
       // Copy the resources, so that they're available when running and testing
       val _ = Keys.copyResources.value

--- a/sbt-bloop/src/main/scala/bloop/SbtBloop.scala
+++ b/sbt-bloop/src/main/scala/bloop/SbtBloop.scala
@@ -33,8 +33,11 @@ object PluginImplementation {
   private val bloopGenerate: sbt.TaskKey[Unit] =
     sbt.taskKey[Unit]("Generate bloop configuration files for this project")
   val projectSettings: Seq[Def.Setting[_]] = List(Compile, Test).flatMap { conf =>
-    inConfig(conf)(List(bloopGenerate := PluginDefaults.bloopGenerate.value))
-  } ++ DiscoveredSbtPlugins.settings // discoveredSbtPlugins triggers compilation in 0.13, we replace it.
+    inConfig(conf) {
+      List(bloopGenerate := PluginDefaults.bloopGenerate.value) ++
+        DiscoveredSbtPlugins.settings // discoveredSbtPlugins triggers compilation in 0.13, we replace it.
+    }
+  }
 
   case class Config(
       name: String,


### PR DESCRIPTION
The sbt plugin is adapted to run `copyResources` when generating the
configuration, which will copy the resources to the classes directory
(thus making them available when running and testing).

Our scripted setup is adapted to copy the generated sources and the
resources out of the scripted environment (scripted tests are run inside
a temporary directory).

Fixes #134