### PR TITLE
Sync up with style changes in kube

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -53,8 +53,10 @@ pipeline:
       - git log | head -n 20
       - ./bin/add-coursier.sh
       - ./bin/detect-community-build.sh
-      - ${SBT_RUN}
-      - ./bin/ci-clean-cache.sh
+      - case "$DRONE_COMMIT_MESSAGE" in 
+        *[DOCS]*) echo "Skipping tests for commit that only changes docs." ;;
+        *) ${SBT_RUN}; ./bin/ci-clean-cache.sh ;;
+        esac
 
   publish:
     image: scalacenter/scala-docs:1.1

--- a/website/content/docs/developer-documentation.md
+++ b/website/content/docs/developer-documentation.md
@@ -11,7 +11,24 @@ toc = true
 This is all the documentation that is relevant for the developers of Bloop and
 anyone who would like to contribute to Bloop.
 
-### Building Bloop locally
+## Improving the docs
+
+Our documentation infrastructure uses the [Hugo](http://gohugo.io/) static site
+generator, together with a custom version of the [Kube](kube.elemnts.org/)
+theme. The docs live in the `website/` folder in our repository.
+
+If you want to make changes to the theme or how the documents are organised (think html or css), head to Scala Center's fork of [Kube](https://github.com/scalacenter/kube) to make the changes and make a pull request.
+
+If you want to make changes to the contents of the docs, you can click on the
+"Edit on GitHub" button in every documentation page or, alternatively, make the
+change in your local copy of Bloop's git repository. All documentation pages
+live in `website/content/docs/`.
+
+We recommend that whenever you make changes to the docs you add `[DOCS]` to the
+commit message to tell the CI server to skip tests and speed up the merge
+process.
+
+## Building Bloop locally
 
 The following sequence of commands is sufficient to build Bloop, publish it
 locally on your machine and generate the binaries that you can immediately run:
@@ -29,7 +46,7 @@ $ cd ..
 $ bin/install.py --dest $HOME/.bloop --nailgun <nailgun-commit-sha> --version <version>
 ```
 
-### Running our test suite
+## Running our test suite
 
 Bloop has a rich integration test suite that requires build definitions to
 exist to be able to compile a project. These build definitions are
@@ -49,7 +66,7 @@ generate the build definitions. Then, run tests with:
 > frontend/test
 ```
 
-### Running our community build
+## Running our community build
 
 A community build is a collection of builds for which we test against on every
 major change in bloop. It helps us keep track of potential regressions in both
@@ -59,11 +76,11 @@ Right now, our community build counts with several sbt 0.13 and 1.0 builds. As
 running the community, build takes a while, it's run only before releases and
 on major breaking changes.
 
-#### Running the community build on a pull request
+### Running the community build on a pull request
 
 The community build on every pull request with the label `community-build`.
 
-#### Running the community build locally
+### Running the community build locally
 
 Run the community build locally by setting the `RUN_COMMUNITY_BUILD`
 environment variable before running the tests locally.
@@ -73,14 +90,14 @@ $ export RUN_COMMUNITY_BUILD=true
 $ sbt "frontend/testOnly bloop.tasks.IntegrationTestSuite"
 ```
 
-### Running our benchmarks
+## Running our benchmarks
 
 Bloop features a benchmark suite to measure how fast Bloop is to perform
 several operations (loading projects for instance), as well as other benchmark
 that compare the compilation speed of Bloop against scalac and sbt. The
 benchmarks run on a dedicated machine located at EPFL.
 
-#### Overview
+### Overview
 
 Our benchmark infrastructure is composed of several pieces:
 
@@ -94,13 +111,13 @@ Our benchmark infrastructure is composed of several pieces:
    benchmark results and displays them on graphs. At this time, it is only accessible from
    within EPFL's network.
 
-#### Running the benchmarks on a pull request
+### Running the benchmarks on a pull request
 
 Schedule the benchmarks in a given pull request by adding a comment that
 contains "test performance please". [bloopoid](https://github.com/bloopoid)
 will then kick in and confirm your request.
 
-#### Running the benchmarks locally
+### Running the benchmarks locally
 
 `bin/run-benchmarks.sh` builds a specified version of Bloop (via CLI) and runs
 the benchmarks for it. Run it to execute the benchmark suite locally, but keep

--- a/website/content/docs/getting-started-sbt.md
+++ b/website/content/docs/getting-started-sbt.md
@@ -34,8 +34,9 @@ $ sbt installBloop
 [success] Bloop wrote the configuration of project 'foo-test' to '/my-project/.bloop-config/foo-test.config'.
 ```
 
-<mark>Note</mark> This configuration contains machine-dependent information. You should not check it
-in your version control.
+<span class="label warning">Note</span>
+This configuration contains machine-dependent information. You should not check
+it in your version control.
 
 ### Start bloop
 
@@ -93,7 +94,8 @@ more information, type:
 $ bloop compile --help
 ```
 
-<mark>Note</mark> All the commands of Bloop support `--help`.
+<span class="label warning">Note</span>
+All the commands of Bloop support `--help`.
 
 ### Testing your project with Bloop
 


### PR DESCRIPTION
The following sync adds the following changes:

1. Prettier button for "View on Github".
2. Reorganisation of "Edit on Github".
3. Use of labels instead of marks.
4. Decrease of font size for title (was too big).
5. Better `code` and `pre` style (more similar to GitHub's)