### PR TITLE
Update the build in every watch iteration

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -96,8 +96,10 @@ object Interpreter {
     val reachable = Dag.dfs(state.build.getDagFor(project))
     val allSourceDirs = reachable.iterator.flatMap(_.sourceDirectories.toList).map(_.underlying)
     val watcher = new SourceWatcher(project, allSourceDirs.toList, state.logger)
+    val fg = (state: State) => f(state).map(state => State.stateCache.updateBuild(state))
+
     // Force the first execution before relying on the file watching task
-    f(state).flatMap(newState => watcher.watch(newState, f))
+    fg(state).flatMap(newState => watcher.watch(newState, fg))
   }
 
   private def compile(cmd: Commands.Compile, state: State): Task[State] = {

--- a/frontend/src/main/scala/bloop/engine/caches/StateCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/StateCache.scala
@@ -24,7 +24,7 @@ final class StateCache(cache: ConcurrentHashMap[AbsolutePath, State]) {
    * @return The passed `State`, with a status code of `Ok`.
    */
   def updateBuild(state: State): State = {
-    cache.put(state.build.origin, state)
+    Option(cache.put(state.build.origin, state)).getOrElse(state)
   }
 
   /**

--- a/frontend/src/test/scala/bloop/engine/FileWatchingSpec.scala
+++ b/frontend/src/test/scala/bloop/engine/FileWatchingSpec.scala
@@ -17,7 +17,7 @@ import org.junit.experimental.categories.Category
 class FileWatchingSpec {
   @scala.annotation.tailrec
   final def readCompilingLines(target: Int, msg: String, out: ByteArrayOutputStream): Int = {
-    Thread.sleep(100) // Wait 100ms for the OS's file system
+    Thread.sleep(100) // Wait 150ms for the OS's file system
     val allContents = out.toString("UTF-8")
     val allLines = allContents.split(System.lineSeparator())
     val compiled = allLines.count(_.replaceAll("\u001B\\[[;\\d]*m", "").contains(msg))

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -196,7 +196,7 @@ object BuildImplementation {
   import ch.epfl.scala.sbt.release.ReleaseEarlyPlugin.{autoImport => ReleaseEarlyKeys}
 
   final val globalSettings: Seq[Def.Setting[_]] = Seq(
-    BuildKeys.schemaVersion := "1.2",
+    BuildKeys.schemaVersion := "1.2-refresh",
     Keys.testOptions in Test += sbt.Tests.Argument("-oD"),
     Keys.onLoadMessage := Header.intro,
     Keys.publishArtifact in Test := false,


### PR DESCRIPTION
Nailgun shuts down the executor service running the "server code"
whenever an exception is catched. This usually takes around 1000s after
the execption has been thrown.

This exception is thrown after a SIGKILL or SIGINT, for example. The
problem is that in 1000s our bloop tasks do not have time to return, and
that means that the `Await.result` in `Interpreter` never finishes.

Therefore, the logic never reaches `Cli` back, and the state is not
saved. This code is a temporary workaround thought to overcome this
limitation. It fixes the current problem in which the compilations that
happen in file watching are thrown away. Now they are cached, and
subsequent compile commands won't trigger compile afresh.