### PR TITLE
Write config to .bloop-config in integration tests

### DIFF
--- a/benchmarks/src/main/scala/bloop/ProjectBenchmark.scala
+++ b/benchmarks/src/main/scala/bloop/ProjectBenchmark.scala
@@ -16,7 +16,7 @@ object ProjectBenchmark {
   }
   val sbtLocation = existing(getProjectBase("sbt"))
   val sbtRootProjectLocation = existing(
-    sbtLocation.resolve("bloop-config").resolve("sbtRoot.config"))
+    sbtLocation.resolve(".bloop-config").resolve("sbtRoot.config"))
   val uTestLocation = existing(getProjectBase("utest"))
 }
 

--- a/frontend/src/test/scala/bloop/tasks/ProjectHelpers.scala
+++ b/frontend/src/test/scala/bloop/tasks/ProjectHelpers.scala
@@ -72,7 +72,7 @@ object ProjectHelpers {
 
   def loadTestProject(projectsBase: Path, name: String): State = {
     val base = projectsBase.resolve(name)
-    val configDir = base.resolve("bloop-config")
+    val configDir = base.resolve(".bloop-config")
     val logger = BloopLogger.default(configDir.toString())
     val baseDirectoryFile = configDir.resolve("base-directory")
     assert(Files.exists(configDir) && Files.exists(baseDirectoryFile))

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -239,10 +239,10 @@ object BuildImplementation {
 
     private def createScriptedSetup(testDir: File) = {
       s"""
-         |bloopConfigDir in Global := file("$testDir/bloop-config")
+         |bloopConfigDir in Global := file("$testDir/.bloop-config")
          |TaskKey[Unit]("registerDirectory") := {
          |  val dir = (baseDirectory in ThisBuild).value
-         |  IO.write(file("$testDir/bloop-config/base-directory"), dir.getAbsolutePath)
+         |  IO.write(file("$testDir/.bloop-config/base-directory"), dir.getAbsolutePath)
          |}
          |TaskKey[Unit]("checkInstall") := {
          |  Thread.sleep(1000) // Let's wait a little bit because of OS's IO latency
@@ -307,7 +307,7 @@ object BuildImplementation {
           (ScriptedKeys.sbtTestDirectory.value / "integration-projects").*(AllPassFilter).get
         tests.foreach { testDir =>
           IO.copyFile(testPluginSrc, testDir / "project" / "TestPlugin.scala")
-          IO.createDirectory(testDir / "bloop-config")
+          IO.createDirectory(testDir / ".bloop-config")
           IO.write(testDir / "project" / "test-config.sbt", addSbtPlugin)
           IO.write(testDir / "test-config.sbt", createScriptedSetup(testDir))
           IO.write(testDir / "test", scriptedTestContents)


### PR DESCRIPTION
I don't remember why we don't write them to the default location. It just makes it annoying when testing with Nailgun afterwards.