### PR TITLE
Use -Xnojline option when starting console

### DIFF
--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -212,7 +212,8 @@ object Tasks {
     val loader = ClasspathUtilities.makeLoader(classpathFiles, scalaInstance)
     val compiler = state.compilerCache.get(scalaInstance).scalac.asInstanceOf[AnalyzingCompiler]
     val classpathOptions = ClasspathOptionsUtil.repl
-    compiler.console(classpathFiles, project.scalacOptions, classpathOptions, "", "", state.logger)(
+    val options = project.scalacOptions :+ "-Xnojline"
+    compiler.console(classpathFiles, options, classpathOptions, "", "", state.logger)(
       Some(loader))
     state
   }


### PR DESCRIPTION
Since we are using Nailgun, the REPL is being run in a different
process than the one connected to the user's terminal, so we cannot
run Scala's ILoop with InteractiveReader - we must use SimpleReader
instead. By passing -Xnojline argument to AnalyzingCompiler.console we
make sure that it will use SimpleReader.

Fixes #385.