### PR TITLE
Added tab-completions for ZSH.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,5 +166,23 @@ Available commands: about, clean, compile, help, projects, test
 Type `bloop 'command' --help` for help on an individual command
 ```
 
+## Tab-completion
+
+Bloop supports tab-completion on ZSH. To install command completion on ZSH,
+copy the [completions][zsh-completions] file to an existing completions
+directory, if it exists.
+
+If not, you can create it, and update your `.zshrc` script as follows:
+
+```sh
+$ mkdir -p ~/.zsh/completion
+$ cp etc/_bloop ~/.zsh/completion/
+$ echo 'fpath=(~/.zsh/completion $fpath)' >> ~/.zshrc
+$ echo 'autoload -Uz compinit ; compinit' >> ~/.zshrc
+```
+
+Closing and reopening your shell should make bloop tab-completions available.
+
 [installation-script]: https://raw.githubusercontent.com/scalacenter/bloop/master/bin/install.sh
+[zsh-completions]: https://raw.githubusercontent.com/scalacenter/bloop/master/etc/_bloop
 [bloop-release-post]: http://www.scala-lang.org/blog/2017/11/30/bloop-release.html

--- a/etc/_bloop
+++ b/etc/_bloop
@@ -1,0 +1,132 @@
+#compdef bloop
+
+_bloop() {
+  local -a cmds
+  
+  cmds=(
+    'about:about Bloop'
+    'clean:remove output files'
+    'compile:compile Scala source code'
+    'configure:set Bloop configuration options'
+    'console:launch the Scala REPL'
+    'help:show a help message'
+    'projects:list available projects'
+    'run:execute a Scala program'
+    'test:run tests for the Scala program'
+  )
+
+  _arguments "1: :{_describe 'command' cmds}" '*:: :->args'
+
+  case $words[1] in
+    about)
+      _arguments -C \
+        {-c,--config-dir}'[File path to the bloop config directory]:directory:_files -/' \
+        {-v,--version}'[if set, print the about section at the beginning of the execution]' \
+        '--verbose[if set, print out debugging information to stderr]' \
+        '--threads[number of threads to use]:threads:_thread_count'
+      ;;
+
+    clean)
+      _arguments \
+        {-p,--projects}'[the projects to clean]:project:_projects' \
+        '--isolated[do not run clean for dependencies. By default, false]' \
+        {-c,--config-dir}'[file path to the bloop config directory]:directory:_files -/' \
+        {-v,--version}'[if set, print the about section at the beginning of the execution]' \
+        '--verbose[if set, print out debugging information to stderr]' \
+        '--threads[number of threads to use]:threads:_thread_count'
+      ;;
+    
+    compile)
+      _arguments \
+        {-p,--project}'[the project to compile]:project:_projects' \
+        '--incremental[compile the project incrementally; by default, true]' \
+        '--reporter[pick reporter to show compilation messages]:reporter:' \
+        {-w,--watch}'[run the command when project source files change; by default, false]' \
+        {-c,--config-dir}'[file path to the bloop config directory]:directory:_files -/' \
+        {-v,--version}'[if set, print the about section at the beginning of the execution]' \
+        '--verbose[if set, print out debugging information to stderr]' \
+        '--threads[number of threads to use]:threads:_thread_count'
+      ;;
+    
+    configure)
+      _arguments \
+        {--threads,--parallelism}'[number of threads to use for parallel compilation and test execution]:threads:_thread_count' \
+        {-c,--config-dir}'[file path to the bloop config directory]:directory:_files -/' \
+        '--verbose[if set, print out debugging information to stderr]' \
+        {-v,--version}'[if set, print the about section at the beginning of the execution]'
+      ;;
+    
+    console)
+      _arguments \
+        {-p,--project}'[the project to compile]:project:_projects' \
+        '--reporter[pick reporter to show compilation messages]:reporter:' \
+        '--exclude-root[Start up the console compiling only the target project dependencies]' \
+        {-c,--config-dir}'[file path to the bloop config directory]:directory:_files -/' \
+        {-v,--version}'[if set, print the about section at the beginning of the execution]' \
+        '--verbose[if set, print out debugging information to stderr]' \
+        '--threads[number of threads to use]:threads:_thread_count'
+      ;;
+    
+    projects)
+      _arguments \
+        {--dot-graph,--dot}'[print out a dot graph you can pipe into `dot`; by default, false]' \
+        {-c,--config-dir}'[file path to the bloop config directory]:directory:_files -/' \
+        {-v,--version}'[if set, print the about section at the beginning of the execution]' \
+        '--verbose[if set, print out debugging information to stderr]' \
+        '--threads[number of threads to use]:threads:_thread_count'
+      ;;
+    
+    run)
+      _arguments \
+        {-p,--project}'[the project to compile]:project:_projects' \
+        {-m,--main}'[the main class to run. Leave unset to let bloop select automatically]:class:' \
+        '--reporter[pick reporter to show compilation messages]:reporter:' \
+        '--args[the arguments to pass to the application]:arguments:' \
+        {-w,--watch}'[if set, run the command when project source files change; by default, false]' \
+        {-c,--config-dir}'[file path to the bloop config directory]:directory:_files -/' \
+        {-v,--version}'[if set, print the about section at the beginning of the execution]' \
+        '--verbose[if set, print out debugging information to stderr]' \
+        '--threads[number of threads to use]:threads:_thread_count'
+      ;;
+    
+    test)
+      _arguments \
+        {-p,--project}'[the project to compile]:project:_projects' \
+        '--isolated[do not run tests for dependencies. By default, false]' \
+        '--reporter[pick reporter to show compilation messages]:reporter:' \
+        {-w,--watch}'[if set, run the command when project source files change; by default, false]' \
+        {-c,--config-dir}'[file path to the bloop config directory]:directory:_files -/' \
+        {-v,--version}'[if set, print the about section at the beginning of the execution]' \
+        '--verbose[if set, print out debugging information to stderr]' \
+        '--threads[number of threads to use]:threads:_thread_count'
+      ;;
+
+    *)
+      ;;
+    
+    
+    
+
+  esac
+
+}
+
+_thread_count() {
+  local thread_count; thread_count=(
+    '1:use 1 thread'
+    '2:use 2 threads'
+    '4:use 4 threads'
+    '6:use 6 threads'
+    '8:use 8 threads'
+    '12:use 12 threads'
+    '16:use 16 threads'
+  )
+  _describe -t thread-count 'thread count' thread_count
+}
+
+_projects() {
+  local projects; projects=( $(ls .bloop-config 2> /dev/null | sed 's/.config$//g') )
+  _describe 'values' projects
+}
+
+_bloop


### PR DESCRIPTION
The installation instructions in the README file are experimental. They
worked for me, though I don't know how special my own configuration is.

The will also be some maintenance overhead involved with this. As
parameters change, the zsh-completions file will need to change with
them. In the long-term, maybe we could auto-generate this file somehow
(for example, by parsing the output from `bloop <subcommand> --help`),
but for now we should probalbly merge early and get feedback sooner.

The definitions for the ZSH completions involve really ugly code. Any
improvements would be very welcome.

You may want to make an additional change after merging this. Having
`bloop`, `bloop-server` and `bloop-shell` all on the PATH at the same
time means that (assuming there are no other commands beginnig with
`blo`), typing `blo<tab>` will autocomplete to `bloop` *without a space*
after it, because of the `bloop-server` and `bloop-shell` completions.

If `bloop-server` and `bloop-shell` were to be renamed to, say,
`blp-server` and `blp-shell` respectively, then `bloop<tab>` would take
you straight to the subcommands list, inevitably saving you valuable
microseconds.  # Please enter the commit message for your changes. Lines
starting.