### PR TITLE
Add source files to bloop config from sbt

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -202,7 +202,12 @@ object PluginImplementation {
       }
 
       val classesDir = AutoImported.bloopProductDirectories.value.head.toPath()
-      val sourceDirs = Keys.sourceDirectories.value.map(_.toPath).toArray
+      val sources = {
+        val sourceDirs = Keys.sourceDirectories.value.iterator.map(_.toPath)
+        val sourceFiles = Keys.sources.value.iterator.map(_.toPath)
+        (sourceDirs ++ sourceFiles).toArray
+      }
+
       val testOptions = {
         val frameworks =
           Keys.testFrameworks.value.map(f => Config.TestFramework(f.implClassNames.toList)).toArray
@@ -255,7 +260,7 @@ object PluginImplementation {
         val java = Config.Java(javacOptions)
         val `scala` = Config.Scala(scalaOrg, scalaName, scalaVersion, scalacOptions, allScalaJars)
         val jvm = Config.Jvm(Some(javaHome.toPath), javaOptions.toArray)
-        val project = Config.Project(projectName, baseDirectory, sourceDirs, dependenciesAndAggregates, classpath, classpathOptions, out, classesDir, `scala`, jvm, java, testOptions)
+        val project = Config.Project(projectName, baseDirectory, sources, dependenciesAndAggregates, classpath, classpathOptions, out, classesDir, `scala`, jvm, java, testOptions)
         Config.File(Config.File.LatestVersion, project)
       }
       // format: ON

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/StraySourceFile.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/StraySourceFile.scala
@@ -1,0 +1,1 @@
+object StraySourceFile

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/build.sbt
@@ -1,4 +1,33 @@
 val foo = project
+  .settings(sources.in(Test) += baseDirectory.in(ThisBuild).value./("StraySourceFile.scala"))
 val bar = project.dependsOn(foo % "test->compile;test->test")
 val baz = project.dependsOn(bar % "compile->test")
 val woo = project.dependsOn(foo % "test->compile")
+
+val checkBloopFile = taskKey[Unit]("Check bloop file contents")
+checkBloopFile in ThisBuild := {
+  import java.nio.file.Files
+  val bloopDir = Keys.baseDirectory.value./(".bloop")
+  val fooConfig = bloopDir./("foo.json")
+  val fooTestConfig = bloopDir./("foo-test.json")
+  val barConfig = bloopDir./("bar.json")
+  val barTestConfig = bloopDir./("bar-test.json")
+  val bazConfig = bloopDir./("baz.json")
+  val bazTestConfig = bloopDir./("baz-test.json")
+  val wooConfig = bloopDir./("woo.json")
+  val wooTestConfig = bloopDir./("woo-test.json")
+  val allConfigs = List(
+    fooConfig,
+    fooTestConfig,
+    barConfig,
+    barTestConfig,
+    bazConfig,
+    bazTestConfig,
+    wooConfig,
+    wooTestConfig
+  )
+
+  allConfigs.foreach(f => assert(Files.exists(f.toPath), s"Missing config file for ${f}."))
+  val fooTestConfigContents = new String(Files.readAllBytes(fooTestConfig.toPath))
+  assert(fooTestConfigContents.contains("StraySourceFile.scala"), "Source file is missing in foo.")
+}

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/test
@@ -2,3 +2,4 @@
 > baz/compile
 > woo/test:compile
 > bloopInstall
+> checkBloopFile


### PR DESCRIPTION
We are supporting all kind of source files and dirs in main bloop, but
we were not adding source files to our sources field in the json config.

Fixes #428.