### PR TITLE
Handle configure in Cli pattern matching

### DIFF
--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -111,6 +111,9 @@ object Cli {
               case Right(c: Commands.Run) =>
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
                 run(newCommand, newCommand.cliOptions)
+              case Right(c: Commands.Configure) =>
+                val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
+                run(newCommand, newCommand.cliOptions)
             }
         }
         newAction.getOrElse {


### PR DESCRIPTION
```
[W]  [E1] /src/main/scala/bloop/Cli.scala
[W]       match may not be exhaustive.
[W]       It would fail on the following input: Right(Configure(_, _))
[W]       L88:             command match {
[W]                        ^
[E] /src/main/scala/bloop/Cli.scala: L88 [E1]
```