### PR TITLE
Sbt: Export custom configurations

### DIFF
--- a/build-integrations/global/src/main/scala/bloop/build/integrations/IntegrationPlugin.scala
+++ b/build-integrations/global/src/main/scala/bloop/build/integrations/IntegrationPlugin.scala
@@ -2,13 +2,13 @@ package bloop.build.integrations
 
 import java.io.File
 
-import bloop.integrations.sbt.{AutoImported => BloopKeys, SbtBloop}
+import bloop.integrations.sbt.{BloopKeys, BloopPlugin => SbtBloopPlugin}
 import sbt.{AutoPlugin, Def, PluginTrigger, Plugins, Keys, ThisBuild, Global}
 
 object IntegrationPlugin extends AutoPlugin {
   import sbt.plugins.JvmPlugin
   override def trigger: PluginTrigger = allRequirements
-  override def requires: Plugins = JvmPlugin && SbtBloop
+  override def requires: Plugins = JvmPlugin && SbtBloopPlugin
   val autoImport = PluginKeys
 
   override def globalSettings: Seq[Def.Setting[_]] =

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -153,8 +153,8 @@ object BloopDefaults {
   lazy val bloopGenerate: Def.Initialize[Task[File]] = Def.task {
     val logger = Keys.streams.value.log
     val project = Keys.thisProject.value
-    def nameFromString(name: String, configuration: Configuration): String =
-      if (configuration == Compile) name else name + "-test"
+      def nameFromString(name: String, configuration: Configuration): String =
+        if (configuration == Compile) name else s"$name-${configuration.name}"
 
     def nameFromRef(dep: ClasspathDep[ProjectRef], configuration: Configuration): String = {
       val ref = dep.project
@@ -326,7 +326,7 @@ object BloopDefaults {
   }
 
   lazy val bloopInstall: Def.Initialize[Task[Unit]] = Def.taskDyn {
-    val filter = sbt.ScopeFilter(sbt.inAnyProject, sbt.inConfigurations(Compile, Test))
+    val filter = sbt.ScopeFilter(sbt.inAnyProject, sbt.inAnyConfiguration, sbt.inTasks(BloopKeys.bloopGenerate))
     val allConfigDirs =
       BloopKeys.bloopConfigDir.?.all(sbt.ScopeFilter(sbt.inAnyProject))
         .map(_.flatMap(_.toList).toSet)

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -25,9 +25,9 @@ object BloopPlugin extends AutoPlugin {
   override def trigger = allRequirements
   final val autoImport = BloopKeys
 
-  override def globalSettings: Seq[Def.Setting[_]] = PluginImplementation.globalSettings
-  override def buildSettings: Seq[Def.Setting[_]] = PluginImplementation.buildSettings
-  override def projectSettings: Seq[Def.Setting[_]] = PluginImplementation.projectSettings
+  override def globalSettings: Seq[Def.Setting[_]] = BloopDefaults.globalSettings
+  override def buildSettings: Seq[Def.Setting[_]] = BloopDefaults.buildSettings
+  override def projectSettings: Seq[Def.Setting[_]] = BloopDefaults.projectSettings
 }
 
 object BloopKeys {
@@ -57,37 +57,39 @@ object BloopKeys {
     settingKey[Option[File]]("User-defined location for the incremental analysis file.")
 }
 
-object PluginImplementation {
-  val globalSettings: Seq[Def.Setting[_]] = List(
-    BloopKeys.bloopInstall := PluginDefaults.bloopInstall.value,
+object BloopDefaults {
+  import Compat._
+  import sbt.{Task, Defaults, State}
+
+  lazy val globalSettings: Seq[Def.Setting[_]] = List(
+    BloopKeys.bloopInstall := bloopInstall.value,
     BloopKeys.bloopAggregateSourceDependencies := false
   )
 
   // We create build setting proxies to global settings so that we get autocompletion (sbt bug)
-  val buildSettings: Seq[Def.Setting[_]] = List(
+  lazy val buildSettings: Seq[Def.Setting[_]] = List(
     BloopKeys.bloopInstall := BloopKeys.bloopInstall.in(Global).value,
     // Bloop users: Do NEVER override this setting as a user if you want it to work
     BloopKeys.bloopAggregateSourceDependencies :=
       BloopKeys.bloopAggregateSourceDependencies.in(Global).value
   )
 
-  import Compat._
-  val configSettings: Seq[Def.Setting[_]] = {
+  lazy val configSettings: Seq[Def.Setting[_]] = {
     val rawSettingsInConfigs = List(
       BloopKeys.bloopProductDirectories := List(BloopKeys.bloopClassDirectory.value),
-      BloopKeys.bloopManagedResourceDirectories := PluginDefaults.managedResourceDirs.value,
-      BloopKeys.bloopClassDirectory := PluginDefaults.generateBloopProductDirectories.value,
-      BloopKeys.bloopInternalClasspath := PluginDefaults.bloopInternalDependencyClasspath.value,
+      BloopKeys.bloopManagedResourceDirectories := managedResourceDirs.value,
+      BloopKeys.bloopClassDirectory := generateBloopProductDirectories.value,
+      BloopKeys.bloopInternalClasspath := bloopInternalDependencyClasspath.value,
       BloopKeys.bloopResourceManaged := BloopKeys.bloopTargetDir.value / "resource_managed",
-      BloopKeys.bloopGenerate := PluginDefaults.bloopGenerate.value,
+      BloopKeys.bloopGenerate := bloopGenerate.value
       BloopKeys.bloopAnalysisOut := None
     )
     val all = rawSettingsInConfigs ++ DiscoveredSbtPlugins.settings
     all.flatMap(ss => sbt.inConfig(Compile)(ss) ++ sbt.inConfig(Test)(ss))
   }
 
-  val projectSettings: Seq[Def.Setting[_]] = configSettings ++ List(
-    BloopKeys.bloopTargetDir := PluginDefaults.bloopTargetDir.value,
+  lazy val projectSettings: Seq[Def.Setting[_]] = configSettings ++ List(
+    BloopKeys.bloopTargetDir := bloopTargetDir.value,
     BloopKeys.bloopConfigDir := Def.settingDyn {
       val ref = Keys.thisProjectRef.value
       val rootBuild = sbt.BuildRef(Keys.loadedBuild.value.root)
@@ -104,342 +106,337 @@ object PluginImplementation {
     }.value
   )
 
-  object PluginDefaults {
-    import Compat._
-    import sbt.{Task, Defaults, State}
+  lazy val bloopTargetDir: Def.Initialize[File] = Def.setting {
+    val project = Keys.thisProject.value
+    val bloopConfigDir = BloopKeys.bloopConfigDir.value
+    Defaults.makeCrossTarget(
+      bloopConfigDir / project.id,
+      Keys.scalaBinaryVersion.value,
+      (Keys.sbtBinaryVersion in Keys.pluginCrossBuild).value,
+      Keys.sbtPlugin.value,
+      Keys.crossPaths.value
+    )
+  }
 
-    lazy val bloopTargetDir: Def.Initialize[File] = Def.setting {
-      val project = Keys.thisProject.value
-      val bloopConfigDir = BloopKeys.bloopConfigDir.value
-      Defaults.makeCrossTarget(
-        bloopConfigDir / project.id,
-        Keys.scalaBinaryVersion.value,
-        (Keys.sbtBinaryVersion in Keys.pluginCrossBuild).value,
-        Keys.sbtPlugin.value,
-        Keys.crossPaths.value
-      )
+  lazy val generateBloopProductDirectories: Def.Initialize[File] = Def.setting {
+    val configuration = Keys.configuration.value
+    val bloopTarget = BloopKeys.bloopTargetDir.value
+    val classesDir = bloopTarget / (Defaults.prefix(configuration.name) + "classes")
+    if (!classesDir.exists()) sbt.IO.createDirectory(classesDir)
+    classesDir
+  }
+
+  // Select only the sources that are not present in the source directories
+  def pruneSources(sourceDirs: Seq[Path], sources: Seq[Path]): Seq[Path] = {
+    def checkIfParent(parent: Path, potentialParent: Path): Boolean = {
+      if (potentialParent == null) false
+      else if (potentialParent == parent) true
+      else checkIfParent(parent, potentialParent.getParent)
     }
 
-    lazy val generateBloopProductDirectories: Def.Initialize[File] = Def.setting {
-      val configuration = Keys.configuration.value
-      val bloopTarget = BloopKeys.bloopTargetDir.value
-      val classesDir = bloopTarget / (Defaults.prefix(configuration.name) + "classes")
-      if (!classesDir.exists()) sbt.IO.createDirectory(classesDir)
-      classesDir
-    }
+    val realSources = sources.map(_.toAbsolutePath())
+    sources.filter(source => !sourceDirs.exists(dir => checkIfParent(dir, source.getParent)))
+  }
 
-    // Select only the sources that are not present in the source directories
-    def pruneSources(sourceDirs: Seq[Path], sources: Seq[Path]): Seq[Path] = {
-      def checkIfParent(parent: Path, potentialParent: Path): Boolean = {
-        if (potentialParent == null) false
-        else if (potentialParent == parent) true
-        else checkIfParent(parent, potentialParent.getParent)
+  object Feedback {
+    def unknownConfigurations(p: ResolvedProject,
+                              confs: Seq[String],
+                              from: ProjectRef): String = {
+      s"""Project ${p.id} depends on unsupported configuration(s) ${confs.mkString(", ")} of ${from.project}.
+         |Bloop will assume this dependency goes to the test configuration.
+         |Report upstream if you run into trouble: https://github.com/scalacenter/bloop/issues/new
+       """.stripMargin
+    }
+  }
+
+  lazy val bloopGenerate: Def.Initialize[Task[File]] = Def.task {
+    val logger = Keys.streams.value.log
+    val project = Keys.thisProject.value
+    def nameFromString(name: String, configuration: Configuration): String =
+      if (configuration == Compile) name else name + "-test"
+
+    def nameFromRef(dep: ClasspathDep[ProjectRef], configuration: Configuration): String = {
+      val ref = dep.project
+      dep.configuration match {
+        case Some(_) =>
+          val mapping = sbt.Classpaths.mapped(
+            dep.configuration,
+            List("compile", "test"),
+            List("compile", "test"),
+            "compile",
+            "*->compile"
+          )
+
+          mapping(configuration.name) match {
+            case Nil => nameFromString(ref.project, configuration)
+            case List(conf) if Compile.name == conf => ref.project
+            case List(conf) if Test.name == conf => s"${ref.project}-test"
+            case List(conf1, conf2) if Test.name == conf1 && Compile.name == conf2 =>
+              s"${ref.project}-test"
+            case List(conf1, conf2) if Compile.name == conf1 && Test.name == conf2 =>
+              s"${ref.project}-test"
+            case unknown =>
+              logger.warn(Feedback.unknownConfigurations(project, unknown, ref))
+              s"${ref.project}-test"
+          }
+        case None => nameFromString(ref.project, configuration)
       }
 
-      val realSources = sources.map(_.toAbsolutePath())
-      sources.filter(source => !sourceDirs.exists(dir => checkIfParent(dir, source.getParent)))
     }
 
-    object Feedback {
-      def unknownConfigurations(p: ResolvedProject,
-                                confs: Seq[String],
-                                from: ProjectRef): String = {
-        s"""Project ${p.id} depends on unsupported configuration(s) ${confs.mkString(", ")} of ${from.project}.
-           |Bloop will assume this dependency goes to the test configuration.
-           |Report upstream if you run into trouble: https://github.com/scalacenter/bloop/issues/new
-         """.stripMargin
+    val configuration = Keys.configuration.value
+    val projectName = nameFromString(project.id, configuration)
+    val baseDirectory = Keys.baseDirectory.value.toPath.toAbsolutePath
+    val buildBaseDirectory = Keys.baseDirectory.in(ThisBuild).value.getAbsoluteFile
+    val rootBaseDirectory = new File(Keys.loadedBuild.value.root)
+
+    // In the test configuration, add a dependency on the base project
+    val baseProjectDependency = if (configuration == Test) List(project.id) else Nil
+
+    val projectDependencies =
+      project.dependencies.map(dep => nameFromRef(dep, configuration)).toList
+    val dependencies = (projectDependencies ++ baseProjectDependency).toArray
+    val aggregates = project.aggregate.map(agg => nameFromString(agg.project, configuration))
+    val dependenciesAndAggregates = dependencies ++ aggregates
+
+    val bloopConfigDir = BloopKeys.bloopConfigDir.value
+    val out = (bloopConfigDir / project.id).toPath.toAbsolutePath
+    val scalaName = "scala-compiler"
+    val scalaVersion = Keys.scalaVersion.value
+    val scalaOrg = Keys.ivyScala.value.map(_.scalaOrganization).getOrElse("org.scala-lang")
+    val allScalaJars = Keys.scalaInstance.value.allJars.map(_.toPath.toAbsolutePath).toArray
+
+    val classpath =
+      emulateDependencyClasspath.value.map(_.toPath.toAbsolutePath).toArray
+    val classpathOptions = {
+      val cpo = Keys.classpathOptions.value
+      Config.ClasspathOptions(cpo.bootLibrary,
+                              cpo.compiler,
+                              cpo.extra,
+                              cpo.autoBoot,
+                              cpo.filterLibrary)
+    }
+
+    val classesDir = BloopKeys.bloopProductDirectories.value.head.toPath()
+
+    /* This is a best-effort to export source directories + stray source files that
+     * are not contained in them. Source directories are superior over source files because
+     * they allow us to watch them and detect the creation of new source files in situ. */
+    val sources = {
+      val sourceDirs = Keys.sourceDirectories.value.map(_.toPath)
+      val sourceFiles = pruneSources(sourceDirs, Keys.sources.value.map(_.toPath))
+      (sourceDirs ++ sourceFiles).toArray
+    }
+
+    val testOptions = {
+      val frameworks =
+        Keys.testFrameworks.value.map(f => Config.TestFramework(f.implClassNames.toList)).toArray
+      val empty = (List.empty[String], List.empty[Config.TestArgument])
+      val options = Keys.testOptions.value.foldLeft(Config.TestOptions.empty) {
+        case (options, sbt.Tests.Argument(framework0, args0)) =>
+          val args = args0.toArray
+          val framework = framework0.map(f => Config.TestFramework(f.implClassNames.toList))
+          options.copy(arguments = Config.TestArgument(args, framework) :: options.arguments)
+        case (options, sbt.Tests.Exclude(tests)) =>
+          options.copy(excludes = tests.toList ++ options.excludes)
+        case (options, other: sbt.TestOption) =>
+          logger.info(s"Skipped test option '${other}' as it can only be used within sbt.")
+          options
+      }
+      Config.Test(frameworks, options)
+    }
+
+    // TODO(jvican): Override classes directories here too (e.g. plugins are defined in the build)
+    val scalacOptions = {
+      val scalacOptions0 = Keys.scalacOptions.value.toArray
+      val internalClasspath = BloopKeys.bloopInternalClasspath.value
+      internalClasspath.foldLeft(scalacOptions0) {
+        case (scalacOptions, (oldClassesDir, newClassesDir)) =>
+          val old1 = oldClassesDir.toString
+          val old2 = oldClassesDir.getAbsolutePath
+          val newClassesDirAbs = newClassesDir.getAbsolutePath
+          scalacOptions.map { scalacOption =>
+            if (scalacOptions.contains(old1) ||
+                scalacOptions.contains(old2)) {
+              logger.warn(
+                s"The scalac option '$scalacOption' contains a reference to '$oldClassesDir'. Bloop will replace it by its own path optimistically, if you find misbehaviours please open a ticket at https://github.com/scalacenter/bloop.")
+              scalacOption.replace(old1, newClassesDirAbs).replace(old2, newClassesDirAbs)
+            } else scalacOption
+          }
       }
     }
 
-    lazy val bloopGenerate: Def.Initialize[Task[File]] = Def.task {
-      val logger = Keys.streams.value.log
-      val project = Keys.thisProject.value
-      def nameFromString(name: String, configuration: Configuration): String =
-        if (configuration == Compile) name else name + "-test"
+    val compileOrder = Keys.compileOrder.value match {
+      case CompileOrder.JavaThenScala => Config.JavaThenScala
+      case CompileOrder.ScalaThenJava => Config.ScalaThenJava
+      case CompileOrder.Mixed => Config.Mixed
+    }
 
-      def nameFromRef(dep: ClasspathDep[ProjectRef], configuration: Configuration): String = {
-        val ref = dep.project
-        dep.configuration match {
-          case Some(_) =>
-            val mapping = sbt.Classpaths.mapped(
-              dep.configuration,
-              List("compile", "test"),
-              List("compile", "test"),
-              "compile",
-              "*->compile"
-            )
+    val javacOptions = Keys.javacOptions.value.toArray
+    val (javaHome, javaOptions) = javaConfiguration.value
+    val outFile = bloopConfigDir / s"$projectName.json"
 
-            mapping(configuration.name) match {
-              case Nil => nameFromString(ref.project, configuration)
-              case List(conf) if Compile.name == conf => ref.project
-              case List(conf) if Test.name == conf => s"${ref.project}-test"
-              case List(conf1, conf2) if Test.name == conf1 && Compile.name == conf2 =>
-                s"${ref.project}-test"
-              case List(conf1, conf2) if Compile.name == conf1 && Test.name == conf2 =>
-                s"${ref.project}-test"
-              case unknown =>
-                logger.warn(Feedback.unknownConfigurations(project, unknown, ref))
-                s"${ref.project}-test"
-            }
-          case None => nameFromString(ref.project, configuration)
+    // Force source generators on this task manually
+    Keys.managedSources.value
+    // Copy the resources, so that they're available when running and testing
+    bloopCopyResourcesTask.value
+
+    // format: OFF
+    val config = {
+      val java = Config.Java(javacOptions)
+      val `scala` = Config.Scala(scalaOrg, scalaName, scalaVersion, scalacOptions, allScalaJars)
+      val jvm = Config.Jvm(Some(javaHome.toPath), javaOptions.toArray)
+
+      val compileOptions = Config.CompileOptions(compileOrder)
+      val analysisOut = out.resolve(Config.Project.analysisFileName(projectName))
+      val project = Config.Project(projectName, baseDirectory, sources, dependenciesAndAggregates, classpath, classpathOptions, compileOptions, out, analysisOut, classesDir, `scala`, jvm, java, testOptions)
+      Config.File(Config.File.LatestVersion, project)
+    }
+    // format: ON
+
+    sbt.IO.createDirectory(bloopConfigDir)
+    Config.File.write(config, outFile.toPath())
+    logger.debug(s"Bloop wrote the configuration of project '$projectName' to '$outFile'.")
+
+    val allInRoot = BloopKeys.bloopAggregateSourceDependencies.in(Global).value
+    // Only shorten path for configuration files written to the the root build
+    val relativeConfigPath = {
+      if (allInRoot || buildBaseDirectory == rootBaseDirectory)
+        outFile.relativeTo(rootBaseDirectory).getOrElse(outFile)
+      else outFile
+    }
+
+    logger.success(s"Generated $relativeConfigPath")
+    outFile
+  }
+
+  private final val allJson = sbt.GlobFilter("*.json")
+  private final val removeStaleProjects = { (allConfigDirs: Set[File]) =>
+    { (s: State, generatedFiles: Set[File]) =>
+      val logger = s.globalLogging.full
+      val allConfigs =
+        allConfigDirs.flatMap(configDir => sbt.PathFinder(configDir).*(allJson).get)
+      allConfigs.diff(generatedFiles).foreach { configFile =>
+        sbt.IO.delete(configFile)
+        logger.warn(s"Removed stale $configFile.")
+      }
+      s
+    }
+  }
+
+  lazy val bloopInstall: Def.Initialize[Task[Unit]] = Def.taskDyn {
+    val filter = sbt.ScopeFilter(sbt.inAnyProject, sbt.inConfigurations(Compile, Test))
+    val allConfigDirs =
+      BloopKeys.bloopConfigDir.?.all(sbt.ScopeFilter(sbt.inAnyProject))
+        .map(_.flatMap(_.toList).toSet)
+        .value
+    val removeProjects = removeStaleProjects(allConfigDirs)
+    BloopKeys.bloopGenerate
+      .all(filter)
+      .map(_.toSet)
+      // Smart trick to modify state once a task has completed (who said tasks cannot alter state?)
+      .apply((t: Task[Set[File]]) => sbt.SessionVar.transform(t, removeProjects))
+      .map(_ => ())
+  }
+
+  lazy val bloopConfigDir: Def.Initialize[Option[File]] = Def.setting { None }
+  import sbt.Classpaths
+
+  /**
+   * Emulates `dependencyClasspath` without triggering compilation of dependent projects.
+   *
+   * Why do we do this instead of a simple `productDirectories ++ libraryDependencies`?
+   * We want the classpath to have the correct topological order of the project dependencies.
+   */
+  final lazy val bloopInternalDependencyClasspath: Def.Initialize[Task[Seq[(File, File)]]] = {
+    Def.taskDyn {
+      val currentProject = Keys.thisProjectRef.value
+      val data = Keys.settingsData.value
+      val deps = Keys.buildDependencies.value
+      val conf = Keys.classpathConfiguration.value
+      val self = Keys.configuration.value
+
+      import scala.collection.JavaConverters._
+      val visited = Classpaths.interSort(currentProject, conf, data, deps)
+      val productDirs = (new java.util.LinkedHashSet[Task[Seq[File]]]).asScala
+      val bloopProductDirs = (new java.util.LinkedHashSet[Task[Seq[File]]]).asScala
+      for ((dep, c) <- visited) {
+        if ((dep != currentProject) || (conf.name != c && self.name != c)) {
+          val classpathKey = (Keys.productDirectories in (dep, sbt.ConfigKey(c)))
+          productDirs += classpathKey.get(data).getOrElse(sbt.std.TaskExtra.constant(Nil))
+          val bloopKey = (BloopKeys.bloopProductDirectories in (dep, sbt.ConfigKey(c)))
+          bloopProductDirs += bloopKey.get(data).getOrElse(sbt.std.TaskExtra.constant(Nil))
         }
-
       }
 
-      val configuration = Keys.configuration.value
-      val projectName = nameFromString(project.id, configuration)
-      val baseDirectory = Keys.baseDirectory.value.toPath.toAbsolutePath
-      val buildBaseDirectory = Keys.baseDirectory.in(ThisBuild).value.getAbsoluteFile
-      val rootBaseDirectory = new File(Keys.loadedBuild.value.root)
-
-      // In the test configuration, add a dependency on the base project
-      val baseProjectDependency = if (configuration == Test) List(project.id) else Nil
-
-      val projectDependencies =
-        project.dependencies.map(dep => nameFromRef(dep, configuration)).toList
-      val dependencies = (projectDependencies ++ baseProjectDependency).toArray
-      val aggregates = project.aggregate.map(agg => nameFromString(agg.project, configuration))
-      val dependenciesAndAggregates = dependencies ++ aggregates
-
-      val bloopConfigDir = BloopKeys.bloopConfigDir.value
-      val out = (bloopConfigDir / projectName).toPath.toAbsolutePath
-      val scalaName = "scala-compiler"
-      val scalaVersion = Keys.scalaVersion.value
-      val scalaOrg = Keys.ivyScala.value.map(_.scalaOrganization).getOrElse("org.scala-lang")
-      val allScalaJars = Keys.scalaInstance.value.allJars.map(_.toPath.toAbsolutePath).toArray
-
-      val classpath =
-        PluginDefaults.emulateDependencyClasspath.value.map(_.toPath.toAbsolutePath).toArray
-      val classpathOptions = {
-        val cpo = Keys.classpathOptions.value
-        Config.ClasspathOptions(cpo.bootLibrary,
-                                cpo.compiler,
-                                cpo.extra,
-                                cpo.autoBoot,
-                                cpo.filterLibrary)
-      }
-
-      val classesDir = BloopKeys.bloopProductDirectories.value.head.toPath()
-
-      /* This is a best-effort to export source directories + stray source files that
-       * are not contained in them. Source directories are superior over source files because
-       * they allow us to watch them and detect the creation of new source files in situ. */
-      val sources = {
-        val sourceDirs = Keys.sourceDirectories.value.map(_.toPath)
-        val sourceFiles = pruneSources(sourceDirs, Keys.sources.value.map(_.toPath))
-        (sourceDirs ++ sourceFiles).toArray
-      }
-
-      val testOptions = {
-        val frameworks =
-          Keys.testFrameworks.value.map(f => Config.TestFramework(f.implClassNames.toList)).toArray
-        val empty = (List.empty[String], List.empty[Config.TestArgument])
-        val options = Keys.testOptions.value.foldLeft(Config.TestOptions.empty) {
-          case (options, sbt.Tests.Argument(framework0, args0)) =>
-            val args = args0.toArray
-            val framework = framework0.map(f => Config.TestFramework(f.implClassNames.toList))
-            options.copy(arguments = Config.TestArgument(args, framework) :: options.arguments)
-          case (options, sbt.Tests.Exclude(tests)) =>
-            options.copy(excludes = tests.toList ++ options.excludes)
-          case (options, other: sbt.TestOption) =>
-            logger.info(s"Skipped test option '${other}' as it can only be used within sbt.")
-            options
-        }
-        Config.Test(frameworks, options)
-      }
-
-      // TODO(jvican): Override classes directories here too (e.g. plugins are defined in the build)
-      val scalacOptions = {
-        val scalacOptions0 = Keys.scalacOptions.value.toArray
-        val internalClasspath = BloopKeys.bloopInternalClasspath.value
-        internalClasspath.foldLeft(scalacOptions0) {
-          case (scalacOptions, (oldClassesDir, newClassesDir)) =>
-            val old1 = oldClassesDir.toString
-            val old2 = oldClassesDir.getAbsolutePath
-            val newClassesDirAbs = newClassesDir.getAbsolutePath
-            scalacOptions.map { scalacOption =>
-              if (scalacOptions.contains(old1) ||
-                  scalacOptions.contains(old2)) {
-                logger.warn(
-                  s"The scalac option '$scalacOption' contains a reference to '$oldClassesDir'. Bloop will replace it by its own path optimistically, if you find misbehaviours please open a ticket at https://github.com/scalacenter/bloop.")
-                scalacOption.replace(old1, newClassesDirAbs).replace(old2, newClassesDirAbs)
-              } else scalacOption
-            }
+      val generatedTask = (productDirs.toList.join).map(_.flatten.distinct).flatMap { a =>
+        (bloopProductDirs.toList.join).map(_.flatten.distinct).map { b =>
+          a.zip(b)
         }
       }
 
-      val compileOrder = Keys.compileOrder.value match {
-        case CompileOrder.JavaThenScala => Config.JavaThenScala
-        case CompileOrder.ScalaThenJava => Config.ScalaThenJava
-        case CompileOrder.Mixed => Config.Mixed
-      }
-
-      val javacOptions = Keys.javacOptions.value.toArray
-      val (javaHome, javaOptions) = javaConfiguration.value
-      val outFile = bloopConfigDir / s"$projectName.json"
-
-      // Force source generators on this task manually
-      Keys.managedSources.value
-      // Copy the resources, so that they're available when running and testing
-      bloopCopyResourcesTask.value
-
-      // format: OFF
-      val config = {
-        val java = Config.Java(javacOptions)
-        val `scala` = Config.Scala(scalaOrg, scalaName, scalaVersion, scalacOptions, allScalaJars)
-        val jvm = Config.Jvm(Some(javaHome.toPath), javaOptions.toArray)
-
-        val compileOptions = Config.CompileOptions(compileOrder)
-        val analysisOut = out.resolve(Config.Project.analysisFileName(projectName))
-        val project = Config.Project(projectName, baseDirectory, sources, dependenciesAndAggregates, classpath, classpathOptions, compileOptions, out, analysisOut, classesDir, `scala`, jvm, java, testOptions)
-        Config.File(Config.File.LatestVersion, project)
-      }
-      // format: ON
-
-      sbt.IO.createDirectory(bloopConfigDir)
-      Config.File.write(config, outFile.toPath())
-      logger.debug(s"Bloop wrote the configuration of project '$projectName' to '$outFile'.")
-
-      val allInRoot = BloopKeys.bloopAggregateSourceDependencies.in(Global).value
-      // Only shorten path for configuration files written to the the root build
-      val relativeConfigPath = {
-        if (allInRoot || buildBaseDirectory == rootBaseDirectory)
-          outFile.relativeTo(rootBaseDirectory).getOrElse(outFile)
-        else outFile
-      }
-
-      logger.success(s"Generated $relativeConfigPath")
-      outFile
+      Def.task(generatedTask.value)
     }
+  }
 
-    private final val allJson = sbt.GlobFilter("*.json")
-    private final val removeStaleProjects = { (allConfigDirs: Set[File]) =>
-      { (s: State, generatedFiles: Set[File]) =>
-        val logger = s.globalLogging.full
-        val allConfigs =
-          allConfigDirs.flatMap(configDir => sbt.PathFinder(configDir).*(allJson).get)
-        allConfigs.diff(generatedFiles).foreach { configFile =>
-          sbt.IO.delete(configFile)
-          logger.warn(s"Removed stale $configFile.")
-        }
-        s
-      }
-    }
+  final lazy val emulateDependencyClasspath: Def.Initialize[Task[Seq[File]]] = Def.task {
+    val internalClasspath = BloopKeys.bloopInternalClasspath.value.map(_._2)
+    val externalClasspath = Keys.externalDependencyClasspath.value.map(_.data)
+    internalClasspath ++ externalClasspath
+  }
 
-    lazy val bloopInstall: Def.Initialize[Task[Unit]] = Def.taskDyn {
-      val filter = sbt.ScopeFilter(sbt.inAnyProject, sbt.inConfigurations(Compile, Test))
-      val allConfigDirs =
-        BloopKeys.bloopConfigDir.?.all(sbt.ScopeFilter(sbt.inAnyProject))
-          .map(_.flatMap(_.toList).toSet)
+  def bloopCopyResourcesTask = Def.taskDyn {
+    val configKey = sbt.ConfigKey(Keys.configuration.value.name)
+    Def.task {
+      import sbt._
+      val t = BloopKeys.bloopClassDirectory.value
+      val dirs =
+        Classpaths
+          .concatSettings(Keys.unmanagedResourceDirectories.in(configKey),
+                          BloopKeys.bloopManagedResourceDirectories.in(configKey))
           .value
-      val removeProjects = removeStaleProjects(allConfigDirs)
-      BloopKeys.bloopGenerate
-        .all(filter)
-        .map(_.toSet)
-        // Smart trick to modify state once a task has completed (who said tasks cannot alter state?)
-        .apply((t: Task[Set[File]]) => sbt.SessionVar.transform(t, removeProjects))
-        .map(_ => ())
+      val s = Keys.streams.value
+      val cacheStore = bloop.integrations.sbt.Compat.generateCacheFile(s, "copy-resources-bloop")
+      val mappings = (sbt.PathFinder(Keys.resources.value) --- dirs) pair (sbt.Path
+        .rebase(dirs, t) | sbt.Path.flat(t))
+      s.log.debug("Copy resource mappings: " + mappings.mkString("\n\t", "\n\t", ""))
+      sbt.Sync(cacheStore)(mappings)
+      mappings
     }
+  }
 
-    lazy val bloopConfigDir: Def.Initialize[Option[File]] = Def.setting { None }
-    import sbt.Classpaths
-
-    /**
-     * Emulates `dependencyClasspath` without triggering compilation of dependent projects.
-     *
-     * Why do we do this instead of a simple `productDirectories ++ libraryDependencies`?
-     * We want the classpath to have the correct topological order of the project dependencies.
-     */
-    final lazy val bloopInternalDependencyClasspath: Def.Initialize[Task[Seq[(File, File)]]] = {
-      Def.taskDyn {
-        val currentProject = Keys.thisProjectRef.value
-        val data = Keys.settingsData.value
-        val deps = Keys.buildDependencies.value
-        val conf = Keys.classpathConfiguration.value
-        val self = Keys.configuration.value
-
-        import scala.collection.JavaConverters._
-        val visited = Classpaths.interSort(currentProject, conf, data, deps)
-        val productDirs = (new java.util.LinkedHashSet[Task[Seq[File]]]).asScala
-        val bloopProductDirs = (new java.util.LinkedHashSet[Task[Seq[File]]]).asScala
-        for ((dep, c) <- visited) {
-          if ((dep != currentProject) || (conf.name != c && self.name != c)) {
-            val classpathKey = (Keys.productDirectories in (dep, sbt.ConfigKey(c)))
-            productDirs += classpathKey.get(data).getOrElse(sbt.std.TaskExtra.constant(Nil))
-            val bloopKey = (BloopKeys.bloopProductDirectories in (dep, sbt.ConfigKey(c)))
-            bloopProductDirs += bloopKey.get(data).getOrElse(sbt.std.TaskExtra.constant(Nil))
-          }
-        }
-
-        val generatedTask = (productDirs.toList.join).map(_.flatten.distinct).flatMap { a =>
-          (bloopProductDirs.toList.join).map(_.flatten.distinct).map { b =>
-            a.zip(b)
-          }
-        }
-
-        Def.task(generatedTask.value)
+  def managedResourceDirs: Def.Initialize[Seq[File]] = Def.settingDyn {
+    val configName = Keys.configuration.value.name
+    val configKey = sbt.ConfigKey(configName)
+    Def.setting {
+      val oldUnmanagedResourceDirs = Keys.managedResourceDirectories.in(configKey).value
+      val oldResourceDir = Keys.resourceManaged.in(configKey).value
+      val newResourceDir =
+        BloopKeys.bloopResourceManaged.in(configKey).value / Defaults.nameForSrc(configName)
+      oldUnmanagedResourceDirs.map { dir =>
+        if (dir == oldResourceDir) newResourceDir else dir
       }
     }
+  }
 
-    final lazy val emulateDependencyClasspath: Def.Initialize[Task[Seq[File]]] = Def.task {
-      val internalClasspath = BloopKeys.bloopInternalClasspath.value.map(_._2)
-      val externalClasspath = Keys.externalDependencyClasspath.value.map(_.data)
-      internalClasspath ++ externalClasspath
-    }
+  private type JavaConfiguration = (File, Seq[String])
 
-    def bloopCopyResourcesTask = Def.taskDyn {
-      val configKey = sbt.ConfigKey(Keys.configuration.value.name)
-      Def.task {
-        import sbt._
-        val t = BloopKeys.bloopClassDirectory.value
-        val dirs =
-          Classpaths
-            .concatSettings(Keys.unmanagedResourceDirectories.in(configKey),
-                            BloopKeys.bloopManagedResourceDirectories.in(configKey))
-            .value
-        val s = Keys.streams.value
-        val cacheStore = bloop.integrations.sbt.Compat.generateCacheFile(s, "copy-resources-bloop")
-        val mappings = (sbt.PathFinder(Keys.resources.value) --- dirs) pair (sbt.Path
-          .rebase(dirs, t) | sbt.Path.flat(t))
-        s.log.debug("Copy resource mappings: " + mappings.mkString("\n\t", "\n\t", ""))
-        sbt.Sync(cacheStore)(mappings)
-        mappings
-      }
-    }
+  /**
+   * Extract the information that we need to configure forking for run or test.
+   */
+  val javaConfiguration: Def.Initialize[Task[JavaConfiguration]] = Def.taskDyn {
+    import sbt.Scoped
+    val configuration = Keys.configuration.value
+    lazy val defaultJavaHome = new File(sys.props("java.home"))
+    def scoped[T, K[T]](key: Scoped.ScopingSetting[K[T]]): K[T] =
+      if (configuration == Test) key.in(Test)
+      else key.in(Keys.run)
 
-    def managedResourceDirs: Def.Initialize[Seq[File]] = Def.settingDyn {
-      val configName = Keys.configuration.value.name
-      val configKey = sbt.ConfigKey(configName)
-      Def.setting {
-        val oldUnmanagedResourceDirs = Keys.managedResourceDirectories.in(configKey).value
-        val oldResourceDir = Keys.resourceManaged.in(configKey).value
-        val newResourceDir =
-          BloopKeys.bloopResourceManaged.in(configKey).value / Defaults.nameForSrc(configName)
-        oldUnmanagedResourceDirs.map { dir =>
-          if (dir == oldResourceDir) newResourceDir else dir
-        }
-      }
-    }
+    Def.task {
+      val javaHome = scoped(Keys.javaHome).value.getOrElse(defaultJavaHome)
+      val javaOptions = scoped(Keys.javaOptions).value
 
-    private type JavaConfiguration = (File, Seq[String])
-
-    /**
-     * Extract the information that we need to configure forking for run or test.
-     */
-    val javaConfiguration: Def.Initialize[Task[JavaConfiguration]] = Def.taskDyn {
-      import sbt.Scoped
-      val configuration = Keys.configuration.value
-      lazy val defaultJavaHome = new File(sys.props("java.home"))
-      def scoped[T, K[T]](key: Scoped.ScopingSetting[K[T]]): K[T] =
-        if (configuration == Test) key.in(Test)
-        else key.in(Keys.run)
-
-      Def.task {
-        val javaHome = scoped(Keys.javaHome).value.getOrElse(defaultJavaHome)
-        val javaOptions = scoped(Keys.javaOptions).value
-
-        (javaHome, javaOptions)
-      }
+      (javaHome, javaOptions)
     }
   }
 }

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/custom-configurations/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/custom-configurations/build.sbt
@@ -1,12 +1,13 @@
 import bloop.integrations.sbt.{BloopDefaults, BloopKeys}
 
-val foo = project.in(file("."))
+val foo = project
+  .in(file("."))
   .configs(IntegrationTest)
-  .settings(inConfig(IntegrationTest)(
-    Defaults.itSettings ++
-      BloopDefaults.configSettings :+
-      (BloopKeys.bloopDependencies := Seq(ThisProject % "test"))
-  ))
+  .settings(
+    inConfig(IntegrationTest)(
+      Defaults.itSettings ++
+        BloopDefaults.configSettings
+    ))
 
 val checkBloopFile = taskKey[Unit]("Check bloop file contents")
 checkBloopFile in ThisBuild := {
@@ -14,6 +15,7 @@ checkBloopFile in ThisBuild := {
   val bloopDir = Keys.baseDirectory.value./(".bloop")
   val fooConfig = bloopDir./("foo.json")
   val fooTestConfig = bloopDir./("foo-test.json")
+  val fooRuntimeConfig = bloopDir./("foo-runtime.json")
   val fooItConfig = bloopDir./("foo-it.json")
   val allConfigs = List(
     fooConfig,
@@ -22,8 +24,10 @@ checkBloopFile in ThisBuild := {
   )
 
   allConfigs.foreach(f => assert(Files.exists(f.toPath), s"Missing config file for ${f}."))
+  assert(!Files.exists(fooRuntimeConfig.toPath), s"Configuration for runtime exists!")
 
   // Read foo-it config file, remove all whitespace
   val fooItConfigContents = new String(Files.readAllBytes(fooItConfig.toPath)).replaceAll("\\s", "")
-  assert(fooItConfigContents.contains(""""dependencies":["foo-test"]"""), "Dependency it->test is missing in foo.")
+  assert(fooItConfigContents.contains(""""dependencies":["foo"]"""),
+         "Dependency it->compile is missing in foo.")
 }

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/custom-configurations/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/custom-configurations/build.sbt
@@ -1,6 +1,29 @@
-import bloop.integrations.sbt.BloopDefaults
+import bloop.integrations.sbt.{BloopDefaults, BloopKeys}
 
 val foo = project.in(file("."))
   .configs(IntegrationTest)
-  .settings(inConfig(IntegrationTest)(Defaults.itSettings))
-  .settings(inConfig(IntegrationTest)(BloopDefaults.configSettings))
+  .settings(inConfig(IntegrationTest)(
+    Defaults.itSettings ++
+      BloopDefaults.configSettings :+
+      (BloopKeys.bloopDependencies := Seq(ThisProject % "test"))
+  ))
+
+val checkBloopFile = taskKey[Unit]("Check bloop file contents")
+checkBloopFile in ThisBuild := {
+  import java.nio.file.Files
+  val bloopDir = Keys.baseDirectory.value./(".bloop")
+  val fooConfig = bloopDir./("foo.json")
+  val fooTestConfig = bloopDir./("foo-test.json")
+  val fooItConfig = bloopDir./("foo-it.json")
+  val allConfigs = List(
+    fooConfig,
+    fooItConfig,
+    fooTestConfig
+  )
+
+  allConfigs.foreach(f => assert(Files.exists(f.toPath), s"Missing config file for ${f}."))
+
+  // Read foo-it config file, remove all whitespace
+  val fooItConfigContents = new String(Files.readAllBytes(fooItConfig.toPath)).replaceAll("\\s", "")
+  assert(fooItConfigContents.contains(""""dependencies":["foo-test"]"""), "Dependency it->test is missing in foo.")
+}

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/custom-configurations/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/custom-configurations/build.sbt
@@ -1,0 +1,6 @@
+import bloop.integrations.sbt.BloopDefaults
+
+val foo = project.in(file("."))
+  .configs(IntegrationTest)
+  .settings(inConfig(IntegrationTest)(Defaults.itSettings))
+  .settings(inConfig(IntegrationTest)(BloopDefaults.configSettings))

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/custom-configurations/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/custom-configurations/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/custom-configurations/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/custom-configurations/test
@@ -2,3 +2,4 @@
 $ exists .bloop/foo.json
 $ exists .bloop/foo-test.json
 $ exists .bloop/foo-it.json
+> checkBloopFile

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/custom-configurations/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/custom-configurations/test
@@ -1,0 +1,4 @@
+> bloopInstall
+$ exists .bloop/foo.json
+$ exists .bloop/foo-test.json
+$ exists .bloop/foo-it.json

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/lagom-compat/.sbtopts
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/lagom-compat/.sbtopts
@@ -1,0 +1,4 @@
+-J-Xms512M
+-J-Xmx2048M
+-J-Xss2M
+-J-XX:MaxMetaspaceSize=512M

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/lagom-compat/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/lagom-compat/build.sbt
@@ -1,0 +1,50 @@
+organization in ThisBuild := "com.example"
+version in ThisBuild := "1.0-SNAPSHOT"
+
+// the Scala version that will be used for cross-compiled libraries
+scalaVersion in ThisBuild := "2.12.4"
+
+val macwire = "com.softwaremill.macwire" %% "macros" % "2.3.0" % "provided"
+val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4" % Test
+
+lazy val `hello` = (project in file("."))
+  .aggregate(`hello-api`, `hello-impl`, `hello-stream-api`, `hello-stream-impl`)
+
+lazy val `hello-api` = (project in file("hello-api"))
+  .settings(
+    libraryDependencies ++= Seq(
+      lagomScaladslApi
+    )
+  )
+
+lazy val `hello-impl` = (project in file("hello-impl"))
+  .enablePlugins(LagomScala)
+  .settings(
+    libraryDependencies ++= Seq(
+      lagomScaladslPersistenceCassandra,
+      lagomScaladslKafkaBroker,
+      lagomScaladslTestKit,
+      macwire,
+      scalaTest
+    )
+  )
+  .settings(lagomForkedTestSettings: _*)
+  .dependsOn(`hello-api`)
+
+lazy val `hello-stream-api` = (project in file("hello-stream-api"))
+  .settings(
+    libraryDependencies ++= Seq(
+      lagomScaladslApi
+    )
+  )
+
+lazy val `hello-stream-impl` = (project in file("hello-stream-impl"))
+  .enablePlugins(LagomScala)
+  .settings(
+    libraryDependencies ++= Seq(
+      lagomScaladslTestKit,
+      macwire,
+      scalaTest
+    )
+  )
+  .dependsOn(`hello-stream-api`, `hello-api`)

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/lagom-compat/hello-impl/src/test/resources/logback.xml
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/lagom-compat/hello-impl/src/test/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.apache.cassandra" level="ERROR" />
+    <logger name="com.datastax.driver" level="WARN" />
+
+    <logger name="akka" level="WARN" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/lagom-compat/project/build.properties
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/lagom-compat/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.4

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/lagom-compat/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/lagom-compat/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.4")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/lagom-compat/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/lagom-compat/test
@@ -1,0 +1,1 @@
+> bloopInstall


### PR DESCRIPTION
To make use of this, one needs to add something along these lines:

```
import bloop.integrations.sbt.BloopDefaults

inConfig(IntegrationTest)(BloopDefaults.configSettings)
```

to project-local settings (preferably a .gitignored `local.sbt`).

TODO:

- [x] Inter-project dependencies (e.g. if `IntegrationTest` depends on `Test`)
- [x] Tests
- [ ] Documentation
- [ ] Probably resolve conflicts with https://github.com/scalacenter/bloop/compare/topic/fix-errors
- [x] Fix CI test failures
- [ ] Update https://github.com/scalacenter/bloop/blob/ticket%2F505-sbt-custom-configs/website/content/faq/_index.md#L44 when the commit ID is known (or change it to `master`?)

Closes #505.