### PR TITLE
Redesign file watching and add client listeners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ bin/.scalafmt*
 .zinc/
 .nailgun/
 
+# Directory in which to install locally bloop binaries to test them
+.devbloop/
+
 # zinc uses this local cache for publishing stuff
 .ivy2/
 

--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -10,6 +10,7 @@ import bloop.logging.Logger
 import sbt.internal.inc.{FreshCompilerCache, Locate, LoggedReporter, ZincUtil}
 
 case class CompileInputs(
+
     scalaInstance: ScalaInstance,
     compilerCache: CompilerCache,
     sourceDirectories: Array[AbsolutePath],

--- a/backend/src/main/scala/bloop/logging/BloopLogger.scala
+++ b/backend/src/main/scala/bloop/logging/BloopLogger.scala
@@ -1,11 +1,10 @@
 package bloop.logging
 
-import java.io.{FileOutputStream, OutputStream, PrintStream}
+import java.io.PrintStream
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.Console.{CYAN, GREEN, RED, RESET, YELLOW}
-
-import bloop.io.AbsolutePath
+import com.martiansoftware.nailgun.NGCommunicator
 
 /**
  * Creates a logger that writes to the given streams.

--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -1,15 +1,14 @@
 package bloop
 
 import bloop.cli.{CliOptions, Commands, ExitStatus}
-import bloop.cli.CliParsers.{inputStreamRead, printStreamRead, OptionsParser, pathParser}
-import bloop.engine.{Build, Exit, Interpreter, Run, State}
+import bloop.cli.CliParsers.{OptionsParser, inputStreamRead, pathParser, printStreamRead}
+import bloop.engine.{Build, Exit, Interpreter, NoPool, Run, State}
 import bloop.engine.tasks.Tasks
 import bloop.io.AbsolutePath
 import bloop.io.Timer.timed
 import bloop.logging.BloopLogger
 import jline.console.ConsoleReader
 import caseapp.{CaseApp, RemainingArgs}
-
 import jline.console.ConsoleReader
 
 import scala.annotation.tailrec
@@ -27,7 +26,7 @@ object Bloop extends CaseApp[CliOptions] {
     logger.verboseIf(options.verbose) {
       val projects = Project.fromDir(configDirectory, logger)
       val build = Build(configDirectory, projects)
-      val state = State(build, options.common, logger)
+      val state = State(build, NoPool, options.common, logger)
       run(state)
     }
   }

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -4,8 +4,7 @@ import bloop.bsp.BspServer
 import bloop.cli.validation.Validate
 import bloop.cli.{CliOptions, CliParsers, Commands, CommonOptions, ExitStatus}
 import bloop.engine.{Action, ClientPool, Exit, Interpreter, NailgunPool, NoPool, Print, Run, State}
-import bloop.io.Paths
-import bloop.logging.{BloopLogger, Logger}
+import bloop.logging.BloopLogger
 import caseapp.core.{DefaultBaseCommand, Messages}
 import com.martiansoftware.nailgun.NGContext
 
@@ -19,10 +18,13 @@ object Cli {
   }
 
   def nailMain(ngContext: NGContext): Unit = {
+    val server = ngContext.getNGServer
     val nailgunOptions = CommonOptions(
       in = ngContext.in,
       out = ngContext.out,
       err = ngContext.err,
+      ngout = server.out,
+      ngerr = server.err,
       workingDirectory = ngContext.getWorkingDirectory,
     )
     val command = ngContext.getCommand

--- a/frontend/src/main/scala/bloop/Server.scala
+++ b/frontend/src/main/scala/bloop/Server.scala
@@ -10,11 +10,15 @@ class Server
 object Server {
   private val defaultPort: Int = 8212 // 8100 + 'p'
   def main(args: Array[String]): Unit = {
+    run(mainTest(args))
+  }
+
+  private[bloop] def mainTest(args: Array[String]): NGServer = {
     val port = Try(args(0).toInt).getOrElse(Server.defaultPort)
     val addr = InetAddress.getLoopbackAddress
     val server = new NGServer(addr, port)
     registerAliases(server)
-    run(server)
+    server
   }
 
   def nailMain(ngContext: NGContext): Unit = {

--- a/frontend/src/main/scala/bloop/Server.scala
+++ b/frontend/src/main/scala/bloop/Server.scala
@@ -10,10 +10,10 @@ class Server
 object Server {
   private val defaultPort: Int = 8212 // 8100 + 'p'
   def main(args: Array[String]): Unit = {
-    run(mainTest(args))
+    run(instantiateServer(args))
   }
 
-  private[bloop] def mainTest(args: Array[String]): NGServer = {
+  private[bloop] def instantiateServer(args: Array[String]): NGServer = {
     val port = Try(args(0).toInt).getOrElse(Server.defaultPort)
     val addr = InetAddress.getLoopbackAddress
     val server = new NGServer(addr, port)

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -71,7 +71,8 @@ class BloopBspServices(callSiteState: State, client: JsonRpcClient, bspLogger: L
 
   private final val defaultOpts = callSiteState.commonOptions
   def reloadState(uri: String): State = {
-    val state0 = State.loadActiveStateFor(AbsolutePath(uri), defaultOpts, bspForwarderLogger)
+    val pool = callSiteState.pool
+    val state0 = State.loadActiveStateFor(AbsolutePath(uri), pool, defaultOpts, bspForwarderLogger)
     state0.copy(logger = bspForwarderLogger, commonOptions = latestState.commonOptions)
   }
 

--- a/frontend/src/main/scala/bloop/cli/CommonOptions.scala
+++ b/frontend/src/main/scala/bloop/cli/CommonOptions.scala
@@ -20,6 +20,8 @@ case class CommonOptions(
     @Hidden out: PrintStream = System.out,
     @Hidden in: InputStream = System.in,
     @Hidden err: PrintStream = System.err,
+    @Hidden ngout: PrintStream = System.out,
+    @Hidden ngerr: PrintStream = System.err,
     threads: Int = ExecutionContext.nCPUs
 ) {
   def workingPath: AbsolutePath = AbsolutePath(workingDirectory)

--- a/frontend/src/main/scala/bloop/engine/ClientPool.scala
+++ b/frontend/src/main/scala/bloop/engine/ClientPool.scala
@@ -1,0 +1,40 @@
+package bloop.engine
+
+import com.martiansoftware.nailgun.{NGClientDisconnectReason, NGClientListener, NGContext}
+
+sealed trait CloseEvent
+case object Heartbeat extends CloseEvent
+case object SocketError extends CloseEvent
+case object SocketTimeout extends CloseEvent
+case object SessionShutdown extends CloseEvent
+case object InternalError extends CloseEvent
+
+sealed trait ClientPool {
+  def addListener(f: CloseEvent => Unit): Unit
+  def removeAllListeners(): Unit
+}
+
+case object NoPool extends ClientPool {
+  override def addListener(f: CloseEvent => Unit): Unit = ()
+  override def removeAllListeners(): Unit = ()
+}
+
+case class NailgunPool(context: NGContext) extends ClientPool {
+  override def addListener(f: CloseEvent => Unit): Unit = {
+    val nailgunListener = new NGClientListener {
+      override def clientDisconnected(reason: NGClientDisconnectReason): Unit = {
+        f(reason match {
+          case NGClientDisconnectReason.HEARTBEAT => Heartbeat
+          case NGClientDisconnectReason.SOCKET_ERROR => SocketError
+          case NGClientDisconnectReason.SOCKET_TIMEOUT => SocketTimeout
+          case NGClientDisconnectReason.SESSION_SHUTDOWN => SessionShutdown
+          case NGClientDisconnectReason.INTERNAL_ERROR => InternalError
+        })
+      }
+    }
+    context.addClientListener(nailgunListener)
+    nailgunListener
+  }
+
+  override def removeAllListeners(): Unit = context.removeAllClientListeners()
+}

--- a/frontend/src/main/scala/bloop/engine/ClientPool.scala
+++ b/frontend/src/main/scala/bloop/engine/ClientPool.scala
@@ -21,7 +21,7 @@ case object NoPool extends ClientPool {
 
 case class NailgunPool(context: NGContext) extends ClientPool {
   override def addListener(f: CloseEvent => Unit): Unit = {
-    val nailgunListener = new NGClientListener {
+    context.addClientListener(new NGClientListener {
       override def clientDisconnected(reason: NGClientDisconnectReason): Unit = {
         f(reason match {
           case NGClientDisconnectReason.HEARTBEAT => Heartbeat
@@ -31,9 +31,7 @@ case class NailgunPool(context: NGContext) extends ClientPool {
           case NGClientDisconnectReason.INTERNAL_ERROR => InternalError
         })
       }
-    }
-    context.addClientListener(nailgunListener)
-    nailgunListener
+    })
   }
 
   override def removeAllListeners(): Unit = context.removeAllClientListeners()

--- a/frontend/src/main/scala/bloop/engine/ExecutionContext.scala
+++ b/frontend/src/main/scala/bloop/engine/ExecutionContext.scala
@@ -17,4 +17,5 @@ object ExecutionContext {
   }
 
   implicit val scheduler: Scheduler = Scheduler(executor)
+  implicit val ioScheduler: Scheduler = Scheduler.io("bloop-io")
 }

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -262,6 +262,7 @@ object Interpreter {
       pool.addListener {
         case e: CloseEvent =>
           previousState.logger.info(s"Client has disconnected with a $e event. Cancelling tasks...")
+          System.out.println(s"Client has disconnected with a $e event. Cancelling tasks...")
           handle.cancel()
           pool.removeAllListeners()
       }

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -261,13 +261,11 @@ object Interpreter {
       val handle = newState.runAsync(previousState.scheduler)
       pool.addListener {
         case e: CloseEvent =>
-          previousState.logger.info(s"Client has disconnected with a $e event. Cancelling tasks...")
-          System.out.println(s"Client has disconnected with a $e event. Cancelling tasks...")
+          System.out.println(s"Client has disconnected with a '$e' event. Cancelling tasks...")
           handle.cancel()
-          pool.removeAllListeners()
       }
       // Duration has to be infinity, we cannot predict how much time compilation takes
-      Await.result(newState.runAsync(previousState.scheduler), Duration.Inf)
+      Await.result(handle, Duration.Inf)
     } catch {
       case NonFatal(t) =>
         previousState.logger.error(t.getMessage)

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -268,7 +268,7 @@ object Interpreter {
       pool.addListener {
         case e: CloseEvent =>
           if (!handle.isCompleted) {
-            System.out.println(
+            ngout.println(
               s"Client in ${previousState.build.origin.syntax} has disconnected with a '$e' event. Cancelling tasks...")
             handle.cancel()
           }

--- a/frontend/src/main/scala/bloop/engine/State.scala
+++ b/frontend/src/main/scala/bloop/engine/State.scala
@@ -125,6 +125,6 @@ object State {
       State(build, pool, opts, logger)
     })
 
-    cached.copy(logger = logger)
+    cached.copy(pool = pool, commonOptions = opts, logger = logger)
   }
 }

--- a/frontend/src/main/scala/bloop/engine/State.scala
+++ b/frontend/src/main/scala/bloop/engine/State.scala
@@ -67,9 +67,6 @@ object State {
     State(build, results, compilerCache, pool, opts, ExitStatus.Ok, logger)
   }
 
-  def apply(build: Build, options: CommonOptions, logger: Logger): State =
-    apply(build, NoPool, options, logger)
-
   def setUpShutdownHoook(): Unit = {
     Runtime
       .getRuntime()

--- a/frontend/src/main/scala/bloop/io/SourceWatcher.scala
+++ b/frontend/src/main/scala/bloop/io/SourceWatcher.scala
@@ -3,12 +3,14 @@ package bloop.io
 import java.nio.file.Path
 
 import bloop.cli.ExitStatus
-import bloop.engine.State
+import bloop.engine.{ExecutionContext, State}
 import bloop.logging.Logger
 
 import scala.collection.JavaConverters._
 import io.methvin.watcher.DirectoryChangeEvent.EventType
 import io.methvin.watcher.{DirectoryChangeEvent, DirectoryChangeListener, DirectoryWatcher}
+import monix.eval.Task
+import monix.reactive.{MulticastStrategy, Observable}
 
 final class SourceWatcher(dirs0: Seq[Path], logger: Logger) {
   private val dirs = dirs0.distinct
@@ -49,6 +51,75 @@ final class SourceWatcher(dirs0: Seq[Path], logger: Logger) {
         logger.error("Unexpected error happened when file watching.")
         logger.trace(t)
         result.mergeStatus(ExitStatus.UnexpectedError)
+    }
+  }
+
+  private final val fakePath = java.nio.file.Paths.get("$$$bloop-monix-trigger-first-event$$$")
+  private final val triggerEventAtFirst =
+    new DirectoryChangeEvent(DirectoryChangeEvent.EventType.OVERFLOW, fakePath, -1)
+
+  def watch(state0: State, action: State => Task[State]): Task[State] = {
+    logger.debug(s"Watching the following directories: ${dirs.mkString(", ")}")
+
+    def runAction(state: State, event: DirectoryChangeEvent): Task[State] = {
+      Task(logger.debug(s"A ${event.eventType()} in ${event.path()} has triggered an event."))
+        .flatMap(_ => action(state))
+        .executeOn(state0.scheduler)
+    }
+
+    val (observer, observable) =
+      Observable.multicast[DirectoryChangeEvent](MulticastStrategy.publish)(
+        ExecutionContext.ioScheduler)
+
+    val compilationTask = observable
+      .foldLeftL(action(state0)) {
+        case (stateTask, e) =>
+          e.eventType match {
+            case EventType.CREATE => stateTask.flatMap(s => runAction(s, e))
+            case EventType.MODIFY => stateTask.flatMap(s => runAction(s, e))
+            case EventType.OVERFLOW => stateTask.flatMap(s => runAction(s, e))
+            case EventType.DELETE => stateTask
+          }
+      }
+      .flatten
+
+    val watcher = DirectoryWatcher.create(
+      dirsAsJava,
+      new DirectoryChangeListener {
+        @volatile var stop: Boolean = false
+        override def onEvent(event: DirectoryChangeEvent): Unit = {
+          val targetFile = event.path()
+          val targetPath = targetFile.toFile.getAbsolutePath()
+          if (Files.isRegularFile(targetFile) &&
+              (targetPath.endsWith(".scala") || targetPath.endsWith(".java"))) {
+            val ack = observer.onNext(event)
+            stop = ack.isCompleted
+          }
+        }
+      }
+    )
+
+    import scala.util.{Try, Success, Failure}
+    val watchingTask = Task {
+      Try {
+        try watcher.watch()
+        finally watcher.close()
+      }
+    }.doOnCancel(Task(watcher.close()))
+
+    val firstEventTriggerTask = Task(observer.onNext(triggerEventAtFirst))
+    val aggregated = Task.zip3(
+      firstEventTriggerTask.executeOn(ExecutionContext.ioScheduler),
+      watchingTask.executeOn(ExecutionContext.ioScheduler),
+      compilationTask.executeOn(state0.scheduler)
+    )
+
+    aggregated.map {
+      case (_, Success(_), state) => state
+      case (_, Failure(t), state) =>
+        state.logger.error("Unexpected file watching error")
+        state.logger.trace(t)
+        state.mergeStatus(ExitStatus.UnexpectedError)
     }
   }
 }

--- a/frontend/src/test/scala/bloop/logging/RecordingLogger.scala
+++ b/frontend/src/test/scala/bloop/logging/RecordingLogger.scala
@@ -15,7 +15,9 @@ class RecordingLogger extends AbstractLogger {
   override def verbose[T](op: => T): T = op
   override def debug(msg: String): Unit = { messages.add(("debug", msg)); () }
   override def info(msg: String): Unit = { messages.add(("info", msg)); () }
+  def serverInfo(msg: String): Unit = { messages.add(("server-info", msg)); () }
   override def error(msg: String): Unit = { messages.add(("error", msg)); () }
+  def serverError(msg: String): Unit = { messages.add(("server-error", msg)); () }
   override def warn(msg: String): Unit = { messages.add(("warn", msg)); () }
   private def trace(msg: String): Unit = { messages.add(("trace", msg)); () }
   override def trace(ex: Throwable): Unit = {

--- a/frontend/src/test/scala/bloop/nailgun/BasicNailgunSpec.scala
+++ b/frontend/src/test/scala/bloop/nailgun/BasicNailgunSpec.scala
@@ -104,14 +104,11 @@ class BasicNailgunSpec extends NailgunTest {
 
     // We check here the logs because until 'exit' the server doesn't flush everything
     val serverInfos = rlogger.getMessages().filter(_._1 == "server-info").map(_._2)
-    val cancellingTasks = serverInfos.filter(_.contains("Cancelling tasks..."))
-    val fileWatchingCancellations = serverInfos.filter(
+    val timesCancelling = serverInfos.count(_.contains("Cancelling tasks..."))
+    val timesCancelled = serverInfos.count(
       _ == "File watching on 'with-resources' and dependent projects has been successfully cancelled.")
 
-    val timesHappened = fileWatchingCancellations.size
-    assertTrue(s"The file watching cancellation happened $timesHappened only!", timesHappened == 2)
-
-    val timesCancelling = cancellingTasks.size
+    assertTrue(s"File watching cancellation happened $timesCancelled only!", timesCancelled == 2)
     assertTrue(s"Bloop registered task cancellation only $timesCancelling", timesCancelling == 2)
   }
 

--- a/frontend/src/test/scala/bloop/nailgun/BasicNailgunSpec.scala
+++ b/frontend/src/test/scala/bloop/nailgun/BasicNailgunSpec.scala
@@ -1,13 +1,16 @@
 package bloop.nailgun
 
+import java.util.concurrent.TimeUnit
+
 import scala.Console.{GREEN, RESET}
-
-import org.junit.{Ignore, Test}
+import org.junit.Test
 import org.junit.Assert.{assertEquals, assertTrue}
-
 import bloop.logging.RecordingLogger
 
 class BasicNailgunSpec extends NailgunTest {
+
+  val out = System.out
+  val err = System.err
 
   @Test
   def unknownCommandTest(): Unit = {
@@ -78,6 +81,38 @@ class BasicNailgunSpec extends NailgunTest {
         case _ => false
       })
     }
+  }
+
+  @Test
+  def testWatchCompileCommand(): Unit = {
+    var rlogger: RecordingLogger = null
+    withServerInProject("with-resources") { (logger, client) =>
+      client.success("clean", "with-resources")
+      val fileWatchingProcess = client.issueAsProcess("compile", "-w", "with-resources")
+      fileWatchingProcess.waitFor(4, TimeUnit.SECONDS)
+      fileWatchingProcess.destroyForcibly()
+
+      // Repeat the whole process again.
+      client.success("clean", "with-resources")
+      val fileWatchingProcess2 = client.issueAsProcess("compile", "-w", "with-resources")
+      fileWatchingProcess2.waitFor(4, TimeUnit.SECONDS)
+      fileWatchingProcess2.destroyForcibly()
+
+      // Ugly, but necessary for the sake of testing.
+      rlogger = logger
+    }
+
+    // We check here the logs because until 'exit' the server doesn't flush everything
+    val serverInfos = rlogger.getMessages().filter(_._1 == "server-info").map(_._2)
+    val cancellingTasks = serverInfos.filter(_.contains("Cancelling tasks..."))
+    val fileWatchingCancellations = serverInfos.filter(
+      _ == "File watching on 'with-resources' and dependent projects has been successfully cancelled.")
+
+    val timesHappened = fileWatchingCancellations.size
+    assertTrue(s"The file watching cancellation happened $timesHappened only!", timesHappened == 2)
+
+    val timesCancelling = cancellingTasks.size
+    assertTrue(s"Bloop registered task cancellation only $timesCancelling", timesCancelling == 2)
   }
 
   @Test

--- a/frontend/src/test/scala/bloop/nailgun/NailgunTest.scala
+++ b/frontend/src/test/scala/bloop/nailgun/NailgunTest.scala
@@ -41,7 +41,7 @@ abstract class NailgunTest {
           System.setOut(outStream)
           System.setErr(errStream)
           try {
-            optServer = Some(Server.mainTest(Array(TEST_PORT.toString)))
+            optServer = Some(Server.instantiateServer(Array(TEST_PORT.toString)))
           } finally {
             System.setOut(oldOut)
             System.setErr(oldErr)


### PR DESCRIPTION
Nailgun has this great concept of client listeners: closures that are called
whenever the nailgun server thinks that the client has disconnected. These
closures receive the kind of event that the nailgun server got, and executes
some logic.

This concept allows bloop to register callbacks that are run to clean
resources. Cleaning resources is paramount to keep the right behaviour of
long-running tasks like file watching and bsp servers.

This PR does three things:

1. Exposes the client listeners to the state, in a new abstraction called `ClientPool`.
2. It uses client listeners to cancel tasks, whenever the tasks accept cancellation.
3. Redesigns file watching in a Monix idiomatic style, with observables and
   consumers that help us reason about file watching events more reasonably.

Fixes https://github.com/scalacenter/bloop/issues/257 which was caused
because the cancellation of tasks for file watching did not work correctly
when `CTRL-C` was used.