### PR TITLE
Remove `Advisory Board` from banner message

### DIFF
--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -297,7 +297,7 @@ object Header {
       |
       |   ***********************************************************
       |   ***       Welcome to the build of `loooooooooop`        ***
-      |   *** An effort funded by the Scala Center Advisory Board ***
+      |   ***        An effort funded by the Scala Center         ***
       |   ***********************************************************
     """.stripMargin
 }


### PR DESCRIPTION
The Advisory Board does not provide or apportion funding. It merely
provides recommendations to the Scala Center on how to spend their
funds. There is an important legal distinction.