### PR TITLE
Mention --coursier in developer documentation [DOCS]

### DIFF
--- a/website/content/docs/developer-documentation.md
+++ b/website/content/docs/developer-documentation.md
@@ -42,12 +42,13 @@ $ git clone --recursive https://github.com/scalacenter/bloop.git
 $ cd bloop
 $ sbt
 > install
-> frontend/version # copy this version number
+> frontend/version # copy this version number as <version>
 $ cd nailgun
-$ git rev-parse HEAD # copy this commit SHA
+$ git rev-parse HEAD # copy this commit SHA as <nailgun-commit-sha>
 $ cd ..
-# paste the version number and SHA obtained above in the following command:
-$ bin/install.py --dest $HOME/.bloop --nailgun <nailgun-commit-sha> --version <version>
+$ grep 'val coursierVersion' project/Dependencies.scala # copy this version number as <coursier-version>
+# paste the version numbers and SHA obtained above in the following command:
+$ bin/install.py --dest $HOME/.bloop --nailgun <nailgun-commit-sha> --coursier <coursier-version> --version <version>
 ```
 
 ## Running our test suite

--- a/website/content/docs/installation.md
+++ b/website/content/docs/installation.md
@@ -293,11 +293,12 @@ This installation script requires more information to install Bloop:
    logs to figure out the exact version number.
  - The SHA of the commit to use to get the Nailgun client. Look at which commit points our `nailgun`
    submodule at a given point in time to find that information.
+ - Coursier's version to use. Look at `project/Dependencies.scala` to find the version number.
 
 Pass this information to the installation script:
 
 ```sh
-$ ./install.py -v $BLOOP_VERSION -n $NAILGUN_COMMIT
+$ ./install.py -v $BLOOP_VERSION -n $NAILGUN_COMMIT -c $COURSIER_VERSION
 ```
 
 <script type="text/javascript">


### PR DESCRIPTION
#472 introduced a new `install.py` parameter: `--coursier` (or `-c`).