### PR TITLE
Early abort execution when no supported scala plugin was found

### DIFF
--- a/integrations/maven-bloop/src/main/java/bloop/integrations/maven/BloopMojo.java
+++ b/integrations/maven-bloop/src/main/java/bloop/integrations/maven/BloopMojo.java
@@ -7,6 +7,7 @@ import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.*;
+import scala.util.Either;
 import scala_maven.AppLauncher;
 import scala_maven.ExtendedScalaContinuousCompileMojo;
 
@@ -58,8 +59,14 @@ public class BloopMojo extends ExtendedScalaContinuousCompileMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        BloopMojo initializedMojo = MojoImplementation.initializeMojo(project, session, mojoExecution, mavenPluginManager, encoding);
-        MojoImplementation.writeCompileAndTestConfiguration(initializedMojo, session, this.getLog());
+        final Either<String, BloopMojo> initializedMojo = MojoImplementation.initializeMojo(
+                project, session, mojoExecution, mavenPluginManager, encoding);
+        if (initializedMojo.isLeft()) {
+            getLog().warn("Skipping configuration file generation: " + initializedMojo.left().get());
+            return;
+        }
+        final BloopMojo bloopMojo = initializedMojo.right().get();
+        MojoImplementation.writeCompileAndTestConfiguration(bloopMojo, session, this.getLog());
     }
 
     public File[] getAllScalaJars() throws Exception {


### PR DESCRIPTION
Fixes one part of https://github.com/scalacenter/bloop/issues/507, the exception in Maven. (#507 is also about the generated bloop files, which should not depend on non-scala projects.)

I'd love to also provide a (integration) test case for this fix, but unfortunately creating the ground for integration tests in sbt is beyond my current scope. (@tues offered to look into that.) 