### PR TITLE
Persist analysis files on the background & in parallel

### DIFF
--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -53,7 +53,7 @@ object Bloop extends CaseApp[CliOptions] {
     val input = reader.readLine()
     input.split(" ") match {
       case Array("exit") =>
-        timed(state.logger) { Tasks.persist(state) }
+        waitForState(Exit(ExitStatus.Ok), Tasks.persist(state).map(_ => state))
         ()
 
       case Array("projects") =>

--- a/frontend/src/main/scala/bloop/Server.scala
+++ b/frontend/src/main/scala/bloop/Server.scala
@@ -53,9 +53,6 @@ object Server {
   }
 
   private def shutDown(server: NGServer): Unit = {
-    import bloop.engine.State
-    import bloop.engine.tasks.Tasks
-    State.stateCache.allStates.foreach(s => Tasks.persist(s))
     server.shutdown( /* exitVM = */ false)
   }
 }

--- a/frontend/src/main/scala/bloop/engine/State.scala
+++ b/frontend/src/main/scala/bloop/engine/State.scala
@@ -65,16 +65,6 @@ object State {
     State(build, results, compilerCache, pool, opts, ExitStatus.Ok, logger)
   }
 
-  def setUpShutdownHoook(): Unit = {
-    Runtime
-      .getRuntime()
-      .addShutdownHook(new Thread {
-        import bloop.engine.tasks.Tasks
-        override def run(): Unit =
-          State.stateCache.allStates.foreach(s => Tasks.persist(s))
-      })
-  }
-
   /**
    * Sets up the cores for the execution context to be used for compiling and testing the project.
    *

--- a/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
@@ -47,5 +47,8 @@ final class ResultsCache(cache: Map[Project, PreviousResult], logger: Logger) {
 }
 
 object ResultsCache {
+  import java.util.concurrent.ConcurrentHashMap
+  // TODO: Enrich this with a guava cache that stores maximum 200 analysis file
+  private[bloop] val persisted = ConcurrentHashMap.newKeySet[PreviousResult]()
   def getEmpty(logger: Logger): ResultsCache = new ResultsCache(Map.empty, logger)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 package build
 
 object Dependencies {
-  val nailgunVersion = "51ddd0d9"
+  val nailgunVersion = "615737a9"
   val zincVersion = "1.1.1+49-1c290cbb"
   val bspVersion = "03e9b72d"
   val coursierVersion = "1.0.0-RC8"


### PR DESCRIPTION
\+ update to latest nailgun.

Previously, bloop would persist the analysis file on `shutDown`.
However, this hook has been removed upstream in
https://github.com/facebook/nailgun/pull/131.

As a result, we take another (more resilient) strategy to persist the
analysis file. We persist analysis file on the io pool after every
`Interpreter` execution, without blocking the return of the request.

All the logs are redirected to the nailgun server output.