### PR TITLE
Add scalameta to the community build

### DIFF
--- a/build-integrations/sbt-0.13/build.sbt
+++ b/build-integrations/sbt-0.13/build.sbt
@@ -2,7 +2,8 @@ val ApacheSpark = Integrations.ApacheSpark
 val LihaoyiUtest = Integrations.LihaoyiUtest
 val ScalaScala = Integrations.ScalaScala
 val ScalaCenterVersions = Integrations.ScalaCenterVersions
-val integrations = List(ApacheSpark, LihaoyiUtest, ScalaScala, ScalaCenterVersions)
+val Scalameta = Integrations.Scalameta
+val integrations = List(ApacheSpark, LihaoyiUtest, ScalaScala, ScalaCenterVersions, Scalameta)
 
 val dummy = project
   .in(file("."))
@@ -16,6 +17,7 @@ val dummy = project
         "spark" -> bloopConfigDir.in(ApacheSpark).value,
         "utest" -> bloopConfigDir.in(LihaoyiUtest).value,
         "scala" -> bloopConfigDir.in(ScalaScala).value,
+        "scalameta" -> bloopConfigDir.in(Scalameta).value,
         "versions" -> bloopConfigDir.in(ScalaCenterVersions).value
       )
     },
@@ -26,6 +28,7 @@ val dummy = project
         clean.in(ApacheSpark),
         clean.in(LihaoyiUtest),
         clean.in(ScalaScala),
+        clean.in(Scalameta),
         clean.in(ScalaCenterVersions)
       ).value
     }

--- a/build-integrations/sbt-0.13/project/Integrations.scala
+++ b/build-integrations/sbt-0.13/project/Integrations.scala
@@ -3,12 +3,14 @@ import sbt.{RootProject, uri}
 object Integrations {
 
   val ApacheSpark = RootProject(
-    uri("git://github.com/scalacenter/spark.git#4e037d614250b855915c28ac1e84471075293124"))
+    uri("git://github.com/scalacenter/spark.git#e7ac5e9fa8ca3eeb4fecdbbfbe745ef71e276498"))
   val LihaoyiUtest = RootProject(
-    uri("git://github.com/lihaoyi/utest.git#b5440d588d5b32c85f6e9392c63edd3d3fed3106"))
+    uri("git://github.com/scalacenter/utest.git#dbe6a554d838c4b4b5997702bfa7791f60ca02ef"))
   val ScalaScala = RootProject(
     uri("git://github.com/scalacenter/scala.git#430deb1f3ff23ae0876434b302808d7b004337f6"))
   val ScalaCenterVersions = RootProject(
     uri("git://github.com/scalacenter/versions.git#c296028a33b06ba3a41d399d77c21f6b7100c001"))
+  val Scalameta = RootProject(
+    uri("git://github.com/scalacenter/scalameta.git#653a0cc3d4d5bf615c6586fade94b5b78c3dd5ba"))
 
 }


### PR DESCRIPTION
The forked version of scalameta:

* Fix an issue with a relative path for the proto sources.
* Upgrade some plugin versions and disable coursier (the 0.13 community build
  doesn't like coursier).
* Removes the two out of three test projects because they require the
  compilation of the semanticdb module.