### PR TITLE
Add Scala.js bridge

### DIFF
--- a/backend/src/main/scala/bloop/DependencyResolution.scala
+++ b/backend/src/main/scala/bloop/DependencyResolution.scala
@@ -61,7 +61,7 @@ object DependencyResolution {
       localArtifacts.collect { case Right(f) => AbsolutePath(f.toPath) }.toArray
     } else {
       sys.error(
-        s"Resolution of Scala instance failed with: ${errors.mkString("\n =>", "=> \n", "\n")}"
+        s"Resolution of module $module failed with: ${errors.mkString("\n =>", "=> \n", "\n")}"
       )
     }
   }

--- a/bridges/scala-native/src/main/scala/bloop/scalanative/NativeBridge.scala
+++ b/bridges/scala-native/src/main/scala/bloop/scalanative/NativeBridge.scala
@@ -1,16 +1,19 @@
 package bloop.scalanative
 
-import bloop.Project
-import bloop.io.AbsolutePath
-import bloop.logging.Logger
+import java.io.File
 
+import bloop.Project
+import bloop.logging.Logger
 import java.nio.file.Path
 
-import scala.scalanative.build.{Discover, Build, Config, GC, Mode, Logger => NativeLogger}
+import scala.scalanative.build.{Build, Config, Discover, GC, Mode, Logger => NativeLogger}
 
 object NativeBridge {
 
-  def nativeLink(project: Project, entry: String, logger: Logger): Path = {
+  def link(project: Project,
+           entry  : String,
+           target : File,
+           logger : Logger): Path = {
     val classpath = project.classpath.map(_.underlying)
     val workdir = project.out.resolve("native").underlying
 
@@ -20,7 +23,6 @@ object NativeBridge {
     val compopts = Discover.compileOptions()
     val triple = Discover.targetTriple(clang, workdir)
     val nativelib = Discover.nativelib(classpath).get
-    val outpath = workdir.resolve("out")
     val nativeLogger = NativeLogger(logger.debug _, logger.info _, logger.warn _, logger.error _)
 
     val config =
@@ -38,7 +40,7 @@ object NativeBridge {
         .withWorkdir(workdir)
         .withLogger(nativeLogger)
 
-    Build.build(config, outpath)
+    Build.build(config, target.toPath)
   }
 
 }

--- a/bridges/scala-native/src/main/scala/bloop/scalanative/NativeBridge.scala
+++ b/bridges/scala-native/src/main/scala/bloop/scalanative/NativeBridge.scala
@@ -1,0 +1,44 @@
+package bloop.scalanative
+
+import bloop.Project
+import bloop.io.AbsolutePath
+import bloop.logging.Logger
+
+import java.nio.file.Path
+
+import scala.scalanative.build.{Discover, Build, Config, GC, Mode, Logger => NativeLogger}
+
+object NativeBridge {
+
+  def nativeLink(project: Project, entry: String, logger: Logger): Path = {
+    val classpath = project.classpath.map(_.underlying)
+    val workdir = project.out.resolve("native").underlying
+
+    val clang = Discover.clang()
+    val clangpp = Discover.clangpp()
+    val linkopts = Discover.linkingOptions()
+    val compopts = Discover.compileOptions()
+    val triple = Discover.targetTriple(clang, workdir)
+    val nativelib = Discover.nativelib(classpath).get
+    val outpath = workdir.resolve("out")
+    val nativeLogger = NativeLogger(logger.debug _, logger.info _, logger.warn _, logger.error _)
+
+    val config =
+      Config.empty
+        .withGC(GC.default)
+        .withMode(Mode.default)
+        .withClang(clang)
+        .withClangPP(clangpp)
+        .withLinkingOptions(linkopts)
+        .withCompileOptions(compopts)
+        .withTargetTriple(triple)
+        .withNativelib(nativelib)
+        .withMainClass(entry)
+        .withClassPath(classpath)
+        .withWorkdir(workdir)
+        .withLogger(nativeLogger)
+
+    Build.build(config, outpath)
+  }
+
+}

--- a/bridges/scalajs/src/main/scala/bloop/scalajs/JsBridge.scala
+++ b/bridges/scalajs/src/main/scala/bloop/scalajs/JsBridge.scala
@@ -1,15 +1,13 @@
 package bloop.scalajs
 
 import scala.collection.JavaConverters._
-
-import java.nio.file.Files
+import java.nio.file.{Files, Path}
 import java.io.File
 
 import org.scalajs.core.tools.io.IRFileCache.IRContainer
 import org.scalajs.core.tools.io.{AtomicWritableFileVirtualJSFile, FileVirtualBinaryFile, FileVirtualScalaJSIRFile, VirtualJarFile}
 import org.scalajs.core.tools.linker.{ModuleInitializer, StandardLinker}
 import org.scalajs.core.tools.logging.{Level, Logger => JsLogger}
-
 import bloop.Project
 import bloop.logging.{Logger => BloopLogger}
 
@@ -27,25 +25,36 @@ object JsBridge {
     override def trace(t: => Throwable): Unit = logger.trace(t)
   }
 
+  @inline private def isIrFile(file: File): Boolean =
+    file.toString.endsWith(".sjsir")
+
+  @inline private def isJarFile(file: File): Boolean =
+    file.toString.endsWith(".jar")
+
+  private def findIrFiles(path: Path): List[File] =
+    Files.walk(path)
+      .iterator()
+      .asScala
+      .map(_.toFile)
+      .filter(isIrFile)
+      .toList
+
   def link(project  : Project,
            mainClass: String,
            target   : File,
            optimise : java.lang.Boolean,
            logger   : BloopLogger): Unit = {
-    val outputPath = project.out.underlying
+    val classPath = project.classpath.map(_.underlying).toList
 
-    val sources = Files.walk(outputPath).iterator().asScala
-      .filter(_.getFileName.toString.endsWith(".sjsir")).map(_.toFile).toList
-    val sourceIrFiles = sources.map(new FileVirtualScalaJSIRFile(_))
+    val classPathIrFiles = classPath
+      .filter(_.toFile.isDirectory)
+      .flatMap(findIrFiles)
+      .map(new FileVirtualScalaJSIRFile(_))
 
-    val classPath = project.classpath.map(_.underlying)
     val jarFiles =
-      classPath.toList.map(_.toFile).filter(_.getName.endsWith(".jar"))
-    val jars = jarFiles.map(jar =>
-      IRContainer.Jar(new FileVirtualBinaryFile(jar) with VirtualJarFile))
-    val jarIrFiles = jars.flatMap(_.jar.sjsirFiles)
-
-    val irFiles = sourceIrFiles ++ jarIrFiles
+      classPath.map(_.toFile).filter(isJarFile).map(jar => IRContainer.Jar(
+        new FileVirtualBinaryFile(jar) with VirtualJarFile))
+    val jarIrFiles = jarFiles.flatMap(_.jar.sjsirFiles)
 
     val initializer =
       ModuleInitializer.mainMethodWithArgs(mainClass, "main")
@@ -53,7 +62,7 @@ object JsBridge {
     val config = StandardLinker.Config().withOptimizer(optimise)
 
     StandardLinker(config).link(
-      irFiles            = irFiles,
+      irFiles            = classPathIrFiles ++ jarIrFiles,
       moduleInitializers = Seq(initializer),
       output             = AtomicWritableFileVirtualJSFile(target),
       logger             = new Logger(logger))

--- a/bridges/scalajs/src/main/scala/bloop/scalajs/JsBridge.scala
+++ b/bridges/scalajs/src/main/scala/bloop/scalajs/JsBridge.scala
@@ -1,0 +1,62 @@
+package bloop.scalajs
+
+import scala.collection.JavaConverters._
+
+import java.nio.file.Files
+import java.io.File
+
+import org.scalajs.core.tools.io.IRFileCache.IRContainer
+import org.scalajs.core.tools.io.{AtomicWritableFileVirtualJSFile, FileVirtualBinaryFile, FileVirtualScalaJSIRFile, VirtualJarFile}
+import org.scalajs.core.tools.linker.{ModuleInitializer, StandardLinker}
+import org.scalajs.core.tools.logging.{Level, Logger => JsLogger}
+
+import bloop.Project
+import bloop.logging.{Logger => BloopLogger}
+
+object JsBridge {
+
+  private class Logger(logger: BloopLogger) extends JsLogger {
+    override def log(level: Level, message: => String): Unit =
+      level match {
+        case Level.Error => logger.error(message)
+        case Level.Warn  => logger.warn(message)
+        case Level.Info  => logger.info(message)
+        case Level.Debug => logger.debug(message)
+      }
+    override def success(message: => String): Unit = logger.info(message)
+    override def trace(t: => Throwable): Unit = logger.trace(t)
+  }
+
+  def link(project  : Project,
+           mainClass: String,
+           target   : File,
+           optimise : java.lang.Boolean,
+           logger   : BloopLogger): Unit = {
+    val outputPath = project.out.underlying
+
+    val sources = Files.walk(outputPath).iterator().asScala
+      .filter(_.getFileName.toString.endsWith(".sjsir")).map(_.toFile).toList
+    val sourceIrFiles = sources.map(new FileVirtualScalaJSIRFile(_))
+
+    val classPath = project.classpath.map(_.underlying)
+    val jarFiles =
+      classPath.toList.map(_.toFile).filter(_.getName.endsWith(".jar"))
+    val jars = jarFiles.map(jar =>
+      IRContainer.Jar(new FileVirtualBinaryFile(jar) with VirtualJarFile))
+    val jarIrFiles = jars.flatMap(_.jar.sjsirFiles)
+
+    val irFiles = sourceIrFiles ++ jarIrFiles
+
+    val initializer =
+      ModuleInitializer.mainMethodWithArgs(mainClass, "main")
+
+    val config = StandardLinker.Config().withOptimizer(optimise)
+
+    StandardLinker(config).link(
+      irFiles            = irFiles,
+      moduleInitializers = Seq(initializer),
+      output             = AtomicWritableFileVirtualJSFile(target),
+      logger             = new Logger(logger))
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ lazy val frontend: Project = project
     name := s"bloop-frontend",
     mainClass in Compile in run := Some("bloop.Cli"),
     buildInfoPackage := "bloop.internal.build",
-    buildInfoKeys := bloopInfoKeys(nativeBridge),
+    buildInfoKeys := bloopInfoKeys(nativeBridge, jsBridge),
     javaOptions in run ++= jvmOptions,
     javaOptions in Test ++= jvmOptions,
     libraryDependencies += Dependencies.graphviz % Test,
@@ -144,6 +144,16 @@ val docs = project
     websiteSettings
   )
 
+lazy val jsBridge = project
+  .dependsOn(frontend)
+  .in(file("bridges") / "scalajs")
+  .disablePlugins(ScriptedPlugin)
+  .settings(testSettings)
+  .settings(
+    name := "bloop-js-bridge",
+    libraryDependencies += Dependencies.scalaJsTools
+  )
+
 lazy val nativeBridge = project
   .dependsOn(frontend)
   .in(file("bridges") / "scala-native")
@@ -154,7 +164,7 @@ lazy val nativeBridge = project
     libraryDependencies += Dependencies.scalaNativeTools
   )
 
-val allProjects = Seq(backend, benchmarks, frontend, jsonConfig, sbtBloop, mavenBloop, nativeBridge)
+val allProjects = Seq(backend, benchmarks, frontend, jsonConfig, sbtBloop, mavenBloop, nativeBridge, jsBridge)
 val allProjectReferences = allProjects.map(p => LocalProject(p.id))
 val bloop = project
   .in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,7 @@ val jsonConfig = project
 
 import build.BuildImplementation.jvmOptions
 // For the moment, the dependency is fixed
-val frontend = project
+lazy val frontend: Project = project
   .dependsOn(backend, backend % "test->test", jsonConfig)
   .disablePlugins(ScriptedPlugin)
   .enablePlugins(BuildInfoPlugin)
@@ -87,7 +87,7 @@ val frontend = project
     name := s"bloop-frontend",
     mainClass in Compile in run := Some("bloop.Cli"),
     buildInfoPackage := "bloop.internal.build",
-    buildInfoKeys := BloopInfoKeys,
+    buildInfoKeys := bloopInfoKeys(nativeBridge),
     javaOptions in run ++= jvmOptions,
     javaOptions in Test ++= jvmOptions,
     libraryDependencies += Dependencies.graphviz % Test,
@@ -144,7 +144,17 @@ val docs = project
     websiteSettings
   )
 
-val allProjects = Seq(backend, benchmarks, frontend, jsonConfig, sbtBloop, mavenBloop)
+lazy val nativeBridge = project
+  .dependsOn(frontend)
+  .in(file("bridges") / "scala-native")
+  .disablePlugins(ScriptedPlugin)
+  .settings(testSettings)
+  .settings(
+    name := "bloop-native-bridge",
+    libraryDependencies += Dependencies.scalaNativeTools
+  )
+
+val allProjects = Seq(backend, benchmarks, frontend, jsonConfig, sbtBloop, mavenBloop, nativeBridge)
 val allProjectReferences = allProjects.map(p => LocalProject(p.id))
 val bloop = project
   .in(file("."))

--- a/config/src/main/scala-2.10/bloop/config/ConfigEncoders.scala
+++ b/config/src/main/scala-2.10/bloop/config/ConfigEncoders.scala
@@ -19,6 +19,10 @@ object ConfigEncoders {
     }
   }
 
+  implicit val platformConfigEncoder: RootEncoder[Platform] = new RootEncoder[Platform] {
+    override final def apply(platform: Platform): Json = Json.fromString(platform.name)
+  }
+
   implicit val javaConfigEncoder: ObjectEncoder[Java] = deriveEncoder
   implicit val jvmConfigEncoder: ObjectEncoder[Jvm] = deriveEncoder
   implicit val testFrameworkConfigEncoder: ObjectEncoder[TestFramework] = deriveEncoder

--- a/config/src/main/scala-2.12/bloop/config/ConfigDecoders.scala
+++ b/config/src/main/scala-2.12/bloop/config/ConfigDecoders.scala
@@ -16,6 +16,15 @@ object ConfigDecoders {
     }
   }
 
+  implicit val platformDecoder: ConfDecoder[Platform] = {
+    ConfDecoder.stringConfDecoder.flatMap { str =>
+      Try(Platform(str)) match {
+        case Success(platform) => Configured.Ok(platform)
+        case Failure(t) => Configured.error(t.getMessage)
+      }
+    }
+  }
+
   implicit val javaConfigSurface: Surface[Java] =
     generic.deriveSurface[Java]
   implicit val javaConfigDecoder: ConfDecoder[Java] =

--- a/config/src/main/scala-2.12/bloop/config/ConfigEncoders.scala
+++ b/config/src/main/scala-2.12/bloop/config/ConfigEncoders.scala
@@ -19,6 +19,10 @@ object ConfigEncoders {
     }
   }
 
+  implicit val platformConfigEncoder: RootEncoder[Platform] = new RootEncoder[Platform] {
+    override final def apply(platform: Platform): Json = Json.fromString(platform.name)
+  }
+
   implicit val javaConfigEncoder: ObjectEncoder[Java] = deriveEncoder
   implicit val jvmConfigEncoder: ObjectEncoder[Jvm] = deriveEncoder
   implicit val testFrameworkConfigEncoder: ObjectEncoder[TestFramework] = deriveEncoder

--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -59,6 +59,22 @@ object Config {
     private[bloop] val empty: Scala = Scala("", "", "", Array(), Array())
   }
 
+  sealed abstract class Platform(val name: String)
+  object Platform {
+    private[bloop] val default: Platform = JVM
+
+    case object JS extends Platform("JS")
+    case object JVM extends Platform("JVM")
+    case object Native extends Platform("Native")
+
+    def apply(platform: String): Platform = platform match {
+      case JS.name => JS
+      case JVM.name => JVM
+      case Native.name => Native
+      case _ => throw new IllegalArgumentException(s"Unknown platform: '$platform'")
+    }
+  }
+
   case class Project(
       name: String,
       directory: Path,
@@ -72,13 +88,14 @@ object Config {
       `scala`: Scala,
       jvm: Jvm,
       java: Java,
-      test: Test
+      test: Test,
+      platform: Platform
   )
 
   object Project {
     // FORMAT: OFF
     private[bloop] val empty: Project =
-      Project("", emptyPath, Array(), Array(), Array(), ClasspathOptions.empty, CompileOptions.empty, emptyPath, emptyPath, Scala.empty, Jvm.empty, Java.empty, Test.empty)
+      Project("", emptyPath, Array(), Array(), Array(), ClasspathOptions.empty, CompileOptions.empty, emptyPath, emptyPath, Scala.empty, Jvm.empty, Java.empty, Test.empty, Platform.default)
     // FORMAT: ON
   }
 

--- a/config/src/test/scala-2.12/bloop/config/JsonSpec.scala
+++ b/config/src/test/scala-2.12/bloop/config/JsonSpec.scala
@@ -51,7 +51,8 @@ class JsonSpec {
       Scala("org.scala-lang", "scala-compiler", "2.12.4", Array("-warn"), Array()),
       Jvm(Some(Paths.get("/usr/lib/jvm/java-8-jdk")), Array()),
       Java(Array("-version")),
-      ConfigTest(Array(), TestOptions(Nil, Nil))
+      ConfigTest(Array(), TestOptions(Nil, Nil)),
+      Platform.default
     )
 
     parseConfig(File(File.LatestVersion, project))

--- a/config/src/test/scala-2.12/bloop/config/JsonSpec.scala
+++ b/config/src/test/scala-2.12/bloop/config/JsonSpec.scala
@@ -2,7 +2,7 @@ package bloop.config
 
 import java.nio.file.{Files, Paths}
 
-import bloop.config.Config.{ClasspathOptions, CompileOptions, File, Java, Jvm, Project, Scala, TestOptions, Test => ConfigTest}
+import bloop.config.Config.{ClasspathOptions, CompileOptions, File, Java, Jvm, Platform, Project, Scala, TestOptions, Test => ConfigTest}
 import bloop.config.ConfigDecoders.allConfigDecoder
 import bloop.config.ConfigEncoders.allConfigEncoder
 import metaconfig.{Conf, Configured}

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -187,6 +187,12 @@ object Cli {
               case Right(c: Commands.Configure) =>
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
                 run(newCommand, newCommand.cliOptions)
+              case Right(c: Commands.NativeLink) =>
+                val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
+                withProject(c.project) { (p: String) =>
+                  val cmd = if (p != c.project) newCommand.copy(project = p) else newCommand
+                  run(cmd, newCommand.cliOptions)
+                }
             }
         }
         newAction.getOrElse {

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -187,7 +187,7 @@ object Cli {
               case Right(c: Commands.Configure) =>
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
                 run(newCommand, newCommand.cliOptions)
-              case Right(c: Commands.NativeLink) =>
+              case Right(c: Commands.Link) =>
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
                 withProject(c.project) { (p: String) =>
                   val cmd = if (p != c.project) newCommand.copy(project = p) else newCommand

--- a/frontend/src/main/scala/bloop/Project.scala
+++ b/frontend/src/main/scala/bloop/Project.scala
@@ -8,6 +8,7 @@ import xsbti.compile.ClasspathOptions
 import _root_.monix.eval.Task
 import bloop.bsp.ProjectUris
 import bloop.config.{Config, ConfigDecoders}
+import bloop.config.Config.Platform
 import bloop.engine.ExecutionContext
 import metaconfig.{Conf, Configured, Input}
 
@@ -25,6 +26,7 @@ final case class Project(
     testFrameworks: Array[Config.TestFramework],
     testOptions: Config.TestOptions,
     javaEnv: JavaEnv,
+    platform: Platform,
     out: AbsolutePath
 ) {
   override def toString: String = s"$name"
@@ -117,6 +119,7 @@ object Project {
       project.test.frameworks,
       project.test.options,
       javaEnv,
+      project.platform,
       AbsolutePath(project.out)
     )
   }

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -156,4 +156,19 @@ object Commands {
       watch: Boolean = false,
       @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends CompilingCommand
+
+  case class NativeLink(
+      @ExtraName("p")
+      @HelpMessage("The project to run (will be inferred from remaining cli args).")
+      project: String = "",
+      @ExtraName("m")
+      @HelpMessage("The main class to link. Leave unset to let bloop select automatically.")
+      main: Option[String] = None,
+      @HelpMessage("Pick reporter to show compilation messages. By default, bloop's used.")
+      reporter: ReporterKind = BloopReporter,
+      @ExtraName("w")
+      @HelpMessage("If set, run the command whenever projects' source files change.")
+      watch: Boolean = false,
+      @Recurse cliOptions: CliOptions = CliOptions.default
+  ) extends CompilingCommand
 }

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -142,7 +142,7 @@ object Commands {
 
   case class Run(
       @ExtraName("p")
-      @HelpMessage("The project to run (will be inferred from remaining cli args).")
+      @HelpMessage("The project to run (will be inferred from remaining cli args). Requires Node.js to be in $PATH for Scala.js.")
       project: String = "",
       @ExtraName("m")
       @HelpMessage("The main class to run. Leave unset to let bloop select automatically.")
@@ -157,7 +157,7 @@ object Commands {
       @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends CompilingCommand
 
-  case class NativeLink(
+  case class Link(
       @ExtraName("p")
       @HelpMessage("The project to run (will be inferred from remaining cli args).")
       project: String = "",
@@ -169,6 +169,12 @@ object Commands {
       @ExtraName("w")
       @HelpMessage("If set, run the command whenever projects' source files change.")
       watch: Boolean = false,
+      @ExtraName("opt")
+      @HelpMessage("Perform additional code optimisations. Only available for Scala.js. Disabled by default.")
+      optimise: Boolean = false,
+      @ExtraName("o")
+      @HelpMessage("Change the output path. By default, the linked output file will be stored in `out`.")
+      output: Option[String] = None,
       @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends CompilingCommand
 }

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -6,11 +6,12 @@ import scala.annotation.tailrec
 import bloop.cli.{BspProtocol, CliOptions, Commands, ExitStatus, ReporterKind}
 import bloop.cli.CliParsers.CommandsMessages
 import bloop.cli.completion.{Case, Mode}
+import bloop.config.Config.Platform
 import bloop.io.{RelativePath, SourceWatcher}
 import bloop.io.Timer.timed
 import bloop.reporter.ReporterConfig
 import bloop.testing.TestInternals
-import bloop.engine.tasks.Tasks
+import bloop.engine.tasks.{ScalaNative, Tasks}
 import bloop.Project
 import monix.eval.Task
 import monix.execution.misc.NonFatal
@@ -52,6 +53,8 @@ object Interpreter {
             execute(next, configure(cmd, state), true)
           case Run(cmd: Commands.Autocomplete, next) =>
             execute(next, autocomplete(cmd, state), true)
+          case Run(cmd: Commands.NativeLink, next) =>
+            execute(next, nativeLink(cmd, state, inRecursion), true)
           case Run(cmd: Commands.Help, next) =>
             val msg = "The handling of help doesn't happen in the `Interpreter`."
             val printAction = Print(msg, cmd.cliOptions.common, Exit(ExitStatus.UnexpectedError))
@@ -270,6 +273,38 @@ object Interpreter {
     state
   }
 
+  private def nativeLink(cmd: Commands.NativeLink,
+                         state: State,
+                         sequential: Boolean): Task[State] = {
+    state.build.getProjectFor(cmd.project) match {
+      case None =>
+        Task(reportMissing(cmd.project :: Nil, state))
+      case Some(project) if project.platform != Platform.Native =>
+        Task {
+          state.logger.error("This command can only be called on a Scala Native project.")
+          state.mergeStatus(ExitStatus.RunError)
+        }
+      case Some(project) =>
+        val reporter = ReporterKind.toReporterConfig(cmd.reporter)
+        def doRun(state: State): Task[State] = {
+          compileAnd(state, project, reporter, false, sequential, "`nativeLink`") { state =>
+            cmd.main.orElse(getMainClass(state, project)) match {
+              case None => Task(state.mergeStatus(ExitStatus.RunError))
+              case Some(main) =>
+                Task {
+                  val out = ScalaNative.nativeLink(project, main, state.logger)
+                  state.logger.info(s"Produced $out")
+                  state
+                }
+            }
+          }
+        }
+
+        if (cmd.watch) watch(project, state, doRun _)
+        else doRun(state)
+    }
+  }
+
   private def configure(cmd: Commands.Configure, state: State): Task[State] = Task {
     if (cmd.threads != ExecutionContext.executor.getCorePoolSize)
       State.setCores(state, cmd.threads)
@@ -288,32 +323,19 @@ object Interpreter {
 
     state.build.getProjectFor(cmd.project) match {
       case Some(project) =>
-        def getMainClass(state: State): Option[String] = {
-          cmd.main.orElse {
-            Tasks.findMainClasses(state, project) match {
-              case Array() =>
-                state.logger.error(s"No main classes found in project '${project.name}'")
-                None
-              case Array(main) =>
-                Some(main)
-              case mainClasses =>
-                val eol = System.lineSeparator
-                val message = s"""Several main classes were found, specify which one:
-                                 |${mainClasses.mkString(" * ", s"$eol * ", "")}""".stripMargin
-                state.logger.error(message)
-                None
-            }
-          }
-        }
-
         def doRun(state: State): Task[State] = {
           compileAnd(state, project, reporter, false, sequential, "`run`") { state =>
-            getMainClass(state) match {
+            cmd.main.orElse(getMainClass(state, project)) match {
               case None => Task(state.mergeStatus(ExitStatus.RunError))
               case Some(main) =>
                 val args = cmd.args.toArray
                 val cwd = cmd.cliOptions.common.workingPath
-                Tasks.run(state, project, cwd, main, args)
+                project.platform match {
+                  case Platform.Native =>
+                    ScalaNative.run(state, project, cwd, main, args)
+                  case _ =>
+                    Tasks.run(state, project, cwd, main, args)
+                }
             }
           }
         }
@@ -332,5 +354,21 @@ object Interpreter {
     state.logger.error(s"No projects named $projects found in '$configDirectory'.")
     state.logger.error(s"Use the `projects` command to list existing projects.")
     state.mergeStatus(ExitStatus.InvalidCommandLineOption)
+  }
+
+  private def getMainClass(state: State, project: Project): Option[String] = {
+    Tasks.findMainClasses(state, project) match {
+      case Array() =>
+        state.logger.error(s"No main classes found in project '${project.name}'")
+        None
+      case Array(main) =>
+        Some(main)
+      case mainClasses =>
+        val eol = System.lineSeparator
+        val message = s"""Several main classes were found, specify which one:
+                         |${mainClasses.mkString(" * ", s"$eol * ", "")}""".stripMargin
+        state.logger.error(message)
+        None
+    }
   }
 }

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -1,25 +1,28 @@
 package bloop.engine
 
+import java.io.File
+
 import bloop.bsp.BspServer
 
-import scala.annotation.tailrec
-import bloop.cli.{BspProtocol, CliOptions, Commands, ExitStatus, ReporterKind}
+import bloop.cli.{BspProtocol, Commands, ExitStatus, ReporterKind}
 import bloop.cli.CliParsers.CommandsMessages
 import bloop.cli.completion.{Case, Mode}
 import bloop.config.Config.Platform
-import bloop.io.{RelativePath, SourceWatcher}
-import bloop.io.Timer.timed
+import bloop.io.{AbsolutePath, RelativePath, SourceWatcher}
 import bloop.reporter.ReporterConfig
 import bloop.testing.TestInternals
-import bloop.engine.tasks.{ScalaNative, Tasks}
+import bloop.engine.tasks.{ScalaJs, ScalaNative, Tasks}
 import bloop.Project
+import bloop.exec.Process
+import bloop.exec.Forker
 import monix.eval.Task
-import monix.execution.misc.NonFatal
-
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
 
 object Interpreter {
+  private val DefaultTargetNames: Map[Platform, String] = Map(
+    Platform.JVM    -> "out.jar",
+    Platform.JS     -> "out.js",
+    Platform.Native -> "out")
+
   // This is stack safe because of monix trampolined execution.
   def execute(action: Action, stateTask: Task[State]): Task[State] = {
     def execute(action: Action, stateTask: Task[State], inRecursion: Boolean): Task[State] = {
@@ -53,8 +56,8 @@ object Interpreter {
             execute(next, configure(cmd, state), true)
           case Run(cmd: Commands.Autocomplete, next) =>
             execute(next, autocomplete(cmd, state), true)
-          case Run(cmd: Commands.NativeLink, next) =>
-            execute(next, nativeLink(cmd, state, inRecursion), true)
+          case Run(cmd: Commands.Link, next) =>
+            execute(next, link(cmd, state, inRecursion), true)
           case Run(cmd: Commands.Help, next) =>
             val msg = "The handling of help doesn't happen in the `Interpreter`."
             val printAction = Print(msg, cmd.cliOptions.common, Exit(ExitStatus.UnexpectedError))
@@ -273,27 +276,43 @@ object Interpreter {
     state
   }
 
-  private def nativeLink(cmd: Commands.NativeLink,
-                         state: State,
-                         sequential: Boolean): Task[State] = {
+  private def link(cmd: Commands.Link,
+                   state: State,
+                   sequential: Boolean): Task[State] = {
+    val cwd    = cmd.cliOptions.common.workingPath
+    val output = cmd.output.map(cwd.resolve)
+
     state.build.getProjectFor(cmd.project) match {
       case None =>
         Task(reportMissing(cmd.project :: Nil, state))
-      case Some(project) if project.platform != Platform.Native =>
+      case _ if output.exists(_.isDirectory) =>
         Task {
-          state.logger.error("This command can only be called on a Scala Native project.")
+          state.logger.error("The output path must point to a file.")
+          state.mergeStatus(ExitStatus.RunError)
+        }
+      case Some(project) if project.platform != Platform.Native &&
+                            project.platform != Platform.JS =>
+        Task {
+          state.logger.error("This command can only be called on a Scala Native or Scala.js project.")
           state.mergeStatus(ExitStatus.RunError)
         }
       case Some(project) =>
         val reporter = ReporterKind.toReporterConfig(cmd.reporter)
         def doRun(state: State): Task[State] = {
-          compileAnd(state, project, reporter, false, sequential, "`nativeLink`") { state =>
+          compileAnd(state, project, reporter, false, sequential, "`link`") { state =>
             cmd.main.orElse(getMainClass(state, project)) match {
               case None => Task(state.mergeStatus(ExitStatus.RunError))
               case Some(main) =>
+                val target = output.getOrElse(
+                  project.out.resolve(DefaultTargetNames(project.platform)))
+
                 Task {
-                  val out = ScalaNative.nativeLink(project, main, state.logger)
-                  state.logger.info(s"Produced $out")
+                  if (project.platform == Platform.Native)
+                    ScalaNative.link(project, main, target.toFile, state.logger)
+                  else ScalaJs.link(
+                    project, main, target.toFile, cmd.optimise, state.logger)
+
+                  state.logger.info(s"Output written to $target.")
                   state
                 }
             }
@@ -327,14 +346,25 @@ object Interpreter {
           compileAnd(state, project, reporter, false, sequential, "`run`") { state =>
             cmd.main.orElse(getMainClass(state, project)) match {
               case None => Task(state.mergeStatus(ExitStatus.RunError))
-              case Some(main) =>
-                val args = cmd.args.toArray
-                val cwd = cmd.cliOptions.common.workingPath
+              case Some(mainClass) =>
+                val args   = cmd.args
+                val cwd    = cmd.cliOptions.common.workingPath
+                val target = new File(
+                  project.out.toFile, DefaultTargetNames(project.platform))
+
                 project.platform match {
                   case Platform.Native =>
-                    ScalaNative.run(state, project, cwd, main, args)
+                    ScalaNative.link(project, mainClass, target, state.logger)
+                    Task(runCommand(state, cwd, target.toString +: args))
+
+                  case Platform.JS =>
+                    ScalaJs.link(project, mainClass, target, optimise = false,
+                      state.logger)
+                    val command = List("node", target.toString) ++ args
+                    Task(runCommand(state, cwd, command))
+
                   case _ =>
-                    Tasks.run(state, project, cwd, main, args)
+                    Tasks.run(state, project, cwd, mainClass, args.toArray)
                 }
             }
           }
@@ -346,6 +376,19 @@ object Interpreter {
       case None =>
         Task(reportMissing(cmd.project :: Nil, state))
     }
+  }
+
+  private def runCommand(state: State,
+                         cwd  : AbsolutePath,
+                         cmd  : List[String]): State = {
+    import scala.collection.JavaConverters.propertiesAsScalaMap
+    val env = propertiesAsScalaMap(state.commonOptions.env).toMap
+    val exitCode = Process.run(cwd, cmd, env, state.logger)
+
+    val exitStatus =
+      if (exitCode == Forker.EXIT_OK) ExitStatus.Ok
+      else ExitStatus.UnexpectedError
+    state.mergeStatus(exitStatus)
   }
 
   private def reportMissing(projectNames: List[String], state: State): State = {

--- a/frontend/src/main/scala/bloop/engine/tasks/BridgeClassLoader.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/BridgeClassLoader.scala
@@ -1,0 +1,35 @@
+package bloop.engine.tasks
+
+import java.net.URLClassLoader
+
+import coursier.core.Repository
+
+import bloop.DependencyResolution
+import bloop.io.AbsolutePath
+import bloop.logging.Logger
+
+object BridgeClassLoader {
+
+  def classLoader(logger  : Logger,
+                  artifact: String,
+                  additionalRepositories: Seq[Repository] = List()
+                 ): ClassLoader = {
+    val jars    = resolveBridge(logger, artifact, additionalRepositories)
+    val entries = jars.map(_.underlying.toUri.toURL)
+    new URLClassLoader(entries, getClass.getClassLoader)
+  }
+
+  /** @return Paths to JAR files */
+  private def resolveBridge(logger  : Logger,
+                            artifact: String,
+                            additionalRepositories: Seq[Repository]
+                           ): Array[AbsolutePath] = {
+    val organization = bloop.internal.build.BuildInfo.organization
+    val version      = bloop.internal.build.BuildInfo.version
+    val files        = DependencyResolution.resolve(
+      organization, artifact, version, logger, additionalRepositories)
+
+    files.filter(_.underlying.toString.endsWith(".jar"))
+  }
+
+}

--- a/frontend/src/main/scala/bloop/engine/tasks/ScalaJs.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/ScalaJs.scala
@@ -1,0 +1,44 @@
+package bloop.engine.tasks
+
+import java.io.File
+
+import coursier.maven.MavenRepository
+
+import bloop.Project
+import bloop.logging.Logger
+
+object ScalaJs {
+
+  private var classLoader: ClassLoader = _
+
+  /**
+    * Compile down to JavaScript using Scala.js' toolchain.
+    *
+    * @param project    The project to link
+    * @param mainClass  The fully qualified main class name
+    * @param target     The target path
+    * @param optimise   Perform code optimisations
+    * @param logger     The logger to use
+    */
+  def link(project  : Project,
+           mainClass: String,
+           target   : File,
+           optimise : Boolean,
+           logger   : Logger): Unit = {
+    // Bintray repository is needed for lsp4s
+    if (classLoader == null)
+      classLoader = BridgeClassLoader.classLoader(
+        logger, bloop.internal.build.BuildInfo.jsBridge,
+        Seq(MavenRepository("https://dl.bintray.com/scalameta/maven/")))
+
+    val bridgeClazz = classLoader.loadClass("bloop.scalajs.JsBridge")
+    val paramTypes =
+      classOf[Project] :: classOf[String] :: classOf[File] ::
+      classOf[java.lang.Boolean] :: classOf[Logger] :: Nil
+    val method = bridgeClazz.getMethod("link", paramTypes: _*)
+
+    val _ = method.invoke(null, project, mainClass, target,
+      optimise: java.lang.Boolean, logger)
+  }
+
+}

--- a/frontend/src/main/scala/bloop/engine/tasks/ScalaNative.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/ScalaNative.scala
@@ -1,18 +1,13 @@
 package bloop.engine.tasks
 
-import java.net.URLClassLoader
-import java.nio.file.Path
+import java.io.File
 
-import monix.eval.Task
-
-import bloop.{DependencyResolution, Project}
-import bloop.cli.ExitStatus
-import bloop.engine.State
-import bloop.exec.{Forker, Process}
-import bloop.io.AbsolutePath
+import bloop.Project
 import bloop.logging.Logger
 
 object ScalaNative {
+
+  private var classLoader: ClassLoader = _
 
   /**
    * Compile down to native binary using Scala Native's toolchain.
@@ -22,66 +17,23 @@ object ScalaNative {
    * @param logger  The logger to use
    * @return The absolute path to the native binary.
    */
-  def nativeLink(project: Project, entry: String, logger: Logger): AbsolutePath = {
+  def link(project: Project,
+           entry  : String,
+           target : File,
+           logger : Logger): Unit = {
+    if (classLoader == null)
+      classLoader = BridgeClassLoader.classLoader(
+        logger, bloop.internal.build.BuildInfo.nativeBridge)
 
-    initializeToolChain(logger)
-
-    val bridgeClazz = nativeClassLoader.loadClass("bloop.scalanative.NativeBridge")
-    val paramTypes = classOf[Project] :: classOf[String] :: classOf[Logger] :: Nil
-    val nativeLinkMeth = bridgeClazz.getMethod("nativeLink", paramTypes: _*)
+    val bridgeClass = classLoader.loadClass("bloop.scalanative.NativeBridge")
+    val paramTypes = classOf[Project] :: classOf[String] :: classOf[File] ::
+                     classOf[Logger] :: Nil
+    val nativeLinkMeth = bridgeClass.getMethod("link", paramTypes: _*)
 
     // The Scala Native toolchain expects to receive the module class' name
     val fullEntry = if (entry.endsWith("$")) entry else entry + "$"
 
-    AbsolutePath(nativeLinkMeth.invoke(null, project, fullEntry, logger).asInstanceOf[Path])
-  }
-
-  /**
-   * Link `project` to a native binary and run it.
-   *
-   * @param state The current state of Bloop.
-   * @param project The project to link.
-   * @param cwd     The working directory in which to start the process.
-   * @param main    The fully qualified main class name.
-   * @param args    The arguments to pass to the program.
-   * @return A task that links and run the project.
-   */
-  def run(state: State,
-          project: Project,
-          cwd: AbsolutePath,
-          main: String,
-          args: Array[String]): Task[State] = Task {
-    import scala.collection.JavaConverters.propertiesAsScalaMap
-    val nativeBinary = nativeLink(project, main, state.logger)
-    val env = propertiesAsScalaMap(state.commonOptions.env).toMap
-    val exitCode = Process.run(cwd, nativeBinary.syntax +: args, env, state.logger)
-
-    val exitStatus =
-      if (exitCode == Forker.EXIT_OK) ExitStatus.Ok
-      else ExitStatus.UnexpectedError
-    state.mergeStatus(exitStatus)
-  }
-
-  private def bridgeJars(logger: Logger): Array[AbsolutePath] = {
-    val organization = bloop.internal.build.BuildInfo.organization
-    val nativeBridge = bloop.internal.build.BuildInfo.nativeBridge
-    val version = bloop.internal.build.BuildInfo.version
-    logger.debug(s"Resolving Native bridge: $organization:$nativeBridge:$version")
-    val files = DependencyResolution.resolve(organization, nativeBridge, version, logger)
-    files.filter(_.underlying.toString.endsWith(".jar"))
-  }
-
-  private def bridgeClassLoader(parent: Option[ClassLoader], logger: Logger): ClassLoader = {
-    val jars = bridgeJars(logger)
-    val entries = jars.map(_.underlying.toUri.toURL)
-    new URLClassLoader(entries, parent.orNull)
-  }
-
-  private[this] var nativeClassLoader: ClassLoader = _
-  private[this] def initializeToolChain(logger: Logger): Unit = synchronized {
-    if (nativeClassLoader == null) {
-      nativeClassLoader = bridgeClassLoader(Some(this.getClass.getClassLoader), logger)
-    }
+    val _ = nativeLinkMeth.invoke(null, project, fullEntry, target, logger)
   }
 
 }

--- a/frontend/src/main/scala/bloop/engine/tasks/ScalaNative.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/ScalaNative.scala
@@ -1,0 +1,87 @@
+package bloop.engine.tasks
+
+import java.net.URLClassLoader
+import java.nio.file.Path
+
+import monix.eval.Task
+
+import bloop.{DependencyResolution, Project}
+import bloop.cli.ExitStatus
+import bloop.engine.State
+import bloop.exec.{Forker, Process}
+import bloop.io.AbsolutePath
+import bloop.logging.Logger
+
+object ScalaNative {
+
+  /**
+   * Compile down to native binary using Scala Native's toolchain.
+   *
+   * @param project The project to link
+   * @param entry   The fully qualified main class name
+   * @param logger  The logger to use
+   * @return The absolute path to the native binary.
+   */
+  def nativeLink(project: Project, entry: String, logger: Logger): AbsolutePath = {
+
+    initializeToolChain(logger)
+
+    val bridgeClazz = nativeClassLoader.loadClass("bloop.scalanative.NativeBridge")
+    val paramTypes = classOf[Project] :: classOf[String] :: classOf[Logger] :: Nil
+    val nativeLinkMeth = bridgeClazz.getMethod("nativeLink", paramTypes: _*)
+
+    // The Scala Native toolchain expects to receive the module class' name
+    val fullEntry = if (entry.endsWith("$")) entry else entry + "$"
+
+    AbsolutePath(nativeLinkMeth.invoke(null, project, fullEntry, logger).asInstanceOf[Path])
+  }
+
+  /**
+   * Link `project` to a native binary and run it.
+   *
+   * @param state The current state of Bloop.
+   * @param project The project to link.
+   * @param cwd     The working directory in which to start the process.
+   * @param main    The fully qualified main class name.
+   * @param args    The arguments to pass to the program.
+   * @return A task that links and run the project.
+   */
+  def run(state: State,
+          project: Project,
+          cwd: AbsolutePath,
+          main: String,
+          args: Array[String]): Task[State] = Task {
+    import scala.collection.JavaConverters.propertiesAsScalaMap
+    val nativeBinary = nativeLink(project, main, state.logger)
+    val env = propertiesAsScalaMap(state.commonOptions.env).toMap
+    val exitCode = Process.run(cwd, nativeBinary.syntax +: args, env, state.logger)
+
+    val exitStatus =
+      if (exitCode == Forker.EXIT_OK) ExitStatus.Ok
+      else ExitStatus.UnexpectedError
+    state.mergeStatus(exitStatus)
+  }
+
+  private def bridgeJars(logger: Logger): Array[AbsolutePath] = {
+    val organization = bloop.internal.build.BuildInfo.organization
+    val nativeBridge = bloop.internal.build.BuildInfo.nativeBridge
+    val version = bloop.internal.build.BuildInfo.version
+    logger.debug(s"Resolving Native bridge: $organization:$nativeBridge:$version")
+    val files = DependencyResolution.resolve(organization, nativeBridge, version, logger)
+    files.filter(_.underlying.toString.endsWith(".jar"))
+  }
+
+  private def bridgeClassLoader(parent: Option[ClassLoader], logger: Logger): ClassLoader = {
+    val jars = bridgeJars(logger)
+    val entries = jars.map(_.underlying.toUri.toURL)
+    new URLClassLoader(entries, parent.orNull)
+  }
+
+  private[this] var nativeClassLoader: ClassLoader = _
+  private[this] def initializeToolChain(logger: Logger): Unit = synchronized {
+    if (nativeClassLoader == null) {
+      nativeClassLoader = bridgeClassLoader(Some(this.getClass.getClassLoader), logger)
+    }
+  }
+
+}

--- a/frontend/src/main/scala/bloop/exec/Process.scala
+++ b/frontend/src/main/scala/bloop/exec/Process.scala
@@ -1,0 +1,45 @@
+package bloop.exec
+
+import bloop.io.AbsolutePath
+import bloop.logging.{Logger, ProcessLogger}
+
+import java.nio.file.Files
+
+object Process {
+
+  /**
+   * Runs `cmd` in a new process and logs the results. Blocks until the process is finished.
+   * The exit code is returned.
+   *
+   * @param cwd         The directory in which to start the process.
+   * @param cmd         The command to run.
+   * @param environment The environment properties to run the program with.
+   * @param logger      The logger that will receive the output emitted by the process.
+   * @return The exit code of the process.
+   */
+  def run(cwd: AbsolutePath,
+          cmd: Seq[String],
+          environment: Map[String, String],
+          logger: Logger): Int = {
+    import scala.collection.JavaConverters.mapAsJavaMapConverter
+
+    if (!Files.exists(cwd.underlying)) {
+      logger.error(s"Couldn't start the process because '$cwd' doesn't exist.")
+      Forker.EXIT_ERROR
+    } else {
+      val processBuilder = new ProcessBuilder(cmd: _*)
+      processBuilder.directory(cwd.toFile)
+      val processEnv = processBuilder.environment()
+      processEnv.clear()
+      processEnv.putAll(environment.asJava)
+      val process = processBuilder.start()
+      val processLogger = new ProcessLogger(logger, process)
+      processLogger.start()
+      val exitCode = process.waitFor()
+
+      logger.debug(s"Process exited with code: $exitCode")
+      exitCode
+    }
+  }
+
+}

--- a/frontend/src/test/scala/bloop/engine/DagSpec.scala
+++ b/frontend/src/test/scala/bloop/engine/DagSpec.scala
@@ -21,7 +21,8 @@ class DagSpec {
   // format: OFF
   def dummyProject(name: String, dependencies: List[String]): Project =
     Project(name, dummyPath, dependencies.toArray, dummyInstance, Array(), classpathOptions,  dummyPath, Array(),
-      Array(), Array(), Array(), Config.TestOptions.empty, JavaEnv.default, dummyPath)
+      Array(), Array(), Array(), Config.TestOptions.empty, JavaEnv.default,
+      Config.Platform.default, dummyPath)
   // format: ON
 
   private object TestProjects {

--- a/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
+++ b/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
@@ -78,6 +78,7 @@ class IntegrationTestSuite(testDirectory: Path) {
           testFrameworks = Array.empty,
           testOptions = Config.TestOptions.empty,
           javaEnv = javaEnv,
+          platform = Config.Platform.default,
           out = classesDir
         )
         val state =

--- a/frontend/src/test/scala/bloop/tasks/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestUtil.scala
@@ -228,6 +228,7 @@ object TestUtil {
       testFrameworks = Array.empty,
       testOptions = Config.TestOptions.empty,
       javaEnv = javaEnv,
+      platform = Config.Platform.default,
       out = AbsolutePath(baseDirectory) // This means nothing in tests
     )
   }

--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -81,6 +81,7 @@ object MojoImplementation {
       val dependencies = project.getProjectReferences().asScala.values.map(_.getArtifactId).toArray
       val allScalaJars = mojo.getAllScalaJars().map(abs).toArray
       val scalacArgs = mojo.getScalacArgs().asScala.toArray
+      val platform = Config.Platform.default
 
       // FORMAT: OFF
       val config = {
@@ -89,8 +90,9 @@ object MojoImplementation {
         val `scala` = Config.Scala(mojo.getScalaOrganization(), mojo.getScalaArtifactID(),
           mojo.getScalaVersion(), scalacArgs, allScalaJars)
         val jvm = Config.Jvm(Some(abs(mojo.getJavaHome())), launcher.getJvmArgs().toArray)
+
         val compileOptions = Config.CompileOptions(Config.Mixed)
-        val project = Config.Project(name, baseDirectory, sourceDirs, dependencies, classpath, classpathOptions, compileOptions, out, classesDir, `scala`, jvm, java, test)
+        val project = Config.Project(name, baseDirectory, sourceDirs, dependencies, classpath, classpathOptions, compileOptions, out, classesDir, `scala`, jvm, java, test, platform)
         Config.File(Config.File.LatestVersion, project)
       }
       // FORMAT: ON

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-project/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-project/build.sbt
@@ -1,0 +1,20 @@
+// shadow sbt-scalajs' crossProject and CrossType until Scala.js 1.0.0 is released
+import sbtcrossproject.{crossProject, CrossType}
+
+val sharedSettings = Seq(
+  scalaVersion := "2.11.12",
+  InputKey[Unit]("check") := {
+    val expected = complete.DefaultParsers.spaceDelimited("").parsed.head
+    val config = bloopConfigDir.value / s"${thisProject.value.id}.json"
+    val lines = IO.read(config)
+    assert(lines.contains(s""""platform" : "$expected""""))
+  }
+)
+
+lazy val bar =
+  crossProject(JSPlatform, JVMPlatform, NativePlatform)
+    .settings(sharedSettings)
+
+lazy val barJS = bar.js
+lazy val barJVM = bar.jvm
+lazy val barNative = bar.native

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-project/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-project/project/plugins.sbt
@@ -1,0 +1,6 @@
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.4.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.7")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-project/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-project/test
@@ -1,0 +1,4 @@
+> bloopInstall
+> barJVM/check JVM
+> barJS/check JS
+> barNative/check Native

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/build.sbt
@@ -1,0 +1,10 @@
+val jsProject = project
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    InputKey[Unit]("check") := {
+      val expected = complete.DefaultParsers.spaceDelimited("").parsed.head
+      val config = bloopConfigDir.value / s"${thisProject.value.id}.json"
+      val lines = IO.read(config)
+      assert(lines.contains(s""""platform" : "$expected""""))
+    }
+  )

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/test
@@ -1,0 +1,2 @@
+> bloopInstall
+> jsProject/check JS

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-native/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-native/build.sbt
@@ -1,0 +1,11 @@
+val nativeProject = project
+  .enablePlugins(ScalaNativePlugin)
+  .settings(
+    scalaVersion := "2.11.12",
+    InputKey[Unit]("check") := {
+      val expected = complete.DefaultParsers.spaceDelimited("").parsed.head
+      val config = bloopConfigDir.value / s"${thisProject.value.id}.json"
+      val lines = IO.read(config)
+      assert(lines.contains(s""""platform" : "$expected""""))
+    }
+  )

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-native/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-native/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.7")

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-native/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-native/test
@@ -1,0 +1,2 @@
+> bloopInstall
+> nativeProject/check Native

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -113,7 +113,7 @@ object BuildKeys {
   )
 
   import sbtbuildinfo.BuildInfoKey
-  def bloopInfoKeys(nativeBridge: Reference) = {
+  def bloopInfoKeys(nativeBridge: Reference, jsBridge: Reference) = {
     val zincKey = BuildInfoKey.constant("zincVersion" -> Dependencies.zincVersion)
     val developersKey = BuildInfoKey.map(Keys.developers) {
       case (k, devs) => k -> devs.map(_.name)
@@ -121,6 +121,11 @@ object BuildKeys {
     val nativeBridgeKey = BuildInfoKey.map(Keys.ivyModule in nativeBridge) {
       case (_, module) =>
         "nativeBridge" -> module.withModule(sbt.util.Logger.Null)((_, mod, _) =>
+          mod.getModuleRevisionId.getName)
+    }
+    val jsBridgeKey = BuildInfoKey.map(Keys.ivyModule in jsBridge) {
+      case (_, module) =>
+        "jsBridge" -> module.withModule(sbt.util.Logger.Null)((_, mod, _) =>
           mod.getModuleRevisionId.getName)
     }
     val commonKeys = List[BuildInfoKey](
@@ -132,7 +137,7 @@ object BuildKeys {
       buildIntegrationsIndex,
       nailgunClientLocation
     )
-    commonKeys ++ List(zincKey, developersKey, nativeBridgeKey)
+    commonKeys ++ List(zincKey, developersKey, nativeBridgeKey, jsBridgeKey)
   }
 
   import sbtassembly.{AssemblyKeys, MergeStrategy}

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -113,12 +113,18 @@ object BuildKeys {
   )
 
   import sbtbuildinfo.BuildInfoKey
-  final val BloopInfoKeys = {
+  def bloopInfoKeys(nativeBridge: Reference) = {
     val zincKey = BuildInfoKey.constant("zincVersion" -> Dependencies.zincVersion)
     val developersKey = BuildInfoKey.map(Keys.developers) {
       case (k, devs) => k -> devs.map(_.name)
     }
+    val nativeBridgeKey = BuildInfoKey.map(Keys.ivyModule in nativeBridge) {
+      case (_, module) =>
+        "nativeBridge" -> module.withModule(sbt.util.Logger.Null)((_, mod, _) =>
+          mod.getModuleRevisionId.getName)
+    }
     val commonKeys = List[BuildInfoKey](
+      Keys.organization,
       Keys.name,
       Keys.version,
       Keys.scalaVersion,
@@ -126,7 +132,7 @@ object BuildKeys {
       buildIntegrationsIndex,
       nailgunClientLocation
     )
-    commonKeys ++ List(zincKey, developersKey)
+    commonKeys ++ List(zincKey, developersKey, nativeBridgeKey)
   }
 
   import sbtassembly.{AssemblyKeys, MergeStrategy}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,6 +23,7 @@ object Dependencies {
   val metaconfigVersion = "0.7.0"
   val circeVersion = "0.9.3"
   val nuprocessVersion = "1.2.0"
+  val scalaNativeVersion = "0.3.7"
 
   import sbt.librarymanagement.syntax.stringToOrganization
   val zinc = "ch.epfl.scala" %% "zinc" % zincVersion
@@ -63,4 +64,5 @@ object Dependencies {
   val circeCore = "io.circe" %% "circe-core" % circeVersion
   val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
   val nuprocess = "com.zaxxer" % "nuprocess" % nuprocessVersion
+  val scalaNativeTools = "org.scala-native" %% "tools" % scalaNativeVersion
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,6 +24,7 @@ object Dependencies {
   val circeVersion = "0.9.3"
   val nuprocessVersion = "1.2.0"
   val scalaNativeVersion = "0.3.7"
+  val scalaJsVersion = "0.6.22"
 
   import sbt.librarymanagement.syntax.stringToOrganization
   val zinc = "ch.epfl.scala" %% "zinc" % zincVersion
@@ -65,4 +66,5 @@ object Dependencies {
   val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
   val nuprocess = "com.zaxxer" % "nuprocess" % nuprocessVersion
   val scalaNativeTools = "org.scala-native" %% "tools" % scalaNativeVersion
+  val scalaJsTools = "org.scala-js" %% "scalajs-tools" % scalaJsVersion
 }


### PR DESCRIPTION
This pull request adds support for linking Scala.js v0.6 projects.

Remaining issues:
- [ ] Implement support for running test cases
- [ ] Linker should only be triggered if sources were changed or if target file does not exist

These changes were based on @Duhemm's pull request https://github.com/scalacenter/bloop/pull/457 since it lays the foundations for bridges.