### PR TITLE
Replace scalacstyle by `reporter` option

### DIFF
--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -60,12 +60,12 @@ object Bloop extends CaseApp[CliOptions] {
         run(Interpreter.execute(action, state))
 
       case Array("runMain", projectName, mainClass, args @ _*) =>
-        val command = Commands.Run(projectName, Some(mainClass), scalacstyle = false, args.toList)
+        val command = Commands.Run(projectName, Some(mainClass), args = args.toList)
         val action = Run(command, Exit(ExitStatus.Ok))
         run(Interpreter.execute(action, state))
 
       case Array("run", projectName, args @ _*) =>
-        val command = Commands.Run(projectName, None, scalacstyle = false, args.toList)
+        val command = Commands.Run(projectName, None, args = args.toList)
         val action = Run(command, Exit(ExitStatus.Ok))
         run(Interpreter.execute(action, state))
 

--- a/frontend/src/main/scala/bloop/cli/CliParsers.scala
+++ b/frontend/src/main/scala/bloop/cli/CliParsers.scala
@@ -19,6 +19,14 @@ object CliParsers {
       toPath.left.map(t => s"The provided path ${supposedPath} is not valid: '${t.getMessage()}'.")
   }
 
+  implicit val reporterKindRead: ArgParser[ReporterKind] = {
+    ArgParser.instance[ReporterKind]("reporter") {
+      case "scalac" => Right(ScalacReporter)
+      case "bloop" => Right(BloopReporter)
+      case w00t => Left(s"Unrecognized reporter: $w00t")
+    }
+  }
+
   val BaseMessages: caseapp.core.Messages[DefaultBaseCommand] =
     caseapp.core.Messages[DefaultBaseCommand]
   val OptionsParser: caseapp.core.Parser[CliOptions] =

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -10,7 +10,7 @@ object Commands {
 
   sealed trait CoreCommand extends Command {
     def project: String
-    def scalacstyle: Boolean
+    def reporter: ReporterKind
   }
 
   case class Help(
@@ -27,8 +27,8 @@ object Commands {
       project: String,
       @HelpMessage("Compile the project incrementally. By default, true.")
       incremental: Boolean = true,
-      @HelpMessage("Disable improved error message format. By default, false.")
-      scalacstyle: Boolean = false,
+      @HelpMessage("Pick reporter to show compilation messages. By default, bloop's used.")
+      reporter: ReporterKind = BloopReporter,
       @ExtraName("w")
       @HelpMessage("Run the command when projects' source files change. By default, false.")
       watch: Boolean = false,
@@ -49,8 +49,8 @@ object Commands {
       @ExtraName("all")
       @HelpMessage("Run the tests in dependencies. Defaults to true.")
       aggregate: Boolean = false,
-      @HelpMessage("Disable improved error message format. By default, false.")
-      scalacstyle: Boolean = false,
+      @HelpMessage("Pick reporter to show compilation messages. By default, bloop's used.")
+      reporter: ReporterKind = BloopReporter,
       @ExtraName("w")
       @HelpMessage("Run the command when projects' source files change. By default, false.")
       watch: Boolean = false,
@@ -75,8 +75,8 @@ object Commands {
       @ExtraName("p")
       @HelpMessage("The project for which to start the console.")
       project: String,
-      @HelpMessage("Disable improved error message format. By default, false.")
-      scalacstyle: Boolean = false,
+      @HelpMessage("Pick reporter to show compilation messages. By default, bloop's used.")
+      reporter: ReporterKind = BloopReporter,
       @HelpMessage("Start up the console compiling only the target project's dependencies.")
       excludeRoot: Boolean = false,
       @Recurse cliOptions: CliOptions = CliOptions.default
@@ -89,8 +89,8 @@ object Commands {
       @ExtraName("m")
       @HelpMessage("The main class to run. Leave unset to let bloop select automatically.")
       main: Option[String] = None,
-      @HelpMessage("If set, disable improved error message format. By default, false.")
-      scalacstyle: Boolean = false,
+      @HelpMessage("Pick reporter to show compilation messages. By default, bloop's used.")
+      reporter: ReporterKind = BloopReporter,
       @HelpMessage("The arguments to pass to the application")
       args: List[String] = Nil,
       @ExtraName("w")

--- a/frontend/src/main/scala/bloop/cli/ReporterKind.scala
+++ b/frontend/src/main/scala/bloop/cli/ReporterKind.scala
@@ -1,0 +1,6 @@
+package bloop.cli
+
+/** Represents a reporter kind that users can pick to display compiler messages. */
+sealed trait ReporterKind
+case object ScalacReporter extends ReporterKind
+case object BloopReporter extends ReporterKind

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -77,7 +77,7 @@ object Interpreter {
   }
 
   private def compile(cmd: Commands.Compile, state: State): State = {
-    val reporterConfig = ReporterConfig.getDefault(cmd.scalacstyle)
+    val reporterConfig = ReporterConfig.toFormat(cmd.reporter)
     def runCompile(project: Project): State = {
       def doCompile(state: State): State =
         Tasks.compile(state, project, reporterConfig).mergeStatus(ExitStatus.Ok)
@@ -115,7 +115,7 @@ object Interpreter {
   }
 
   private def console(cmd: Commands.Console, state: State): State = {
-    val reporterConfig = ReporterConfig.getDefault(cmd.scalacstyle)
+    val reporterConfig = ReporterConfig.toFormat(cmd.reporter)
     def runConsole(project: Project) =
       Tasks.console(state, project, reporterConfig, cmd.excludeRoot)
 
@@ -129,7 +129,7 @@ object Interpreter {
     def compileAndTest(state: State, project: Project): State = {
       def run(state: State) = {
         // Note that we always compile incrementally for test execution
-        val reporter = ReporterConfig.getDefault(cmd.scalacstyle)
+        val reporter = ReporterConfig.toFormat(cmd.reporter)
         val state1 = Tasks.compile(state, project, reporter)
         Tasks.test(state1, project, cmd.aggregate)
       }
@@ -171,7 +171,7 @@ object Interpreter {
   }
 
   private def run(cmd: Commands.Run, state: State): State = {
-    val reporter = ReporterConfig.getDefault(cmd.scalacstyle)
+    val reporter = ReporterConfig.toFormat(cmd.reporter)
     def getMainClass(state: State, project: Project): Option[String] = {
       Tasks.findMainClasses(state, project) match {
         case Array() =>

--- a/frontend/src/main/scala/bloop/reporter/ReporterConfig.scala
+++ b/frontend/src/main/scala/bloop/reporter/ReporterConfig.scala
@@ -65,6 +65,10 @@ object ReporterConfig {
       ScalacFormat
     )
 
-  def getDefault(value: Boolean): ReporterConfig =
-    if (value) scalacFormat else defaultFormat
+
+  import bloop.cli.{ReporterKind, ScalacReporter, BloopReporter}
+  def toFormat(kind: ReporterKind): ReporterConfig = kind match {
+    case ScalacReporter => scalacFormat
+    case BloopReporter => defaultFormat
+  }
 }


### PR DESCRIPTION
I found `scalacstyle` a little bit confusing. Using `--reporter=scalac`
or `--reporter=bloop` is better IMO.