### PR TITLE
Change the `bloop` alias suggested in the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We suggest that you add the following to your shell configuration:
 
 ```sh
 export PATH="$PATH:~/.bloop"
-alias bloop="~/.bloop/bloop-ng.py bloop.Cli --"
+alias bloop="bloop-ng.py bloop.Cli --"
 ```
 
 The next sections assume that you've added those lines to your profile, and reloaded your shell.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We suggest that you add the following to your shell configuration:
 
 ```sh
 export PATH="$PATH:~/.bloop"
-alias bloop="bloop-ng.py"
+alias bloop="~/.bloop/bloop-ng.py bloop.Cli --"
 ```
 
 The next sections assume that you've added those lines to your profile, and reloaded your shell.


### PR DESCRIPTION
As suggested here,

  https://github.com/scalacenter/bloop/issues/100

Even if there's a better long-term solution, it would be good to merge
this so that nobody else hits the same problems I did.