### PR TITLE
Add one more core to the available processors

### DIFF
--- a/frontend/src/main/scala/bloop/engine/ExecutionContext.scala
+++ b/frontend/src/main/scala/bloop/engine/ExecutionContext.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.{LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
 import monix.execution.Scheduler
 
 object ExecutionContext {
-  private[bloop] val nCPUs = Runtime.getRuntime.availableProcessors()
+  private[bloop] val nCPUs = Runtime.getRuntime.availableProcessors() + 1
 
   // This inlines the implementation of `Executors.newFixedThreadPool` to avoid losing the type
   private[bloop] val executor: ThreadPoolExecutor =


### PR DESCRIPTION
Let's add one more core because the monix infrastructure steals us one
blocking. Blocking is something that computers can easily put on timers,
so this way we won't waste one core that could be used to compile.