### PR TITLE
Allow the project load of non-Scala projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,10 +21,14 @@ val benchmarkBridge = project
 import build.Dependencies
 
 val backend = project
+  .enablePlugins(BuildInfoPlugin)
   .disablePlugins(ScriptedPlugin)
   .settings(testSettings)
   .settings(
     name := "bloop-backend",
+    buildInfoPackage := "bloop.internal.build",
+    buildInfoKeys := BloopBackendInfoKeys,
+    buildInfoObject := "BloopScalaInfo",
     libraryDependencies ++= List(
       Dependencies.zinc,
       Dependencies.nailgun,

--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -97,5 +97,44 @@ object Config {
       Files.write(target, contents.getBytes(DefaultCharset))
       ()
     }
+
+    private[bloop] def dummyForTests: File = {
+      val workingDirectory = Paths.get(System.getProperty("user.dir"))
+      val sourceFile = Files.createTempFile("Foo", ".scala")
+      sourceFile.toFile.deleteOnExit()
+
+      // Just add one classpath with the scala library in it
+      val scalaLibraryJar = Files.createTempFile("scala-library", ".jar")
+      scalaLibraryJar.toFile.deleteOnExit()
+
+      // This is like `target` in sbt.
+      val outDir = Files.createTempFile("out", "test")
+      outDir.toFile.deleteOnExit()
+
+      val outAnalysisFile = outDir.resolve("out-analysis.bin")
+      outAnalysisFile.toFile.deleteOnExit()
+
+      val classesDir = Files.createTempFile("classes", "test")
+      classesDir.toFile.deleteOnExit()
+
+      val project = Project(
+        "dummy-project",
+        workingDirectory,
+        Array(sourceFile),
+        Array("dummy-2"),
+        Array(scalaLibraryJar),
+        ClasspathOptions.empty,
+        CompileOptions.empty,
+        classesDir,
+        outDir,
+        outAnalysisFile,
+        Scala("org.scala-lang", "scala-compiler", "2.12.4", Array("-warn"), Array()),
+        Jvm(Some(Paths.get("/usr/lib/jvm/java-8-jdk")), Array()),
+        Java(Array("-version")),
+        Test(Array(), TestOptions(Nil, Nil))
+      )
+
+      File(LatestVersion, project)
+    }
   }
 }

--- a/config/src/test/scala-2.12/bloop/config/JsonSpec.scala
+++ b/config/src/test/scala-2.12/bloop/config/JsonSpec.scala
@@ -37,36 +37,6 @@ class JsonSpec {
   }
 
   @Test def testSimpleConfigJson(): Unit = {
-    val workingDirectory = Paths.get(System.getProperty("user.dir"))
-    val sourceFile = Files.createTempFile("Foo", ".scala")
-    sourceFile.toFile.deleteOnExit()
-    val scalaLibraryJar = Files.createTempFile("scala-library", ".jar")
-    scalaLibraryJar.toFile.deleteOnExit()
-    // This is like `target` in sbt.
-    val outDir = Files.createTempFile("out", "test")
-    outDir.toFile.deleteOnExit()
-    val outAnalysisFile = outDir.resolve("out-analysis.bin")
-    outAnalysisFile.toFile.deleteOnExit()
-    val classesDir = Files.createTempFile("classes", "test")
-    classesDir.toFile.deleteOnExit()
-
-    val project = Project(
-      "dummy-project",
-      workingDirectory,
-      Array(sourceFile),
-      Array("dummy-2"),
-      Array(scalaLibraryJar),
-      ClasspathOptions.empty,
-      CompileOptions.empty,
-      classesDir,
-      outDir,
-      outAnalysisFile,
-      Scala("org.scala-lang", "scala-compiler", "2.12.4", Array("-warn"), Array()),
-      Jvm(Some(Paths.get("/usr/lib/jvm/java-8-jdk")), Array()),
-      Java(Array("-version")),
-      ConfigTest(Array(), TestOptions(Nil, Nil))
-    )
-
-    parseConfig(File(File.LatestVersion, project))
+    parseConfig(File.dummyForTests)
   }
 }

--- a/frontend/src/main/scala/bloop/Project.scala
+++ b/frontend/src/main/scala/bloop/Project.scala
@@ -85,8 +85,16 @@ object Project {
   def fromConfig(file: Config.File, logger: Logger): Project = {
     val project = file.project
     val scala = project.`scala`
-    val scalaJars = scala.jars.map(AbsolutePath.apply).toArray
-    val instance = ScalaInstance(scala.organization, scala.name, scala.version, scalaJars, logger)
+    val isEmpty = scala.organization.isEmpty && scala.name.isEmpty && scala.version.isEmpty && scala.jars.isEmpty
+
+    // Use the default Bloop scala instance if it's not a Scala project
+    val instance = {
+      if (isEmpty) ScalaInstance.bloopScalaInstance(logger)
+      else {
+        val scalaJars = scala.jars.map(AbsolutePath.apply).toArray
+        ScalaInstance(scala.organization, scala.name, scala.version, scalaJars, logger)
+      }
+    }
 
     val classpathOptions = {
       val opts = project.classpathOptions

--- a/frontend/src/test/scala/bloop/engine/LoadProjectSpec.scala
+++ b/frontend/src/test/scala/bloop/engine/LoadProjectSpec.scala
@@ -3,6 +3,7 @@ package bloop.engine
 import java.util.concurrent.TimeUnit
 
 import bloop.Project
+import bloop.config.Config
 import bloop.io.AbsolutePath
 import bloop.logging.RecordingLogger
 import bloop.tasks.TestUtil
@@ -28,5 +29,16 @@ class LoadProjectSpec {
     try TestUtil.await(FiniteDuration(7, TimeUnit.SECONDS))(t)
     catch { case t: Throwable => logger.dump(); throw t }
     ()
+  }
+
+  @Test def loadJavaProject(): Unit = {
+    // Make sure that when no scala setup is configured the project load succeeds
+    val logger = new RecordingLogger()
+    val config0 = Config.File.dummyForTests
+    val project = config0.project
+    val emptyScala = Config.Scala("", "", "", Array(), Array())
+    val configWithNoScala = config0.copy(config0.version, project.copy(scala = emptyScala))
+    val inferredInstance = Project.fromConfig(configWithNoScala, logger).scalaInstance
+    assert(inferredInstance.version.nonEmpty)
   }
 }

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -112,11 +112,16 @@ object BuildKeys {
   )
 
   import sbtbuildinfo.BuildInfoKey
-  final val BloopInfoKeys = {
+  final val BloopBackendInfoKeys: List[BuildInfoKey] = {
+    val scalaJarsKey =
+      BuildInfoKey.map(Keys.scalaInstance) { case (_, i) => "scalaJars" -> i.allJars.toList }
+    List(Keys.scalaVersion, Keys.scalaOrganization, scalaJarsKey)
+  }
+
+  final val BloopInfoKeys: List[BuildInfoKey] = {
     val zincKey = BuildInfoKey.constant("zincVersion" -> Dependencies.zincVersion)
-    val developersKey = BuildInfoKey.map(Keys.developers) {
-      case (k, devs) => k -> devs.map(_.name)
-    }
+    val developersKey =
+      BuildInfoKey.map(Keys.developers) { case (k, devs) => k -> devs.map(_.name) }
     val commonKeys = List[BuildInfoKey](
       Keys.name,
       Keys.version,


### PR DESCRIPTION
This commit allows Bloop to load up projects that don't have any Scala
setup. This can happen when build tools like Maven want to generate
configuration files for java-only projects.

This could have been workarounded by creating default scala options from
the build tool side, but that's uglier and slower than just setting all
the fields of the `Scala` setup to empty because if there is no default
scala instance defined it would need to be resolved to fill in the `scalaJars`
field. 

This is a quick fix to unblock @lefou.

The ideal would be to modify the configuration file format to allow for
an optional scala setup, but that change would be quite breaking and
would conflict with some contributors' efforts that are already
undergoing. I think it's something we need to do anyway, so I'll carry
it out in one week or so.