### PR TITLE
Add compile order option to the bloop config

### DIFF
--- a/config/src/main/scala-2.10/bloop/config/ConfigEncoders.scala
+++ b/config/src/main/scala-2.10/bloop/config/ConfigEncoders.scala
@@ -11,6 +11,14 @@ object ConfigEncoders {
     override final def apply(a: Path): Json = Json.fromString(a.toString)
   }
 
+  implicit val compileOrderEncoder: RootEncoder[CompileOrder] = new RootEncoder[CompileOrder] {
+    override final def apply(o: CompileOrder): Json = o match {
+      case Mixed => Json.fromString("mixed")
+      case JavaThenScala => Json.fromString("java->scala")
+      case ScalaThenJava => Json.fromString("scala->java")
+    }
+  }
+
   implicit val javaConfigEncoder: ObjectEncoder[Java] = deriveEncoder
   implicit val jvmConfigEncoder: ObjectEncoder[Jvm] = deriveEncoder
   implicit val testFrameworkConfigEncoder: ObjectEncoder[TestFramework] = deriveEncoder
@@ -18,6 +26,7 @@ object ConfigEncoders {
   implicit val testOptionsConfigEncoder: ObjectEncoder[TestOptions] = deriveEncoder
   implicit val testConfigEncoder: ObjectEncoder[Test] = deriveEncoder
   implicit val classpathOptionsEncoder: ObjectEncoder[ClasspathOptions] = deriveEncoder
+  implicit val compileOptionsEncoder: ObjectEncoder[CompileOptions] = deriveEncoder
   implicit val scalaConfigEncoder: ObjectEncoder[Scala] = deriveEncoder
   implicit val projectConfigEncoder: ObjectEncoder[Project] = deriveEncoder
   implicit val allConfigEncoder: ObjectEncoder[File] = deriveEncoder

--- a/config/src/main/scala-2.12/bloop/config/ConfigDecoders.scala
+++ b/config/src/main/scala-2.12/bloop/config/ConfigDecoders.scala
@@ -3,8 +3,8 @@ package bloop.config
 import java.nio.file.{Files, Path, Paths}
 
 import bloop.config.Config._
-import metaconfig.generic.Surface
-import metaconfig.{ConfDecoder, ConfError, Configured, generic}
+import metaconfig.generic.{Field, Surface}
+import metaconfig.{Conf, ConfDecoder, ConfError, Configured, generic}
 
 import scala.util.{Failure, Success, Try}
 
@@ -55,6 +55,30 @@ object ConfigDecoders {
     generic.deriveSurface[ClasspathOptions]
   implicit val classpathOptionsConfigDecoder: ConfDecoder[ClasspathOptions] =
     generic.deriveDecoder[ClasspathOptions](ClasspathOptions.empty)
+
+  implicit val compileOrderConfigSurface: Surface[CompileOrder] = {
+    val field = new Field("compileOrder", "string", Nil, Nil)
+    new Surface[CompileOrder](List(List(field)))
+  }
+
+  implicit val compileOrderConfigDecoder: ConfDecoder[CompileOrder] = {
+    new ConfDecoder[CompileOrder] {
+      override def read(conf: Conf): Configured[CompileOrder] = {
+        conf match {
+          case Conf.Str("mixed") | Conf.Str("Mixed") => Configured.ok(Mixed)
+          case Conf.Str("java->Scala") => Configured.ok(JavaThenScala)
+          case Conf.Str("scala->java") => Configured.ok(ScalaThenJava)
+          case Conf.Str(unknown) => Configured.error(s"Unknown compile order $unknown")
+          case conf => Configured.typeMismatch("string", conf)
+        }
+      }
+    }
+  }
+
+  implicit val compileOptionsConfigSurface: Surface[CompileOptions] =
+    generic.deriveSurface[CompileOptions]
+  implicit val compileOptionsConfigDecoder: ConfDecoder[CompileOptions] =
+    generic.deriveDecoder[CompileOptions](CompileOptions.empty)
 
   implicit val projectConfigSurface: Surface[Project] =
     generic.deriveSurface[Project]

--- a/config/src/main/scala-2.12/bloop/config/ConfigEncoders.scala
+++ b/config/src/main/scala-2.12/bloop/config/ConfigEncoders.scala
@@ -11,6 +11,14 @@ object ConfigEncoders {
     override final def apply(a: Path): Json = Json.fromString(a.toString)
   }
 
+  implicit val compileOrderEncoder: RootEncoder[CompileOrder] = new RootEncoder[CompileOrder] {
+    override final def apply(o: CompileOrder): Json = o match {
+      case Mixed => Json.fromString("mixed")
+      case JavaThenScala => Json.fromString("java->scala")
+      case ScalaThenJava => Json.fromString("scala->java")
+    }
+  }
+
   implicit val javaConfigEncoder: ObjectEncoder[Java] = deriveEncoder
   implicit val jvmConfigEncoder: ObjectEncoder[Jvm] = deriveEncoder
   implicit val testFrameworkConfigEncoder: ObjectEncoder[TestFramework] = deriveEncoder
@@ -18,6 +26,7 @@ object ConfigEncoders {
   implicit val testOptionsConfigEncoder: ObjectEncoder[TestOptions] = deriveEncoder
   implicit val testConfigEncoder: ObjectEncoder[Test] = deriveEncoder
   implicit val classpathOptionsEncoder: ObjectEncoder[ClasspathOptions] = deriveEncoder
+  implicit val compileOptionsEncoder: ObjectEncoder[CompileOptions] = deriveEncoder
   implicit val scalaConfigEncoder: ObjectEncoder[Scala] = deriveEncoder
   implicit val projectConfigEncoder: ObjectEncoder[Project] = deriveEncoder
   implicit val allConfigEncoder: ObjectEncoder[File] = deriveEncoder

--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -33,6 +33,20 @@ object Config {
     private[bloop] val empty: ClasspathOptions = ClasspathOptions(true, false, false, true, true)
   }
 
+  sealed trait CompileOrder
+  case object Mixed extends CompileOrder
+  case object JavaThenScala extends CompileOrder
+  case object ScalaThenJava extends CompileOrder
+
+  // TODO(jvican): Move the classpath options to this field before 1.0.0. Holding off of this breaking change for now.
+  case class CompileOptions(
+      order: CompileOrder
+  )
+
+  object CompileOptions {
+    private[bloop] val empty: CompileOptions = CompileOptions(Mixed)
+  }
+
   case class Scala(
       organization: String,
       name: String,
@@ -52,6 +66,7 @@ object Config {
       dependencies: Array[String],
       classpath: Array[Path],
       classpathOptions: ClasspathOptions,
+      compileOptions: CompileOptions,
       out: Path,
       classesDir: Path,
       `scala`: Scala,
@@ -63,7 +78,7 @@ object Config {
   object Project {
     // FORMAT: OFF
     private[bloop] val empty: Project =
-      Project("", emptyPath, Array(), Array(), Array(), ClasspathOptions.empty, emptyPath, emptyPath, Scala.empty, Jvm.empty, Java.empty, Test.empty)
+      Project("", emptyPath, Array(), Array(), Array(), ClasspathOptions.empty, CompileOptions.empty, emptyPath, emptyPath, Scala.empty, Jvm.empty, Java.empty, Test.empty)
     // FORMAT: ON
   }
 

--- a/config/src/test/scala-2.12/bloop/config/JsonSpec.scala
+++ b/config/src/test/scala-2.12/bloop/config/JsonSpec.scala
@@ -2,17 +2,7 @@ package bloop.config
 
 import java.nio.file.{Files, Paths}
 
-import bloop.config.Config.{
-  File,
-  ClasspathOptions,
-  Java,
-  Jvm,
-  Project,
-  Scala,
-  TestOptions,
-  Test => ConfigTest
-}
-
+import bloop.config.Config.{ClasspathOptions, CompileOptions, File, Java, Jvm, Project, Scala, TestOptions, Test => ConfigTest}
 import bloop.config.ConfigDecoders.allConfigDecoder
 import bloop.config.ConfigEncoders.allConfigEncoder
 import metaconfig.{Conf, Configured}
@@ -55,6 +45,7 @@ class JsonSpec {
       Array("dummy-2"),
       Array(scalaLibraryJar),
       ClasspathOptions.empty,
+      CompileOptions.empty,
       classesDir,
       outDir,
       Scala("org.scala-lang", "scala-compiler", "2.12.4", Array("-warn"), Array()),

--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -89,7 +89,8 @@ object MojoImplementation {
         val `scala` = Config.Scala(mojo.getScalaOrganization(), mojo.getScalaArtifactID(),
           mojo.getScalaVersion(), scalacArgs, allScalaJars)
         val jvm = Config.Jvm(Some(abs(mojo.getJavaHome())), launcher.getJvmArgs().toArray)
-        val project = Config.Project(name, baseDirectory, sourceDirs, dependencies, classpath, classpathOptions, out, classesDir, `scala`, jvm, java, test)
+        val compileOptions = Config.CompileOptions(Config.Mixed)
+        val project = Config.Project(name, baseDirectory, sourceDirs, dependencies, classpath, classpathOptions, compileOptions, out, classesDir, `scala`, jvm, java, test)
         Config.File(Config.File.LatestVersion, project)
       }
       // FORMAT: ON

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -15,6 +15,7 @@ import sbt.{
   Test,
   ThisBuild
 }
+import xsbti.compile.CompileOrder
 
 object SbtBloop extends AutoPlugin {
   import sbt.plugins.JvmPlugin
@@ -241,6 +242,12 @@ object PluginImplementation {
         }
       }
 
+      val compileOrder = Keys.compileOrder.value match {
+        case CompileOrder.JavaThenScala => Config.JavaThenScala
+        case CompileOrder.ScalaThenJava => Config.ScalaThenJava
+        case CompileOrder.Mixed => Config.Mixed
+      }
+
       val javacOptions = Keys.javacOptions.value.toArray
       val (javaHome, javaOptions) = javaConfiguration.value
       val outFile = bloopConfigDir / s"$projectName.json"
@@ -255,7 +262,8 @@ object PluginImplementation {
         val java = Config.Java(javacOptions)
         val `scala` = Config.Scala(scalaOrg, scalaName, scalaVersion, scalacOptions, allScalaJars)
         val jvm = Config.Jvm(Some(javaHome.toPath), javaOptions.toArray)
-        val project = Config.Project(projectName, baseDirectory, sourceDirs, dependenciesAndAggregates, classpath, classpathOptions, out, classesDir, `scala`, jvm, java, testOptions)
+        val compileOptions = Config.CompileOptions(compileOrder)
+        val project = Config.Project(projectName, baseDirectory, sourceDirs, dependenciesAndAggregates, classpath, classpathOptions, compileOptions, out, classesDir, `scala`, jvm, java, testOptions)
         Config.File(Config.File.LatestVersion, project)
       }
       // format: ON

--- a/website/static/bloop-schema.json
+++ b/website/static/bloop-schema.json
@@ -128,6 +128,23 @@
             }
           }
         },
+        "compileOptions": {
+          "$id": "/properties/project/properties/compileOptions",
+          "type": "object",
+          "properties": {
+            "compileOrder": {
+              "$id": "/properties/project/properties/compileOptions/properties/compileOrder",
+              "type": "string",
+              "title": "The compile order for Java and Scala sources ",
+              "default": "mixed",
+              "examples": [
+                "mixed",
+                "java->scala",
+                "scala->java"
+              ]
+            }
+          }
+        },
         "out": {
           "$id": "/properties/project/properties/out",
           "type": "string",


### PR DESCRIPTION
The compile order is important because many projects define their own
compile order and that changes the semantics of compilation.

Let's add this option under a `CompileOptions` field in our bloop config
file. This new field will in the future, before 1.0.0, host
`classpathOptions` which seems kinda out of place. But for now, we
abstain ourselves from making this breaking change.