### PR TITLE
Use Python3 in Homebrew formula

### DIFF
--- a/project/ReleaseUtils.scala
+++ b/project/ReleaseUtils.scala
@@ -67,12 +67,12 @@ object ReleaseUtils {
        |  sha256 "$installSha"
        |  bottle :unneeded
        |
-       |  depends_on "python"
+       |  depends_on "python3"
        |  depends_on :java => "1.8+"
        |
        |  def install
        |      mkdir "bin"
-       |      system "python", "install.py", "--dest", "bin", "--version", version
+       |      system "python3", "install.py", "--dest", "bin", "--version", version
        |      zsh_completion.install "bin/zsh/_bloop"
        |      bash_completion.install "bin/bash/bloop"
        |      File.delete("bin/blp-coursier")


### PR DESCRIPTION
Our homebrew formula download Coursier from the installation script.
Sometimes, this fails because it looks like some versions of MacOS have
an outdated version of Python 2 with a faulty SSL module (or something
along those lines).

This commit forces Python3 to be used for running the installation
script from the Homebrew formula, so that downloading Coursier no longer
fails.