### PR TITLE
Add akka and detect 'test->compile' and 'compile->test' better

### DIFF
--- a/build-integrations/sbt-1.0/.sbtopts
+++ b/build-integrations/sbt-1.0/.sbtopts
@@ -1,2 +1,2 @@
 # Required because of sbt bug when picking up the property from the working directory
--Dsbt.version=1.1.1
+-Dsbt.version=1.1.4

--- a/build-integrations/sbt-1.0/build.sbt
+++ b/build-integrations/sbt-1.0/build.sbt
@@ -3,7 +3,8 @@ val GuardianFrontend = Integrations.GuardianFrontend
 val MiniBetterFiles = Integrations.MiniBetterFiles
 val WithResources = Integrations.WithResources
 val WithTests = Integrations.WithTests
-val integrations = List(SbtSbt, GuardianFrontend, MiniBetterFiles, WithResources, WithTests)
+val AkkaAkka = Integrations.AkkaAkka
+val integrations = List(SbtSbt, GuardianFrontend, MiniBetterFiles, WithResources, WithTests, AkkaAkka)
 
 import bloop.build.integrations.PluginKeys
 val dummy = project
@@ -18,7 +19,8 @@ val dummy = project
         "frontend" -> bloopConfigDir.in(GuardianFrontend).in(Compile).value,
         "mini-better-files" -> bloopConfigDir.in(MiniBetterFiles).in(Compile).value,
         "with-resources" -> bloopConfigDir.in(WithResources).in(Compile).value,
-        "with-tests" -> bloopConfigDir.in(WithTests).in(Compile).value
+        "with-tests" -> bloopConfigDir.in(WithTests).in(Compile).value,
+        "akka" -> bloopConfigDir.in(AkkaAkka).in(Compile).value
       )
     },
     cleanAllBuilds := {
@@ -29,7 +31,8 @@ val dummy = project
         clean.in(GuardianFrontend),
         clean.in(MiniBetterFiles),
         clean.in(WithResources),
-        clean.in(WithTests)
+        clean.in(WithTests),
+        clean.in(AkkaAkka)
       )
     }
   )

--- a/build-integrations/sbt-1.0/project/Integrations.scala
+++ b/build-integrations/sbt-1.0/project/Integrations.scala
@@ -12,5 +12,7 @@ object Integrations {
     uri("git://github.com/scalacenter/with-resources.git#f0a46830cae7ef6282d9bba64b6da34bae18f339"))
   val WithTests = RootProject(
     uri("git://github.com/scalacenter/with-tests.git#3be26f4f21427c5bc0b83deb96d6e66973102eb2"))
+  val AkkaAkka = RootProject(
+    uri("git://github.com/akka/akka.git#577b38ce7b75752f443ecf6b3481d911f8564891"))
 
 }

--- a/build-integrations/sbt-1.0/project/build.properties
+++ b/build-integrations/sbt-1.0/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.1.4

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/bar/src/test/scala/BTest.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/bar/src/test/scala/BTest.scala
@@ -1,0 +1,6 @@
+package bar
+
+import foo.A
+import foo.ATest
+
+class BTest

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/baz/src/main/scala/C.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/baz/src/main/scala/C.scala
@@ -1,0 +1,3 @@
+package baz
+import bar.BTest
+class C

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/build.sbt
@@ -1,0 +1,4 @@
+val foo = project
+val bar = project.dependsOn(foo % "test->compile;test->test")
+val baz = project.dependsOn(bar % "compile->test")
+val woo = project.dependsOn(foo % "test->compile")

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/foo/src/main/scala/A.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/foo/src/main/scala/A.scala
@@ -1,0 +1,2 @@
+package foo
+class A

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/foo/src/test/scala/ATest.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/foo/src/test/scala/ATest.scala
@@ -1,0 +1,2 @@
+package foo
+class ATest

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/test
@@ -1,0 +1,4 @@
+> bar/test:compile
+> baz/compile
+> woo/test:compile
+> bloopInstall

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/woo/src/test/scala/D.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/woo/src/test/scala/D.scala
@@ -1,0 +1,5 @@
+package woo
+
+import foo.A
+
+class D

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -344,7 +344,7 @@ object BuildImplementation {
     val fixScalaVersionForSbtPlugin: Def.Initialize[String] = Def.setting {
       val orig = Keys.scalaVersion.value
       val is013 = (Keys.sbtVersion in Keys.pluginCrossBuild).value.startsWith("0.13")
-      if (is013) "2.10.6" else orig
+      if (is013) "2.10.7" else orig
     }
 
     // From sbt-sensible https://gitlab.com/fommil/sbt-sensible/issues/5, legal requirement

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.1.4


### PR DESCRIPTION
Use `Classpaths.mapped` from sbt to parse classpath configuration dependencies
*only* for compile/test dependencies.