### PR TITLE
Add improvements to sbt plugin and migrate to `.bloop`

### DIFF
--- a/build-integrations/global/plugins.sbt
+++ b/build-integrations/global/plugins.sbt
@@ -22,7 +22,8 @@ libraryDependencies := {
   // We dont' add sbt-coursier to all because of sbt-native-packager issues, sigh
   if (sbtVersion.startsWith("1.")) {
     List(
-      sbtPluginExtra("com.lucidchart" % "sbt-scalafmt" % "1.15", sbtVersion, scalaVersion)
+      sbtPluginExtra("com.lucidchart" % "sbt-scalafmt" % "1.15", sbtVersion, scalaVersion),
+      sbtPluginExtra("com.eed3si9n" % "sbt-assembly" % "0.14.6", sbtVersion, scalaVersion)
     )
   } else {
     List()

--- a/build-integrations/sbt-1.0/.sbtopts
+++ b/build-integrations/sbt-1.0/.sbtopts
@@ -1,2 +1,2 @@
 # Required because of sbt bug when picking up the property from the working directory
--Dsbt.version=1.1.0
+-Dsbt.version=1.1.1

--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -17,7 +17,7 @@ object Bloop extends CaseApp[CliOptions] {
   private val reader = consoleReader()
 
   override def run(options: CliOptions, remainingArgs: RemainingArgs): Unit = {
-    val configDirectory = options.configDir.map(AbsolutePath.apply).getOrElse(AbsolutePath(".bloop-config"))
+    val configDirectory = options.configDir.map(AbsolutePath.apply).getOrElse(AbsolutePath(".bloop"))
     val logger = BloopLogger.default(configDirectory.syntax)
     logger.warn("The Nailgun integration should be preferred over the Bloop shell.")
     logger.warn(

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -199,7 +199,7 @@ object Cli {
     def getConfigDir(cliOptions: CliOptions): AbsolutePath = {
       cliOptions.configDir
         .map(AbsolutePath.apply)
-        .getOrElse(cliOptions.common.workingPath.resolve(".bloop-config"))
+        .getOrElse(cliOptions.common.workingPath.resolve(".bloop"))
     }
 
     val cliOptions = action match {

--- a/frontend/src/main/scala/bloop/cli/CliOptions.scala
+++ b/frontend/src/main/scala/bloop/cli/CliOptions.scala
@@ -7,7 +7,7 @@ import caseapp.{ExtraName, HelpMessage, Recurse, ValueDescription}
 case class CliOptions(
     @ExtraName("c")
     @HelpMessage("File path to the bloop config directory.")
-    @ValueDescription(".bloop-config")
+    @ValueDescription(".bloop")
     configDir: Option[Path] = None,
     @ExtraName("v")
     @HelpMessage("If set, print the about section at the beginning of the execution.")

--- a/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
@@ -63,10 +63,10 @@ object BspClientTest {
       val lsServer = new LanguageServer(messages, lsClient, services, scheduler, slf4jLogger)
       val runningClientServer = lsServer.startTask.runAsync(scheduler)
 
-      val cwd = configDirectory.getParent
+      val cwd = ProjectHelpers.getBaseFromConfigDir(configDirectory.underlying)
       val initializeServer = endpoints.Build.initialize.request(
         InitializeBuildParams(
-          rootUri = cwd.syntax,
+          rootUri = cwd.toAbsolutePath.toString,
           Some(BuildClientCapabilities(List("scala")))
         )
       )

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -14,7 +14,7 @@ import org.langmeta.lsp.LanguageClient
 
 class BspProtocolSpec {
   private final val configDir = AbsolutePath(ProjectHelpers.getBloopConfigDir("utest"))
-  private final val cwd = configDir.getParent
+  private final val cwd = AbsolutePath(ProjectHelpers.getBaseFromConfigDir(configDir.underlying))
   private final val tempDir = Files.createTempDirectory("temp-sockets")
   tempDir.toFile.deleteOnExit()
 

--- a/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
+++ b/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
@@ -29,7 +29,7 @@ object IntegrationTestSuite {
 @Category(Array(classOf[bloop.SlowTests]))
 @RunWith(classOf[Parameterized])
 class IntegrationTestSuite(testDirectory: Path) {
-  val integrationTestName = testDirectory.getParent.getFileName.toString
+  val integrationTestName = ProjectHelpers.getBaseFromConfigDir(testDirectory).getFileName.toString
 
   def isCommunityBuildEnabled: Boolean = {
     import scala.util.Try

--- a/frontend/src/test/scala/bloop/tasks/ProjectHelpers.scala
+++ b/frontend/src/test/scala/bloop/tasks/ProjectHelpers.scala
@@ -23,6 +23,8 @@ object ProjectHelpers {
   def getProject(name: String, state: State): Project =
     state.build.getProjectFor(name).getOrElse(sys.error(s"Project '$name' does not exist!"))
 
+  def getBaseFromConfigDir(configDir: Path): Path = configDir.getParent.getParent
+
   val RootProject = "target-project"
   def checkAfterCleanCompilation(
       structures: Map[String, Map[String, String]],

--- a/integrations/maven-bloop/src/main/java/bloop/integrations/maven/BloopMojo.java
+++ b/integrations/maven-bloop/src/main/java/bloop/integrations/maven/BloopMojo.java
@@ -22,7 +22,7 @@ public class BloopMojo extends ExtendedScalaContinuousCompileMojo {
     @Component
     private MavenPluginManager mavenPluginManager;
 
-    @Parameter(property = "bloop.configDirectory", defaultValue = "${session.executionRootDirectory}/.bloop-config")
+    @Parameter(property = "bloop.configDirectory", defaultValue = "${session.executionRootDirectory}/.bloop")
     private File bloopConfigDir;
 
     @Parameter(property = "scala.artifactID", defaultValue = "scala-compiler")

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -60,6 +60,7 @@ object PluginImplementation {
   // We create build setting proxies to global settings so that we get autocompletion (sbt bug)
   val buildSettings: Seq[Def.Setting[_]] = List(
     BloopKeys.bloopInstall := BloopKeys.bloopInstall.in(Global).value,
+    // Bloop users: Do NEVER override this setting as a user if you want it to work
     BloopKeys.bloopAggregateSourceDependencies :=
       BloopKeys.bloopAggregateSourceDependencies.in(Global).value
   )
@@ -150,6 +151,7 @@ object PluginImplementation {
       val projectName = nameFromString(project.id, configuration)
       val baseDirectory = Keys.baseDirectory.value.getAbsoluteFile
       val buildBaseDirectory = Keys.baseDirectory.in(ThisBuild).value.getAbsoluteFile
+      val rootBaseDirectory = new File(Keys.loadedBuild.value.root)
 
       // In the test configuration, add a dependency on the base project
       val baseProjectDependency = if (configuration == Test) List(project.id) else Nil
@@ -217,7 +219,15 @@ object PluginImplementation {
       sbt.IO.createDirectory(bloopConfigDir)
       config.writeTo(outFile)
       logger.debug(s"Bloop wrote the configuration of project '$projectName' to '$outFile'.")
-      val relativeConfigPath = outFile.relativeTo(buildBaseDirectory).getOrElse(outFile)
+
+      val allInRoot = BloopKeys.bloopAggregateSourceDependencies.in(Global).value
+      // Only shorten path for configuration files written to the the root build
+      val relativeConfigPath = {
+        if (allInRoot || buildBaseDirectory == rootBaseDirectory)
+          outFile.relativeTo(rootBaseDirectory).getOrElse(outFile)
+        else outFile
+      }
+
       logger.success(s"Generated $relativeConfigPath")
       // format: ON
     }

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -87,10 +87,10 @@ object PluginImplementation {
       Def.setting {
         (BloopKeys.bloopConfigDir in Global).?.value.getOrElse {
           if (BloopKeys.bloopAggregateSourceDependencies.in(Global).value) {
-            (Keys.baseDirectory in rootBuild).value / ".bloop-config"
+            (Keys.baseDirectory in rootBuild).value / ".bloop"
           } else {
             // We do this so that it works nicely with source dependencies.
-            (Keys.baseDirectory in ref in ThisBuild).value / ".bloop-config"
+            (Keys.baseDirectory in ref in ThisBuild).value / ".bloop"
           }
         }
       }

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -367,6 +367,7 @@ object BuildImplementation {
 
     val buildIntegrationsBase = BuildKeys.buildIntegrationsBase.value
     val buildIndexFile = BuildKeys.buildIntegrationsIndex.value
+    val schemaVersion = BuildKeys.schemaVersion.value
     val stagingBase = BuildKeys.integrationStagingBase.value.getCanonicalFile.getAbsolutePath
     val cacheDirectory = file(stagingBase) / "integrations-cache"
 
@@ -389,7 +390,8 @@ object BuildImplementation {
         val settingsProperty = s"-D${BuildPaths.GlobalSettingsProperty}=${globalSettingsBase}"
         val pluginsProperty = s"-D${BuildPaths.GlobalPluginsProperty}=${globalPluginsBase}"
         val indexProperty = s"-Dbloop.integrations.index=${buildIndexFile.getAbsolutePath}"
-        val properties = stagingProperty :: indexProperty :: pluginsProperty :: settingsProperty :: Nil
+        val schemaProperty = s"-Dbloop.integrations.schemaVersion=$schemaVersion"
+        val properties = stagingProperty :: indexProperty :: pluginsProperty :: settingsProperty :: schemaProperty :: Nil
         val toRun = "cleanAllBuilds" :: "bloopInstall" :: "buildIndex" :: Nil
         val cmdBase = if (isWindows) "cmd.exe" :: "/C" :: "sbt.bat" :: Nil else "sbt" :: Nil
         val cmd = cmdBase ::: properties ::: toRun

--- a/website/content/docs/commands-reference.md
+++ b/website/content/docs/commands-reference.md
@@ -14,7 +14,7 @@ This commands displays all the projects that have been loaded from the current w
 
 ```
 $ bloop projects
-Projects loaded from '/Users/martin/foobar/.bloop-config':
+Projects loaded from '/Users/martin/foobar/.bloop':
  * foobar
  * foobar-test
 ```

--- a/website/content/docs/installation.md
+++ b/website/content/docs/installation.md
@@ -89,6 +89,16 @@ $ sbt bloopInstall
 
 The configuration files contain the information of the sbt build at the moment of running `bloopInstall`. Note that it contains machine-dependent information (the path of every resolved jar) so you should not check it into your version control system.
 
+#### Support for source dependencies
+
+If you use source dependencies in sbt, add the following setting definition to your `build.sbt`:
+
+```scala
+bloopAggregateSourceDependencies in Global := true
+```
+
+<span class="label warning">Note</span> that `bloopAggregateSourceDependencies` has to be scoped globally.
+
 #### Start bloop
 
 Before using the bloop client, you need to start the Bloop server. There is usually only one bloop server running in a machine.

--- a/website/content/docs/installation.md
+++ b/website/content/docs/installation.md
@@ -83,8 +83,8 @@ Once sbt is configured, you can run `bloopInstall` to generate the Bloop configu
 $ sbt bloopInstall
 [info] Loading global plugins from /Users/martin/.sbt/1.0/plugins
 (...)
-[success] Bloop wrote the configuration of project 'foo' to '/my-project/.bloop-config/foo.config'.
-[success] Bloop wrote the configuration of project 'foo-test' to '/my-project/.bloop-config/foo-test.config'.
+[success] Bloop wrote the configuration of project 'foo' to '/my-project/.bloop/foo.config'.
+[success] Bloop wrote the configuration of project 'foo-test' to '/my-project/.bloop/foo-test.config'.
 ```
 
 The configuration files contain the information of the sbt build at the moment of running `bloopInstall`. Note that it contains machine-dependent information (the path of every resolved jar) so you should not check it into your version control system.
@@ -136,7 +136,7 @@ bloop has detected in that configuration directory. If you get none, you can che
 
 ```sh
 $ bloop projects --verbose
-[D] Projects loaded from '/my-project/.bloop-config':
+[D] Projects loaded from '/my-project/.bloop':
 foo
 foo-test
 ```

--- a/website/content/faq/_index.md
+++ b/website/content/faq/_index.md
@@ -35,7 +35,7 @@ Good question! In short, it's not. Read about it in our [Basics]({{< relref
 
 Bloop uses a different classes directory than sbt to avoid synchronization
 and cache invalidation issues. The classes directories for all projects are
-typically stored in the `.bloop-config/` directory, where every project gets
+typically stored in the `.bloop/` directory, where every project gets
 its own folder.
 
 A classes directory is stored in a similar path as sbt: `target/classes`, and


### PR DESCRIPTION
I noticed that our `integrationSetUpBloop` was displaying logs with the
paths shortened, when they shouldn't because all the configuration files
are written in the staging sbt directory (because they are source deps).
This commit fixes it.