### PR TITLE
Support linking and running of Scala Native projects

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,7 @@ matrix:
           "frontend/integrationSetUpBloop" \
           "backend/test" \
           "frontend/test" \
+          "nativeBridge/test" \
           "docs/makeSite"
 
   SBT_RUN_BENCHMARKS_AND_SCRIPTED:
@@ -61,7 +62,7 @@ pipeline:
       - /drone/.sbt
 
   build:
-    image: scalacenter/scala-docs:1.1
+    image: scalacenter/scala-docs:1.3
     group: build
     when:
       ref: [ refs/heads/master, refs/tags/*, refs/pull/*/head ]
@@ -76,7 +77,7 @@ pipeline:
       - ${SBT_RUN}; ./bin/ci-clean-cache.sh
 
   run_benchmarks_scripted:
-    image: scalacenter/scala-docs:1.1
+    image: scalacenter/scala-docs:1.3
     group: build
     when:
       ref: [ refs/heads/master, refs/tags/*, refs/pull/*/head ]
@@ -102,7 +103,7 @@ pipeline:
       - ./bin/stream-jenkins-log.sh "bloop:$BLOOP_JENKINS_TOKEN"
 
   publish:
-    image: scalacenter/scala-docs:1.1
+    image: scalacenter/scala-docs:1.3
     secrets: [ sonatype_user, sonatype_password, pgp_password, bintray_user, bintray_pass, bloopoid_private_key ]
     volumes:
       - /scalacenter:/keys
@@ -124,7 +125,7 @@ pipeline:
       - ./bin/ci-clean-cache.sh
 
   release:
-    image: scalacenter/scala-docs:1.1
+    image: scalacenter/scala-docs:1.3
     secrets: [ bloopoid_github_token ]
     volumes:
       - /scalacenter:/keys

--- a/bridges/scala-native/src/main/scala/bloop/scalanative/NativeBridge.scala
+++ b/bridges/scala-native/src/main/scala/bloop/scalanative/NativeBridge.scala
@@ -4,10 +4,39 @@ import bloop.Project
 import bloop.io.AbsolutePath
 import bloop.logging.Logger
 
+import java.nio.file.Path
+
+import scala.scalanative.build.{Discover, Build, Config, GC, Mode}
+
 object NativeBridge {
 
-  def nativeLink(project: Project, entry: String, logger: Logger): AbsolutePath = {
-    ???
+  def nativeLink(project: Project, entry: String, logger: Logger): Path = {
+    val classpath = project.classpath.map(_.underlying)
+    val workdir = project.out.resolve("native").underlying
+
+    val clang = Discover.clang()
+    val clangpp = Discover.clangpp()
+    val linkopts = Discover.linkingOptions()
+    val compopts = Discover.compileOptions()
+    val triple = Discover.targetTriple(clang, workdir)
+    val nativelib = Discover.nativelib(classpath).get
+    val outpath = workdir.resolve("out")
+
+    val config =
+      Config.empty
+        .withGC(GC.default)
+        .withMode(Mode.default)
+        .withClang(clang)
+        .withClangPP(clangpp)
+        .withLinkingOptions(linkopts)
+        .withCompileOptions(compopts)
+        .withTargetTriple(triple)
+        .withNativelib(nativelib)
+        .withMainClass(entry)
+        .withClassPath(classpath)
+        .withWorkdir(workdir)
+
+    Build.build(config, outpath)
   }
 
 }

--- a/bridges/scala-native/src/main/scala/bloop/scalanative/NativeBridge.scala
+++ b/bridges/scala-native/src/main/scala/bloop/scalanative/NativeBridge.scala
@@ -2,10 +2,10 @@ package bloop.scalanative
 
 import bloop.Project
 import bloop.config.Config.NativeConfig
-import bloop.io.AbsolutePath
+import bloop.io.{AbsolutePath, Paths}
 import bloop.logging.Logger
 
-import java.nio.file.Path
+import java.nio.file.{Files, Path}
 
 import scala.scalanative.build.{Discover, Build, Config, GC, Mode, Logger => NativeLogger}
 
@@ -13,7 +13,11 @@ object NativeBridge {
 
   def nativeLink(project: Project, entry: String, logger: Logger): Path = {
     val classpath = project.classpath.map(_.underlying)
-    val workdir = project.out.resolve("native").underlying
+    val workdir = project.out.resolve("native")
+
+    Paths.delete(workdir)
+    Files.createDirectories(workdir.underlying)
+
     val outpath = workdir.resolve("out")
     val nativeLogger = NativeLogger(logger.debug _, logger.info _, logger.warn _, logger.error _)
     val nativeConfig = project.nativeConfig.getOrElse(defaultNativeConfig(project))
@@ -31,10 +35,10 @@ object NativeBridge {
         .withLinkStubs(nativeConfig.linkStubs)
         .withMainClass(entry)
         .withClassPath(classpath)
-        .withWorkdir(workdir)
+        .withWorkdir(workdir.underlying)
         .withLogger(nativeLogger)
 
-    Build.build(config, outpath)
+    Build.build(config, outpath.underlying)
   }
 
   private[scalanative] def defaultNativeConfig(project: Project): NativeConfig = {

--- a/bridges/scala-native/src/main/scala/bloop/scalanative/NativeBridge.scala
+++ b/bridges/scala-native/src/main/scala/bloop/scalanative/NativeBridge.scala
@@ -6,7 +6,7 @@ import bloop.logging.Logger
 
 import java.nio.file.Path
 
-import scala.scalanative.build.{Discover, Build, Config, GC, Mode}
+import scala.scalanative.build.{Discover, Build, Config, GC, Mode, Logger => NativeLogger}
 
 object NativeBridge {
 
@@ -21,6 +21,7 @@ object NativeBridge {
     val triple = Discover.targetTriple(clang, workdir)
     val nativelib = Discover.nativelib(classpath).get
     val outpath = workdir.resolve("out")
+    val nativeLogger = NativeLogger(logger.debug _, logger.info _, logger.warn _, logger.error _)
 
     val config =
       Config.empty
@@ -35,6 +36,7 @@ object NativeBridge {
         .withMainClass(entry)
         .withClassPath(classpath)
         .withWorkdir(workdir)
+        .withLogger(nativeLogger)
 
     Build.build(config, outpath)
   }

--- a/bridges/scala-native/src/main/scala/bloop/scalanative/NativeBridge.scala
+++ b/bridges/scala-native/src/main/scala/bloop/scalanative/NativeBridge.scala
@@ -1,0 +1,13 @@
+package bloop.scalanative
+
+import bloop.Project
+import bloop.io.AbsolutePath
+import bloop.logging.Logger
+
+object NativeBridge {
+
+  def nativeLink(project: Project, entry: String, logger: Logger): AbsolutePath = {
+    ???
+  }
+
+}

--- a/bridges/scala-native/src/test/scala/bloop/scalanative/ScalaNativeSpec.scala
+++ b/bridges/scala-native/src/test/scala/bloop/scalanative/ScalaNativeSpec.scala
@@ -1,4 +1,4 @@
-package bloop.tasks
+package bloop.scalanative
 
 import bloop.{DependencyResolution, Project, ScalaInstance}
 import bloop.cli.Commands
@@ -7,6 +7,7 @@ import bloop.engine.{Run, State}
 import bloop.exec.JavaEnv
 import bloop.io.AbsolutePath
 import bloop.logging.{Logger, RecordingLogger}
+import bloop.tasks.TestUtil
 
 import scala.concurrent.duration.Duration
 import java.util.concurrent.TimeUnit
@@ -21,7 +22,9 @@ class ScalaNativeSpec {
   @Test
   def canLinkScalaNativeProject(): Unit = {
     val logger = new RecordingLogger
-    val state = TestUtil.loadTestProject("cross-platform", _.map(setScalaNativeClasspath)).copy(logger = logger)
+    val state = TestUtil
+      .loadTestProject("cross-platform", _.map(setScalaNativeClasspath))
+      .copy(logger = logger)
     val action = Run(Commands.Link(project = "crossNative"))
     val resultingState = TestUtil.blockingExecute(action, state, maxDuration)
 
@@ -40,7 +43,9 @@ class ScalaNativeSpec {
   @Test
   def canRunScalaNativeProject(): Unit = {
     val logger = new RecordingLogger
-    val state = TestUtil.loadTestProject("cross-platform", _.map(setScalaNativeClasspath)).copy(logger = logger)
+    val state = TestUtil
+      .loadTestProject("cross-platform", _.map(setScalaNativeClasspath))
+      .copy(logger = logger)
     val action = Run(Commands.Run(project = "crossNative"))
     val resultingState = TestUtil.blockingExecute(action, state, maxDuration)
     assertTrue(s"Run failed: ${logger.getMessages.mkString("\n")}", resultingState.status.isOk)
@@ -62,7 +67,7 @@ class ScalaNativeSpec {
   // and will work because the toolchain is on this module's classpath.
   private val setScalaNativeClasspath: Project => Project = {
     case prj if prj.platform == Config.Platform.Native =>
-      prj.copy(nativeClasspath = Array(AbsolutePath(".")))
+      prj.copy(nativeConfig = Some(NativeBridge.defaultNativeConfig(prj)))
     case other =>
       other
   }

--- a/bridges/scala-native/src/test/scala/bloop/scalanative/ScalaNativeToolchainSpec.scala
+++ b/bridges/scala-native/src/test/scala/bloop/scalanative/ScalaNativeToolchainSpec.scala
@@ -17,7 +17,7 @@ import org.junit.Test
 import org.junit.experimental.categories.Category
 
 @Category(Array(classOf[bloop.FastTests]))
-class ScalaNativeSpec {
+class ScalaNativeToolchainSpec {
 
   @Test
   def canLinkScalaNativeProject(): Unit = {

--- a/bridges/scala-native/src/test/scala/bloop/tasks/ScalaNativeSpec.scala
+++ b/bridges/scala-native/src/test/scala/bloop/tasks/ScalaNativeSpec.scala
@@ -1,0 +1,70 @@
+package bloop.tasks
+
+import bloop.{DependencyResolution, Project, ScalaInstance}
+import bloop.cli.Commands
+import bloop.config.Config
+import bloop.engine.{Run, State}
+import bloop.exec.JavaEnv
+import bloop.io.AbsolutePath
+import bloop.logging.{Logger, RecordingLogger}
+
+import scala.concurrent.duration.Duration
+import java.util.concurrent.TimeUnit
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.experimental.categories.Category
+
+@Category(Array(classOf[bloop.FastTests]))
+class ScalaNativeSpec {
+
+  @Test
+  def canLinkScalaNativeProject(): Unit = {
+    val logger = new RecordingLogger
+    val state = TestUtil.loadTestProject("cross-platform", _.map(setScalaNativeClasspath)).copy(logger = logger)
+    val action = Run(Commands.Link(project = "crossNative"))
+    val resultingState = TestUtil.blockingExecute(action, state, maxDuration)
+
+    assertTrue(s"Linking failed: ${logger.getMessages.mkString("\n")}", resultingState.status.isOk)
+
+    val needle = "Scala Native binary:"
+    assertTrue(
+      s"Logs didn't contain '$needle': ${logger.getMessages.mkString("\n")}",
+      logger.getMessages.exists {
+        case ("info", msg) => msg.startsWith(needle)
+        case _ => false
+      }
+    )
+  }
+
+  @Test
+  def canRunScalaNativeProject(): Unit = {
+    val logger = new RecordingLogger
+    val state = TestUtil.loadTestProject("cross-platform", _.map(setScalaNativeClasspath)).copy(logger = logger)
+    val action = Run(Commands.Run(project = "crossNative"))
+    val resultingState = TestUtil.blockingExecute(action, state, maxDuration)
+    assertTrue(s"Run failed: ${logger.getMessages.mkString("\n")}", resultingState.status.isOk)
+
+    val needle = "Hello, world!"
+    assertTrue(
+      s"Logs didn't contain '$needle': ${logger.getMessages.mkString("\n")}",
+      logger.getMessages.exists {
+        case ("info", msg) => msg.startsWith(needle)
+        case _ => false
+      }
+    )
+  }
+
+  private val maxDuration = Duration.apply(30, TimeUnit.SECONDS)
+
+  // Set a dummy `nativeClasspath` for the Scala Native toolchain.
+  // This is to avoid trying to resolve the toolchain with Coursier,
+  // and will work because the toolchain is on this module's classpath.
+  private val setScalaNativeClasspath: Project => Project = {
+    case prj if prj.platform == Config.Platform.Native =>
+      prj.copy(nativeClasspath = Array(AbsolutePath(".")))
+    case other =>
+      other
+  }
+
+}

--- a/build-integrations/sbt-1.0/build.sbt
+++ b/build-integrations/sbt-1.0/build.sbt
@@ -4,7 +4,9 @@ val MiniBetterFiles = Integrations.MiniBetterFiles
 val WithResources = Integrations.WithResources
 val WithTests = Integrations.WithTests
 val AkkaAkka = Integrations.AkkaAkka
-val integrations = List(SbtSbt, GuardianFrontend, MiniBetterFiles, WithResources, WithTests, AkkaAkka)
+val CrossPlatform = Integrations.CrossPlatform
+val integrations =
+  List(SbtSbt, GuardianFrontend, MiniBetterFiles, WithResources, WithTests, AkkaAkka, CrossPlatform)
 
 import bloop.build.integrations.PluginKeys
 val dummy = project
@@ -20,7 +22,8 @@ val dummy = project
         "mini-better-files" -> bloopConfigDir.in(MiniBetterFiles).in(Compile).value,
         "with-resources" -> bloopConfigDir.in(WithResources).in(Compile).value,
         "with-tests" -> bloopConfigDir.in(WithTests).in(Compile).value,
-        "akka" -> bloopConfigDir.in(AkkaAkka).in(Compile).value
+        "akka" -> bloopConfigDir.in(AkkaAkka).in(Compile).value,
+        "cross-platform" -> bloopConfigDir.in(CrossPlatform).in(Compile).value
       )
     },
     cleanAllBuilds := {
@@ -32,7 +35,8 @@ val dummy = project
         clean.in(MiniBetterFiles),
         clean.in(WithResources),
         clean.in(WithTests),
-        clean.in(AkkaAkka)
+        clean.in(AkkaAkka),
+        clean.in(CrossPlatform)
       )
     }
   )

--- a/build-integrations/sbt-1.0/project/Integrations.scala
+++ b/build-integrations/sbt-1.0/project/Integrations.scala
@@ -14,5 +14,7 @@ object Integrations {
     uri("git://github.com/scalacenter/with-tests.git#3be26f4f21427c5bc0b83deb96d6e66973102eb2"))
   val AkkaAkka = RootProject(
     uri("git://github.com/scalacenter/akka.git#ad1c3fcad5f5521792f3772a195b0b9167f570fd"))
+  val CrossPlatform = RootProject(
+    uri("git://github.com/scalacenter/cross-platform.git#5ab789edfad025db7f1042bb207c7efba4da9514"))
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -150,7 +150,7 @@ val docs = project
   )
 
 lazy val nativeBridge = project
-  .dependsOn(frontend % Provided)
+  .dependsOn(frontend % Provided, frontend % "test->test")
   .in(file("bridges") / "scala-native")
   .disablePlugins(ScriptedPlugin)
   .settings(testSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ val jsonConfig = project
 
 import build.BuildImplementation.jvmOptions
 // For the moment, the dependency is fixed
-val frontend = project
+lazy val frontend: Project = project
   .dependsOn(backend, backend % "test->test", jsonConfig)
   .disablePlugins(ScriptedPlugin)
   .enablePlugins(BuildInfoPlugin)
@@ -91,7 +91,7 @@ val frontend = project
     name := s"bloop-frontend",
     mainClass in Compile in run := Some("bloop.Cli"),
     buildInfoPackage := "bloop.internal.build",
-    buildInfoKeys := BloopInfoKeys,
+    buildInfoKeys := BloopInfoKeys(nativeBridge),
     javaOptions in run ++= jvmOptions,
     javaOptions in Test ++= jvmOptions,
     libraryDependencies += Dependencies.graphviz % Test,
@@ -149,7 +149,17 @@ val docs = project
     websiteSettings
   )
 
-val allProjects = Seq(backend, benchmarks, frontend, jsonConfig, sbtBloop, mavenBloop)
+lazy val nativeBridge = project
+  .dependsOn(frontend % Provided)
+  .in(file("bridges") / "scala-native")
+  .disablePlugins(ScriptedPlugin)
+  .settings(testSettings)
+  .settings(
+    name := "bloop-native-bridge",
+    libraryDependencies += Dependencies.scalaNativeTools
+  )
+
+val allProjects = Seq(backend, benchmarks, frontend, jsonConfig, sbtBloop, mavenBloop, nativeBridge)
 val allProjectReferences = allProjects.map(p => LocalProject(p.id))
 val bloop = project
   .in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -185,7 +185,8 @@ addCommandAlias(
     s"^${sbtBloop.id}/$publishLocalCmd",
     s"${mavenBloop.id}/$publishLocalCmd",
     s"${backend.id}/$publishLocalCmd",
-    s"${frontend.id}/$publishLocalCmd"
+    s"${frontend.id}/$publishLocalCmd",
+    s"${nativeBridge.id}/$publishLocalCmd"
   ).mkString(";", ";", "")
 )
 
@@ -198,6 +199,7 @@ val allBloopReleases = List(
   s"+${jsonConfig.id}/$releaseEarlyCmd",
   s"^${sbtBloop.id}/$releaseEarlyCmd",
   s"${mavenBloop.id}/$releaseEarlyCmd",
+  s"${nativeBridge.id}/$releaseEarlyCmd"
 )
 
 val allReleaseActions = allBloopReleases ++ List("sonatypeReleaseAll")

--- a/config/src/main/scala-2.10/bloop/config/ConfigEncoders.scala
+++ b/config/src/main/scala-2.10/bloop/config/ConfigEncoders.scala
@@ -23,6 +23,7 @@ object ConfigEncoders {
     override final def apply(platform: Platform): Json = Json.fromString(platform.name)
   }
 
+  implicit val nativeConfigEncoder: ObjectEncoder[NativeConfig] = deriveEncoder
   implicit val javaConfigEncoder: ObjectEncoder[Java] = deriveEncoder
   implicit val jvmConfigEncoder: ObjectEncoder[Jvm] = deriveEncoder
   implicit val testFrameworkConfigEncoder: ObjectEncoder[TestFramework] = deriveEncoder

--- a/config/src/main/scala-2.10/bloop/config/ConfigEncoders.scala
+++ b/config/src/main/scala-2.10/bloop/config/ConfigEncoders.scala
@@ -19,6 +19,10 @@ object ConfigEncoders {
     }
   }
 
+  implicit val platformConfigEncoder: RootEncoder[Platform] = new RootEncoder[Platform] {
+    override final def apply(platform: Platform): Json = Json.fromString(platform.name)
+  }
+
   implicit val javaConfigEncoder: ObjectEncoder[Java] = deriveEncoder
   implicit val jvmConfigEncoder: ObjectEncoder[Jvm] = deriveEncoder
   implicit val testFrameworkConfigEncoder: ObjectEncoder[TestFramework] = deriveEncoder

--- a/config/src/main/scala-2.12/bloop/config/ConfigDecoders.scala
+++ b/config/src/main/scala-2.12/bloop/config/ConfigDecoders.scala
@@ -25,6 +25,11 @@ object ConfigDecoders {
     }
   }
 
+  implicit val nativeConfigSurface: Surface[NativeConfig] =
+    generic.deriveSurface[NativeConfig]
+  implicit val nativeConfigDecoder: ConfDecoder[NativeConfig] =
+    generic.deriveDecoder[NativeConfig](NativeConfig.empty)
+
   implicit val javaConfigSurface: Surface[Java] =
     generic.deriveSurface[Java]
   implicit val javaConfigDecoder: ConfDecoder[Java] =

--- a/config/src/main/scala-2.12/bloop/config/ConfigDecoders.scala
+++ b/config/src/main/scala-2.12/bloop/config/ConfigDecoders.scala
@@ -16,6 +16,15 @@ object ConfigDecoders {
     }
   }
 
+  implicit val platformDecoder: ConfDecoder[Platform] = {
+    ConfDecoder.stringConfDecoder.flatMap { str =>
+      Try(Platform(str)) match {
+        case Success(platform) => Configured.Ok(platform)
+        case Failure(t) => Configured.error(t.getMessage)
+      }
+    }
+  }
+
   implicit val javaConfigSurface: Surface[Java] =
     generic.deriveSurface[Java]
   implicit val javaConfigDecoder: ConfDecoder[Java] =

--- a/config/src/main/scala-2.12/bloop/config/ConfigEncoders.scala
+++ b/config/src/main/scala-2.12/bloop/config/ConfigEncoders.scala
@@ -23,6 +23,7 @@ object ConfigEncoders {
     override final def apply(platform: Platform): Json = Json.fromString(platform.name)
   }
 
+  implicit val nativeConfigEncoder: ObjectEncoder[NativeConfig] = deriveEncoder
   implicit val javaConfigEncoder: ObjectEncoder[Java] = deriveEncoder
   implicit val jvmConfigEncoder: ObjectEncoder[Jvm] = deriveEncoder
   implicit val testFrameworkConfigEncoder: ObjectEncoder[TestFramework] = deriveEncoder

--- a/config/src/main/scala-2.12/bloop/config/ConfigEncoders.scala
+++ b/config/src/main/scala-2.12/bloop/config/ConfigEncoders.scala
@@ -19,6 +19,10 @@ object ConfigEncoders {
     }
   }
 
+  implicit val platformConfigEncoder: RootEncoder[Platform] = new RootEncoder[Platform] {
+    override final def apply(platform: Platform): Json = Json.fromString(platform.name)
+  }
+
   implicit val javaConfigEncoder: ObjectEncoder[Java] = deriveEncoder
   implicit val jvmConfigEncoder: ObjectEncoder[Jvm] = deriveEncoder
   implicit val testFrameworkConfigEncoder: ObjectEncoder[TestFramework] = deriveEncoder

--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -75,6 +75,30 @@ object Config {
     }
   }
 
+  case class NativeConfig(
+      toolchainClasspath: Array[Path],
+      gc: String,
+      clang: Path,
+      clangPP: Path,
+      linkingOptions: Array[String],
+      compileOptions: Array[String],
+      targetTriple: String,
+      nativelib: Path,
+      linkStubs: Boolean
+  )
+
+  object NativeConfig {
+    private[bloop] val empty = NativeConfig(Array.empty,
+                                            "",
+                                            emptyPath,
+                                            emptyPath,
+                                            Array.empty,
+                                            Array.empty,
+                                            "",
+                                            emptyPath,
+                                            false)
+  }
+
   case class Project(
       name: String,
       directory: Path,
@@ -91,7 +115,7 @@ object Config {
       java: Java,
       test: Test,
       platform: Platform,
-      nativeClasspath: Array[Path]
+      nativeConfig: Option[NativeConfig]
   )
 
   object Project {
@@ -99,7 +123,7 @@ object Config {
     private[bloop] val empty: Project =
       Project("", emptyPath, Array(), Array(), Array(), ClasspathOptions.empty,
         CompileOptions.empty, emptyPath, emptyPath, emptyPath, Scala.empty, Jvm.empty, Java.empty,
-        Test.empty, Platform.default, Array())
+        Test.empty, Platform.default, None)
     // FORMAT: ON
 
     def analysisFileName(projectName: String) = s"$projectName-analysis.bin"
@@ -153,7 +177,7 @@ object Config {
         Java(Array("-version")),
         Test(Array(), TestOptions(Nil, Nil)),
         Platform.default,
-        Array.empty
+        None
       )
 
       File(LatestVersion, project)

--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -59,6 +59,22 @@ object Config {
     private[bloop] val empty: Scala = Scala("", "", "", Array(), Array())
   }
 
+  sealed abstract class Platform(val name: String)
+  object Platform {
+    private[bloop] val default: Platform = JVM
+
+    case object JS extends Platform("JS")
+    case object JVM extends Platform("JVM")
+    case object Native extends Platform("Native")
+
+    def apply(platform: String): Platform = platform match {
+      case JS.name => JS
+      case JVM.name => JVM
+      case Native.name => Native
+      case _ => throw new IllegalArgumentException(s"Unknown platform: '$platform'")
+    }
+  }
+
   case class Project(
       name: String,
       directory: Path,
@@ -73,13 +89,16 @@ object Config {
       `scala`: Scala,
       jvm: Jvm,
       java: Java,
-      test: Test
+      test: Test,
+      platform: Platform
   )
 
   object Project {
     // FORMAT: OFF
     private[bloop] val empty: Project =
-      Project("", emptyPath, Array(), Array(), Array(), ClasspathOptions.empty, CompileOptions.empty, emptyPath, emptyPath, emptyPath, Scala.empty, Jvm.empty, Java.empty, Test.empty)
+      Project("", emptyPath, Array(), Array(), Array(), ClasspathOptions.empty,
+        CompileOptions.empty, emptyPath, emptyPath, emptyPath, Scala.empty, Jvm.empty, Java.empty,
+        Test.empty, Platform.default)
     // FORMAT: ON
 
     def analysisFileName(projectName: String) = s"$projectName-analysis.bin"
@@ -131,7 +150,8 @@ object Config {
         Scala("org.scala-lang", "scala-compiler", "2.12.4", Array("-warn"), Array()),
         Jvm(Some(Paths.get("/usr/lib/jvm/java-8-jdk")), Array()),
         Java(Array("-version")),
-        Test(Array(), TestOptions(Nil, Nil))
+        Test(Array(), TestOptions(Nil, Nil)),
+        Platform.default
       )
 
       File(LatestVersion, project)

--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -63,11 +63,11 @@ object Config {
   object Platform {
     private[bloop] val default: Platform = JVM
 
-    case object JS extends Platform("JS")
-    case object JVM extends Platform("JVM")
-    case object Native extends Platform("Native")
+    case object JS extends Platform("js")
+    case object JVM extends Platform("jvm")
+    case object Native extends Platform("native")
 
-    def apply(platform: String): Platform = platform match {
+    def apply(platform: String): Platform = platform.toLowerCase match {
       case JS.name => JS
       case JVM.name => JVM
       case Native.name => Native

--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -75,6 +75,11 @@ object Config {
     }
   }
 
+  /**
+   * Configures how to start and use the Scala Native toolchain, if needed.
+   * For the description of these fields, see:
+   * http://static.javadoc.io/org.scala-native/tools_2.10/0.3.7/index.html#scala.scalanative.build.Config
+   */
   case class NativeConfig(
       toolchainClasspath: Array[Path],
       gc: String,
@@ -88,15 +93,11 @@ object Config {
   )
 
   object NativeConfig {
-    private[bloop] val empty = NativeConfig(Array.empty,
-                                            "",
-                                            emptyPath,
-                                            emptyPath,
-                                            Array.empty,
-                                            Array.empty,
-                                            "",
-                                            emptyPath,
-                                            false)
+    // FORMAT: OFF
+    private[bloop] val empty: NativeConfig =
+      NativeConfig(Array.empty, "", emptyPath, emptyPath, Array.empty, Array.empty, "", emptyPath,
+        false)
+    // FORMAT: ON
   }
 
   case class Project(

--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -90,7 +90,8 @@ object Config {
       jvm: Jvm,
       java: Java,
       test: Test,
-      platform: Platform
+      platform: Platform,
+      nativeClasspath: Array[Path]
   )
 
   object Project {
@@ -98,7 +99,7 @@ object Config {
     private[bloop] val empty: Project =
       Project("", emptyPath, Array(), Array(), Array(), ClasspathOptions.empty,
         CompileOptions.empty, emptyPath, emptyPath, emptyPath, Scala.empty, Jvm.empty, Java.empty,
-        Test.empty, Platform.default)
+        Test.empty, Platform.default, Array())
     // FORMAT: ON
 
     def analysisFileName(projectName: String) = s"$projectName-analysis.bin"
@@ -151,7 +152,8 @@ object Config {
         Jvm(Some(Paths.get("/usr/lib/jvm/java-8-jdk")), Array()),
         Java(Array("-version")),
         Test(Array(), TestOptions(Nil, Nil)),
-        Platform.default
+        Platform.default,
+        Array.empty
       )
 
       File(LatestVersion, project)

--- a/config/src/test/scala-2.12/bloop/config/JsonSpec.scala
+++ b/config/src/test/scala-2.12/bloop/config/JsonSpec.scala
@@ -8,6 +8,7 @@ import bloop.config.Config.{
   File,
   Java,
   Jvm,
+  Platform,
   Project,
   Scala,
   TestOptions,

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -187,6 +187,12 @@ object Cli {
               case Right(c: Commands.Configure) =>
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
                 run(newCommand, newCommand.cliOptions)
+              case Right(c: Commands.NativeLink) =>
+                val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
+                withProject(c.project) { (p: String) =>
+                  val cmd = if (p != c.project) newCommand.copy(project = p) else newCommand
+                  run(cmd, newCommand.cliOptions)
+                }
             }
         }
         newAction.getOrElse {

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -187,7 +187,7 @@ object Cli {
               case Right(c: Commands.Configure) =>
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
                 run(newCommand, newCommand.cliOptions)
-              case Right(c: Commands.NativeLink) =>
+              case Right(c: Commands.Link) =>
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
                 withProject(c.project) { (p: String) =>
                   val cmd = if (p != c.project) newCommand.copy(project = p) else newCommand

--- a/frontend/src/main/scala/bloop/Project.scala
+++ b/frontend/src/main/scala/bloop/Project.scala
@@ -8,6 +8,7 @@ import xsbti.compile.ClasspathOptions
 import _root_.monix.eval.Task
 import bloop.bsp.ProjectUris
 import bloop.config.{Config, ConfigDecoders}
+import bloop.config.Config.Platform
 import bloop.engine.ExecutionContext
 import metaconfig.{Conf, Configured, Input}
 
@@ -26,7 +27,8 @@ final case class Project(
     testOptions: Config.TestOptions,
     javaEnv: JavaEnv,
     out: AbsolutePath,
-    analysisOut: AbsolutePath
+    analysisOut: AbsolutePath,
+    platform: Platform
 ) {
   override def toString: String = s"$name"
   override val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
@@ -127,7 +129,8 @@ object Project {
       project.test.options,
       javaEnv,
       AbsolutePath(project.out),
-      AbsolutePath(project.analysisOut)
+      AbsolutePath(project.analysisOut),
+      project.platform
     )
   }
 

--- a/frontend/src/main/scala/bloop/Project.scala
+++ b/frontend/src/main/scala/bloop/Project.scala
@@ -28,7 +28,8 @@ final case class Project(
     javaEnv: JavaEnv,
     out: AbsolutePath,
     analysisOut: AbsolutePath,
-    platform: Platform
+    platform: Platform,
+    nativeClasspath: Array[AbsolutePath]
 ) {
   override def toString: String = s"$name"
   override val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
@@ -130,7 +131,8 @@ object Project {
       javaEnv,
       AbsolutePath(project.out),
       AbsolutePath(project.analysisOut),
-      project.platform
+      project.platform,
+      project.nativeClasspath.map(AbsolutePath.apply)
     )
   }
 

--- a/frontend/src/main/scala/bloop/Project.scala
+++ b/frontend/src/main/scala/bloop/Project.scala
@@ -8,7 +8,7 @@ import xsbti.compile.ClasspathOptions
 import _root_.monix.eval.Task
 import bloop.bsp.ProjectUris
 import bloop.config.{Config, ConfigDecoders}
-import bloop.config.Config.Platform
+import bloop.config.Config.{NativeConfig, Platform}
 import bloop.engine.ExecutionContext
 import metaconfig.{Conf, Configured, Input}
 
@@ -29,7 +29,7 @@ final case class Project(
     out: AbsolutePath,
     analysisOut: AbsolutePath,
     platform: Platform,
-    nativeClasspath: Array[AbsolutePath]
+    nativeConfig: Option[NativeConfig]
 ) {
   override def toString: String = s"$name"
   override val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
@@ -132,7 +132,7 @@ object Project {
       AbsolutePath(project.out),
       AbsolutePath(project.analysisOut),
       project.platform,
-      project.nativeClasspath.map(AbsolutePath.apply)
+      project.nativeConfig
     )
   }
 

--- a/frontend/src/main/scala/bloop/cli/CliParsers.scala
+++ b/frontend/src/main/scala/bloop/cli/CliParsers.scala
@@ -30,6 +30,14 @@ object CliParsers {
     }
   }
 
+  implicit val optimizerConfigRead: ArgParser[OptimizerConfig] = {
+    ArgParser.instance[OptimizerConfig]("optimize") {
+      case "debug" => Right(OptimizerConfig.Debug)
+      case "release" => Right(OptimizerConfig.Release)
+      case w00t => Left(s"Unrecognized optimizer config: $w00t")
+    }
+  }
+
   implicit val propertiesParser: ArgParser[CommonOptions.PrettyProperties] = {
     ArgParser.instance("A properties parser") {
       case whatever => Left("You cannot pass in properties through the command line.")
@@ -63,8 +71,10 @@ object CliParsers {
   implicit val implicitOptionDefaultInputStream: Implicit[Option[Default[InputStream]]] =
     Implicit.instance(Some(Default.instance[InputStream](System.in)))
 
-  implicit val labelledGenericCommonOptions: LabelledGeneric[CommonOptions] = LabelledGeneric.materializeProduct
-  implicit val labelledGenericCliOptions: LabelledGeneric[CliOptions] = LabelledGeneric.materializeProduct
+  implicit val labelledGenericCommonOptions: LabelledGeneric[CommonOptions] =
+    LabelledGeneric.materializeProduct
+  implicit val labelledGenericCliOptions: LabelledGeneric[CliOptions] =
+    LabelledGeneric.materializeProduct
   implicit val coParser: Parser[CommonOptions] = Parser.generic
   implicit val cliParser: Parser[CliOptions] = Parser.generic
 

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -158,4 +158,19 @@ object Commands {
       watch: Boolean = false,
       @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends CompilingCommand
+
+  case class NativeLink(
+      @ExtraName("p")
+      @HelpMessage("The project to run (will be inferred from remaining cli args).")
+      project: String = "",
+      @ExtraName("m")
+      @HelpMessage("The main class to link. Leave unset to let bloop select automatically.")
+      main: Option[String] = None,
+      @HelpMessage("Pick reporter to show compilation messages. By default, bloop's used.")
+      reporter: ReporterKind = BloopReporter,
+      @ExtraName("w")
+      @HelpMessage("If set, run the command whenever projects' source files change.")
+      watch: Boolean = false,
+      @Recurse cliOptions: CliOptions = CliOptions.default
+  ) extends CompilingCommand
 }

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -156,6 +156,10 @@ object Commands {
       @ExtraName("w")
       @HelpMessage("If set, run the command whenever projects' source files change.")
       watch: Boolean = false,
+      @ExtraName("o")
+      @HelpMessage(
+        "If an optimizer is used (e.g. Scala Native or Scala.js), run it in `debug` or `release` mode. Defaults to `debug`.")
+      optimize: OptimizerConfig = OptimizerConfig.Debug,
       @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends CompilingCommand
 
@@ -171,6 +175,10 @@ object Commands {
       @ExtraName("w")
       @HelpMessage("If set, run the command whenever projects' source files change.")
       watch: Boolean = false,
+      @ExtraName("o")
+      @HelpMessage(
+        "If an optimizer is used (e.g. Scala Native or Scala.js), run it in `debug` or `release` mode. Defaults to `debug`.")
+      optimize: OptimizerConfig = OptimizerConfig.Debug,
       @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends CompilingCommand
 }

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -159,7 +159,7 @@ object Commands {
       @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends CompilingCommand
 
-  case class NativeLink(
+  case class Link(
       @ExtraName("p")
       @HelpMessage("The project to run (will be inferred from remaining cli args).")
       project: String = "",

--- a/frontend/src/main/scala/bloop/cli/ExitStatus.scala
+++ b/frontend/src/main/scala/bloop/cli/ExitStatus.scala
@@ -30,7 +30,7 @@ object ExitStatus {
   }
 
   // FORMAT: OFF
-  val Ok, UnexpectedError, ParseError, InvalidCommandLineOption, CompilationError, TestExecutionError, RunError: ExitStatus = generateExitStatus
+  val Ok, UnexpectedError, ParseError, InvalidCommandLineOption, CompilationError, LinkingError, TestExecutionError, RunError: ExitStatus = generateExitStatus
   // FORMAT: ON
 
   def apply(code: Int): ExitStatus = {

--- a/frontend/src/main/scala/bloop/cli/OptimizerConfig.scala
+++ b/frontend/src/main/scala/bloop/cli/OptimizerConfig.scala
@@ -1,0 +1,19 @@
+package bloop.cli
+
+/** The configuration of the optimizer, if any. */
+sealed trait OptimizerConfig
+
+object OptimizerConfig {
+
+  /**
+   * Runs the optimizer in `debug` mode.
+   * Optimization step is faster, but the produced code is slower.
+   */
+  case object Debug extends OptimizerConfig
+
+  /**
+   * Runs the optimizer in `release` mode.
+   * Optimization step is slower, but the produced code is faster.
+   */
+  case object Release extends OptimizerConfig
+}

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -292,7 +292,7 @@ object Interpreter {
               case None => Task(state.mergeStatus(ExitStatus.RunError))
               case Some(main) =>
                 val nativeToolchain = ScalaNative.forProject(project, state.logger)
-                nativeToolchain.link(project, main, state.logger).map {
+                nativeToolchain.link(project, main, state.logger, cmd.optimize).map {
                   case Success(nativeBinary) =>
                     state.logger.info(s"Scala Native binary: '${nativeBinary.syntax}'")
                     state
@@ -337,7 +337,7 @@ object Interpreter {
                 project.platform match {
                   case Platform.Native =>
                     val nativeToolchain = ScalaNative.forProject(project, state.logger)
-                    nativeToolchain.run(state, project, cwd, main, args)
+                    nativeToolchain.run(state, project, cwd, main, args, cmd.optimize)
                   case _ =>
                     Tasks.run(state, project, cwd, main, args)
                 }

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -291,7 +291,8 @@ object Interpreter {
             cmd.main.orElse(getMainClass(state, project)) match {
               case None => Task(state.mergeStatus(ExitStatus.RunError))
               case Some(main) =>
-                ScalaNative.link(project, main, state.logger).map {
+                val nativeToolchain = ScalaNative.forProject(project, state.logger)
+                nativeToolchain.link(project, main, state.logger).map {
                   case Success(nativeBinary) =>
                     state.logger.info(s"Scala Native binary: '${nativeBinary.syntax}'")
                     state
@@ -335,7 +336,8 @@ object Interpreter {
                 val cwd = cmd.cliOptions.common.workingPath
                 project.platform match {
                   case Platform.Native =>
-                    ScalaNative.run(state, project, cwd, main, args)
+                    val nativeToolchain = ScalaNative.forProject(project, state.logger)
+                    nativeToolchain.run(state, project, cwd, main, args)
                   case _ =>
                     Tasks.run(state, project, cwd, main, args)
                 }

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -282,7 +282,7 @@ object Interpreter {
       case Some(project) if project.platform != Platform.Native =>
         Task {
           state.logger.error("This command can only be called on a Scala Native project.")
-          state.mergeStatus(ExitStatus.RunError)
+          state.mergeStatus(ExitStatus.InvalidCommandLineOption)
         }
       case Some(project) =>
         val reporter = ReporterKind.toReporterConfig(cmd.reporter)
@@ -297,7 +297,7 @@ object Interpreter {
                     state.logger.info(s"Scala Native binary: '${nativeBinary.syntax}'")
                     state
                   case Failure(ex) =>
-                    state.mergeStatus(ExitStatus.UnexpectedError)
+                    state.mergeStatus(ExitStatus.LinkingError)
                 }
             }
           }

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -11,7 +11,7 @@ import bloop.io.{RelativePath, SourceWatcher}
 import bloop.io.Timer.timed
 import bloop.reporter.ReporterConfig
 import bloop.testing.{LoggingEventHandler, TestInternals}
-import bloop.engine.tasks.{ScalaNative, Tasks}
+import bloop.engine.tasks.{ScalaNativeToolchain, Tasks}
 import bloop.Project
 import monix.eval.Task
 import monix.execution.misc.NonFatal
@@ -291,7 +291,7 @@ object Interpreter {
             cmd.main.orElse(getMainClass(state, project)) match {
               case None => Task(state.mergeStatus(ExitStatus.RunError))
               case Some(main) =>
-                val nativeToolchain = ScalaNative.forProject(project, state.logger)
+                val nativeToolchain = ScalaNativeToolchain.forProject(project, state.logger)
                 nativeToolchain.link(project, main, state.logger, cmd.optimize).map {
                   case Success(nativeBinary) =>
                     state.logger.info(s"Scala Native binary: '${nativeBinary.syntax}'")
@@ -336,7 +336,7 @@ object Interpreter {
                 val cwd = cmd.cliOptions.common.workingPath
                 project.platform match {
                   case Platform.Native =>
-                    val nativeToolchain = ScalaNative.forProject(project, state.logger)
+                    val nativeToolchain = ScalaNativeToolchain.forProject(project, state.logger)
                     nativeToolchain.run(state, project, cwd, main, args, cmd.optimize)
                   case _ =>
                     Tasks.run(state, project, cwd, main, args)

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -332,7 +332,12 @@ object Interpreter {
               case Some(main) =>
                 val args = cmd.args.toArray
                 val cwd = cmd.cliOptions.common.workingPath
-                Tasks.run(state, project, cwd, main, args)
+                project.platform match {
+                  case Platform.Native =>
+                    ScalaNative.run(state, project, cwd, main, args)
+                  case _ =>
+                    Tasks.run(state, project, cwd, main, args)
+                }
             }
           }
         }

--- a/frontend/src/main/scala/bloop/engine/tasks/ScalaNative.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/ScalaNative.scala
@@ -7,7 +7,7 @@ import java.nio.file.{Files, Path}
 import java.util.concurrent.ConcurrentHashMap
 
 import bloop.{DependencyResolution, Project}
-import bloop.cli.ExitStatus
+import bloop.cli.{ExitStatus, OptimizerConfig}
 import bloop.engine.State
 import bloop.exec.Forker
 import bloop.io.AbsolutePath
@@ -67,21 +67,26 @@ class ScalaNative private (classLoader: ClassLoader) {
   /**
    * Compile down to native binary using Scala Native's toolchain.
    *
-   * @param project The project to link
-   * @param entry   The fully qualified main class name
-   * @param logger  The logger to use
+   * @param project  The project to link
+   * @param entry    The fully qualified main class name
+   * @param logger   The logger to use
+   * @param optimize The configuration of the optimizer.
    * @return The absolute path to the native binary.
    */
-  def link(project: Project, entry: String, logger: Logger): Task[Try[AbsolutePath]] = {
+  def link(project: Project,
+           entry: String,
+           logger: Logger,
+           optimize: OptimizerConfig): Task[Try[AbsolutePath]] = {
 
     val bridgeClazz = classLoader.loadClass("bloop.scalanative.NativeBridge")
-    val paramTypes = classOf[Project] :: classOf[String] :: classOf[Logger] :: Nil
+    val paramTypes = classOf[Project] :: classOf[String] :: classOf[Logger] :: classOf[
+      OptimizerConfig] :: Nil
     val nativeLinkMeth = bridgeClazz.getMethod("nativeLink", paramTypes: _*)
 
     // The Scala Native toolchain expects to receive the module class' name
     val fullEntry = if (entry.endsWith("$")) entry else entry + "$"
 
-    Task(nativeLinkMeth.invoke(null, project, fullEntry, logger)).materialize.map {
+    Task(nativeLinkMeth.invoke(null, project, fullEntry, logger, optimize)).materialize.map {
       _.collect { case path: Path => AbsolutePath(path) }
     }
   }
@@ -89,19 +94,21 @@ class ScalaNative private (classLoader: ClassLoader) {
   /**
    * Link `project` to a native binary and run it.
    *
-   * @param state The current state of Bloop.
-   * @param project The project to link.
-   * @param cwd     The working directory in which to start the process.
-   * @param main    The fully qualified main class name.
-   * @param args    The arguments to pass to the program.
+   * @param state    The current state of Bloop.
+   * @param project  The project to link.
+   * @param cwd      The working directory in which to start the process.
+   * @param main     The fully qualified main class name.
+   * @param args     The arguments to pass to the program.
+   * @param optimize The configuration of the optimizer.
    * @return A task that links and run the project.
    */
   def run(state: State,
           project: Project,
           cwd: AbsolutePath,
           main: String,
-          args: Array[String]): Task[State] = {
-    link(project, main, state.logger).flatMap {
+          args: Array[String],
+          optimize: OptimizerConfig): Task[State] = {
+    link(project, main, state.logger, optimize).flatMap {
       case Success(nativeBinary) =>
         val cmd = nativeBinary.syntax +: args
         Forker.run(cwd, cmd, state.logger, state.commonOptions).map { exitCode =>

--- a/frontend/src/main/scala/bloop/engine/tasks/ScalaNative.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/ScalaNative.scala
@@ -22,8 +22,13 @@ object ScalaNative {
     new ConcurrentHashMap
 
   def forProject(project: Project, logger: Logger): ScalaNative = {
-    if (project.nativeClasspath.isEmpty) ivyResolved(logger)
-    else direct(project.nativeClasspath)
+    project.nativeConfig match {
+      case None =>
+        ivyResolved(logger)
+      case Some(config) =>
+        val classpath = config.toolchainClasspath.map(AbsolutePath.apply)
+        direct(classpath)
+    }
   }
 
   def ivyResolved(logger: Logger): ScalaNative = synchronized {

--- a/frontend/src/main/scala/bloop/engine/tasks/ScalaNative.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/ScalaNative.scala
@@ -1,0 +1,52 @@
+package bloop.engine.tasks
+
+import java.net.URLClassLoader
+import java.nio.file.{Files, Path}
+
+import bloop.{DependencyResolution, Project}
+import bloop.io.AbsolutePath
+import bloop.logging.Logger
+
+object ScalaNative {
+
+  /**
+   * Compile down to native binary using Scala Native's toolchain.
+   *
+   * @param project The project to link
+   * @param entry   The fully qualified main class name
+   * @param logger  The logger to use
+   * @return The absolute path to the native binary.
+   */
+  def nativeLink(project: Project, entry: String, logger: Logger): AbsolutePath = {
+
+    initializeToolChain(logger)
+
+    val bridgeClazz = nativeClassLoader.loadClass("bloop.scalanative.NativeBridge")
+    val paramTypes = classOf[Project] :: classOf[String] :: classOf[Logger] :: Nil
+    val nativeLinkMeth = bridgeClazz.getMethod("nativeLink", paramTypes: _*)
+    AbsolutePath(nativeLinkMeth.invoke(null, project, entry, logger).asInstanceOf[Path])
+  }
+
+  private def bridgeJars(logger: Logger): Array[AbsolutePath] = {
+    val organization = bloop.internal.build.BuildInfo.organization
+    val nativeBridge = bloop.internal.build.BuildInfo.nativeBridge
+    val version = bloop.internal.build.BuildInfo.version
+    logger.debug(s"Resolving Native bridge: $organization:$nativeBridge:$version")
+    val files = DependencyResolution.resolve(organization, nativeBridge, version, logger)
+    files.filter(_.underlying.toString.endsWith(".jar"))
+  }
+
+  private def bridgeClassLoader(parent: Option[ClassLoader], logger: Logger): ClassLoader = {
+    val jars = bridgeJars(logger)
+    val entries = jars.map(_.underlying.toUri.toURL)
+    new URLClassLoader(entries, parent.orNull)
+  }
+
+  private[this] var nativeClassLoader: ClassLoader = _
+  private[this] def initializeToolChain(logger: Logger): Unit = synchronized {
+    if (nativeClassLoader == null) {
+      nativeClassLoader = bridgeClassLoader(Some(this.getClass.getClassLoader), logger)
+    }
+  }
+
+}

--- a/frontend/src/main/scala/bloop/engine/tasks/ScalaNative.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/ScalaNative.scala
@@ -24,7 +24,11 @@ object ScalaNative {
     val bridgeClazz = nativeClassLoader.loadClass("bloop.scalanative.NativeBridge")
     val paramTypes = classOf[Project] :: classOf[String] :: classOf[Logger] :: Nil
     val nativeLinkMeth = bridgeClazz.getMethod("nativeLink", paramTypes: _*)
-    AbsolutePath(nativeLinkMeth.invoke(null, project, entry, logger).asInstanceOf[Path])
+
+    // The Scala Native toolchain expects to receive the module class' name
+    val fullEntry = if (entry.endsWith("$")) entry else entry + "$"
+
+    AbsolutePath(nativeLinkMeth.invoke(null, project, fullEntry, logger).asInstanceOf[Path])
   }
 
   private def bridgeJars(logger: Logger): Array[AbsolutePath] = {

--- a/frontend/src/main/scala/bloop/engine/tasks/ScalaNativeToolchain.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/ScalaNativeToolchain.scala
@@ -67,7 +67,7 @@ class ScalaNativeToolchain private (classLoader: ClassLoader) {
         Forker.run(cwd, cmd, state.logger, state.commonOptions).map { exitCode =>
           val exitStatus = {
             if (exitCode == Forker.EXIT_OK) ExitStatus.Ok
-            else ExitStatus.UnexpectedError
+            else ExitStatus.RunError
           }
           state.mergeStatus(exitStatus)
         }
@@ -75,7 +75,7 @@ class ScalaNativeToolchain private (classLoader: ClassLoader) {
         Task {
           state.logger.error("Couldn't create native binary.")
           state.logger.trace(ex)
-          state.mergeStatus(ExitStatus.UnexpectedError)
+          state.mergeStatus(ExitStatus.LinkingError)
         }
     }
   }

--- a/frontend/src/main/scala/bloop/engine/tasks/ScalaNativeToolchain.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/ScalaNativeToolchain.scala
@@ -15,7 +15,7 @@ import bloop.logging.Logger
 
 import monix.eval.Task
 
-class ScalaNative private (classLoader: ClassLoader) {
+class ScalaNativeToolchain private (classLoader: ClassLoader) {
 
   /**
    * Compile down to native binary using Scala Native's toolchain.
@@ -82,13 +82,13 @@ class ScalaNative private (classLoader: ClassLoader) {
 
 }
 
-object ScalaNative {
+object ScalaNativeToolchain {
 
-  private[this] var _ivyResolved: ScalaNative = _
-  private[this] val instancesCache: ConcurrentHashMap[Array[AbsolutePath], ScalaNative] =
+  private[this] var _ivyResolved: ScalaNativeToolchain = _
+  private[this] val instancesCache: ConcurrentHashMap[Array[AbsolutePath], ScalaNativeToolchain] =
     new ConcurrentHashMap
 
-  def forProject(project: Project, logger: Logger): ScalaNative = {
+  def forProject(project: Project, logger: Logger): ScalaNativeToolchain = {
     project.nativeConfig match {
       case None =>
         ivyResolved(logger)
@@ -98,18 +98,18 @@ object ScalaNative {
     }
   }
 
-  def ivyResolved(logger: Logger): ScalaNative = synchronized {
+  def ivyResolved(logger: Logger): ScalaNativeToolchain = synchronized {
     if (_ivyResolved == null) {
       val jars = bridgeJars(logger)
       val nativeClassLoader = toClassLoader(jars)
-      _ivyResolved = new ScalaNative(nativeClassLoader)
+      _ivyResolved = new ScalaNativeToolchain(nativeClassLoader)
     }
     _ivyResolved
   }
 
-  def direct(classpath: Array[AbsolutePath]): ScalaNative = {
+  def direct(classpath: Array[AbsolutePath]): ScalaNativeToolchain = {
     instancesCache.computeIfAbsent(classpath,
-                                   classpath => new ScalaNative(toClassLoader(classpath)))
+                                   classpath => new ScalaNativeToolchain(toClassLoader(classpath)))
   }
 
   private def bridgeJars(logger: Logger): Array[AbsolutePath] = {

--- a/frontend/src/main/scala/bloop/engine/tasks/ScalaNativeToolchain.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/ScalaNativeToolchain.scala
@@ -84,6 +84,7 @@ class ScalaNativeToolchain private (classLoader: ClassLoader) {
 
 object ScalaNativeToolchain {
 
+  private[this] var resolvedInstance: ScalaNativeToolchain = _
   private[this] val instancesCache: ConcurrentHashMap[Array[AbsolutePath], ScalaNativeToolchain] =
     new ConcurrentHashMap
 
@@ -97,9 +98,12 @@ object ScalaNativeToolchain {
     }
   }
 
-  def resolveNativeToolchain(logger: Logger): ScalaNativeToolchain = {
-    val jars = bridgeJars(logger)
-    direct(jars)
+  def resolveNativeToolchain(logger: Logger): ScalaNativeToolchain = synchronized {
+    if (resolvedInstance == null) {
+      val jars = bridgeJars(logger)
+      resolvedInstance = direct(jars)
+    }
+    resolvedInstance
   }
 
   def direct(classpath: Array[AbsolutePath]): ScalaNativeToolchain = {

--- a/frontend/src/test/scala/bloop/engine/DagSpec.scala
+++ b/frontend/src/test/scala/bloop/engine/DagSpec.scala
@@ -22,7 +22,7 @@ class DagSpec {
   def dummyProject(name: String, dependencies: List[String]): Project =
     Project(name, dummyPath, dependencies.toArray, dummyInstance, Array(), classpathOptions,  dummyPath, Array(),
       Array(), Array(), Array(), Config.TestOptions.empty, JavaEnv.default, dummyPath, dummyPath,
-      Config.Platform.default)
+      Config.Platform.default, Array())
   // format: ON
 
   private object TestProjects {

--- a/frontend/src/test/scala/bloop/engine/DagSpec.scala
+++ b/frontend/src/test/scala/bloop/engine/DagSpec.scala
@@ -21,7 +21,8 @@ class DagSpec {
   // format: OFF
   def dummyProject(name: String, dependencies: List[String]): Project =
     Project(name, dummyPath, dependencies.toArray, dummyInstance, Array(), classpathOptions,  dummyPath, Array(),
-      Array(), Array(), Array(), Config.TestOptions.empty, JavaEnv.default, dummyPath, dummyPath)
+      Array(), Array(), Array(), Config.TestOptions.empty, JavaEnv.default, dummyPath, dummyPath,
+      Config.Platform.default)
   // format: ON
 
   private object TestProjects {

--- a/frontend/src/test/scala/bloop/engine/DagSpec.scala
+++ b/frontend/src/test/scala/bloop/engine/DagSpec.scala
@@ -22,7 +22,7 @@ class DagSpec {
   def dummyProject(name: String, dependencies: List[String]): Project =
     Project(name, dummyPath, dependencies.toArray, dummyInstance, Array(), classpathOptions,  dummyPath, Array(),
       Array(), Array(), Array(), Config.TestOptions.empty, JavaEnv.default, dummyPath, dummyPath,
-      Config.Platform.default, Array())
+      Config.Platform.default, None)
   // format: ON
 
   private object TestProjects {

--- a/frontend/src/test/scala/bloop/engine/FileWatchingSpec.scala
+++ b/frontend/src/test/scala/bloop/engine/FileWatchingSpec.scala
@@ -9,6 +9,7 @@ import bloop.Project
 import bloop.cli.{CliOptions, Commands, ExitStatus}
 import bloop.logging.BloopLogger
 import bloop.exec.JavaEnv
+import bloop.io.Paths.delete
 import bloop.tasks.{CompilationHelpers, TestUtil}
 import bloop.tasks.TestUtil.{RootProject, noPreviousResult, withState}
 import monix.eval.Task
@@ -158,8 +159,8 @@ class FileWatchingSpec {
         }
 
         // Deletion doesn't trigger recompilation -- done to avoid file from previous test run
-        val newSource = project.sources.head.resolve("D.scala").underlying
-        if (Files.exists(newSource)) TestUtil.delete(newSource)
+        val newSource = project.sources.head.resolve("D.scala")
+        if (Files.exists(newSource.underlying)) delete(newSource)
 
         val dirsToWatch = existingProjectSources.length
 
@@ -176,7 +177,7 @@ class FileWatchingSpec {
                            bloopOut)
 
         // Write the contents of a source back to the same source
-        Files.write(newSource, "object ForceRecompilation {}".getBytes("UTF-8"))
+        Files.write(newSource.underlying, "object ForceRecompilation {}".getBytes("UTF-8"))
 
         // Wait for #2 compilation to finish
         readCompilingLines(2, "Compiling 1 Scala source to", bloopOut)

--- a/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
+++ b/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
@@ -52,7 +52,7 @@ class IntegrationTestSuite(testDirectory: Path) {
   }
 
   def compileProject0: Unit = {
-    val state0 = TestUtil.loadTestProject(testDirectory, integrationTestName)
+    val state0 = TestUtil.loadTestProject(testDirectory, integrationTestName, identity)
     val (initialState, projectToCompile) = getModuleToCompile(testDirectory) match {
       case Some(projectName) =>
         (state0, state0.build.getProjectFor(projectName).get)

--- a/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
+++ b/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
@@ -78,7 +78,8 @@ class IntegrationTestSuite(testDirectory: Path) {
           testOptions = Config.TestOptions.empty,
           javaEnv = javaEnv,
           out = classesDir,
-          analysisOut = classesDir.resolve(Config.Project.analysisFileName(rootProjectName))
+          analysisOut = classesDir.resolve(Config.Project.analysisFileName(rootProjectName)),
+          platform = Config.Platform.default
         )
         val state =
           state0.copy(build = state0.build.copy(projects = rootProject :: previousProjects))

--- a/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
+++ b/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
@@ -80,7 +80,7 @@ class IntegrationTestSuite(testDirectory: Path) {
           out = classesDir,
           analysisOut = classesDir.resolve(Config.Project.analysisFileName(rootProjectName)),
           platform = Config.Platform.default,
-          nativeClasspath = Array.empty
+          nativeConfig = None
         )
         val state =
           state0.copy(build = state0.build.copy(projects = rootProject :: previousProjects))

--- a/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
+++ b/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
@@ -79,7 +79,8 @@ class IntegrationTestSuite(testDirectory: Path) {
           javaEnv = javaEnv,
           out = classesDir,
           analysisOut = classesDir.resolve(Config.Project.analysisFileName(rootProjectName)),
-          platform = Config.Platform.default
+          platform = Config.Platform.default,
+          nativeClasspath = Array.empty
         )
         val state =
           state0.copy(build = state0.build.copy(projects = rootProject :: previousProjects))

--- a/frontend/src/test/scala/bloop/tasks/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestUtil.scala
@@ -237,7 +237,7 @@ object TestUtil {
       // Let's store the analysis file in target even though we usually do it in `out`
       analysisOut = AbsolutePath(target.resolve(Config.Project.analysisFileName(name))),
       platform = Config.Platform.default,
-      nativeClasspath = Array.empty
+      nativeConfig = None
     )
   }
 

--- a/frontend/src/test/scala/bloop/tasks/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestUtil.scala
@@ -231,7 +231,8 @@ object TestUtil {
       javaEnv = javaEnv,
       out = AbsolutePath(baseDirectory), // This means nothing in tests
       // Let's store the analysis file in target even though we usually do it in `out`
-      analysisOut = AbsolutePath(target.resolve(Config.Project.analysisFileName(name)))
+      analysisOut = AbsolutePath(target.resolve(Config.Project.analysisFileName(name))),
+      platform = Config.Platform.default
     )
   }
 

--- a/frontend/src/test/scala/bloop/tasks/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestUtil.scala
@@ -232,7 +232,8 @@ object TestUtil {
       out = AbsolutePath(baseDirectory), // This means nothing in tests
       // Let's store the analysis file in target even though we usually do it in `out`
       analysisOut = AbsolutePath(target.resolve(Config.Project.analysisFileName(name))),
-      platform = Config.Platform.default
+      platform = Config.Platform.default,
+      nativeClasspath = Array.empty
     )
   }
 

--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -130,8 +130,8 @@ object MojoImplementation {
         val jvm = Config.Jvm(Some(abs(mojo.getJavaHome().getParentFile.getParentFile)), launcher.getJvmArgs().toArray)
         val compileOptions = Config.CompileOptions(Config.Mixed)
         val platform = Config.Platform.default
-        val nativeClasspath = Array.empty[Path]
-        val project = Config.Project(name, baseDirectory, sourceDirs, dependencyNames, classpath, classpathOptions, compileOptions, out, analysisOut, classesDir, `scala`, jvm, java, test, platform, nativeClasspath)
+        val nativeConfig = None
+        val project = Config.Project(name, baseDirectory, sourceDirs, dependencyNames, classpath, classpathOptions, compileOptions, out, analysisOut, classesDir, `scala`, jvm, java, test, platform, nativeConfig)
         Config.File(Config.File.LatestVersion, project)
       }
       // FORMAT: ON

--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -129,7 +129,8 @@ object MojoImplementation {
           mojo.getScalaVersion(), scalacArgs, allScalaJars)
         val jvm = Config.Jvm(Some(abs(mojo.getJavaHome().getParentFile.getParentFile)), launcher.getJvmArgs().toArray)
         val compileOptions = Config.CompileOptions(Config.Mixed)
-        val project = Config.Project(name, baseDirectory, sourceDirs, dependencyNames, classpath, classpathOptions, compileOptions, out, analysisOut, classesDir, `scala`, jvm, java, test)
+        val platform = Config.Platform.default
+        val project = Config.Project(name, baseDirectory, sourceDirs, dependencyNames, classpath, classpathOptions, compileOptions, out, analysisOut, classesDir, `scala`, jvm, java, test, platform)
         Config.File(Config.File.LatestVersion, project)
       }
       // FORMAT: ON

--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -130,7 +130,8 @@ object MojoImplementation {
         val jvm = Config.Jvm(Some(abs(mojo.getJavaHome().getParentFile.getParentFile)), launcher.getJvmArgs().toArray)
         val compileOptions = Config.CompileOptions(Config.Mixed)
         val platform = Config.Platform.default
-        val project = Config.Project(name, baseDirectory, sourceDirs, dependencyNames, classpath, classpathOptions, compileOptions, out, analysisOut, classesDir, `scala`, jvm, java, test, platform)
+        val nativeClasspath = Array.empty[Path]
+        val project = Config.Project(name, baseDirectory, sourceDirs, dependencyNames, classpath, classpathOptions, compileOptions, out, analysisOut, classesDir, `scala`, jvm, java, test, platform, nativeClasspath)
         Config.File(Config.File.LatestVersion, project)
       }
       // FORMAT: ON

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -109,6 +109,9 @@ object BloopDefaults {
         }.value
       )
 
+  private final val ScalaNativePluginLabel = "scala.scalanative.sbtplugin.ScalaNativePlugin"
+  private final val ScalaJsPluginLabel = "org.scalajs.sbtplugin.ScalaJSPlugin"
+
   lazy val bloopTargetDir: Def.Initialize[File] = Def.setting {
     val project = Keys.thisProject.value
     val bloopConfigDir = BloopKeys.bloopConfigDir.value
@@ -354,6 +357,13 @@ object BloopDefaults {
     val (javaHome, javaOptions) = javaConfiguration.value
     val outFile = bloopConfigDir / s"$projectName.json"
 
+    val platform = {
+      val pluginLabels = project.autoPlugins.map(_.label).toSet
+      if (pluginLabels.contains(ScalaNativePluginLabel)) Config.Platform.Native
+      else if (pluginLabels.contains(ScalaJsPluginLabel)) Config.Platform.JS
+      else Config.Platform.JVM
+    }
+
     // Force source generators on this task manually
     Keys.managedSources.value
     // Copy the resources, so that they're available when running and testing
@@ -367,7 +377,9 @@ object BloopDefaults {
 
       val compileOptions = Config.CompileOptions(compileOrder)
       val analysisOut = out.resolve(Config.Project.analysisFileName(projectName))
-      val project = Config.Project(projectName, baseDirectory, sources, dependenciesAndAggregates, classpath, classpathOptions, compileOptions, out, analysisOut, classesDir, `scala`, jvm, java, testOptions)
+      val project = Config.Project(projectName, baseDirectory, sources, dependenciesAndAggregates,
+        classpath, classpathOptions, compileOptions, out, analysisOut, classesDir, `scala`, jvm,
+        java, testOptions, platform)
       Config.File(Config.File.LatestVersion, project)
     }
     // format: ON

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -363,6 +363,7 @@ object BloopDefaults {
       else if (pluginLabels.contains(ScalaJsPluginLabel)) Config.Platform.JS
       else Config.Platform.JVM
     }
+    val nativeClasspath = Array.empty[Path]
 
     // Force source generators on this task manually
     Keys.managedSources.value
@@ -379,7 +380,7 @@ object BloopDefaults {
       val analysisOut = out.resolve(Config.Project.analysisFileName(projectName))
       val project = Config.Project(projectName, baseDirectory, sources, dependenciesAndAggregates,
         classpath, classpathOptions, compileOptions, out, analysisOut, classesDir, `scala`, jvm,
-        java, testOptions, platform)
+        java, testOptions, platform, nativeClasspath)
       Config.File(Config.File.LatestVersion, project)
     }
     // format: ON

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -363,7 +363,7 @@ object BloopDefaults {
       else if (pluginLabels.contains(ScalaJsPluginLabel)) Config.Platform.JS
       else Config.Platform.JVM
     }
-    val nativeClasspath = Array.empty[Path]
+    val nativeConfig = None
 
     // Force source generators on this task manually
     Keys.managedSources.value
@@ -380,7 +380,7 @@ object BloopDefaults {
       val analysisOut = out.resolve(Config.Project.analysisFileName(projectName))
       val project = Config.Project(projectName, baseDirectory, sources, dependenciesAndAggregates,
         classpath, classpathOptions, compileOptions, out, analysisOut, classesDir, `scala`, jvm,
-        java, testOptions, platform, nativeClasspath)
+        java, testOptions, platform, nativeConfig)
       Config.File(Config.File.LatestVersion, project)
     }
     // format: ON

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-project/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-project/build.sbt
@@ -1,0 +1,20 @@
+// shadow sbt-scalajs' crossProject and CrossType until Scala.js 1.0.0 is released
+import sbtcrossproject.{crossProject, CrossType}
+
+val sharedSettings = Seq(
+  scalaVersion := "2.11.12",
+  InputKey[Unit]("check") := {
+    val expected = complete.DefaultParsers.spaceDelimited("").parsed.head
+    val config = bloopConfigDir.value / s"${thisProject.value.id}.json"
+    val lines = IO.read(config)
+    assert(lines.contains(s""""platform" : "$expected""""))
+  }
+)
+
+lazy val bar =
+  crossProject(JSPlatform, JVMPlatform, NativePlatform)
+    .settings(sharedSettings)
+
+lazy val barJS = bar.js
+lazy val barJVM = bar.jvm
+lazy val barNative = bar.native

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-project/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-project/project/plugins.sbt
@@ -1,0 +1,6 @@
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.4.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.7")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-project/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-project/test
@@ -1,4 +1,4 @@
 > bloopInstall
-> barJVM/check JVM
-> barJS/check JS
-> barNative/check Native
+> barJVM/check jvm
+> barJS/check js
+> barNative/check native

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-project/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-project/test
@@ -1,0 +1,4 @@
+> bloopInstall
+> barJVM/check JVM
+> barJS/check JS
+> barNative/check Native

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/build.sbt
@@ -1,0 +1,10 @@
+val jsProject = project
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    InputKey[Unit]("check") := {
+      val expected = complete.DefaultParsers.spaceDelimited("").parsed.head
+      val config = bloopConfigDir.value / s"${thisProject.value.id}.json"
+      val lines = IO.read(config)
+      assert(lines.contains(s""""platform" : "$expected""""))
+    }
+  )

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/test
@@ -1,2 +1,2 @@
 > bloopInstall
-> jsProject/check JS
+> jsProject/check js

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/test
@@ -1,0 +1,2 @@
+> bloopInstall
+> jsProject/check JS

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-native/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-native/build.sbt
@@ -1,0 +1,11 @@
+val nativeProject = project
+  .enablePlugins(ScalaNativePlugin)
+  .settings(
+    scalaVersion := "2.11.12",
+    InputKey[Unit]("check") := {
+      val expected = complete.DefaultParsers.spaceDelimited("").parsed.head
+      val config = bloopConfigDir.value / s"${thisProject.value.id}.json"
+      val lines = IO.read(config)
+      assert(lines.contains(s""""platform" : "$expected""""))
+    }
+  )

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-native/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-native/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.7")

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-native/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-native/test
@@ -1,0 +1,2 @@
+> bloopInstall
+> nativeProject/check Native

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-native/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-native/test
@@ -1,2 +1,2 @@
 > bloopInstall
-> nativeProject/check Native
+> nativeProject/check native

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -214,7 +214,7 @@ object BuildImplementation {
   import ch.epfl.scala.sbt.release.ReleaseEarlyPlugin.{autoImport => ReleaseEarlyKeys}
 
   final val globalSettings: Seq[Def.Setting[_]] = Seq(
-    BuildKeys.schemaVersion := "2.3",
+    BuildKeys.schemaVersion := "2.4",
     Keys.testOptions in Test += sbt.Tests.Argument("-oD"),
     Keys.onLoadMessage := Header.intro,
     Keys.publishArtifact in Test := false,

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -118,11 +118,17 @@ object BuildKeys {
     List(Keys.scalaVersion, Keys.scalaOrganization, scalaJarsKey)
   }
 
-  final val BloopInfoKeys: List[BuildInfoKey] = {
+  def BloopInfoKeys(nativeBridge: Reference): List[BuildInfoKey] = {
     val zincKey = BuildInfoKey.constant("zincVersion" -> Dependencies.zincVersion)
     val developersKey =
       BuildInfoKey.map(Keys.developers) { case (k, devs) => k -> devs.map(_.name) }
+    val nativeBridgeKey = BuildInfoKey.map(Keys.ivyModule in nativeBridge) {
+      case (_, module) =>
+        "nativeBridge" -> module.withModule(sbt.util.Logger.Null)((_, mod, _) =>
+          mod.getModuleRevisionId.getName)
+    }
     val commonKeys = List[BuildInfoKey](
+      Keys.organization,
       Keys.name,
       Keys.version,
       Keys.scalaVersion,
@@ -130,7 +136,7 @@ object BuildKeys {
       buildIntegrationsIndex,
       nailgunClientLocation
     )
-    commonKeys ++ List(zincKey, developersKey)
+    commonKeys ++ List(zincKey, developersKey, nativeBridgeKey)
   }
 
   import sbtassembly.{AssemblyKeys, MergeStrategy}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,6 +24,7 @@ object Dependencies {
   val circeVersion = "0.9.3"
   val nuprocessVersion = "1.2.3"
   val shapelessVersion = "2.3.3-lower-priority-coproduct"
+  val scalaNativeVersion = "0.3.7"
 
   import sbt.librarymanagement.syntax.stringToOrganization
   val zinc = "ch.epfl.scala" %% "zinc" % zincVersion
@@ -65,4 +66,6 @@ object Dependencies {
   val circeCore = "io.circe" %% "circe-core" % circeVersion
   val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
   val nuprocess = "com.zaxxer" % "nuprocess" % nuprocessVersion
+
+  val scalaNativeTools = "org.scala-native" %% "tools" % scalaNativeVersion
 }


### PR DESCRIPTION
I have an implementation that also supports testing of Scala Native projects; however it needs the test runner to be split out of sbt-scala-native (see scala-native/scala-native#1234).

Also missing from this PR: extracting the other options relevant only for Scala Native (GC to use, release vs debug mode, etc.)

This is already large enough for one PR, I think it'd be better to open another PR for the rest.