### PR TITLE
Set the default nail class in case alias is incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We suggest that you add the following to your shell configuration:
 
 ```sh
 export PATH="$PATH:~/.bloop"
-alias bloop="bloop-ng.py bloop.Cli"
+alias bloop="bloop-ng.py"
 ```
 
 The next sections assume that you've added those lines to your profile, and reloaded your shell.
@@ -76,7 +76,7 @@ We suggest that you add the following to your shell configuration:
 
 ```sh
 export PATH="$PATH:~/.bloop"
-alias bloop="bloop-ng.py bloop.Cli"
+alias bloop="bloop-ng.py"
 ```
 
 The next sections assume that you've added those lines to your profile, and reloaded your shell.

--- a/frontend/src/main/scala/bloop/Server.scala
+++ b/frontend/src/main/scala/bloop/Server.scala
@@ -38,6 +38,11 @@ object Server {
     aliasManager.addAlias(new Alias("configure", "Configure the bloop server.", classOf[Cli]))
     aliasManager.addAlias(new Alias("help", "Show bloop help message.", classOf[Cli]))
     aliasManager.addAlias(new Alias("exit", "Kill the bloop server.", classOf[Server]))
+
+    // Register the default entrypoint in case the user doesn't use the right alias
+    server.setDefaultNailClass(classOf[Cli])
+    // Disable nails by class name so that we prevent classloading incorrect aliases
+    server.setAllowNailsByClassName(false)
   }
 
   private def shutDown(server: NGServer): Unit = {


### PR DESCRIPTION
@olafurpg has correctly pointed out in
https://github.com/scalacenter/bloop/issues/173 that if the user doesn't
write the right alias, Nailgun will throw at it a weird message.

We fix this by setting the default nail class, so that if the alias or
fqn that the user types is incorrect we automatically redirect to our
entrypoint `Cli`.

This should finally fix all usability issues that Nailgun places on us.