### PR TITLE
Report compilation logs via publishDiagnostics

### DIFF
--- a/backend/src/main/scala/bloop/reporter/DefaultReporterFormat.scala
+++ b/backend/src/main/scala/bloop/reporter/DefaultReporterFormat.scala
@@ -8,6 +8,11 @@ import scala.compat.Platform.EOL
 object DefaultReporterFormat extends (ConfigurableReporter => ReporterFormat) {
   override def apply(reporter: ConfigurableReporter): DefaultReporterFormat =
     new DefaultReporterFormat(reporter)
+
+  def toOption[T](m: java.util.Optional[T]): Option[T] = if (m.isPresent) Some(m.get) else None
+  def position(position: xsbti.Position): Option[(Int, Int)] = {
+    toOption(position.line).flatMap(l => toOption(position.pointer).map(c => (l, c)))
+  }
 }
 
 /**

--- a/backend/src/main/scala/bloop/reporter/ReporterConfig.scala
+++ b/backend/src/main/scala/bloop/reporter/ReporterConfig.scala
@@ -33,7 +33,7 @@ final case class ReporterConfig(
 )
 
 object ReporterConfig {
-  final val defaultFormat =
+  final val defaultFormat = {
     new ReporterConfig(
       true,
       true,
@@ -48,8 +48,9 @@ object ReporterConfig {
       scala.Console.BLUE,
       DefaultReporterFormat
     )
+  }
 
-  final val scalacFormat =
+  final val scalacFormat = {
     new ReporterConfig(
       true,
       true,
@@ -64,4 +65,5 @@ object ReporterConfig {
       scala.Console.BLUE,
       ScalacFormat
     )
+  }
 }

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -4,14 +4,18 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import bloop.{Compiler, Project}
 import bloop.cli.{Commands, ExitStatus}
-import bloop.engine.{Action, Dag, Exit, Interpreter, Leaf, Parent, Run, State}
+import bloop.engine.{Action, Dag, Exit, Interpreter, Run, State}
 import bloop.io.{AbsolutePath, RelativePath}
 import bloop.logging.BspLogger
 import ch.epfl.`scala`.bsp.schema._
 import monix.eval.Task
 import ch.epfl.scala.bsp.endpoints
-import org.langmeta.jsonrpc.{JsonRpcClient, Response => JsonRpcResponse, Services => JsonRpcServices}
-import xsbti.{Problem, Severity}
+import org.langmeta.jsonrpc.{
+  JsonRpcClient,
+  Response => JsonRpcResponse,
+  Services => JsonRpcServices
+}
+import xsbti.Problem
 
 final class BloopBspServices(
     callSiteState: State,

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -5,7 +5,8 @@ import bloop.engine.caches.ResultsCache
 import bloop.engine.{Dag, Leaf, Parent, State}
 import bloop.exec.ForkProcess
 import bloop.io.AbsolutePath
-import bloop.reporter.{Problem, Reporter, ReporterConfig}
+import bloop.logging.BspLogger
+import bloop.reporter.{BspReporter, LogReporter, Problem, Reporter, ReporterConfig}
 import bloop.testing.{DiscoveredTests, TestInternals}
 import bloop.{CompileInputs, Compiler, Project}
 import monix.eval.Task
@@ -66,7 +67,14 @@ object Tasks {
       val javacOptions = project.javacOptions
       val classpathOptions = project.classpathOptions
       val cwd = state.build.origin.getParent
-      val reporter = new Reporter(logger, cwd, identity, config)
+      // Set the reporter based on the kind of logger to publish diagnostics
+      val reporter = logger match {
+        case bspLogger: BspLogger =>
+          // Don't show errors in reverse order, log as they come!
+          new BspReporter(bspLogger, cwd, identity, config.copy(reverseOrder = false))
+        case _ => new LogReporter(logger, cwd, identity, config)
+      }
+
       // FORMAT: OFF
       CompileInputs(instance, compilerCache, sources, classpath, classesDir, target, scalacOptions, javacOptions, classpathOptions, result, reporter, logger)
       // FORMAT: ON

--- a/frontend/src/main/scala/bloop/logging/BspLogger.scala
+++ b/frontend/src/main/scala/bloop/logging/BspLogger.scala
@@ -3,8 +3,10 @@ package bloop.logging
 import java.util.concurrent.atomic.AtomicInteger
 
 import bloop.engine.State
+import bloop.reporter.{DefaultReporterFormat, Problem}
 import org.langmeta.jsonrpc.JsonRpcClient
-import org.langmeta.lsp.Window
+import org.langmeta.lsp
+import xsbti.Severity
 
 /**
  * Creates a logger that will forward all the messages to the underlying bsp client.
@@ -13,7 +15,7 @@ import org.langmeta.lsp.Window
 final class BspLogger private (
     override val name: String,
     underlying: Logger,
-    client: JsonRpcClient,
+    implicit val client: JsonRpcClient,
     ansiSupported: Boolean
 ) extends Logger {
 
@@ -28,18 +30,45 @@ final class BspLogger private (
   override def trace(t: Throwable): Unit = underlying.trace(t)
 
   override def error(msg: String): Unit = {
-    underlying.error(msg)
-    Window.showMessage.error(msg)(client)
+    lsp.Window.showMessage.error(msg)
   }
 
   override def warn(msg: String): Unit = {
-    underlying.warn(msg)
-    Window.showMessage.warn(msg)(client)
+    lsp.Window.showMessage.warn(msg)
   }
 
   override def info(msg: String): Unit = {
-    underlying.info(msg)
-    Window.showMessage.info(msg)(client)
+    lsp.Window.showMessage.info(msg)
+  }
+
+  def diagnostic(problem: Problem): Unit = {
+    val message = problem.message
+    val sourceFile = DefaultReporterFormat.toOption(problem.position.sourceFile())
+    val rangeAndUri = DefaultReporterFormat
+      .position(problem.position)
+      .map(lc => lsp.Position(lc._1, lc._2))
+      .map(p => lsp.Range(p, p))
+      .flatMap(r => sourceFile.map(f => (r, f)))
+
+    rangeAndUri match {
+      case Some((range, file)) =>
+        val severity = problem.severity match {
+          case Severity.Error => lsp.DiagnosticSeverity.Error
+          case Severity.Warn => lsp.DiagnosticSeverity.Warning
+          case Severity.Info => lsp.DiagnosticSeverity.Information
+        }
+
+        val uri = file.toURI.toString
+        val diagnostic = lsp.Diagnostic(range, Some(severity), None, None, message)
+        val diagnostics = lsp.PublishDiagnostics(uri, List(diagnostic))
+        lsp.TextDocument.publishDiagnostics.notify(diagnostics)
+      case None =>
+        problem.severity match {
+          case Severity.Error => error(message)
+          case Severity.Warn => warn(message)
+          case Severity.Info => info(message)
+        }
+    }
   }
 }
 

--- a/frontend/src/main/scala/bloop/reporter/BspReporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/BspReporter.scala
@@ -1,0 +1,18 @@
+package bloop.reporter
+
+import bloop.io.AbsolutePath
+import bloop.logging.BspLogger
+import xsbti.Position
+
+import scala.collection.mutable
+
+final class BspReporter(
+    override val logger: BspLogger,
+    override val cwd: AbsolutePath,
+    sourcePositionMapper: Position => Position,
+    override val config: ReporterConfig,
+    override val _problems: mutable.Buffer[Problem] = mutable.ArrayBuffer.empty
+) extends Reporter(logger, cwd, sourcePositionMapper, config, _problems) {
+  override def printSummary(): Unit = () // Not implemented in bsp.
+  override protected def logFull(problem: Problem): Unit = logger.diagnostic(problem)
+}

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -323,7 +323,6 @@ class BspProtocolSpec {
   @Test def TestCompileViaLocal(): Unit = {
     if (!BspServer.isWindows) testCompile(createLocalBspCommand(configDir))
   }
-
   @Test def TestCompileViaTcp(): Unit = {
     testCompile(createTcpBspCommand(configDir, verbose = true))
   }


### PR DESCRIPTION
The previous implementation was sending the compilation infos as if they
were normal logs. This patch splits up the reporters in two: one used
for normal logging and the other one used for bsp. The bsp reporter will
`textDocument/publishDiagnostics` all the compilation infos instead of
forwarding them with `window/showMessage`.