### PR TITLE
Kebabize arg names

### DIFF
--- a/frontend/src/main/scala/bloop/cli/completion/Case.scala
+++ b/frontend/src/main/scala/bloop/cli/completion/Case.scala
@@ -18,7 +18,8 @@ object Case {
   }
 
   def kebabizeArg(arg: Arg): Arg = {
+    val kebabizedName = camelToKebab(arg.name)
     val kebabizedExtraNames = arg.extraNames.map((n: Name) => Name(camelToKebab(n.name)))
-    arg.copy(extraNames = kebabizedExtraNames)
+    arg.copy(name = kebabizedName, extraNames = kebabizedExtraNames)
   }
 }


### PR DESCRIPTION
We were not kebabizing the name of the arguments, only the extra names,
which lead to wrong completion (like `--configDir` for instance).

This commit changes that behavior, so that we kebabize the name and the
extra names of the arguments of commands.