### PR TITLE
Fix config directory in Bloop shell

### DIFF
--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -19,7 +19,7 @@ object Bloop extends CaseApp[CliOptions] {
   private val reader = consoleReader()
 
   override def run(options: CliOptions, remainingArgs: RemainingArgs): Unit = {
-    val configDirectory = options.configDir.map(AbsolutePath.apply).getOrElse(AbsolutePath("."))
+    val configDirectory = options.configDir.map(AbsolutePath.apply).getOrElse(AbsolutePath(".bloop-config"))
     val logger = BloopLogger.default(configDirectory.syntax)
     logger.warn("The Nailgun integration should be preferred over the Bloop shell.")
     logger.warn("The Bloop shell provides less features, is not supported and can be removed without notice.")


### PR DESCRIPTION
This bug was undiscovered because we didn't have a `xxx.config` in any
of our benchmarks before, but now we do and Bloop tries to load it.