### PR TITLE
Add `ScalaBuildTarget` and project deps to bsp

### DIFF
--- a/frontend/src/main/scala/bloop/Project.scala
+++ b/frontend/src/main/scala/bloop/Project.scala
@@ -6,6 +6,7 @@ import bloop.io.Timer.timed
 import bloop.logging.Logger
 import xsbti.compile.ClasspathOptions
 import _root_.monix.eval.Task
+import bloop.bsp.ProjectUris
 import bloop.config.{Config, ConfigDecoders}
 import metaconfig.{Conf, Configured}
 import org.langmeta.inputs.Input
@@ -27,6 +28,9 @@ final case class Project(
     out: AbsolutePath
 ) {
   override def toString: String = s"$name"
+
+  /** The bsp uri associated with this project. */
+  val bspUri: String = ProjectUris.toUri(baseDirectory, name).toString
 
   /** This project's full classpath (classes directory and raw classpath) */
   val classpath: Array[AbsolutePath] = classesDir +: rawClasspath

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -1,5 +1,6 @@
 package bloop.bsp
 
+import java.nio.charset.{Charset, StandardCharsets}
 import java.util.concurrent.atomic.AtomicInteger
 
 import bloop.{Compiler, Project}
@@ -10,11 +11,14 @@ import bloop.logging.BspLogger
 import ch.epfl.`scala`.bsp.schema._
 import monix.eval.Task
 import ch.epfl.scala.bsp.endpoints
+import ch.epfl.scala.bsp.schema.ScalaBuildTarget.ScalaPlatform
+import com.google.protobuf.ByteString
 import org.langmeta.jsonrpc.{
   JsonRpcClient,
   Response => JsonRpcResponse,
   Services => JsonRpcServices
 }
+import scalapb_circe.JsonFormat
 import xsbti.Problem
 
 final class BloopBspServices(
@@ -169,6 +173,18 @@ final class BloopBspServices(
   private def toBuildTargetId(project: Project): BuildTargetIdentifier =
     BuildTargetIdentifier(project.bspUri)
 
+  def toScalaBuildTarget(project: Project): ScalaBuildTarget = {
+    val instance = project.scalaInstance
+    val jars = instance.allJars.iterator.map(_.toURI.toString).toList
+    ScalaBuildTarget(
+      scalaOrganization = instance.organization,
+      scalaVersion = instance.version,
+      scalaBinaryVersion = instance.version,
+      platform = ScalaPlatform.JVM,
+      jars = jars
+    )
+  }
+
   def buildTargets(request: WorkspaceBuildTargetsRequest): BspResponse[WorkspaceBuildTargets] = {
     ifInitialized {
       val build = currentState.build
@@ -176,11 +192,14 @@ final class BloopBspServices(
         build.projects.map { p =>
           val id = toBuildTargetId(p)
           val deps = p.dependencies.iterator.flatMap(build.getProjectFor(_).toList)
+          val scalaTarget = JsonFormat.toJsonString(toScalaBuildTarget(p))
+          val extra = ByteString.copyFrom(scalaTarget, StandardCharsets.UTF_8)
           BuildTarget(
             id = Some(id),
             displayName = p.name,
             languageIds = List("scala", "java"),
-            dependencies = deps.map(toBuildTargetId).toList
+            dependencies = deps.map(toBuildTargetId).toList,
+            data = extra
           )
         }
       )

--- a/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
@@ -69,7 +69,7 @@ final class ResultsCache private (
     import bloop.util.JavaCompat.EnrichOptional
 
     def fetchPreviousResult(p: Project): Compiler.Result = {
-      val analysisFile = project.out.getParent.resolve(s"${project.name}-analysis.bin")
+      val analysisFile = ResultsCache.pathToAnalysis(p)
       if (Files.exists(analysisFile.underlying)) {
         val contents = FileAnalysisStore.binary(analysisFile.toFile).get().toOption
         contents match {
@@ -109,4 +109,7 @@ object ResultsCache {
       case (results, project) => results.initializeResult(project, cwd)
     }
   }
+
+  def pathToAnalysis(project: Project): AbsolutePath =
+    project.out.resolve(s"${project.name}-analysis.bin")
 }

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -210,7 +210,7 @@ object Tasks {
     import bloop.util.JavaCompat.EnrichOptional
     def persist(project: Project, result: PreviousResult): Unit = {
       def toBinaryFile(analysis: CompileAnalysis, setup: MiniSetup): Unit = {
-        val storeFile = project.out.resolve(s"${project.name}-analysis.bin")
+        val storeFile = ResultsCache.pathToAnalysis(project)
         state.commonOptions.ngout.println(s"Writing ${storeFile.syntax}.")
         FileAnalysisStore.binary(storeFile.toFile).set(ConcreteAnalysisContents(analysis, setup))
         ResultsCache.persisted.add(result)

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -175,7 +175,7 @@ class BspProtocolSpec {
               optionItems.map { uriOptions =>
                 val expectedUriOptions = Project
                   .eagerLoadFromDir(configDir, logger.underlying)
-                  .map(p => (ProjectUris.toUri(p.baseDirectory, p.name).toString, p))
+                  .map(p => (p.bspUri, p))
                   .sortBy(_._1)
 
                 Assert

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package build
 object Dependencies {
   val nailgunVersion = "615737a9"
   val zincVersion = "1.1.1+49-1c290cbb"
-  val bspVersion = "b3d16806"
+  val bspVersion = "ce87199c"
   val coursierVersion = "1.0.0-RC8"
   val lmVersion = "1.0.0"
   val configDirsVersion = "5"


### PR DESCRIPTION
1. Fixes a bug in loading analysis files at server startup. 
2. Add project dependencies to build targets (to get the language server working).
3. Add `ScalaBuildTarget` to the build target bytes so that Intellij knows what Scala SDK to use for each project.