### PR TITLE
Ensure that file watching task exits

### DIFF
--- a/frontend/src/main/scala/bloop/engine/ExecutionContext.scala
+++ b/frontend/src/main/scala/bloop/engine/ExecutionContext.scala
@@ -1,7 +1,16 @@
 package bloop.engine
 
-import java.util.concurrent.{LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
-import monix.execution.Scheduler
+import java.lang.Thread.UncaughtExceptionHandler
+import java.util.concurrent.{
+  LinkedBlockingQueue,
+  SynchronousQueue,
+  ThreadFactory,
+  ThreadPoolExecutor,
+  TimeUnit
+}
+
+import monix.execution.{ExecutionModel, UncaughtExceptionReporter}
+import monix.execution.schedulers.ExecutorScheduler
 
 object ExecutionContext {
   private[bloop] val nCPUs = Runtime.getRuntime.availableProcessors() + 1
@@ -16,6 +25,42 @@ object ExecutionContext {
     java.util.concurrent.Executors.newFixedThreadPool(4)
   }
 
-  implicit val scheduler: Scheduler = Scheduler(executor)
-  implicit val ioScheduler: Scheduler = Scheduler.io("bloop-io")
+  implicit lazy val scheduler: Scheduler = Scheduler(executor)
+
+  val ioReporter = UncaughtExceptionReporter.LogExceptionsToStandardErr
+  lazy val ioExecutor: ThreadPoolExecutor = {
+    val threadFactory = monixThreadFactoryBuilder("bloop-io", ioReporter, daemonic = true)
+    new ThreadPoolExecutor(
+      0,
+      Int.MaxValue,
+      60,
+      TimeUnit.SECONDS,
+      new SynchronousQueue[Runnable](false),
+      threadFactory
+    )
+  }
+
+  implicit lazy val ioScheduler: Scheduler =
+    ExecutorScheduler(ioExecutor, ioReporter, ExecutionModel.Default)
+
+  // Inlined from `monix.execution.schedulers.ThreadFactoryBuilder`
+  private def monixThreadFactoryBuilder(
+      name: String,
+      reporter: UncaughtExceptionReporter,
+      daemonic: Boolean
+  ): ThreadFactory = {
+    new ThreadFactory {
+      def newThread(r: Runnable) = {
+        val thread = new Thread(r)
+        thread.setName(name + "-" + thread.getId)
+        thread.setDaemon(daemonic)
+        thread.setUncaughtExceptionHandler(new UncaughtExceptionHandler {
+          override def uncaughtException(t: Thread, e: Throwable): Unit =
+            reporter.reportFailure(e)
+        })
+
+        thread
+      }
+    }
+  }
 }

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -92,7 +92,7 @@ object Interpreter {
     BspServer.run(cmd, state, scheduler)
   }
 
-  private def watch(project: Project, state: State, f: State => Task[State]): Task[State] = {
+  private[bloop] def watch(project: Project, state: State, f: State => Task[State]): Task[State] = {
     val reachable = Dag.dfs(state.build.getDagFor(project))
     val allSourceDirs = reachable.iterator.flatMap(_.sourceDirectories.toList).map(_.underlying)
     val watcher = new SourceWatcher(project, allSourceDirs.toList, state.logger)

--- a/frontend/src/main/scala/bloop/engine/caches/StateCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/StateCache.scala
@@ -18,13 +18,14 @@ final class StateCache(cache: ConcurrentHashMap[AbsolutePath, State]) {
   }
 
   /**
-   * Updates the cache with `state`. The
+   * Updates the cache with `state`.
    *
    * @param state The state to put in the cache.
-   * @return The passed `State`, with a status code of `Ok`.
+   * @return The updated `State`.
    */
   def updateBuild(state: State): State = {
-    Option(cache.put(state.build.origin, state)).getOrElse(state)
+    cache.put(state.build.origin, state)
+    state
   }
 
   /**

--- a/frontend/src/main/scala/bloop/monix/FoldLeftAsyncConsumer.scala
+++ b/frontend/src/main/scala/bloop/monix/FoldLeftAsyncConsumer.scala
@@ -1,0 +1,83 @@
+package bloop.monix
+
+import monix.eval.{Callback, Task}
+import monix.execution.Ack.{Continue, Stop}
+import monix.execution.{Ack, Cancelable, Scheduler}
+import monix.execution.cancelables.{AssignableCancelable, CompositeCancelable}
+import monix.execution.misc.NonFatal
+import monix.reactive.{Consumer, Observable}
+import monix.reactive.observers.Subscriber
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.Future
+
+// Fork of `FoldLeftAsyncConsumer` from Monix
+final class FoldLeftAsyncConsumer[A, R](
+    initial: () => R,
+    f: (R, A) => Task[R]
+) extends Consumer[A, R] {
+
+  def createSubscriber(cb: Callback[R], s: Scheduler): (Subscriber[A], AssignableCancelable) = {
+    val cancelables = new ListBuffer[Cancelable]()
+    val out = new Subscriber[A] {
+      implicit val scheduler = s
+      private[this] var isDone = false
+      private[this] var state = initial()
+
+      def onNext(elem: A): Future[Ack] = {
+        // Protects calls to user code from within the operator,
+        // as a matter of contract.
+        try {
+          val task = f(state, elem).transform(update => {
+            state = update
+            Continue: Continue
+          }, error => {
+            onError(error)
+            Stop: Stop
+          })
+
+          val future = task.runAsync
+          cancelables.+=(future)
+          future
+        } catch {
+          case NonFatal(ex) =>
+            onError(ex)
+            Stop
+        }
+      }
+
+      def onComplete(): Unit =
+        if (!isDone) {
+          isDone = true
+          cb.onSuccess(state)
+        }
+
+      def onError(ex: Throwable): Unit =
+        if (!isDone) {
+          isDone = true
+          cb.onError(ex)
+        }
+    }
+
+    val completer = Cancelable(() => out.onComplete())
+    val cancelable = AssignableCancelable.multi { () =>
+      Cancelable.cancelAll(completer :: cancelables.toList)
+    }
+
+    (out, cancelable)
+  }
+
+  override def apply(source: Observable[A]): Task[R] = {
+    Task.create[R] { (scheduler, cb) =>
+      val (out, consumerSubscription) = createSubscriber(cb, scheduler)
+      val sourceSubscription = source.subscribe(out)
+      CompositeCancelable(sourceSubscription, consumerSubscription)
+    }
+  }
+
+}
+
+object FoldLeftAsyncConsumer {
+  def consume[S, A](initial: => S)(f: (S, A) => Task[S]): Consumer[A, S] =
+    new FoldLeftAsyncConsumer[A, S](initial _, f)
+}


### PR DESCRIPTION
Previously, `cancel` would not complete the task. This refactoring makes
sure that the task is cancelled and that the completion returns the last
state processed by the consumer.

Such improvement makes sure that there's no hanging task listening to file
watching events.

Fixes #379.