### PR TITLE
Remove stale configuration files

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,8 +1,10 @@
 # We publishLocal the maven plugin instead of compile to check the maven plugin integration
+# Only test sbt-bloop 1.x because of bug in `^`
 matrix:
   SBT_RUN:
     - sbt "benchmarks/compile" \
           "jsonConfig/test" \
+          "sbtBloop/scripted" \
           "frontend/integrationSetUpBloop" \
           "backend/test" \
           "frontend/test" \

--- a/build.sbt
+++ b/build.sbt
@@ -114,7 +114,8 @@ lazy val sbtBloop = project
     bintrayPackage := "sbt-bloop",
     bintrayOrganization := Some("sbt"),
     bintrayRepository := "sbt-plugin-releases",
-    publishMavenStyle := releaseEarlyWith.value == SonatypePublisher
+    publishMavenStyle := releaseEarlyWith.value == SonatypePublisher,
+    publishLocal := publishLocal.dependsOn(publishLocal in jsonConfig).value
   )
 
 val mavenBloop = project

--- a/build.sbt
+++ b/build.sbt
@@ -103,8 +103,10 @@ val benchmarks = project
   )
 
 lazy val sbtBloop = project
+  .enablePlugins(ScriptedPlugin)
   .in(file("integrations") / "sbt-bloop")
   .dependsOn(jsonConfig)
+  .settings(BuildDefaults.scriptedSettings)
   .settings(
     name := "sbt-bloop",
     sbtPlugin := true,

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -272,7 +272,9 @@ object PluginImplementation {
     lazy val bloopInstall: Def.Initialize[Task[Unit]] = Def.taskDyn {
       val filter = sbt.ScopeFilter(sbt.inAnyProject, sbt.inConfigurations(Compile, Test))
       val allConfigDirs =
-        BloopKeys.bloopConfigDir.all(sbt.ScopeFilter(sbt.inAnyProject)).map(_.toSet).value
+        BloopKeys.bloopConfigDir.?.all(sbt.ScopeFilter(sbt.inAnyProject))
+          .map(_.flatMap(_.toList).toSet)
+          .value
       val removeProjects = removeStaleProjects(allConfigDirs)
       BloopKeys.bloopGenerate
         .all(filter)

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/stale-projects/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/stale-projects/build.sbt
@@ -1,0 +1,2 @@
+val foo = project.in(file("."))
+val bar = project

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/stale-projects/changes/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/stale-projects/changes/build.sbt
@@ -1,0 +1,1 @@
+val foo = project.in(file("."))

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/stale-projects/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/stale-projects/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/stale-projects/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/stale-projects/test
@@ -1,0 +1,12 @@
+> bloopInstall
+$ exists .bloop/foo.json
+$ exists .bloop/foo-test.json
+$ exists .bloop/bar.json
+$ exists .bloop/bar-test.json
+$ copy-file changes/build.sbt build.sbt
+> reload
+> bloopInstall
+$ exists .bloop/foo.json
+$ exists .bloop/foo-test.json
+-$ exists .bloop/bar.json
+-$ exists .bloop/bar-test.json

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -313,6 +313,14 @@ object BuildImplementation {
       ),
     )
 
+    import sbt.ScriptedPlugin.{autoImport => ScriptedKeys}
+    val scriptedSettings: Seq[Def.Setting[_]] = List(
+      ScriptedKeys.scriptedBufferLog := false,
+      ScriptedKeys.scriptedLaunchOpts := { ScriptedKeys.scriptedLaunchOpts.value ++
+        Seq("-Xmx1024M", "-Dplugin.version=" + Keys.version.value)
+      }
+    )
+
     val releaseEarlyPublish: Def.Initialize[Task[Unit]] = Def.task {
       val logger = Keys.streams.value.log
       val name = Keys.name.value

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -22,6 +22,7 @@ val root = project
     addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.1"),
     addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2"),
     addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.1"),
+    libraryDependencies += { "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value },
     // Let's add our sbt plugin to the sbt too ;)
     unmanagedSourceDirectories in Compile ++= {
       val baseDir = baseDirectory.value.getParentFile

--- a/website/content/faq/_index.md
+++ b/website/content/faq/_index.md
@@ -47,6 +47,17 @@ in your sbt build like [here](https://github.com/scalacenter/bloop/blob/6e1d55cc
 <span class="label warning">Note</span> that you need to scope it in every
 sbt project.
 
+## Why does `bloopInstall` trigger compilation or a time-consuming task?
+
+`bloopInstall` is usually a quick task to run, but it can be slow if the classpath
+of any of your projects depends on a binary dependency from your build (requiring
+`compile` + `publishLocal`) or if you depend on expensive tasks that do source
+and resource generation.
+
+You can speed it up by avoiding binary dependencies on modules that your build defines
+or by making sure that all the source and resource generators are cached (if you depend
+on a plugin, the plugin should make sure of that).
+
 ## Is Bloop open source?
 
 Yes. Bloop is released under the Apache-2.0 license and is free and open source software.


### PR DESCRIPTION
Fixes #104.

* Use `transformState` to remove configuration files at the very end.
* Test with scripted that we remove stale configuration files.
* Change signature of `bloopGenerate` to return the path of configuration file that it writes to.
* Add a faq to the docs.