### PR TITLE
Fix versioned installation script

### DIFF
--- a/bin/install.py
+++ b/bin/install.py
@@ -10,6 +10,7 @@ from os.path import expanduser, isdir, isfile, join
 from subprocess import CalledProcessError, check_call
 import sys
 
+# INSERT_INSTALL_VARIABLES
 BLOOP_DEFAULT_INSTALLATION_TARGET = join(expanduser("~"), ".bloop")
 COURSIER_URL = "https://git.io/vgvpD"
 


### PR DESCRIPTION
We used to put the variables that we insert at the very beginning of the
script, but we can no longer do this because this breaks with
`__future__` in Python that must appear before any actual code.

Fixes #334