### PR TITLE
Make sure we always create source dirs in tests

### DIFF
--- a/frontend/src/test/scala/bloop/engine/FileWatchingSpec.scala
+++ b/frontend/src/test/scala/bloop/engine/FileWatchingSpec.scala
@@ -152,6 +152,14 @@ class FileWatchingSpec {
         // Start the compilation
         workerThread.start()
 
+        // Create non-existing source dirs in tests Xhttps://github.com/scalacenter/bloop/pull/471
+        project.sources.foreach { a =>
+          val p = a.underlying
+          val s = p.toString
+          if (!Files.exists(p) && !s.endsWith(".scala") && !s.endsWith(".java"))
+            Files.createDirectories(p)
+        }
+
         // Deletion doesn't trigger recompilation -- done to avoid file from previous test run
         val newSource = project.sources.head.resolve("D.scala").underlying
         if (Files.exists(newSource)) TestUtil.delete(newSource)


### PR DESCRIPTION
I have no idea why this hasn't been caught sooner, but
https://ci.scala-lang.org/scalacenter/bloop/3062/11 seems to point out
that as 6 directories don't exist within `with-tests`, we only print
that we're watching 2.

So let's see what happens with two.