### PR TITLE
Better shortening of path in compilation errors

### DIFF
--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -49,7 +49,8 @@ object Tasks {
       val target = project.tmp
       val scalacOptions = project.scalacOptions
       val javacOptions = project.javacOptions
-      val reporter = new Reporter(logger, project.baseDirectory.syntax, identity, config)
+      val cwd = state.build.origin.getParent
+      val reporter = new Reporter(logger, cwd, identity, config)
       // FORMAT: OFF
       CompileInputs(instance, compilerCache, sourceDirs, classpath, classesDir, target, scalacOptions, javacOptions, result, reporter, logger)
       // FORMAT: ON

--- a/frontend/src/main/scala/bloop/reporter/ConfigurableReporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/ConfigurableReporter.scala
@@ -1,5 +1,6 @@
 package bloop.reporter
 
+import bloop.io.AbsolutePath
 import bloop.logging.Logger
 
 /**
@@ -11,8 +12,8 @@ trait ConfigurableReporter {
   /** Where to log the message */
   def logger: Logger
 
-  /** The base directory of this reporter. */
-  def base: String
+  /** The current working directory of the user who started compilation. */
+  def cwd: AbsolutePath
 
   /** The configuration for this reporter. */
   def config: ReporterConfig

--- a/frontend/src/main/scala/bloop/reporter/Reporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/Reporter.scala
@@ -1,5 +1,6 @@
 package bloop.reporter
 
+import bloop.io.AbsolutePath
 import bloop.logging.Logger
 import xsbti.{Position, Severity}
 
@@ -9,12 +10,12 @@ import xsbti.{Position, Severity}
  * etc.
  *
  * @param logger The logger that will receive the output of the reporter.
- * @param base   The base prefix to remove from paths.
+ * @param cwd    The current working directory of the user who started compilation.
  * @param sourcePositionMapper A function that transforms positions.
  * @param config The configuration for this reporter.
  */
 final class Reporter(val logger: Logger,
-                     val base: String,
+                     val cwd: AbsolutePath,
                      sourcePositionMapper: Position => Position,
                      val config: ReporterConfig)
     extends xsbti.Reporter

--- a/frontend/src/main/scala/bloop/reporter/ReporterFormat.scala
+++ b/frontend/src/main/scala/bloop/reporter/ReporterFormat.scala
@@ -7,6 +7,8 @@ import scala.compat.Platform.EOL
 import java.io.File
 import java.util.Optional
 
+import bloop.io.AbsolutePath
+
 /**
  * Describes how messages should be formatted by a `ConfigurableReporter`.
  *
@@ -65,18 +67,18 @@ abstract class ReporterFormat(reporter: ConfigurableReporter) {
     }
 
   /**
-   * Returns the absolute path of `file` with `base` stripped, if the reporter
+   * Returns the absolute path of `file` with `cwd` stripped, if the reporter
    * if configured with `shortenPaths = true`.
    *
    * @param file The file whose path to show.
-   * @return The absolute path of `file` with `base` stripped if `shortenPaths = true`,
+   * @return The absolute path of `file` with `cwd` stripped if `shortenPaths = true`,
    *         or the original path otherwise.
    */
   protected def showPath(file: File): Option[String] = {
-    val absolutePath = Option(file).map(_.getAbsolutePath)
+    val absolutePath = Option(file).map(AbsolutePath(_))
     if (reporter.config.shortenPaths)
-      absolutePath.map(_.stripPrefix(reporter.base))
-    else absolutePath
+      absolutePath.map(_.toRelative(reporter.cwd).toString)
+    else absolutePath.map(_.toString)
   }
 
   /**


### PR DESCRIPTION
Also, relativize the compilation error messages to the base of the build
instead of the base of the project.

Fixes #263