### PR TITLE
Use range positions in bsp if Zinc returns them

### DIFF
--- a/backend/src/main/scala/bloop/reporter/DefaultReporterFormat.scala
+++ b/backend/src/main/scala/bloop/reporter/DefaultReporterFormat.scala
@@ -9,9 +9,11 @@ object DefaultReporterFormat extends (ConfigurableReporter => ReporterFormat) {
   override def apply(reporter: ConfigurableReporter): DefaultReporterFormat =
     new DefaultReporterFormat(reporter)
 
+  case class Position(line: Int, column: Int)
+
   def toOption[T](m: java.util.Optional[T]): Option[T] = if (m.isPresent) Some(m.get) else None
-  def position(position: xsbti.Position): Option[(Int, Int)] = {
-    toOption(position.line).flatMap(l => toOption(position.pointer).map(c => (l, c)))
+  def position(position: xsbti.Position): Option[Position] = {
+    toOption(position.line).flatMap(l => toOption(position.pointer).map(c => Position(l, c)))
   }
 }
 

--- a/backend/src/main/scala/sbt/internal/inc/bloop/ZincInternals.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/ZincInternals.scala
@@ -4,8 +4,9 @@ import java.nio.file.Files
 
 import bloop.ScalaInstance
 import bloop.io.AbsolutePath
-import xsbti.ComponentProvider
+import xsbti.{ComponentProvider, Position}
 import sbt.internal.inc.ZincComponentCompiler
+import sbt.internal.inc.javac.DiagnosticsReporter
 import sbt.librarymanagement.{Configurations, ModuleID}
 
 object ZincInternals {
@@ -52,5 +53,15 @@ object ZincInternals {
     val id = s"${sources.organization}-${sources.name}-${sources.revision}"
     val scalaVersion = scalaInstance.actualVersion()
     s"$id$binSeparator${scalaVersion}__$javaClassVersion"
+  }
+
+  case class LineRange(start: Int, end: Int)
+  def rangeFromPosition(position: Position): Option[LineRange] = {
+    position match {
+      case impl: DiagnosticsReporter.PositionImpl =>
+        // We are forced to use int here because lsp diagnostics only take ints
+        impl.startPosition.flatMap(s => impl.endPosition.map(e => LineRange(s.toInt, e.toInt)))
+      case _ => None
+    }
   }
 }


### PR DESCRIPTION
The trick to get access to this info was in downcasting to the internal
position in Zinc's land that exposes `startPosition` and `endPosition`,
meaning the start and end of the column count.

With this information, Intellij is now able to show the red squigglies
in the editor.

I couldn't resist, thanks @olafurpg for the reminder and @jastice for getting
my excitement up with the comment on red squigglies.