### PR TITLE
Set logger when loading cached State

### DIFF
--- a/frontend/src/main/scala/bloop/engine/State.scala
+++ b/frontend/src/main/scala/bloop/engine/State.scala
@@ -104,6 +104,6 @@ object State {
       val projects = Project.fromDir(configDir, logger)
       val build: Build = Build(configDir, projects)
       State(build, opts, logger)
-    })
+    }).copy(logger = logger)
   }
 }


### PR DESCRIPTION
Otherwise, we would reuse an old logger, which had an extremely strange
impact on verbose mode.