### PR TITLE
Add debugging instructions to developer documentation [DOCS]

### DIFF
--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -226,6 +226,7 @@ object BuildImplementation {
   import ch.epfl.scala.sbt.release.ReleaseEarlyPlugin.{autoImport => ReleaseEarlyKeys}
 
   final val globalSettings: Seq[Def.Setting[_]] = Seq(
+    Keys.cancelable := true,
     BuildKeys.schemaVersion := "2.6",
     Keys.testOptions in Test += sbt.Tests.Argument("-oD"),
     Keys.onLoadMessage := Header.intro,

--- a/website/content/docs/developer-documentation.md
+++ b/website/content/docs/developer-documentation.md
@@ -128,3 +128,52 @@ will then kick in and confirm your request.
 the benchmarks for it. Run it to execute the benchmark suite locally, but keep
 in mind that you must make sure your machine is stable and has been tweaked to
 get stable results.
+
+## Debugging
+
+When analysing a bug, it is often infeasible to rely only on tests. It might be
+more convenient to run Bloop and attach a debugger instead.
+
+### Running Bloop server from sbt
+
+To run the server directly from sbt:
+
+```sh
+$ sbt
+> frontend/runMain bloop.Server
+```
+
+If you want to be able to stop the server with <kbd>Ctrl</kbd><kbd>C</kbd>
+without killing the sbt shell, you need to set `cancelable` to `true` first:
+
+```
+> set cancelable in Global := true
+```
+
+#### Attaching debugger
+
+In order to attach a debugger you need to run Bloop with some additional JVM
+options to enable debugging in the first place. Here we will use the standard
+JDWP (Java Debug Wire Protocol) agent. Type the following in your sbt shell:
+
+```sh
+$ sbt
+> set javaOptions in (frontend, run) += "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
+> frontend/runMain bloop.Server
+```
+
+Now attach your favourite debugger using port `5005`. The JVM will wait with
+starting Bloop until a debugger is attached -- change `suspend` to `n` if you
+don't want this behaviour.
+
+#### Ensime
+
+If you are using [Ensime](https://ensime.github.io/), there is `ensimeRunDebug`
+task defined by `sbt-ensime` plugin which lets you simply do:
+
+```sh
+$ sbt
+> frontend/ensimeRunDebug bloop.Server
+```
+
+which is equivalent to setting `javaOptions` like above.

--- a/website/content/docs/developer-documentation.md
+++ b/website/content/docs/developer-documentation.md
@@ -131,7 +131,7 @@ get stable results.
 
 ## Debugging
 
-If you're trying to catch a bug, it might ben convenient to attach a debugger
+If you're trying to catch a bug, it might be convenient to attach a debugger
 to Bloop instead of creating your own tests and `println`ing.
 
 In order to attach a debugger you need to run Bloop with some additional JVM
@@ -179,18 +179,14 @@ Kill the bloop server with <kbd>Ctrl</kbd><kbd>C</kbd>.
 
 #### Attaching debugger in local bloop
 
-This is mostly useful for Bloop developers. If you have a local copy of bloop
-and you're implementing a new feature that seems to behave abnormally, you can
-debug with bloop itself (if you're using it to compile/test the codebase), sbt
-or Ensime.
-
-Remember to replace the configuration directory `/foo/bar` with the
-configuration directory of the project you want to test.
+This is mostly useful for Bloop developers that have a local copy of bloop
+they want to debug. You can debug bloop with three tools: `bloop` (if you use
+it to develop `bloop`), `sbt` or `ensime`.
 
 ##### bloop
 
 ```bash
-bloop run frontend bloop.Server -- -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005
+bloop run frontend -- -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005
 Listening for transport dt_socket at address: 5005
 ```
 
@@ -199,7 +195,7 @@ Listening for transport dt_socket at address: 5005
 ```sh
 $ sbt
 > set javaOptions in (frontend, run) += "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
-> frontend/runMain bloop.Server --config-dir /foo/bar
+> frontend/runMain bloop.Server
 Listening for transport dt_socket at address: 5005
 ```
 
@@ -207,6 +203,6 @@ Listening for transport dt_socket at address: 5005
 
 ```sh
 $ sbt
-> frontend/ensimeRunDebug bloop.Server --config-dir /foo/bar
+> frontend/ensimeRunDebug bloop.Server
 Listening for transport dt_socket at address: 5005
 ```


### PR DESCRIPTION
It's not that obvious how to run Bloop server directly from sbt and how to enable debugging for forked processes. Hopefully these instructions will save people some time figuring things out.