### PR TITLE
Change commit to test for scala

### DIFF
--- a/build-integrations/sbt-0.13/build.sbt
+++ b/build-integrations/sbt-0.13/build.sbt
@@ -3,7 +3,7 @@ val ApacheSpark = RootProject(
 val LihaoyiUtest = RootProject(
   uri("git://github.com/lihaoyi/utest.git#b5440d588d5b32c85f6e9392c63edd3d3fed3106"))
 val ScalaScala = RootProject(
-  uri("git://github.com/scala/scala.git#d1b745c2e97cc89e5d26b8f5a5696a2611c01af7"))
+  uri("git://github.com/scalacenter/scala.git#f3e19469abbfb570f79154f63d6bb27867a4c8f7"))
 val ScalaCenterVersions = RootProject(
   uri("git://github.com/scalacenter/versions.git#c296028a33b06ba3a41d399d77c21f6b7100c001"))
 val integrations = List(ApacheSpark, LihaoyiUtest, ScalaScala, ScalaCenterVersions)


### PR DESCRIPTION
This commit changed the structure of the projects to make it easier to
integrate with the rest of our benchmarking suite.

Currently, the benchmarks are broken because the scalac benchmark won't find the sources for the `library` project.