### PR TITLE
Simple improvement to zsh completion when server is not started

### DIFF
--- a/etc/bash/bloop
+++ b/etc/bash/bloop
@@ -5,13 +5,13 @@ _files() {
 }
 
 _projects() {
-    projects=$(bloop autocomplete --mode=projects --format=bash)
+    projects=$(bloop autocomplete --mode=projects --format=bash 2> /dev/null)
     COMPREPLY=( $(compgen -W "$projects" -- $cur) )
     return 0
 }
 
 _commands() {
-    commands=$(bloop autocomplete --mode=commands --format=bash)
+    commands=$(bloop autocomplete --mode=commands --format=bash 2> /dev/null || _notStarted)
     COMPREPLY=( $(compgen -W "$commands" -- $cur) )
     return 0
 }
@@ -60,6 +60,10 @@ _callCompletionForCommandAndFlag() {
 
     return 0
 
+}
+
+_notStarted() {
+    echo "server"
 }
 
 _bloop() {

--- a/etc/zsh/_bloop
+++ b/etc/zsh/_bloop
@@ -1,11 +1,15 @@
 #compdef bloop
 
 _projects() {
-    compadd "$@" $(bloop autocomplete --format zsh --mode projects)
+    compadd "$@" $(bloop autocomplete --format zsh --mode projects 2> /dev/null)
 }
 
 _commands() {
-    compadd "$@" $(bloop autocomplete --format zsh --mode commands)
+    compadd "$@" $(bloop autocomplete --format zsh --mode commands 2> /dev/null || _notStarted)
+}
+
+_notStarted() {
+    echo "server"
 }
 
 _reporters() {


### PR DESCRIPTION
This will hide the error if attempting a tab completion to bloop while
the bloop server has not been started, and will offer the single
completion of `bloop server` instead.

Someone might like to do the same thing for bash....