### PR TITLE
Use different classes directory than sbt

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -87,8 +87,9 @@ object PluginImplementation {
         Keys.crossPaths.value
       )
 
-      if (!bloopTarget.exists()) sbt.io.IO.createDirectory(bloopTarget)
       val classesDir = bloopTarget / (Defaults.prefix(configuration.name) + "classes")
+      if (!classesDir.exists()) sbt.io.IO.createDirectory(classesDir)
+
       val sourceDirs = Keys.sourceDirectories.value
       val testFrameworks = Keys.testFrameworks.value.map(_.implClassNames)
       val scalacOptions = Keys.scalacOptions.value

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -50,7 +50,7 @@ object PluginImplementation {
 
   object PluginDefaults {
     import Compat._
-    import sbt.Task
+    import sbt.{Task, Defaults}
 
     lazy val bloopGenerate: Def.Initialize[Task[Unit]] = Def.task {
       def makeName(name: String, configuration: Configuration): String =
@@ -73,12 +73,22 @@ object PluginImplementation {
       val aggregates = project.aggregate.map(agg => makeName(agg.project, configuration))
       val dependenciesAndAggregates = dependencies ++ aggregates
 
+      val bloopConfigDir = BloopKeys.bloopConfigDir.value
       val scalaName = "scala-compiler"
       val scalaVersion = Keys.scalaVersion.value
       val scalaOrg = Keys.ivyScala.value.map(_.scalaOrganization).getOrElse("org.scala-lang")
       val allScalaJars = Keys.scalaInstance.value.allJars.map(_.getAbsoluteFile)
       val classpath = PluginDefaults.emulateDependencyClasspath.value.map(_.getAbsoluteFile)
-      val classesDir = Keys.classDirectory.value.getAbsoluteFile
+      val bloopTarget = Defaults.makeCrossTarget(
+        bloopConfigDir,
+        Keys.scalaBinaryVersion.value,
+        (Keys.sbtBinaryVersion in Keys.pluginCrossBuild).value,
+        Keys.sbtPlugin.value,
+        Keys.crossPaths.value
+      )
+
+      if (!bloopTarget.exists()) sbt.io.IO.createDirectory(bloopTarget)
+      val classesDir = bloopTarget / (Defaults.prefix(configuration.name) + "classes")
       val sourceDirs = Keys.sourceDirectories.value
       val testFrameworks = Keys.testFrameworks.value.map(_.implClassNames)
       val scalacOptions = Keys.scalacOptions.value
@@ -87,7 +97,6 @@ object PluginImplementation {
       val (javaHome, javaOptions) = javaConfiguration.value
 
       val tmp = Keys.target.value / "tmp-bloop"
-      val bloopConfigDir = BloopKeys.bloopConfigDir.value
       val outFile = bloopConfigDir / s"$projectName.config"
 
       // Force source generators on this task manually


### PR DESCRIPTION
Fixes https://github.com/scalacenter/bloop/issues/344.

We don't do what the ticket describes yet because that's something left
for the future. So far, reusing the `.bloop` directory (which should
already be in .gitignore) for the target makes sense.

In the future, we'll get the sbt integration to talk to the bsp server
of bloop and compile to that directory, making the experience of
switching from sbt to bloop and back and forth smooth.