### PR TITLE
Add scalameta bintray repo in installation script

### DIFF
--- a/bin/install.py
+++ b/bin/install.py
@@ -68,6 +68,7 @@ def coursier_bootstrap(target, main):
     try:
         check_call([
             "java", "-jar", BLOOP_COURSIER_TARGET, "bootstrap", BLOOP_ARTIFACT,
+            "-r", "bintray:scalameta/maven",
             "-o", target, "--standalone", "--main", main
         ])
     except CalledProcessError as e:


### PR DESCRIPTION
This is the repository where lsp4s lives. We need to tell coursier to
use it, otherwise we won't find this artifact.

Also, make the installation script executable.