### PR TITLE
Remove `coursier` after building Homebrew formula

### DIFF
--- a/project/ReleaseUtils.scala
+++ b/project/ReleaseUtils.scala
@@ -72,6 +72,7 @@ object ReleaseUtils {
        |  def install
        |      mkdir "bin"
        |      system "python2", "install.py", "--dest", "bin", "--version", version
+       |      File.delete("bin/coursier")
        |      prefix.install "bin"
        |  end
        |


### PR DESCRIPTION
Because we download coursier in `install.py`, it was installed along
with the rest of Bloop in our Homebrew formula.

The easiest solution is to just remove it before copying the files. The
harder would be to have a build dependency on coursier, and use a
different installations script that wouldn't download coursier.