### PR TITLE
Change python2 to python in install instructions

### DIFF
--- a/website/content/docs/installation.md
+++ b/website/content/docs/installation.md
@@ -39,7 +39,7 @@ Homebrew also automatically installs completions for zsh and Bash.
 Install bloop in other platforms (Windows, Unix, \*bsd) via our python script:
 
 <pre><code class="language-sh">
-$ curl -L https://github.com/scalacenter/bloop/releases/download/v<span class="latest-version">1.0.0-M7</span>/install.py | python2
+$ curl -L https://github.com/scalacenter/bloop/releases/download/v<span class="latest-version">1.0.0-M7</span>/install.py | python
 </code></pre>
 
 The installation script will also install completions for zsh and Bash, but


### PR DESCRIPTION
Changes the installation instructions for other platforms to use generic `python` now that install scripts support both python 2 and 3.
This appears to be the last reference to `python2` in the project.