### PR TITLE
Infer projects from cli remaining args

### DIFF
--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -161,7 +161,9 @@ object Cli {
                   run(newCommand, newCommand.cliOptions)
                 }
               case Right(c: Commands.Clean) =>
-                val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
+                val newCommand = c
+                  .copy(cliOptions = c.cliOptions.copy(common = commonOptions))
+                  .copy(projects = c.projects ++ remainingArgs)
                 run(newCommand, newCommand.cliOptions)
               case Right(c: Commands.Projects) =>
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -42,10 +42,11 @@ object Cli {
 
   import CliParsers.{CommandsMessages, CommandsParser, BaseMessages, OptionsParser}
   val commands: Seq[String] = CommandsMessages.messages.map(_._1)
+  // Getting the name from the sbt generated metadata gives us `bloop-frontend` instead.
   val beforeCommandMessages: Messages[DefaultBaseCommand] = BaseMessages.copy(
-    appName = bloop.internal.build.BuildInfo.name,
+    appName = "bloop",
     appVersion = bloop.internal.build.BuildInfo.version,
-    progName = bloop.internal.build.BuildInfo.name,
+    progName = "bloop",
     optionsDesc = s"[options] [command] [command-options]"
   )
 
@@ -56,8 +57,12 @@ object Cli {
        |Type `$progName 'command' --help` for help on an individual command
      """.stripMargin
 
-  private def commandHelpAsked(command: String): String =
-    CommandsMessages.messagesMap(command).helpMessage(beforeCommandMessages.progName, command)
+  private def commandHelpAsked(command: String): String = {
+    // We have to do this ourselves because case-app 1.2.0 has a bug in its `ArgsName` handling.
+    val messages = CommandsMessages.messagesMap(command)
+    val argsName = if (messages.args.exists(_.name.startsWith("project"))) Some("project") else None
+    messages.copy(argsNameOption = argsName).helpMessage(beforeCommandMessages.progName, command)
+  }
 
   private def usageAsked: String = {
     s"""${beforeCommandMessages.usageMessage}
@@ -75,6 +80,14 @@ object Cli {
   def parse(args: Array[String], commonOptions: CommonOptions): Action = {
     import caseapp.core.WithHelp
 
+    def inferProjectFromRemaining(args: Seq[String], cmd: String): Either[Action, String] = {
+      if (args.isEmpty)
+        Left(printErrorAndExit(s"Required project name not specified for '$cmd'.", commonOptions))
+      else if (args.size >= 2)
+        Left(printErrorAndExit("Too many projects have been specified for '$cmd'.", commonOptions))
+      else Right(args.head)
+    }
+
     CommandsParser.withHelp.detailedParse(args)(OptionsParser.withHelp) match {
       case Left(err) => printErrorAndExit(err, commonOptions)
       case Right((WithHelp(_, help @ true, _), _, _)) =>
@@ -88,11 +101,23 @@ object Cli {
             Print(commandHelpAsked(commandName), commonOptions, Exit(ExitStatus.Ok))
           case Right((commandName, WithHelp(usage @ true, _, _), _, _)) =>
             Print(commandUsageAsked(commandName), commonOptions, Exit(ExitStatus.Ok))
-          case Right((commandName, WithHelp(_, _, command), _, _)) =>
+          case Right((commandName, WithHelp(_, _, command), remainingArgs, _)) =>
             // Override common options depending who's the caller of parse (whether nailgun or main)
             def run(command: Commands.RawCommand, cliOptions: CliOptions): Run = {
               if (!cliOptions.version) Run(command, Exit(ExitStatus.Ok))
               else Run(Commands.About(cliOptions), Run(command, Exit(ExitStatus.Ok)))
+            }
+
+            // Infer project from the context if the current project is empty.
+            def withInferredProject(currentProject: String)(f: String => Action) = {
+              inferProjectFromRemaining(remainingArgs, commandName) match {
+                case Left(action) => action
+                case Right(inferredProject) if currentProject.isEmpty => f(inferredProject)
+                case Right(inferredProject) =>
+                  printErrorAndExit(
+                    s"Detected '$currentProject' and '$inferredProject' are ambiguous projects for '${commandName}'.",
+                    commonOptions)
+              }
             }
 
             command match {
@@ -107,21 +132,37 @@ object Cli {
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
                 Validate.bsp(newCommand, BspServer.isWindows)
               case Right(c: Commands.Compile) =>
-                val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
-                run(newCommand, newCommand.cliOptions)
+                withInferredProject(c.project) { (inferredProject: String) =>
+                  val newCommand = c
+                    .copy(cliOptions = c.cliOptions.copy(common = commonOptions))
+                    .copy(project = inferredProject)
+                  run(newCommand, newCommand.cliOptions)
+                }
               case Right(c: Commands.Console) =>
-                val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
-                run(newCommand, newCommand.cliOptions)
+                withInferredProject(c.project) { (inferredProject: String) =>
+                  val newCommand = c
+                    .copy(cliOptions = c.cliOptions.copy(common = commonOptions))
+                    .copy(project = inferredProject)
+                  run(newCommand, newCommand.cliOptions)
+                }
               case Right(c: Commands.Test) =>
-                val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
-                run(newCommand, newCommand.cliOptions)
+                withInferredProject(c.project) { (inferredProject: String) =>
+                  val newCommand = c
+                    .copy(cliOptions = c.cliOptions.copy(common = commonOptions))
+                    .copy(project = inferredProject)
+                  run(newCommand, newCommand.cliOptions)
+                }
+              case Right(c: Commands.Run) =>
+                withInferredProject(c.project) { (inferredProject: String) =>
+                  val newCommand = c
+                    .copy(cliOptions = c.cliOptions.copy(common = commonOptions))
+                    .copy(project = inferredProject)
+                  run(newCommand, newCommand.cliOptions)
+                }
               case Right(c: Commands.Clean) =>
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
                 run(newCommand, newCommand.cliOptions)
               case Right(c: Commands.Projects) =>
-                val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
-                run(newCommand, newCommand.cliOptions)
-              case Right(c: Commands.Run) =>
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
                 run(newCommand, newCommand.cliOptions)
               case Right(c: Commands.Configure) =>

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -101,7 +101,7 @@ object Cli {
             Print(commandHelpAsked(commandName), commonOptions, Exit(ExitStatus.Ok))
           case Right((commandName, WithHelp(usage @ true, _, _), _, _)) =>
             Print(commandUsageAsked(commandName), commonOptions, Exit(ExitStatus.Ok))
-          case Right((commandName, WithHelp(_, _, command), remainingArgs, _)) =>
+          case Right((commandName, WithHelp(_, _, command), remainingArgs, extraArgs)) =>
             // Override common options depending who's the caller of parse (whether nailgun or main)
             def run(command: Commands.RawCommand, cliOptions: CliOptions): Run = {
               if (!cliOptions.version) Run(command, Exit(ExitStatus.Ok))
@@ -157,6 +157,7 @@ object Cli {
                   val newCommand = c
                     .copy(cliOptions = c.cliOptions.copy(common = commonOptions))
                     .copy(project = inferredProject)
+                    .copy(args = c.args ++ extraArgs) // Infer everything after '--' as args
                   run(newCommand, newCommand.cliOptions)
                 }
               case Right(c: Commands.Clean) =>

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -55,7 +55,7 @@ object Commands {
   case class Clean(
       @ExtraName("p")
       @HelpMessage("The projects to clean.")
-      projects: List[String],
+      project: List[String] = Nil,
       @HelpMessage("Do not run clean for dependencies. By default, false.")
       isolated: Boolean = false,
       @Recurse cliOptions: CliOptions = CliOptions.default,

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -74,7 +74,7 @@ object Commands {
       @ExtraName("s")
       @HelpMessage("A path to a socket file to communicate through Unix sockets (local only).")
       socket: Option[Path] = None,
-      @ExtraName("np")
+      @ExtraName("pn")
       @HelpMessage(
         "A path to a new existing socket file to communicate through Unix sockets (local only).")
       pipeName: Option[String] = None,

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -5,7 +5,7 @@ import java.nio.file.Path
 
 import bloop.engine.ExecutionContext
 import bloop.io.AbsolutePath
-import caseapp.{CommandName, ExtraName, HelpMessage, Recurse}
+import caseapp.{ArgsName, CommandName, ExtraName, HelpMessage, Hidden, Recurse}
 
 object Commands {
 
@@ -83,8 +83,8 @@ object Commands {
 
   case class Compile(
       @ExtraName("p")
-      @HelpMessage("The project to compile.")
-      project: String,
+      @HelpMessage("The project to compile (will be inferred from remaining cli args).")
+      project: String = "",
       @HelpMessage("Compile the project incrementally. By default, true.")
       incremental: Boolean = true,
       @HelpMessage("Pick reporter to show compilation messages. By default, bloop's used.")
@@ -97,8 +97,8 @@ object Commands {
 
   case class Test(
       @ExtraName("p")
-      @HelpMessage("The project to test.")
-      project: String,
+      @HelpMessage("The project to test (will be inferred from remaining cli args).")
+      project: String = "",
       @HelpMessage("Do not run tests for dependencies. By default, false.")
       isolated: Boolean = false,
       @ExtraName("f")
@@ -114,8 +114,8 @@ object Commands {
 
   case class Console(
       @ExtraName("p")
-      @HelpMessage("The project for which to start the console.")
-      project: String,
+      @HelpMessage("The project to run the console at (will be inferred from remaining cli args).")
+      project: String = "",
       @HelpMessage("Pick reporter to show compilation messages. By default, bloop's used.")
       reporter: ReporterKind = BloopReporter,
       @HelpMessage("Start up the console compiling only the target project's dependencies.")
@@ -125,8 +125,8 @@ object Commands {
 
   case class Run(
       @ExtraName("p")
-      @HelpMessage("The project to run.")
-      project: String,
+      @HelpMessage("The project to run (will be inferred from remaining cli args).")
+      project: String = "",
       @ExtraName("m")
       @HelpMessage("The main class to run. Leave unset to let bloop select automatically.")
       main: Option[String] = None,

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -195,7 +195,7 @@ object Interpreter {
   }
 
   private def clean(cmd: Commands.Clean, state: State): Task[State] = {
-    val (projects, missing) = lookupProjects(cmd.projects, state)
+    val (projects, missing) = lookupProjects(cmd.project, state)
     if (missing.isEmpty)
       Tasks.clean(state, projects, cmd.isolated).map(_.mergeStatus(ExitStatus.Ok))
     else Task(reportMissing(missing, state))

--- a/frontend/src/test/scala/bloop/nailgun/BasicNailgunSpec.scala
+++ b/frontend/src/test/scala/bloop/nailgun/BasicNailgunSpec.scala
@@ -1,8 +1,5 @@
 package bloop.nailgun
 
-import bloop.logging.RecordingLogger
-import bloop.tasks.ProjectHelpers
-
 import org.junit.{Ignore, Test}
 import org.junit.Assert.{assertEquals, assertTrue}
 
@@ -20,7 +17,7 @@ class BasicNailgunSpec extends NailgunTest {
   }
 
   @Test
-  def helpCommandTest(): Unit = {
+  def testHelpCommand(): Unit = {
     withServerInProject("with-resources") { (logger, client) =>
       client.success("help")
       val messages = logger.getMessages()
@@ -33,7 +30,7 @@ class BasicNailgunSpec extends NailgunTest {
   }
 
   @Test
-  def aboutCommandTest(): Unit = {
+  def testAboutCommand(): Unit = {
     withServerInProject("with-resources") { (logger, client) =>
       client.success("about")
       val messages = logger.getMessages()
@@ -49,7 +46,7 @@ class BasicNailgunSpec extends NailgunTest {
   }
 
   @Test
-  def projectsCommandTest(): Unit = {
+  def testProjectsCommand(): Unit = {
     withServerInProject("with-resources") { (logger, client) =>
       client.success("projects")
       val messages = logger.getMessages()
@@ -63,8 +60,10 @@ class BasicNailgunSpec extends NailgunTest {
   }
 
   @Test
-  def compileCommandTest(): Unit = {
+  def testCompileCommand(): Unit = {
     withServerInProject("with-resources") { (logger, client) =>
+      client.success("clean", "with-resources")
+      client.success("compile", "with-resources")
       client.success("clean", "-p", "with-resources")
       client.success("compile", "-p", "with-resources")
       val messages = logger.getMessages()
@@ -78,8 +77,9 @@ class BasicNailgunSpec extends NailgunTest {
   }
 
   @Test
-  def runCommandTest(): Unit = {
+  def testRunCommand(): Unit = {
     withServerInProject("with-resources") { (logger, client) =>
+      client.success("run", "with-resources")
       client.success("run", "-p", "with-resources")
       val messages = logger.getMessages()
       val needle = ("info", "OK")
@@ -88,8 +88,9 @@ class BasicNailgunSpec extends NailgunTest {
   }
 
   @Test
-  def testCommandTest(): Unit = {
+  def testTestCommand(): Unit = {
     withServerInProject("with-resources") { (logger, client) =>
+      client.success("test", "with-resources")
       client.success("test", "-p", "with-resources")
       val messages = logger.getMessages()
       val needle = "- should be found"
@@ -102,19 +103,23 @@ class BasicNailgunSpec extends NailgunTest {
   }
 
   @Test
-  def cleanCommandTest(): Unit = {
+  def testCleanCommand(): Unit = {
     withServerInProject("with-resources") { (logger, client) =>
       client.success("clean", "-p", "with-resources")
       client.success("compile", "-p", "with-resources")
       client.success("clean", "-p", "with-resources")
       client.success("compile", "-p", "with-resources")
+      client.success("clean", "with-resources")
+      client.success("compile", "with-resources")
+      client.success("clean", "with-resources")
+      client.success("compile", "with-resources")
       val messages = logger.getMessages()
       val needle = "Compiling"
       val matches = messages.count {
         case ("info", msg) => msg.contains(needle)
         case _ => false
       }
-      assertEquals(s"${messages.mkString("\n")} should contain twice '$needle'", 2, matches.toLong)
+      assertEquals(s"${messages.mkString("\n")} should contain four times '$needle'", 4, matches.toLong)
     }
   }
 

--- a/frontend/src/test/scala/bloop/nailgun/NailgunTest.scala
+++ b/frontend/src/test/scala/bloop/nailgun/NailgunTest.scala
@@ -28,11 +28,11 @@ abstract class NailgunTest {
     val serverThread =
       new Thread {
         override def run(): Unit = {
-          Server.main(Array(TEST_PORT.toString))
           val outStream = ProcessLogger.toOutputStream(log.info)
           val errStream = ProcessLogger.toOutputStream(log.error)
           Console.withOut(outStream) {
             Console.withErr(errStream) {
+              Server.main(Array(TEST_PORT.toString))
             }
           }
         }

--- a/frontend/src/test/scala/bloop/nailgun/NailgunTest.scala
+++ b/frontend/src/test/scala/bloop/nailgun/NailgunTest.scala
@@ -28,11 +28,11 @@ abstract class NailgunTest {
     val serverThread =
       new Thread {
         override def run(): Unit = {
+          Server.main(Array(TEST_PORT.toString))
           val outStream = ProcessLogger.toOutputStream(log.info)
           val errStream = ProcessLogger.toOutputStream(log.error)
           Console.withOut(outStream) {
             Console.withErr(errStream) {
-              Server.main(Array(TEST_PORT.toString))
             }
           }
         }

--- a/website/content/docs/commands-reference.md
+++ b/website/content/docs/commands-reference.md
@@ -238,6 +238,7 @@ The following options are supported:
 ### `bloop bsp`
 
 This command is used to start the <abbr title="Build Server Protocol">BSP</abbr> server.
+You can check a specification of BSP <a href="https://github.com/scalacenter/bsp">here</a>.
 
 The following options are supported:
 
@@ -284,23 +285,23 @@ The following options are supported:
   <dt><code>-s</code> or <code>--socket</code></dt>
   <dd>
     <p>
-      The path to the socket file to use to communicate throught UNIX sockets.
+      The path to the UNIX socket file. Ignored if OS is not Unix (Linux, OSX, *bsd).
     </p>
     <p>
       <span class="label warning">Note</span>
-      this option can only be set when the `--protocol` is set to `only`.
+      this option can only be set when the `--protocol` is set to `local`. You can specify the pipe name as well if you aim to support Windows too.
     </p>
     <p><em>example:</em> <samp>bloop bsp --socket /var/run/bsp</p>
   </dd>
 
-  <dt><code>--np</code> or <code>--pipename</code></dt>
+  <dt><code>--pn</code> or <code>--pipename</code></dt>
   <dd>
     <p>
-      The path to the socket file to use to communicate throught UNIX sockets.
+      The name of the Windows communication pipe. Ignored if OS is not Windows.
     </p>
     <p>
       <span class="label warning">Note</span>
-      this option can only be set when the `--protocol` is set to `only`.
+      this option can only be set when the `--protocol` is set to `local`. You can specify the UNIX socket path if you aim to support UNIX systems too.
     </p>
     <p><em>example:</em> <samp>bloop bsp --protocol local --pipename /var/run/bsp</p>
   </dd>

--- a/website/content/docs/commands-reference.md
+++ b/website/content/docs/commands-reference.md
@@ -244,7 +244,8 @@ The following options are supported:
       The accepted values are <code>local</code> and <code>tcp</code>
     </p>
     <p>
-      <mark>Note</mark> when using the `tcp` protocol, the `--socket` option must be set, too.
+      <span class="label warning">Note</span>
+      when using the `tcp` protocol, the `--socket` option must be set, too.
     </p>
     <p><em>example:</em> <samp>bloop bsp --protocol tcp</samp></p>
   </dd>
@@ -255,7 +256,8 @@ The following options are supported:
       The hostname of the server.
     </p>
     <p>
-      <mark>Note</mark> this option can only be set when the `--protocol` is set to `tcp`.
+      <span class="label warning">Note</span>
+      this option can only be set when the `--protocol` is set to `tcp`.
     </p>
     <p><em>example:</em> <samp>bloop bsp --protocol tcp --host my-server.com</p>
   </dd>
@@ -266,7 +268,8 @@ The following options are supported:
       The port on which the server is listening. Defaults to <code>5001</code>
     </p>
     <p>
-      <mark>Note</mark> this option can only be set when the `--protocol` is set to `tcp`.
+      <span class="label warning">Note</span>
+      this option can only be set when the `--protocol` is set to `tcp`.
     </p>
     <p><em>example:</em> <samp>bloop bsp --protocol tcp --port 65001</p>
   </dd>
@@ -277,7 +280,8 @@ The following options are supported:
       The path to the socket file to use to communicate throught UNIX sockets.
     </p>
     <p>
-      <mark>Note</mark> this option can only be set when the `--protocol` is set to `only`.
+      <span class="label warning">Note</span>
+      this option can only be set when the `--protocol` is set to `only`.
     </p>
     <p><em>example:</em> <samp>bloop bsp --socket /var/run/bsp</p>
   </dd>
@@ -288,7 +292,8 @@ The following options are supported:
       The path to the socket file to use to communicate throught UNIX sockets.
     </p>
     <p>
-      <mark>Note</mark> this option can only be set when the `--protocol` is set to `only`.
+      <span class="label warning">Note</span>
+      this option can only be set when the `--protocol` is set to `only`.
     </p>
     <p><em>example:</em> <samp>bloop bsp --protocol local --pipename /var/run/bsp</p>
   </dd>

--- a/website/content/docs/commands-reference.md
+++ b/website/content/docs/commands-reference.md
@@ -204,7 +204,9 @@ The following options are supported:
   <dd>
     <p>Select the project to clean. This argument is required.</p>
     <p><em>example:</em> <samp>bloop clean -p foobar</samp></p>
+    <p><em>example:</em> <samp>bloop clean foobar</samp></p>
     <p><em>example:</em> <samp>bloop clean -p baz biz</samp></p>
+    <p><em>example:</em> <samp>bloop clean baz biz</samp></p>
   </dd>
 
   <dt><code>--isolated</code></dt>

--- a/website/content/docs/commands-reference.md
+++ b/website/content/docs/commands-reference.md
@@ -205,8 +205,8 @@ The following options are supported:
     <p>Select the project to clean. This argument is required.</p>
     <p><em>example:</em> <samp>bloop clean -p foobar</samp></p>
     <p><em>example:</em> <samp>bloop clean foobar</samp></p>
-    <p><em>example:</em> <samp>bloop clean -p baz biz</samp></p>
-    <p><em>example:</em> <samp>bloop clean baz biz</samp></p>
+    <p><em>example:</em> <samp>bloop clean -p foobar foobar-test</samp></p>
+    <p><em>example:</em> <samp>bloop clean foobar foobar-test biz</samp></p>
   </dd>
 
   <dt><code>--isolated</code></dt>

--- a/website/content/docs/commands-reference.md
+++ b/website/content/docs/commands-reference.md
@@ -30,7 +30,8 @@ The supported options are:
 <dl>
   <dt><code>-p</code> or <code>--project</code></dt>
   <dd>
-    <p>Select the project to compile. This argument is required.</p>
+    <p>Select the project to compile. This argument is required, but will be inferred if it's a remaining CLI args.</p>
+    <p><em>example:</em> <samp>bloop compile foobar</samp></p>
     <p><em>example:</em> <samp>bloop compile -p foobar</samp></p>
   </dd>
 
@@ -40,7 +41,7 @@ The supported options are:
       Whether to compile the project incrementally. Defaults to <code>true</code>. If this option is
       set to false, then the compiler will recompile all the sources.
     </p>
-    <p><em>example:</em> <samp>bloop compile -p foobar --incremental=false</samp></p>
+    <p><em>example:</em> <samp>bloop compile foobar --incremental=false</samp></p>
   </dd>
 
   <dt><code>--reporter</code></dt>
@@ -49,7 +50,7 @@ The supported options are:
       The error reporter to use. By default, Bloop's error reporter is use. The possible choices
       are <code>bloop</code> and <code>scalac</code>.
     </p>
-    <p><em>example:</em> <samp>bloop compile -p foobar --reporter scalac</samp>
+    <p><em>example:</em> <samp>bloop compile foobar --reporter scalac</samp>
   </dd>
 
   <dt><code>--watch</code></dt>
@@ -59,7 +60,7 @@ The supported options are:
       file of the project, or of the dependencies of the project, is modified, the
       <code>compile</code> command will be issued again, automatically.
     </p>
-    <p><em>example:</em> <samp>bloop compile -p foobar --watch</samp></p>
+    <p><em>example:</em> <samp>bloop compile foobar --watch</samp></p>
   </dd>
 </dl>
 
@@ -72,7 +73,8 @@ The supported options are:
 <dl>
   <dt><code>-p</code> or <code>--project</code></dt>
   <dd>
-    <p>Select the project to test. This argument is required.</p>
+    <p>Select the project to test. This argument is required, but will be inferred if it's a remaining CLI args.</p>
+    <p><em>example:</em> <samp>bloop test foobar</samp></p>
     <p><em>example:</em> <samp>bloop test -p foobar</samp></p>
   </dd>
 
@@ -82,7 +84,7 @@ The supported options are:
       Whether to run the tests only for the specified project, not including its dependencies. By
       default, the tests are run for the dependencies of the specified project and the project.
     </p>
-    <p><em>example:</em> <samp>bloop test -p foobar --isolated</samp></p>
+    <p><em>example:</em> <samp>bloop test foobar --isolated</samp></p>
   </dd>
 
   <dt><code>--reporter</code></dt>
@@ -91,7 +93,7 @@ The supported options are:
       The error reporter to use. By default, Bloop's error reporter is use. The possible choices
       are <code>bloop</code> and <code>scalac</code>.
     </p>
-    <p><em>example:</em> <samp>bloop test -p foobar --reporter scalac</samp>
+    <p><em>example:</em> <samp>bloop test foobar --reporter scalac</samp>
   </dd>
 
   <dt><code>--watch</code></dt>
@@ -101,7 +103,7 @@ The supported options are:
       file of the project, or of the dependencies of the project, is modified, the
       <code>test</code> command will be issued again, automatically.
     </p>
-    <p><em>example:</em> <samp>bloop test -p foobar --watch</samp></p>
+    <p><em>example:</em> <samp>bloop test foobar --watch</samp></p>
   </dd>
 </dl>
 
@@ -115,7 +117,8 @@ The supported options are:
 <dl>
   <dt><code>-p</code> or <code>--project</code></dt>
   <dd>
-    <p>Select the project to run. This argument is required.</p>
+    <p>Select the project to run. This argument is required, but will be inferred if it's a remaining CLI args.</p>
+    <p><em>example:</em> <samp>bloop run foobar</samp></p>
     <p><em>example:</em> <samp>bloop run -p foobar</samp></p>
   </dd>
 
@@ -125,7 +128,7 @@ The supported options are:
       The fully qualified class name of the class to run. Leave blank to let Bloop select
       automatically the class to run.
     </p>
-    <p><em>example:</em> <samp>bloop run -p foobar --main com.acme.Main</samp></p>
+    <p><em>example:</em> <samp>bloop run foobar --main com.acme.Main</samp></p>
   </dd>
 
   <dt><code>--reporter</code></dt>
@@ -134,7 +137,7 @@ The supported options are:
       The error reporter to use. By default, Bloop's error reporter is use. The possible choices
       are <code>bloop</code> and <code>scalac</code>.
     </p>
-    <p><em>example:</em> <samp>bloop run -p foobar --reporter scalac</samp>
+    <p><em>example:</em> <samp>bloop run foobar --reporter scalac</samp>
   </dd>
 
   <dt><code>--args</code></dt>
@@ -143,7 +146,7 @@ The supported options are:
       The arguments to pass to the <code>main()</code> function of the application. it is possible
       to specify this option more than once to pass several parameters.
     </p>
-    <p><em>example:</em> <samp>bloop run -p foobar --args hello --args world</samp>
+    <p><em>example:</em> <samp>bloop run foobar --args hello --args world</samp>
   </dd>
 
   <dt><code>--watch</code></dt>
@@ -153,7 +156,7 @@ The supported options are:
       file of the project, or of the dependencies of the project, is modified, the
       <code>test</code> command will be issued again, automatically.
     </p>
-    <p><em>example:</em> <samp>bloop test -p foobar --watch</samp></p>
+    <p><em>example:</em> <samp>bloop test foobar --watch</samp></p>
   </dd>
 </dl>
 
@@ -166,7 +169,8 @@ The following options are supported:
 <dl>
   <dt><code>-p</code> or <code>--project</code></dt>
   <dd>
-    <p>Select the project for which to start the console. This argument is required.</p>
+    <p>Select the project for which to start the console. This argument is required, but will be inferred if it's a remaining CLI args.</p>
+    <p><em>example:</em> <samp>bloop console foobar</samp></p>
     <p><em>example:</em> <samp>bloop console -p foobar</samp></p>
   </dd>
 
@@ -176,7 +180,7 @@ The following options are supported:
       The error reporter to use. By default, Bloop's error reporter is use. The possible choices
       are <code>bloop</code> and <code>scalac</code>.
     </p>
-    <p><em>example:</em> <samp>bloop console -p foobar --reporter scalac</samp>
+    <p><em>example:</em> <samp>bloop console foobar --reporter scalac</samp>
   </dd>
 
   <dt><code>--exclude-root</code></dt>
@@ -185,7 +189,7 @@ The following options are supported:
       Use this argument to start the console with all the dependencies of your project on the
       classpath, but not the project itself.
     </p>
-    <p><em>example:</em> <samp>bloop console -p foobar --exclude-root</samp>
+    <p><em>example:</em> <samp>bloop console foobar --exclude-root</samp>
   </dd>
 </dl>
 
@@ -200,6 +204,7 @@ The following options are supported:
   <dd>
     <p>Select the project to clean. This argument is required.</p>
     <p><em>example:</em> <samp>bloop clean -p foobar</samp></p>
+    <p><em>example:</em> <samp>bloop clean -p baz biz</samp></p>
   </dd>
 
   <dt><code>--isolated</code></dt>

--- a/website/content/docs/developer-documentation.md
+++ b/website/content/docs/developer-documentation.md
@@ -28,6 +28,15 @@ We recommend that whenever you make changes to the docs you add `[DOCS]` to the
 commit message to tell the CI server to skip tests and speed up the merge
 process.
 
+## Opening up our sbt build
+
+Bloop builds with sbt. For now, the bloop build only works if you have coursier
+as a global sbt plugin. We plan on fixing this limitation in the future if
+there is enough contributor activity in the repository.
+
+To check how to add coursier as a global plugin, check [coursier's
+instructions](https://github.com/coursier/coursier/).
+
 ## Building Bloop locally
 
 The following sequence of commands is sufficient to build Bloop, publish it


### PR DESCRIPTION
This is probably not the best patch this repository has seen, but I'm
quite happy with being able to do it at all so I won't complain.

The CLI handling in bloop has to fundamentally change because it's
introducing a lot of complexity, but for now we can deal with this
complexity since there are more important blockers on the road to
success.

The issue in this commit is that, because case-app derives the CLI
parsers from case classes, we have to turn projects into an optional
argument and set it in our CLI interpreter if the `-p` or `--project`
flags have not been passsed.

This introduces the problem that we, as maintainers, could be creating
instances of these case classes with no specified project at all, but
there is no short-term solution to this problem rather than rewriting
the whole CLI support and having two different ADTs for both parsing and
interpreting.

How bad the state of the art is doesn't matter much for now, this is
something that should affect core developers only and it solves a real
pain in the ass.

Fixes https://github.com/scalacenter/bloop/issues/154.