### PR TITLE
Detect "compile->test" configurations in sbt

### DIFF
--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -196,7 +196,7 @@ object BuildImplementation {
   import ch.epfl.scala.sbt.release.ReleaseEarlyPlugin.{autoImport => ReleaseEarlyKeys}
 
   final val globalSettings: Seq[Def.Setting[_]] = Seq(
-    BuildKeys.schemaVersion := "1.3-refresh",
+    BuildKeys.schemaVersion := "1.3-refresh2",
     Keys.testOptions in Test += sbt.Tests.Argument("-oD"),
     Keys.onLoadMessage := Header.intro,
     Keys.publishArtifact in Test := false,


### PR DESCRIPTION
I detect this problem when using bloop. The configuration of the project
reference is important because a classpath dependency may point to an
arbitrary project dependency. An example of this is the "compile->test"
dependency to frontend from our `benchmark` project.

To solve this issue, we need to select the right name from the
configuration of the project ref, and only fallback to the configuration
of the scoped running task when that one is empty.