### PR TITLE
Fix reference to the bloop Compat which gets mixed up with sbt.Compat

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -341,7 +341,7 @@ object PluginImplementation {
                             AutoImported.bloopManagedResourceDirectories.in(configKey))
             .value
         val s = Keys.streams.value
-        val cacheStore = Compat.generateCacheFile(s, "copy-resources-bloop")
+        val cacheStore = bloop.integrations.sbt.Compat.generateCacheFile(s, "copy-resources-bloop")
         val mappings = (sbt.PathFinder(Keys.resources.value) --- dirs) pair (sbt.Path
           .rebase(dirs, t) | sbt.Path.flat(t))
         s.log.debug("Copy resource mappings: " + mappings.mkString("\n\t", "\n\t", ""))


### PR DESCRIPTION
The conflicting plugin appears to be sbt-metals 🌵 See https://github.com/scalameta/metals/pull/266 :trollface: 

/cc @Duhemm 