### PR TITLE
Docs: Advanced sbt configuration

### DIFF
--- a/website/content/docs/sbt.md
+++ b/website/content/docs/sbt.md
@@ -1,0 +1,64 @@
++++
+title = "Advanced sbt configuration"
+description = "How to use Bloop in sbt projects"
+bref = "Learn advanced configuration of Bloop's sbt plugin"
+date = "2018-06-06T23:39:00+02:00"
+draft = false
+weight = 5
+toc = true
++++
+
+## Custom project configurations
+
+By default Bloop generates its project files only for the standard `Compile`
+(`project.json`) and `Test` (`project-test.json`) sbt configurations. If your
+sbt project defines other configurations like `IntegrationTest`, you might want
+to export them as Bloop projects too.
+
+In order for Bloop to export your custom configurations, they need to include
+some
+[Bloop-specific settings and tasks](https://github.com/scalacenter/bloop/blob/405896f4164cb96bfd39a7369a714d8f73257dd5/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala#L80-L89),
+of which the most important is the `bloopGenerate` task. You can do this either
+by temporarily setting them in your sbt shell, or by permanently adding them to
+your build file.
+
+### Temporary solution: sbt shell
+
+In your sbt shell, type:
+
+```
+sbt> set inConfig(IntegrationTest)(bloop.integrations.sbt.BloopDefaults.configSettings)
+```
+
+where `IntegrationTest` is the configuration which you want to export. Now you
+can run `bloopInstall` as usual:
+
+```
+sbt> bloopInstall
+[info] Loading global plugins from /home/user/.sbt/1.0/plugins
+(...)
+[success] Generated '/my-project/.bloop/foo.json'.
+[success] Generated '/my-project/.bloop/foo-test.json'.
+[success] Generated '/my-project/.bloop/foo-it.json'.
+```
+
+Please note that these settings will be lost after you exit sbt, so if you need
+to regenerate Bloop configuration files later you will need to run the `set`
+command above again.
+
+### Permanent solution: `*.sbt` file
+
+You can also add the relevant settings to an `*.sbt` file in your project's
+root directory. Normally, that would be `build.sbt`, but if you don't want to
+pollute your main build file with Bloop-specific settings, you can create
+another one (e.g. `local.sbt`) and add this file to your `.gitignore` (or some
+other VCS-specific ignore file if not using Git).
+
+The code you need to add (again, assuming `IntegrationTest` is the sbt
+configuration you want to export):
+
+```scala
+import bloop.integrations.sbt.BloopDefaults
+
+inConfig(IntegrationTest)(BloopDefaults.configSettings)
+```

--- a/website/content/faq/_index.md
+++ b/website/content/faq/_index.md
@@ -58,6 +58,12 @@ You can speed it up by avoiding binary dependencies on modules that your build d
 or by making sure that all the source and resource generators are cached (if you depend
 on a plugin, the plugin should make sure of that).
 
+## Bloop doesn't detect some of my sbt configurations!
+
+By default the sbt plugin exports only `Compile` and `Test` configurations.
+If you want to export other sbt configurations too, please read about
+[advanced sbt configuration]({{<relref "docs/sbt.md" >}}).
+
 ## Is Bloop open source?
 
 Yes. Bloop is released under the Apache-2.0 license and is free and open source software.

--- a/website/content/faq/_index.md
+++ b/website/content/faq/_index.md
@@ -41,8 +41,8 @@ its own folder.
 A classes directory is stored in a similar path as sbt: `target/classes`, and
 `target/test-classes` for test projects. If you want to change that, you can
 by redefining
-[`bloopTargetDir`](https://github.com/scalacenter/bloop/blob/6e1d55cc840905c475d4e97eaf443fdacfcf1e34/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala#L26-L27)
-in your sbt build like [here](https://github.com/scalacenter/bloop/blob/6e1d55cc840905c475d4e97eaf443fdacfcf1e34/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala#L59).
+[`bloopTargetDir`](https://github.com/scalacenter/bloop/blob/405896f4164cb96bfd39a7369a714d8f73257dd5/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala#L49-L50)
+in your sbt build like [here](https://github.com/scalacenter/bloop/blob/405896f4164cb96bfd39a7369a714d8f73257dd5/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala#L95).
 
 <span class="label warning">Note</span> that you need to scope it in every
 sbt project.


### PR DESCRIPTION
Add the docs for #512:

* Update links to `bloopTargetDir` in the FAQ
* Add new page "Advanced sbt configuration" and describe how to export custom sbt configurations
* Add a FAQ entry about custom sbt configurations