### PR TITLE
Speed up compilation speed of `frontend` by 8x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,8 @@ val frontend = project
       Dependencies.monix,
       Dependencies.caseApp,
       Dependencies.ipcsocket % Test
-    )
+    ),
+    dependencyOverrides += Dependencies.shapeless
   )
 
 val benchmarks = project

--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -6,7 +6,9 @@ import bloop.cli.CliParsers.{
   inputStreamRead,
   pathParser,
   printStreamRead,
-  propertiesParser
+  propertiesParser,
+  coParser,
+  cliParser
 }
 import bloop.engine.{Action, Build, Exit, Interpreter, NoPool, Print, Run, State}
 import bloop.engine.tasks.Tasks

--- a/frontend/src/main/scala/bloop/cli/CliParsers.scala
+++ b/frontend/src/main/scala/bloop/cli/CliParsers.scala
@@ -5,7 +5,9 @@ import java.nio.file.{Path, Paths}
 import java.util.Properties
 
 import caseapp.CommandParser
-import caseapp.core.{ArgParser, DefaultBaseCommand}
+import caseapp.core.{ArgParser, Default, DefaultBaseCommand, Parser}
+import caseapp.util.Implicit
+import shapeless.LabelledGeneric
 
 import scala.util.Try
 
@@ -33,6 +35,49 @@ object CliParsers {
       case whatever => Left("You cannot pass in properties through the command line.")
     }
   }
+
+  import shapeless.{HNil, CNil, :+:, ::, Coproduct}
+  implicit val implicitHNil: Implicit[HNil] = Implicit.hnil
+  implicit val implicitNone: Implicit[None.type] = Implicit.instance(None)
+  implicit val implicitNoneCnil: Implicit[None.type :+: CNil] =
+    Implicit.instance(Coproduct(None))
+
+  implicit val implicitOptionDefaultString: Implicit[Option[Default[String]]] =
+    Implicit.instance(Some(caseapp.core.Defaults.string))
+
+  implicit val implicitOptionDefaultInt: Implicit[Option[Default[Int]]] =
+    Implicit.instance(Some(caseapp.core.Defaults.int))
+
+  implicit val implicitOptionDefaultBoolean: Implicit[Option[Default[Boolean]]] =
+    Implicit.instance(Some(caseapp.core.Defaults.boolean))
+
+  implicit val implicitDefaultBoolean: Implicit[Default[Boolean]] =
+    Implicit.instance(caseapp.core.Defaults.boolean)
+
+  implicit val implicitOptionDefaultOptionPath: Implicit[Option[Default[Option[Path]]]] =
+    Implicit.instance(None)
+
+  implicit val implicitOptionDefaultPrintStream: Implicit[Option[Default[PrintStream]]] =
+    Implicit.instance(Some(Default.instance[PrintStream](System.out)))
+
+  implicit val implicitOptionDefaultInputStream: Implicit[Option[Default[InputStream]]] =
+    Implicit.instance(Some(Default.instance[InputStream](System.in)))
+
+  implicit val labelledGenericCommonOptions: LabelledGeneric[CommonOptions] = LabelledGeneric.materializeProduct
+  implicit val labelledGenericCliOptions: LabelledGeneric[CliOptions] = LabelledGeneric.materializeProduct
+  implicit val coParser: Parser[CommonOptions] = Parser.generic
+  implicit val cliParser: Parser[CliOptions] = Parser.generic
+
+  implicit val autocompleteParser: Parser[Commands.Autocomplete] = Parser.generic
+  implicit val aboutParser: Parser[Commands.About] = Parser.generic
+  implicit val bspParser: Parser[Commands.Bsp] = Parser.generic
+  implicit val cleanParser: Parser[Commands.Clean] = Parser.generic
+  implicit val compileParser: Parser[Commands.Compile] = Parser.generic
+  implicit val configureParser: Parser[Commands.Configure] = Parser.generic
+  implicit val helpParser: Parser[Commands.Help] = Parser.generic
+  implicit val projectsParser: Parser[Commands.Projects] = Parser.generic
+  implicit val runParser: Parser[Commands.Run] = Parser.generic
+  implicit val testParser: Parser[Commands.Test] = Parser.generic
 
   val BaseMessages: caseapp.core.Messages[DefaultBaseCommand] =
     caseapp.core.Messages[DefaultBaseCommand]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val coursierVersion = "1.1.0-M3"
   val lmVersion = "1.0.0"
   val configDirsVersion = "10"
-  val caseAppVersion = "1.2.0"
+  val caseAppVersion = "1.2.0-faster-compile-time"
   val sourcecodeVersion = "0.1.4"
   val sbtTestInterfaceVersion = "1.0"
   val sbtTestAgentVersion = "1.0.4"
@@ -23,6 +23,7 @@ object Dependencies {
   val metaconfigVersion = "0.7.0"
   val circeVersion = "0.9.3"
   val nuprocessVersion = "1.2.0"
+  val shapelessVersion = "2.3.3-lower-priority-coproduct"
 
   import sbt.librarymanagement.syntax.stringToOrganization
   val zinc = "ch.epfl.scala" %% "zinc" % zincVersion
@@ -36,7 +37,8 @@ object Dependencies {
   val coursier = "io.get-coursier" %% "coursier" % coursierVersion
   val coursierCache = "io.get-coursier" %% "coursier-cache" % coursierVersion
   val coursierScalaz = "io.get-coursier" %% "coursier-scalaz-interop" % coursierVersion
-  val caseApp = "com.github.alexarchambault" %% "case-app" % caseAppVersion
+  val shapeless = "ch.epfl.scala" %% "shapeless" % shapelessVersion
+  val caseApp = "ch.epfl.scala" %% "case-app" % caseAppVersion
   val sourcecode = "com.lihaoyi" %% "sourcecode" % sourcecodeVersion
   val sbtTestInterface = "org.scala-sbt" % "test-interface" % sbtTestInterfaceVersion
   val sbtTestAgent = "org.scala-sbt" % "test-agent" % sbtTestAgentVersion


### PR DESCRIPTION
Strategy:

* Cache expensive implicits that are generated by implicit search.
* Replace by custom version of shapeless and case-app that are faster.