### PR TITLE
Pretty print projects to be script friendly

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -129,12 +129,9 @@ object Interpreter {
       val contents = Dag.toDotGraph(state.build.dags)
       logger.info(contents)
     } else {
-      // TODO: Pretty print output of show projects, please.
       val configDirectory = state.build.origin.syntax
-      logger.info(s"Projects loaded from '$configDirectory':")
-      state.build.projects.map(_.name).sorted.foreach { projectName =>
-        logger.info(s" * $projectName")
-      }
+      logger.debug(s"Projects loaded from '$configDirectory':")
+      state.build.projects.map(_.name).sorted.foreach(logger.info)
     }
 
     state.mergeStatus(ExitStatus.Ok)

--- a/frontend/src/test/scala/bloop/engine/InterpreterSpec.scala
+++ b/frontend/src/test/scala/bloop/engine/InterpreterSpec.scala
@@ -31,7 +31,7 @@ class InterpreterSpec {
     val action = Run(Commands.Projects(cliOptions = cliOptions))
     Interpreter.execute(action, state)
     val output = outStream.toString("UTF-8")
-    assert(output.contains("Projects loaded from"), "Loaded projects were not shown on the logger.")
+    assert(output.contains("sbtRoot"), "Loaded projects were not shown on the logger.")
   }
 
   @Test def ShowAbout(): Unit = {

--- a/frontend/src/test/scala/bloop/nailgun/BasicNailgunSpec.scala
+++ b/frontend/src/test/scala/bloop/nailgun/BasicNailgunSpec.scala
@@ -57,8 +57,7 @@ class BasicNailgunSpec extends NailgunTest {
       val expectedProjects = "with-resources" :: "with-resources-test" :: Nil
 
       expectedProjects.foreach { proj =>
-        val needle = s" * $proj"
-        assertTrue(s"$messages didn't contain $needle'", messages.contains(("info", needle)))
+        assertTrue(s"$messages didn't contain $proj'", messages.contains(("info", proj)))
       }
     }
   }


### PR DESCRIPTION
Now, the "Projects loaded from" is hidden behind the verbose flag.

Fixes https://github.com/scalacenter/bloop/issues/338.