### PR TITLE
Export configurations of sbt meta builds automatically

### DIFF
--- a/build-integrations/sbt-0.13/project/Integrations.scala
+++ b/build-integrations/sbt-0.13/project/Integrations.scala
@@ -7,7 +7,7 @@ object Integrations {
   val LihaoyiUtest = RootProject(
     uri("git://github.com/lihaoyi/utest.git#b5440d588d5b32c85f6e9392c63edd3d3fed3106"))
   val ScalaScala = RootProject(
-    uri("git://github.com/scalacenter/scala.git#430deb1f3ff23ae0876434b302808d7b004337f6"))
+    uri("git://github.com/scalacenter/scala.git#dc36e73a10ca2835489c878b5068c6cc64c7d6b6"))
   val ScalaCenterVersions = RootProject(
     uri("git://github.com/scalacenter/versions.git#c296028a33b06ba3a41d399d77c21f6b7100c001"))
 

--- a/integrations/sbt-bloop/src/main/scala-sbt-1.0/bloop/integrations/sbt/Compat.scala
+++ b/integrations/sbt-bloop/src/main/scala-sbt-1.0/bloop/integrations/sbt/Compat.scala
@@ -2,13 +2,15 @@ package bloop.integrations.sbt
 
 import bloop.config.Config
 import sbt.io.syntax.File
-import sbt.{Artifact, Keys, SettingKey}
+import sbt.{Artifact, Exec, Keys, SettingKey}
 import sbt.librarymanagement.ScalaModuleInfo
 
 object Compat {
   implicit class WithIvyScala(keys: Keys.type) {
     def ivyScala: SettingKey[Option[ScalaModuleInfo]] = keys.scalaModuleInfo
   }
+
+  implicit def execToString(e: Exec): String = e.commandLine
 
   implicit def fileToRichFile(file: File): sbt.RichFile = new sbt.RichFile(file)
 

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/meta-builds/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/meta-builds/build.sbt
@@ -1,0 +1,16 @@
+val foo = project.in(file("."))
+val bar = project
+
+import java.nio.file.Files
+val checkSourceAndDocs = taskKey[Unit]("Check source and doc jars are resolved and persisted")
+checkSourceAndDocs in ThisBuild := {
+  def readBareFile(p: java.nio.file.Path): String =
+    new String(Files.readAllBytes(p)).replaceAll("\\s", "")
+
+  val bloopDir = Keys.baseDirectory.value./("project")./(".bloop")
+  val metaBuildConfig = bloopDir./("meta-builds-build.json")
+  val metaBuildTestConfig = bloopDir./("meta-builds-build-test.json")
+  val contents = readBareFile(metaBuildConfig.toPath)
+  assert(contents.contains("\"classifier\":\"sources\""), "Missing source jar.")
+  assert(contents.contains("\"classifier\":\"javadoc\""), "Missing doc jar.")
+}

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/meta-builds/changes/set-sources.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/meta-builds/changes/set-sources.sbt
@@ -1,0 +1,1 @@
+bloopExportSourceAndDocJars in ThisBuild := true

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/meta-builds/project/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/meta-builds/project/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))
+

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/meta-builds/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/meta-builds/test
@@ -1,0 +1,6 @@
+> show name
+$ exists project/.bloop/meta-builds-build.json
+-$ exists project/.bloop/meta-builds-build-test.json
+$ copy-file changes/set-sources.sbt project/set-sources.sbt
+> reload
+> checkSourceAndDocs


### PR DESCRIPTION
This means that if you add the plugin as a global plugin OR as a plugin of
your meta project, Bloop will automatically generate the bloop
configuration files when it reloads.

This generation is super fast because meta projects are usually really
small and they only have one build.