### PR TITLE
Remove clean terminal before file watching

### DIFF
--- a/frontend/src/main/scala/bloop/io/SourceWatcher.scala
+++ b/frontend/src/main/scala/bloop/io/SourceWatcher.scala
@@ -26,8 +26,6 @@ final class SourceWatcher(project: Project, dirs0: Seq[Path], logger: Logger) {
     val ngout = state0.commonOptions.ngout
     def runAction(state: State, event: DirectoryChangeEvent): Task[State] = {
       // Someone that wants this to be supported by Windows will need to make it work for all terminals
-      if (!BspServer.isWindows)
-        logger.info("\u001b[H\u001b[2J") // Clean the terminal before acting on the file event action
       logger.debug(s"A ${event.eventType()} in ${event.path()} has triggered an event.")
       action(state)
     }


### PR DESCRIPTION
This is causing misbehaviours in the terminals, because it sometimes
cleans the screen right after the compilation logs are outputted, and
therefore they are lost.

Fixes https://github.com/scalacenter/bloop/issues/379.