### PR TITLE
Use `MultiplexedStreams` for in-process testing

### DIFF
--- a/frontend/src/main/scala/bloop/testing/TestInternals.scala
+++ b/frontend/src/main/scala/bloop/testing/TestInternals.scala
@@ -1,7 +1,7 @@
 package bloop.testing
 
 import bloop.DependencyResolution
-import bloop.exec.{Fork, InProcess, JavaEnv, ProcessConfig}
+import bloop.exec.{Fork, InProcess, JavaEnv, MultiplexedStreams, ProcessConfig}
 import bloop.io.AbsolutePath
 import bloop.logging.Logger
 import sbt.testing.{
@@ -107,13 +107,15 @@ object TestInternals {
       }
     }
 
-    discoveredTests.tests.iterator.foreach {
-      case (framework, taskDefs) =>
-        val runner = getRunner(framework, discoveredTests.classLoader)
-        val tasks = runner.tasks(taskDefs.toArray).toList
-        loop(tasks)
-        val summary = runner.done()
-        if (summary.nonEmpty) logger.info(summary)
+    MultiplexedStreams.withLoggerAsStreams(logger) {
+      discoveredTests.tests.iterator.foreach {
+        case (framework, taskDefs) =>
+          val runner = getRunner(framework, discoveredTests.classLoader)
+          val tasks = runner.tasks(taskDefs.toArray).toList
+          loop(tasks)
+          val summary = runner.done()
+          if (summary.nonEmpty) logger.info(summary)
+      }
     }
   }
 

--- a/frontend/src/test/scala/bloop/engine/FileWatchingSpec.scala
+++ b/frontend/src/test/scala/bloop/engine/FileWatchingSpec.scala
@@ -135,7 +135,7 @@ class FileWatchingSpec {
 
         // Wait for #1 compilation to finish
         readCompilingLines(1, "Compiling 1 Scala source to", bloopOut)
-        readCompilingLines(1, "Compiling 4 Scala sources to", bloopOut)
+        readCompilingLines(1, "Compiling 5 Scala sources to", bloopOut)
         readCompilingLines(1, "+ is very personal", bloopOut)
         readCompilingLines(1, "+ Greeting.is personal: OK", bloopOut)
         readCompilingLines(1, "- should be very personal", bloopOut)
@@ -146,7 +146,7 @@ class FileWatchingSpec {
 
         // Wait for #2 compilation to finish
         readCompilingLines(2, "Compiling 1 Scala source to", bloopOut)
-        readCompilingLines(1, "Compiling 4 Scala sources to", bloopOut)
+        readCompilingLines(1, "Compiling 5 Scala sources to", bloopOut)
         readCompilingLines(2, "+ is very personal", bloopOut)
         readCompilingLines(2, "+ Greeting.is personal: OK", bloopOut)
         readCompilingLines(2, "- should be very personal", bloopOut)

--- a/frontend/src/test/scala/bloop/tasks/TestLoggingSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestLoggingSpec.scala
@@ -18,7 +18,8 @@ class TestLoggingSpec {
       val state = ProjectHelpers.loadTestProject(projectName)
       val inProcessEnv = JavaEnv.default(fork = false)
       val build = state.build
-      val beforeCompilation = state.copy(build = build.copy(projects = build.projects.map(_.copy(javaEnv = inProcessEnv))))
+      val beforeCompilation = state.copy(
+        build = build.copy(projects = build.projects.map(_.copy(javaEnv = inProcessEnv))))
       val action = Run(Commands.Compile(moduleName))
       Interpreter.execute(action, beforeCompilation)
     }

--- a/frontend/src/test/scala/bloop/tasks/TestLoggingSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestLoggingSpec.scala
@@ -1,0 +1,53 @@
+package bloop.tasks
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+import bloop.cli.Commands
+import bloop.engine.{Interpreter, Run, State}
+import bloop.exec.JavaEnv
+import bloop.logging.RecordingLogger
+
+class TestLoggingSpec {
+
+  @Test
+  def concurrentInProcessTestRunsHaveDifferentStreams = {
+    val projectName = "with-tests"
+    val moduleName = "with-tests-test"
+    val state = {
+      val state = ProjectHelpers.loadTestProject(projectName)
+      val inProcessEnv = JavaEnv.default(fork = false)
+      val build = state.build
+      val beforeCompilation = state.copy(build = build.copy(projects = build.projects.map(_.copy(javaEnv = inProcessEnv))))
+      val action = Run(Commands.Compile(moduleName))
+      Interpreter.execute(action, beforeCompilation)
+    }
+
+    val testAction = Run(Commands.Test(moduleName))
+    def mkThread(state: State) = {
+      new Thread {
+        override def run(): Unit = Interpreter.execute(testAction, state)
+      }
+    }
+
+    val l0 = new RecordingLogger
+    val state0 = state.copy(logger = l0)
+    val thread0 = mkThread(state0)
+
+    val l1 = new RecordingLogger
+    val state1 = state.copy(logger = l1)
+    val thread1 = mkThread(state1)
+
+    thread0.start()
+    thread1.start()
+    thread0.join()
+    thread1.join()
+
+    val needle = ("info", "message")
+    val messages0 = l0.getMessages()
+    val messages1 = l1.getMessages()
+    assertEquals(10, messages0.count(_ == needle).toLong)
+    assertEquals(10, messages1.count(_ == needle).toLong)
+  }
+
+}

--- a/integration-tests/integration-projects/with-tests/src/test/scala/hello/WritingTest.scala
+++ b/integration-tests/integration-projects/with-tests/src/test/scala/hello/WritingTest.scala
@@ -1,0 +1,9 @@
+package hello
+
+import org.scalatest._
+
+class WritingTest extends FlatSpec with Matchers {
+  "A test" should "be able to print stuff" in {
+    (1 to 10).foreach(_ => println("message"))
+  }
+}


### PR DESCRIPTION
Otherwise, the output produced by tests on stdout and stderr is not
captured by the logger, and would get intertwined with other concurrent
test runs.

Fixes #158