### PR TITLE
Filter out directories that don't exist

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -103,7 +103,7 @@ object Interpreter {
   private[bloop] def watch(project: Project, state: State, f: State => Task[State]): Task[State] = {
     val reachable = Dag.dfs(state.build.getDagFor(project))
     val allSources = reachable.iterator.flatMap(_.sources.toList).map(_.underlying)
-    val watcher = new SourceWatcher(project, allSources.toList, state.logger)
+    val watcher = SourceWatcher(project, allSources.toList, state.logger)
     val fg = (state: State) =>
       f(state).map { state =>
         watcher.notifyWatch()


### PR DESCRIPTION
If users want the non-existing directories to be picked up by bloop they
need to run `bloop compile blabla -w` again.