### PR TITLE
Add batch of last minute improvements

### DIFF
--- a/frontend/src/main/scala/bloop/Project.scala
+++ b/frontend/src/main/scala/bloop/Project.scala
@@ -8,8 +8,9 @@ import bloop.exec.JavaEnv
 import bloop.io.{AbsolutePath, Paths}
 import bloop.io.Timer.timed
 import bloop.logging.Logger
-
 import xsbti.compile.ClasspathOptions
+
+import scala.util.control.NoStackTrace
 
 case class Project(name: String,
                    baseDirectory: AbsolutePath,
@@ -105,10 +106,20 @@ object Project {
     val classpath = toPaths(properties.getProperty("classpath"))
     val classesDir = toPath(properties.getProperty("classesDir"))
     val classpathOptions = {
-      val values = properties.getProperty("classpathOptions").split(",")
-      val Array(bootLibrary, compiler, extra, autoBoot, filterLibrary) =
-        values.map(java.lang.Boolean.parseBoolean)
-      ClasspathOptions.of(bootLibrary, compiler, extra, autoBoot, filterLibrary)
+      val opts = properties.getProperty("classpathOptions")
+      // Protecting our users from breaking changes in the configuration file format.
+      if (opts == null) {
+        throw new Exception(
+          """The field for classpath options doesn't exist.
+            |Please export your project again from your build tool (e.g. `bloopInstall`).
+            |Check the installation page for further information: https://scalacenter.github.io/bloop/docs/installation
+          """.stripMargin) with NoStackTrace
+      } else {
+        val values = opts.split(",")
+        val Array(bootLibrary, compiler, extra, autoBoot, filterLibrary) =
+          values.map(java.lang.Boolean.parseBoolean)
+        ClasspathOptions.of(bootLibrary, compiler, extra, autoBoot, filterLibrary)
+      }
     }
     val scalacOptions =
       properties.getProperty("scalacOptions").split(";").filterNot(_.isEmpty)

--- a/frontend/src/test/scala/bloop/logging/RecordingLogger.scala
+++ b/frontend/src/test/scala/bloop/logging/RecordingLogger.scala
@@ -9,7 +9,9 @@ class RecordingLogger extends AbstractLogger {
   def clear(): Unit = messages.clear()
   def getMessages(): List[(String, String)] = messages.iterator.asScala.toList.map {
     // Remove trailing '\r' so that we don't have to special case for Windows
-    case (category, msg) => (category, msg.stripSuffix("\r"))
+    case (category, msg0) =>
+      val msg = if (msg0 == null) "<null reference>" else msg0
+      (category, msg.stripSuffix("\r"))
   }
 
   override val name: String = "RecordingLogger"

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -117,6 +117,7 @@ object PluginImplementation {
       val configuration = Keys.configuration.value
       val projectName = makeName(project.id, configuration)
       val baseDirectory = Keys.baseDirectory.value.getAbsoluteFile
+      val buildBaseDirectory = Keys.baseDirectory.in(ThisBuild).value.getAbsoluteFile
 
       // In the test configuration, add a dependency on the base project
       val baseProjectDependency = if (configuration == Test) List(project.id) else Nil
@@ -184,7 +185,7 @@ object PluginImplementation {
       sbt.IO.createDirectory(bloopConfigDir)
       config.writeTo(outFile)
       logger.debug(s"Bloop wrote the configuration of project '$projectName' to '$outFile'.")
-      val relativeConfigPath = outFile.relativeTo(baseDirectory).getOrElse(outFile)
+      val relativeConfigPath = outFile.relativeTo(buildBaseDirectory).getOrElse(outFile)
       logger.success(s"Generated $relativeConfigPath")
       // format: ON
     }


### PR DESCRIPTION
1. Prettify exception reporting.
2. Stringify `null` in `RecordingLogger` to catch spurious test errors in CI.
3. Use build base directory to shorten paths.
4. Tell users to regenerate configuration files if `classpathOptions` is missing.

All has been tested locally.