### PR TITLE
Generalize `sourceDirectories` to `sources`

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -12,7 +12,7 @@ import sbt.internal.inc.{FreshCompilerCache, Locate, LoggedReporter, ZincUtil}
 case class CompileInputs(
     scalaInstance: ScalaInstance,
     compilerCache: CompilerCache,
-    sourceDirectories: Array[AbsolutePath],
+    sources: Array[AbsolutePath],
     classpath: Array[AbsolutePath],
     classesDir: AbsolutePath,
     baseDirectory: AbsolutePath,
@@ -41,9 +41,9 @@ object Compiler {
     }
 
     def getCompilationOptions(inputs: CompileInputs): CompileOptions = {
-      val sources = inputs.sourceDirectories.distinct
-        .flatMap(src => Paths.getAll(src, "glob:**.{scala,java}"))
-        .distinct
+      val uniqueSources = inputs.sources.distinct
+      // Get all the source files in the directories that may be present in `sources`
+      val sources = uniqueSources.flatMap(src => Paths.getAll(src, "glob:**.{scala,java}")).distinct
       val classesDir = inputs.classesDir.toFile
       val classpath = inputs.classpath.map(_.toFile)
 

--- a/frontend/src/main/scala/bloop/Project.scala
+++ b/frontend/src/main/scala/bloop/Project.scala
@@ -20,7 +20,7 @@ final case class Project(
     classesDir: AbsolutePath,
     scalacOptions: Array[String],
     javacOptions: Array[String],
-    sourceDirectories: Array[AbsolutePath],
+    sources: Array[AbsolutePath],
     testFrameworks: Array[Config.TestFramework],
     testOptions: Config.TestOptions,
     javaEnv: JavaEnv,

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -94,12 +94,11 @@ object Interpreter {
   }
 
   private[bloop] def watch(project: Project, state: State, f: State => Task[State]): Task[State] = {
-    import state.logger
     val reachable = Dag.dfs(state.build.getDagFor(project))
-    val allSourceDirs = reachable.iterator.flatMap(_.sourceDirectories.toList).map(_.underlying)
-    val watcher = new SourceWatcher(project, allSourceDirs.toList, state.logger)
+    val allSources = reachable.iterator.flatMap(_.sources.toList).map(_.underlying)
+    val watcher = new SourceWatcher(project, allSources.toList, state.logger)
     val fg = (state: State) => f(state).map { state =>
-      logger.info("Waiting for source changes... (press C-c to interrupt)")
+      watcher.notifyWatch()
       State.stateCache.updateBuild(state)
     }
 

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -64,7 +64,7 @@ object Tasks {
     import state.{logger, compilerCache}
     def toInputs(project: Project, config: ReporterConfig, result: PreviousResult) = {
       val instance = project.scalaInstance
-      val sourceDirs = project.sourceDirectories
+      val sources = project.sources
       val classpath = project.classpath
       val classesDir = project.classesDir
       val target = project.out
@@ -74,7 +74,7 @@ object Tasks {
       val cwd = state.build.origin.getParent
       val reporter = new Reporter(logger, cwd, identity, config)
       // FORMAT: OFF
-      CompileInputs(instance, compilerCache, sourceDirs, classpath, classesDir, target, scalacOptions, javacOptions, classpathOptions, result, reporter, logger)
+      CompileInputs(instance, compilerCache, sources, classpath, classesDir, target, scalacOptions, javacOptions, classpathOptions, result, reporter, logger)
       // FORMAT: ON
     }
 

--- a/frontend/src/test/scala/bloop/engine/FileWatchingSpec.scala
+++ b/frontend/src/test/scala/bloop/engine/FileWatchingSpec.scala
@@ -96,7 +96,7 @@ class FileWatchingSpec {
         Thread.sleep(1500)
 
         // Write the contents of a new file to force recompilation
-        val newSource = project.sourceDirectories.head.resolve("D.scala").underlying
+        val newSource = project.sources.head.resolve("D.scala").underlying
         Files.write(newSource, "object ForceRecompilation {}".getBytes("UTF-8"))
         // Wait for #2 compilation to finish
         readCompilingLines(4, "Compiling 1 Scala source to", bloopOut)
@@ -141,7 +141,7 @@ class FileWatchingSpec {
         workerThread.start()
 
         // Deletion doesn't trigger recompilation -- done to avoid file from previous test run
-        val newSource = project.sourceDirectories.head.resolve("D.scala").underlying
+        val newSource = project.sources.head.resolve("D.scala").underlying
         if (Files.exists(newSource)) TestUtil.delete(newSource)
 
         // Wait for #1 compilation to finish
@@ -152,7 +152,7 @@ class FileWatchingSpec {
         readCompilingLines(1, "- should be very personal", bloopOut)
         readCompilingLines(1, "Total for specification Specs2Test", bloopOut)
         readCompilingLines(2, "Terminating test server.", bloopOut)
-        readCompilingLines(1, "File watching 8 directories.", bloopOut)
+        readCompilingLines(1, "Watching 8 directories... (press C-c to interrupt)", bloopOut)
 
         // Write the contents of a source back to the same source
         Files.write(newSource, "object ForceRecompilation {}".getBytes("UTF-8"))

--- a/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
+++ b/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
@@ -74,7 +74,7 @@ class IntegrationTestSuite(testDirectory: Path) {
           classesDir = classesDir,
           scalacOptions = Array.empty,
           javacOptions = Array.empty,
-          sourceDirectories = Array.empty,
+          sources = Array.empty,
           testFrameworks = Array.empty,
           testOptions = Config.TestOptions.empty,
           javaEnv = javaEnv,

--- a/frontend/src/test/scala/bloop/tasks/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestUtil.scala
@@ -206,7 +206,7 @@ object TestUtil {
       classesDir = AbsolutePath(target),
       scalacOptions = Array.empty,
       javacOptions = Array.empty,
-      sourceDirectories = sourceDirectories,
+      sources = sourceDirectories,
       testFrameworks = Array.empty,
       testOptions = Config.TestOptions.empty,
       javaEnv = javaEnv,


### PR DESCRIPTION
Our project abstraction only accepted source directories. This
limitation is unfounded and makes it difficult to support build tools
whose project definitions have no source directories. One example of
such a build tool is Bazel, whose `Target`s only know about source
files.

This patch:

1. Renames `sourceDirectories` in the source code.
2. Makes the rest of the code (`Tasks` and `SourceWatcher`) aware that
sources does not strictly mean directories.
3. Build upon @rberenguel's work to show the same "Watching ..." message
in every watch iteration.