### PR TITLE
Add systemd service file

### DIFF
--- a/bin/install.py
+++ b/bin/install.py
@@ -12,10 +12,8 @@ import re
 IS_PY2 = sys.version[0] == '2'
 if IS_PY2:
     from urllib import urlretrieve as urlretrieve
-    from urllib import urlopen as urlopen
 else:
     from urllib.request import urlretrieve as urlretrieve
-    from urllib.request import urlopen as urlopen
 
 # INSERT_INSTALL_VARIABLES
 BLOOP_DEFAULT_INSTALLATION_TARGET = join(expanduser("~"), ".bloop")
@@ -86,29 +84,29 @@ SYSTEMD_SERVICE_TARGET = join(SYSTEMD_SERVICE_DIR, "bloop.service")
 
 BLOOP_ARTIFACT = "ch.epfl.scala:bloop-frontend_2.12:%s" % BLOOP_VERSION
 
+def download(url, target):
+    try:
+        urlretrieve(url, target)
+    except IOError:
+        print("Couldn't download %s, please try again." % url)
+        sys.exit(1)
+
+def download_and_install(url, target, permissions=0o644):
+    download(url, target)
+    os.chmod(target, permissions)
+
 def replace_template_variables(template):
     return template.replace("__BLOOP_INSTALLATION_TARGET__", BLOOP_INSTALLATION_TARGET)
 
-def download_and_install(url, target):
-    try:
-        urlretrieve(url, target)
-        os.chmod(target, 0o755)
-    except IOError:
-        print("Couldn't download %s, please try again." % url)
-        sys.exit(1)
-
-def download_and_install_template(url, target):
-    try:
-        socket = urlopen(url)
-        template = socket.read()
-        with open(target, "w") as file:
-            output = replace_template_variables(template)
-            file.write(output)
-        socket.close()
-        os.chmod(target, 0o755)
-    except IOError:
-        print("Couldn't download %s, please try again." % url)
-        sys.exit(1)
+def download_and_install_template(url, target, permissions=0o644):
+    template_target = target + ".tmp"
+    download(url, template_target)
+    with open(template_target, "r") as template_file, open(target, "w") as output_file:
+        template = template_file.read()
+        output = replace_template_variables(template)
+        output_file.write(output)
+    os.remove(template_target)
+    os.chmod(target, permissions)
 
 def coursier_bootstrap(target, main):
     try:
@@ -135,18 +133,18 @@ makedir(BASH_COMPLETION_DIR)
 makedir(SYSTEMD_SERVICE_DIR)
 
 if not isfile(BLOOP_COURSIER_TARGET):
-    download_and_install(COURSIER_URL, BLOOP_COURSIER_TARGET)
+    download_and_install(COURSIER_URL, BLOOP_COURSIER_TARGET, 0o755)
 
 coursier_bootstrap(BLOOP_SERVER_TARGET, "bloop.Server")
 print("Installed bloop server in '%s'" % BLOOP_SERVER_TARGET)
 
-download_and_install(NAILGUN_CLIENT_URL, BLOOP_CLIENT_TARGET)
+download_and_install(NAILGUN_CLIENT_URL, BLOOP_CLIENT_TARGET, 0o755)
 print("Installed bloop client in '%s'" % BLOOP_CLIENT_TARGET)
 
-download_and_install(ZSH_COMPLETION_URL, ZSH_COMPLETION_TARGET)
+download_and_install(ZSH_COMPLETION_URL, ZSH_COMPLETION_TARGET, 0o755)
 print("Installed zsh completion in '%s'" % ZSH_COMPLETION_TARGET)
 
-download_and_install(BASH_COMPLETION_URL, BASH_COMPLETION_TARGET)
+download_and_install(BASH_COMPLETION_URL, BASH_COMPLETION_TARGET, 0o755)
 print("Installed Bash completion in '%s'" % BASH_COMPLETION_TARGET)
 
 download_and_install_template(SYSTEMD_SERVICE_URL, SYSTEMD_SERVICE_TARGET)

--- a/bin/install.py
+++ b/bin/install.py
@@ -56,28 +56,31 @@ BLOOP_VERSION = args.version
 NAILGUN_COMMIT = args.nailgun
 ZSH_COMPLETION_DIR = join(BLOOP_INSTALLATION_TARGET, "zsh")
 BASH_COMPLETION_DIR = join(BLOOP_INSTALLATION_TARGET, "bash")
+SYSTEMD_SERVICE_DIR = join(BLOOP_INSTALLATION_TARGET, "systemd")
 
 # If this is not a released version of Bloop, we need to extract the commit SHA
-# to know how to download the completion scripts.
+# to know how to download the completion and startup scripts.
 # If we can't get the SHA, just download from master.
 if CUSTOMIZED_SCRIPT:
-    COMPLETION_VERSION = "v" + BLOOP_VERSION
+    ETC_VERSION = "v" + BLOOP_VERSION
 else:
     pattern = '(?:.+?)-([0-9a-f]{8})(?:\+\d{8}-\d{4})?'
     matches = re.search(pattern, BLOOP_VERSION)
     if matches is not None:
-        COMPLETION_VERSION = matches.group(1)
+        ETC_VERSION = matches.group(1)
     else:
-        COMPLETION_VERSION = "master"
+        ETC_VERSION = "master"
 
 NAILGUN_CLIENT_URL = "https://raw.githubusercontent.com/scalacenter/nailgun/%s/pynailgun/ng.py" % NAILGUN_COMMIT
-ZSH_COMPLETION_URL = "https://raw.githubusercontent.com/scalacenter/bloop/%s/etc/zsh/_bloop" % COMPLETION_VERSION
-BASH_COMPLETION_URL = "https://raw.githubusercontent.com/scalacenter/bloop/%s/etc/bash/bloop" % COMPLETION_VERSION
+ZSH_COMPLETION_URL = "https://raw.githubusercontent.com/scalacenter/bloop/%s/etc/zsh/_bloop" % ETC_VERSION
+BASH_COMPLETION_URL = "https://raw.githubusercontent.com/scalacenter/bloop/%s/etc/bash/bloop" % ETC_VERSION
+SYSTEMD_SERVICE_URL = "https://raw.githubusercontent.com/scalacenter/bloop/%s/etc/systemd/bloop.service" % ETC_VERSION
 BLOOP_COURSIER_TARGET = join(BLOOP_INSTALLATION_TARGET, "blp-coursier")
 BLOOP_SERVER_TARGET = join(BLOOP_INSTALLATION_TARGET, "blp-server")
 BLOOP_CLIENT_TARGET = join(BLOOP_INSTALLATION_TARGET, "bloop")
 ZSH_COMPLETION_TARGET = join(ZSH_COMPLETION_DIR, "_bloop")
 BASH_COMPLETION_TARGET = join(BASH_COMPLETION_DIR, "bloop")
+SYSTEMD_SERVICE_TARGET = join(SYSTEMD_SERVICE_DIR, "bloop.service")
 
 BLOOP_ARTIFACT = "ch.epfl.scala:bloop-frontend_2.12:%s" % BLOOP_VERSION
 
@@ -111,6 +114,7 @@ def makedir(directory):
 makedir(BLOOP_INSTALLATION_TARGET)
 makedir(ZSH_COMPLETION_DIR)
 makedir(BASH_COMPLETION_DIR)
+makedir(SYSTEMD_SERVICE_DIR)
 
 if not isfile(BLOOP_COURSIER_TARGET):
     download_and_install(COURSIER_URL, BLOOP_COURSIER_TARGET)
@@ -126,3 +130,6 @@ print("Installed zsh completion in '%s'" % ZSH_COMPLETION_TARGET)
 
 download_and_install(BASH_COMPLETION_URL, BASH_COMPLETION_TARGET)
 print("Installed Bash completion in '%s'" % BASH_COMPLETION_TARGET)
+
+download_and_install(SYSTEMD_SERVICE_URL, SYSTEMD_SERVICE_TARGET)
+print("Installed systemd service in '%s'" % SYSTEMD_SERVICE_TARGET)

--- a/bin/install.py
+++ b/bin/install.py
@@ -8,12 +8,13 @@ from os.path import expanduser, isdir, isfile, join
 from subprocess import CalledProcessError, check_call
 import sys
 import re
+from shutil import copyfileobj
 
 IS_PY2 = sys.version[0] == '2'
 if IS_PY2:
-    from urllib import urlretrieve as urlretrieve
+    from urllib2 import urlopen as urlopen
 else:
-    from urllib.request import urlretrieve as urlretrieve
+    from urllib.request import urlopen as urlopen
 
 # INSERT_INSTALL_VARIABLES
 BLOOP_DEFAULT_INSTALLATION_TARGET = join(expanduser("~"), ".bloop")
@@ -84,9 +85,14 @@ SYSTEMD_SERVICE_TARGET = join(SYSTEMD_SERVICE_DIR, "bloop.service")
 
 BLOOP_ARTIFACT = "ch.epfl.scala:bloop-frontend_2.12:%s" % BLOOP_VERSION
 
+BUFFER_SIZE = 4096
+
 def download(url, target):
     try:
-        urlretrieve(url, target)
+        socket = urlopen(url)
+        with open(target, "wb") as file:
+            copyfileobj(socket, file, BUFFER_SIZE)
+        socket.close()
     except IOError:
         print("Couldn't download %s, please try again." % url)
         sys.exit(1)

--- a/bin/install.py
+++ b/bin/install.py
@@ -12,7 +12,7 @@ import re
 IS_PY2 = sys.version[0] == '2'
 if IS_PY2:
     from urllib import urlretrieve as urlretrieve
-    from urllib2 import urlopen as urlopen
+    from urllib import urlopen as urlopen
 else:
     from urllib.request import urlretrieve as urlretrieve
     from urllib.request import urlopen as urlopen

--- a/etc/systemd/bloop.service
+++ b/etc/systemd/bloop.service
@@ -3,6 +3,9 @@ Description=Bloop Scala build server
 
 [Service]
 ExecStart=%h/.bloop/bloop server
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=bloop
 
 [Install]
 WantedBy=default.target

--- a/etc/systemd/bloop.service
+++ b/etc/systemd/bloop.service
@@ -2,7 +2,7 @@
 Description=Bloop Scala build server
 
 [Service]
-ExecStart=%h/.bloop/bloop server
+ExecStart=__BLOOP_INSTALLATION_TARGET__/bloop server
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=bloop

--- a/etc/systemd/bloop.service
+++ b/etc/systemd/bloop.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Bloop Scala build server
+
+[Service]
+ExecStart=%h/.bloop/bloop server
+
+[Install]
+WantedBy=default.target

--- a/website/content/docs/installation.md
+++ b/website/content/docs/installation.md
@@ -41,8 +41,14 @@ Install bloop in other platforms (Windows, Unix, \*bsd) via our python script:
 <pre><code class="language-sh">$ curl -L https://github.com/scalacenter/bloop/releases/download/v<span class="latest-version">1.0.0-M8</span>/install.py | python
 </code></pre>
 
-The installation script will also install completions for zsh and Bash, but
-you need to set them up manually.
+The installation script will also install:
+
+ * completions for zsh and Bash
+ * service file for systemd
+
+but you need to set them up manually.
+
+### Shell completions
 
 #### Zsh completions
 
@@ -60,6 +66,33 @@ To get the command line completions with Bash, add the following to your `~/.bas
 
 ```sh
 . $HOME/.bloop/bash/bloop
+```
+
+### Automatic startup
+
+#### Systemd
+
+One way to run Bloop server automatically if you are using systemd is to
+install the provided user service file:
+
+```sh
+$ cp $HOME/.bloop/systemd/bloop.service $HOME/.config/systemd/user/
+$ systemctl --user enable bloop
+```
+
+This way, Bloop server will be started when you log in for the first time and
+stopped when you exit your last session. It is also possible to start the
+service right after boot and keep it running until the system shuts down.
+Please refer to [this wiki page about user services in systemd]
+(https://wiki.archlinux.org/index.php/Systemd/User) if you want some advanced
+options.
+
+You can also check the status, start and stop the service manually:
+
+```
+$ systemctl --user status bloop
+$ systemctl --user start bloop
+$ systemctl --user stop bloop
 ```
 
 ## Use bloop with sbt

--- a/website/content/docs/installation.md
+++ b/website/content/docs/installation.md
@@ -95,6 +95,12 @@ $ systemctl --user start bloop
 $ systemctl --user stop bloop
 ```
 
+Logs can be viewed using:
+
+```
+$ journalctl --user-unit bloop
+```
+
 ## Use bloop with sbt
 
 The first step is to generate the configuration files for Bloop with our sbt

--- a/website/content/docs/installation.md
+++ b/website/content/docs/installation.md
@@ -76,6 +76,7 @@ One way to run Bloop server automatically if you are using systemd is to
 install the provided user service file:
 
 ```sh
+$ mkdir -p $HOME/.config/systemd/user
 $ cp $HOME/.bloop/systemd/bloop.service $HOME/.config/systemd/user/
 $ systemctl --user enable bloop
 ```


### PR DESCRIPTION
Adds a user service file for systemd and makes `install.py` download it
automatically to `~/.bloop/systemd/bloop.service`.
Updates the documentation with steps needed to enable this service.

Fixes systemd part of #337. A Desktop Entry solution will follow (most likely).