### PR TITLE
Improve deficiencies in test infrastructure

### DIFF
--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -165,7 +165,8 @@ object Cli {
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
                 withProject(c.project) { (p: String) =>
                   val cmd = if (p != c.project) newCommand.copy(project = p) else newCommand
-                  run(cmd, newCommand.cliOptions)
+                  // Infer everything after '--' as if they were test framework args
+                  run(cmd.copy(args = c.args ++ extraArgs), newCommand.cliOptions)
                 }
               case Right(c: Commands.Run) =>
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -112,6 +112,8 @@ object Commands {
       @ExtraName("o")
       @HelpMessage("The list of test suite filters to test for only.")
       only: List[String] = Nil,
+      @HelpMessage("The arguments to pass in to the test framework.")
+      args: List[String] = Nil,
       @HelpMessage("Pick reporter to show compilation messages. By default, bloop's used.")
       reporter: ReporterKind = BloopReporter,
       @ExtraName("w")
@@ -140,7 +142,7 @@ object Commands {
       main: Option[String] = None,
       @HelpMessage("Pick reporter to show compilation messages. By default, bloop's used.")
       reporter: ReporterKind = BloopReporter,
-      @HelpMessage("The arguments to pass to the application")
+      @HelpMessage("The arguments to pass in to the main class.")
       args: List[String] = Nil,
       @ExtraName("w")
       @HelpMessage("If set, run the command whenever projects' source files change.")

--- a/frontend/src/main/scala/bloop/cli/validation/Validate.scala
+++ b/frontend/src/main/scala/bloop/cli/validation/Validate.scala
@@ -20,7 +20,7 @@ object Validate {
     val cliOptions = cmd.cliOptions
     val commonOptions = cliOptions.common
 
-    def validateSocket = cmd.socket match {
+    def validateSocket = cmd.socket.map(_.toAbsolutePath) match {
       case Some(socket) if Files.exists(socket) =>
         cliError(Feedback.existingSocketFile(socket), commonOptions)
       case Some(socket) if !Files.exists(socket.getParent) =>

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -189,7 +189,7 @@ object Interpreter {
           val cwd = cmd.cliOptions.common.workingPath
 
           compileAnd(state, project, reporterConfig, excludeRoot = false, "`test`") { state =>
-            Tasks.test(state, project, cwd, cmd.isolated, testFilter)
+            Tasks.test(state, project, cwd, cmd.isolated, cmd.args, testFilter)
           }
         }
         if (cmd.watch) watch(project, state, doTest _)

--- a/frontend/src/test/scala/bloop/cli/validation/ValidateSuite.scala
+++ b/frontend/src/test/scala/bloop/cli/validation/ValidateSuite.scala
@@ -42,6 +42,18 @@ class ValidateSuite {
     )
   }
 
+  @Test def SucceedAtNonExistingSocketRelativeFile(): Unit = {
+    // Don't specify the parent on purpose, simulate relative paths from CLI
+    val socketPath = java.nio.file.Paths.get("test.socket")
+    val bspCommand = Commands.Bsp(
+      protocol = BspProtocol.Local,
+      socket = Some(socketPath),
+      pipeName = None
+    )
+
+    checkIsCommand[Commands.UnixLocalBsp](Validate.bsp(bspCommand, isWindows = false))
+  }
+
   @Test def FailAtNonExistingSocketFolder(): Unit = {
     val socketPath = tempDir.resolve("folder").resolve("test.socket")
     val bspCommand = Commands.Bsp(

--- a/frontend/src/test/scala/bloop/nailgun/BasicNailgunSpec.scala
+++ b/frontend/src/test/scala/bloop/nailgun/BasicNailgunSpec.scala
@@ -114,6 +114,7 @@ class BasicNailgunSpec extends NailgunTest {
   @Test
   def testRunCommand(): Unit = {
     withServerInProject("with-resources") { (logger, client) =>
+      client.success("clean", "with-resources")
       client.success("run", "with-resources")
       client.success("run", "-p", "with-resources")
       val messages = logger.getMessages()
@@ -125,6 +126,7 @@ class BasicNailgunSpec extends NailgunTest {
   @Test
   def testTestCommand(): Unit = {
     withServerInProject("with-resources") { (logger, client) =>
+      client.success("clean", "with-resources")
       client.success("test", "with-resources")
       client.success("test", "-p", "with-resources")
       val messages = logger.getMessages()


### PR DESCRIPTION
1. Resolve test agent jars lazily.
2. Allow to pass in test options via CLI.
3. Handle NPE in bsp CLI validator.