### PR TITLE
Add flag to support source dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,8 @@
 import build.BuildImplementation.BuildDefaults
 
+// Tell bloop to aggregate source deps (benchmark) config files in the same bloop config dir
+bloopAggregateSourceDependencies in Global := true
+
 /***************************************************************************************************/
 /*                      This is the build definition of the source deps                            */
 /***************************************************************************************************/


### PR DESCRIPTION
The main issue with source deps in Bloop arises from the fact that, by
design, `bloopConfigDir` is build dependent, which means that it changes
across different source deps.

We don't want this to be the case for source dependencies though, since
Bloop needs all the project dependencies to be in the same directory.
For that reason, this flag aggregates the bloop config files to be
written to the same bloop configuration directory, and hence have it
work nicely with bloop.

Fixes #375.