### PR TITLE
Upgrade to latest nailgun master ebe7ab23

### DIFF
--- a/frontend/src/main/scala/bloop/Server.scala
+++ b/frontend/src/main/scala/bloop/Server.scala
@@ -34,6 +34,7 @@ object Server {
     aliasManager.addAlias(new Alias("test", "Run project(s)' tests in the build.", classOf[Cli]))
     aliasManager.addAlias(
       new Alias("run", "Run a main entrypoint for project(s) in the build.", classOf[Cli]))
+    aliasManager.addAlias(new Alias("bsp", "Spawn a build server protocol instance.", classOf[Cli]))
     aliasManager.addAlias(
       new Alias("console", "Run the console for project(s) in the build.", classOf[Cli]))
     aliasManager.addAlias(new Alias("projects", "Show projects in the build.", classOf[Cli]))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 package build
 
 object Dependencies {
-  val nailgunVersion = "12448b9b"
+  val nailgunVersion = "ebe7ab23"
   val zincVersion = "1.1.0+9-57ca9e0f"
   val bspVersion = "03e9b72d"
   val coursierVersion = "1.0.0-RC8"


### PR DESCRIPTION
Two PRs got merged:

1. https://github.com/scalacenter/nailgun/pull/4
2. https://github.com/scalacenter/nailgun/pull/3

Accessible in https://github.com/scalacenter/nailgun/commits/bloop.

Release ebe7ab23 is already out.