### PR TITLE
Use bintray to release everything

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -138,6 +138,7 @@ lazy val sbtBloop = project
     sbtPlugin := true,
     BuildDefaults.scriptedSettings,
     scalaVersion := BuildDefaults.fixScalaVersionForSbtPlugin.value,
+    releaseEarlyWith := SonatypePublisher
   )
 
 val mavenBloop = project

--- a/build.sbt
+++ b/build.sbt
@@ -198,8 +198,9 @@ val releaseEarlyCmd = releaseEarly.key.label
 val bloopModules = allProjectReferences
   .filterNot(_ == LocalProject(sbtBloop.id))
   .filterNot(_ == LocalProject(benchmarks.id))
-val sourceProjects = List(bridgeIntegration, zincIntegration, bspIntegration, nailgunIntegration)
+val sourceProjects = List(bridgeIntegration, bspIntegration, nailgunIntegration)
 val sourceModules = sourceProjects.map(m => LocalProject(m.id)) 
 val actions = (bloopModules ++ sourceModules).map(m => s"+${m.project}/$releaseEarlyCmd")
-val extra = Seq(s"^${sbtBloop.id}/releaseEarly")
+// We don't need the zinc integration to be cross-published, Bloop is only 2.12.x
+val extra = Seq(s"${zincIntegration.id}/$releaseEarlyCmd", s"^${sbtBloop.id}/$releaseEarlyCmd")
 addCommandAlias("releaseBloop", (actions ++ extra).mkString(";", ";", ""))

--- a/build.sbt
+++ b/build.sbt
@@ -116,11 +116,15 @@ val benchmarks = project
   .dependsOn(frontend % "compile->test", BenchmarkBridgeCompilation % "compile->jmh")
   .enablePlugins(BuildInfoPlugin, JmhPlugin)
   .settings(benchmarksSettings(frontend))
+  .settings(
+    skip in publish := true,
+  )
 
 lazy val integrationsCore = project
   .in(file("integrations") / "core")
   .disablePlugins(sbt.ScriptedPlugin)
   .settings(
+    name := "bloop-integrations-core",
     crossScalaVersions := List("2.12.4", "2.10.7"),
     // We compile in both so that the maven integration can be tested locally
     publishLocal := publishLocal.dependsOn(publishM2).value
@@ -146,6 +150,8 @@ val docs = project
   .in(file("website"))
   .enablePlugins(HugoPlugin)
   .settings(
+    name := "bloop-website",
+    skip in publish := true,
     sourceDirectory in Hugo := baseDirectory.value
     // baseURL in Hugo := uri("https://scala.epfl.ch"),
   )

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -183,12 +183,15 @@ object BuildImplementation {
     BintrayKeys.bintrayRepository := "releases",
   )
 
+  import ch.epfl.scala.sbt.release.ReleaseEarly
   final val globalSettings: Seq[Def.Setting[_]] = Seq(
     Keys.testOptions in Test += sbt.Tests.Argument("-oD"),
     Keys.onLoadMessage := Header.intro,
     Keys.commands ~= BuildDefaults.fixPluginCross _,
     Keys.onLoad := BuildDefaults.onLoad.value,
-    Keys.publishArtifact in Test := false
+    Keys.publishArtifact in Test := false,
+    Keys.concurrentRestrictions -= ReleaseEarly.ExclusiveReleaseTag,
+    Keys.resolvers += Resolver.bintrayRepo("scalacenter", "releases"),
   )
 
   final val buildSettings: Seq[Def.Setting[_]] = Seq(

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -181,6 +181,13 @@ object BuildImplementation {
 
   final lazy val sharedProjectPublishSettings: Seq[Def.Setting[_]] = Seq(
     BintrayKeys.bintrayRepository := "releases",
+    BintrayKeys.bintrayPackage := {
+      val ref = Keys.thisProjectRef.value
+      if (ref.build == BuildKeys.ZincProject.build) "zinc"
+      else if (ref.build == BuildKeys.NailgunProject.build) "nailgun"
+      else if (ref.build == BuildKeys.BspProject.build) "bsp"
+      else "bloop" // As a fallback, we release to bloop.
+    }
   )
 
   import ch.epfl.scala.sbt.release.ReleaseEarly

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -191,7 +191,10 @@ object BuildImplementation {
     Keys.onLoad := BuildDefaults.onLoad.value,
     Keys.publishArtifact in Test := false,
     // Add resolver so that we can lazy publish modules that are only in bintray
-    Keys.resolvers += Resolver.bintrayRepo("scalacenter", "releases"),
+    Keys.resolvers := {
+      val previous = Keys.resolvers.value
+      (previous :+ Resolver.bintrayRepo("scalacenter", "releases")).distinct
+    },
   )
 
   final val buildSettings: Seq[Def.Setting[_]] = Seq(

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -220,6 +220,7 @@ object BuildImplementation {
     },
     // Legal requirement: license and notice files must be in the published jar
     Keys.resources in Compile ++= BuildDefaults.getLicense.value,
+    Keys.publishArtifact in Test := false,
     Keys.publishArtifact in (Compile, Keys.packageDoc) := {
       val output = DynVerKeys.dynverGitDescribeOutput.value
       val version = Keys.version.value
@@ -276,6 +277,7 @@ object BuildImplementation {
               if (previousLicenses.nonEmpty) previousLicenses
               else (Keys.licenses in ThisBuild).value
             },
+            Keys.publishArtifact in Test := false,
             Keys.publishArtifact in (Compile, Keys.packageDoc) := {
               val output = DynVerKeys.dynverGitDescribeOutput.in(ref).in(ThisBuild).value
               val version = Keys.version.in(ref).value

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -191,12 +191,12 @@ object BuildImplementation {
     Keys.onLoad := BuildDefaults.onLoad.value,
     Keys.publishArtifact in Test := false,
     Keys.concurrentRestrictions -= ReleaseEarly.ExclusiveReleaseTag,
+    // Add resolver so that we can lazy publish modules that are only in bintray
     Keys.resolvers += Resolver.bintrayRepo("scalacenter", "releases"),
   )
 
   final val buildSettings: Seq[Def.Setting[_]] = Seq(
     Keys.organization := "ch.epfl.scala",
-    Keys.resolvers += Resolver.jcenterRepo,
     Keys.updateOptions := Keys.updateOptions.value.withCachedResolution(true),
     Keys.scalaVersion := "2.12.4",
     Keys.triggeredMessage := Watched.clearWhenTriggered,

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -190,7 +190,6 @@ object BuildImplementation {
     Keys.commands ~= BuildDefaults.fixPluginCross _,
     Keys.onLoad := BuildDefaults.onLoad.value,
     Keys.publishArtifact in Test := false,
-    Keys.concurrentRestrictions -= ReleaseEarly.ExclusiveReleaseTag,
     // Add resolver so that we can lazy publish modules that are only in bintray
     Keys.resolvers += Resolver.bintrayRepo("scalacenter", "releases"),
   )

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -2,7 +2,7 @@ val mvnVersion = "3.5.2"
 val mvnPluginToolsVersion = "3.5"
 val root = project
   .in(file("."))
-  .dependsOn(RootProject(uri("git://github.com/scalacenter/sbt-release-early#7143fef953e479e9c51db968970967269a65cfd3")))
+  .dependsOn(RootProject(uri("git://github.com/scalacenter/sbt-release-early#d5a820af6c678e6961c7d77f7cecfbb972d4d97a")))
   .settings(
     scalaVersion := "2.12.4",
     resolvers += Resolver.sonatypeRepo("staging"),

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -2,7 +2,7 @@ val mvnVersion = "3.5.2"
 val mvnPluginToolsVersion = "3.5"
 val root = project
   .in(file("."))
-  .dependsOn(RootProject(uri("git://github.com/scalacenter/sbt-release-early#b17b16370af9e161337e4c79d2ffb3152d9a9a45")))
+  .dependsOn(RootProject(uri("git://github.com/scalacenter/sbt-release-early#7143fef953e479e9c51db968970967269a65cfd3")))
   .settings(
     scalaVersion := "2.12.4",
     resolvers += Resolver.sonatypeRepo("staging"),


### PR DESCRIPTION
Bintray is so much nicer and faster. The slugishness of sbt-sonatype is
unbearable. We still publish to sonatype the sbt-bloop plugin because Bintray
does not allow to sync to Maven Central repositories that use the sbt plugin
repository layout.