### PR TITLE
Add basic mill integration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -137,6 +137,13 @@ val mavenBloop = project
   .settings(name := "maven-bloop")
   .settings(BuildDefaults.mavenPluginBuildSettings)
 
+val millBloop = project
+  .in(file("integrations") / "mill-bloop")
+  .disablePlugins(ScriptedPlugin)
+  .dependsOn(jsonConfig)
+  .settings(name := "mill-bloop")
+  .settings(BuildDefaults.millModuleBuildSettings)
+
 val docs = project
   .in(file("website"))
   .enablePlugins(HugoPlugin, GhpagesPlugin, ScriptedPlugin)
@@ -181,7 +188,7 @@ lazy val nativeBridge = project
   )
 
 val allProjects =
-  Seq(backend, benchmarks, frontend, jsonConfig, sbtBloop, mavenBloop, nativeBridge, jsBridge06, jsBridge10)
+  Seq(backend, benchmarks, frontend, jsonConfig, sbtBloop, mavenBloop, millBloop, nativeBridge, jsBridge06, jsBridge10)
 val allProjectReferences = allProjects.map(p => LocalProject(p.id))
 val bloop = project
   .in(file("."))

--- a/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
+++ b/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
@@ -1,3 +1,138 @@
-object MillBloop {
+package bloop.integrations.mill
+
+import _root_.mill._
+import _root_.mill.define._
+import _root_.mill.scalalib._
+import _root_.mill.eval.Evaluator
+
+import ammonite.ops._
+
+object Bloop extends ExternalModule {
+
+  def install(ev: Evaluator[Any]) = T.command {
+    val bloopDir = pwd / ".bloop"
+    mkdir(bloopDir)
+
+    val rootModule = ev.rootModule
+    val modules = rootModule.millInternal.segmentsToModules.values.collect {
+      case m: scalalib.JavaModule => m
+    }.toSeq
+
+    Task.traverse(modules)(genBloopConfig(bloopDir, _))
+  }
+
+  implicit def millScoptEvaluatorReads[T] = new mill.main.EvaluatorScopt[T]()
+
+  def genBloopConfig(bloopDir: Path, module: JavaModule): Task[Path] = {
+
+    import bloop.config.Config
+
+    def name(m: JavaModule) = m.millModuleSegments.render
+    def out(m: JavaModule) = bloopDir / "out" / m.millModuleSegments.render
+    def analysisOut(m: JavaModule) = out(m) / Config.Project.analysisFileName(name(m))
+    def classes(m: JavaModule) = out(m) / "classes"
+
+    val javaConfig = module.javacOptions.map(opts => Config.Java(options = opts.toArray))
+
+    val scalaConfig = module match {
+      case s: ScalaModule =>
+        T.task {
+          val pluginOptions = s.scalacPluginClasspath().map { pathRef =>
+            s"-Xplugin:${pathRef.path}"
+          }
+
+          Config.Scala(
+            organization = "org.scala-lang",
+            name = "scala-compiler",
+            version = s.scalaVersion(),
+            options = (s.scalacOptions() ++ pluginOptions).toArray,
+            jars = s.scalaCompilerClasspath().map(_.path.toNIO).toArray
+          )
+        }
+      case _ => T.task(Config.Scala.empty)
+    }
+
+    val jvmConfig = T.task {
+      Config.Jvm(
+        home = T.ctx().env.get("JAVA_HOME").map(s => Path(s).toNIO),
+        options = module.forkArgs().toArray
+      )
+    }
+
+    val testConfig = module match {
+      case m: TestModule =>
+        T.task {
+          Config.Test(
+            frameworks = m
+              .testFrameworks()
+              .map(f => Config.TestFramework(List(f)))
+              .toArray,
+            options = Config.TestOptions(
+              excludes = List(),
+              arguments = List()
+            )
+          )
+        }
+      case _ => T.task(Config.Test.empty)
+    }
+
+    val ivyDepsClasspath =
+      module
+        .resolveDeps(T.task { module.compileIvyDeps() ++ module.transitiveIvyDeps() })
+        .map(_.map(_.path).toSeq)
+
+    def transitiveClasspath(m: JavaModule): Task[Seq[Path]] = T.task {
+      m.moduleDeps.map(classes) ++
+        m.resources().map(_.path) ++
+        m.unmanagedClasspath().map(_.path) ++
+        Task.traverse(m.moduleDeps)(transitiveClasspath)().flatten
+    }
+
+    val classpath = T.task(transitiveClasspath(module)() ++ ivyDepsClasspath())
+
+    val project = T.task {
+      Config.Project(
+        name = name(module),
+        directory = module.millSourcePath.toNIO,
+        sources = module.sources().map(_.path.toNIO).toArray,
+        dependencies = module.moduleDeps.map(name).toArray,
+        classpath = classpath().map(_.toNIO).toArray,
+        classpathOptions = Config.ClasspathOptions(
+          bootLibrary = true,
+          compiler = false,
+          extra = false,
+          autoBoot = true,
+          filterLibrary = true
+        ),
+        compileOptions = Config.CompileOptions(
+          Config.Mixed
+        ),
+        out = out(module).toNIO,
+        analysisOut = analysisOut(module).toNIO,
+        classesDir = classes(module).toNIO,
+        scala = scalaConfig(),
+        jvm = jvmConfig(),
+        java = javaConfig(),
+        test = testConfig(),
+        platform = Config.Platform.JVM,
+        nativeConfig = None,
+        jsConfig = None,
+        resolution = Config.Resolution.empty
+      )
+    }
+
+    T.task {
+      val filePath = bloopDir / s"${name(module)}.json"
+      val file = Config.File(
+        version = Config.File.LatestVersion,
+        project = project()
+      )
+
+      bloop.config.write(file, filePath.toNIO)
+      filePath
+    }
+  }
+
+  lazy val millDiscover = mill.define.Discover[this.type]
 
 }

--- a/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
+++ b/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
@@ -1,0 +1,3 @@
+object MillBloop {
+
+}

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -344,6 +344,12 @@ object BuildImplementation {
       ),
     )
 
+    val millModuleBuildSettings: Seq[Def.Setting[_]] = List(
+      Keys.libraryDependencies ++= List(
+        Dependencies.mill
+      )
+    )
+
     import sbt.ScriptedPlugin.{autoImport => ScriptedKeys}
     val scriptedSettings: Seq[Def.Setting[_]] = List(
       ScriptedKeys.scriptedBufferLog := false,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,6 +26,7 @@ object Dependencies {
   val scalaNativeVersion = "0.3.7"
   val scalaJs06Version = "0.6.23"
   val scalaJs10Version = "1.0.0-M2"
+  val millVersion = "0.2.3"
 
   import sbt.librarymanagement.syntax.stringToOrganization
   val zinc = "ch.epfl.scala" %% "zinc" % zincVersion
@@ -68,4 +69,5 @@ object Dependencies {
   val scalaNativeTools = "org.scala-native" %% "tools" % scalaNativeVersion
   val scalaJsTools06 = "org.scala-js" %% "scalajs-tools" % scalaJs06Version
   val scalaJsTools10 = "org.scala-js" %% "scalajs-tools" % scalaJs10Version
+  val mill = "com.lihaoyi" %% "mill-scalalib"	% millVersion
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,5 +69,5 @@ object Dependencies {
   val scalaNativeTools = "org.scala-native" %% "tools" % scalaNativeVersion
   val scalaJsTools06 = "org.scala-js" %% "scalajs-tools" % scalaJs06Version
   val scalaJsTools10 = "org.scala-js" %% "scalajs-tools" % scalaJs10Version
-  val mill = "com.lihaoyi" %% "mill-scalalib"	% millVersion
+  val mill = "com.lihaoyi" %% "mill-scalalib"	% millVersion % Provided
 }


### PR DESCRIPTION
Adds a `bloop.integrations.mill.BloopModule` mill external module that can be used to generate bloop config from mill. The support is limited to JVM modules at the moment, and does not fill the "resolution" configuration element.

See https://www.lihaoyi.com/mill/page/modules.html#external-modules

## Usage :

1. add ```import $ivy.`ch.epfl.scala::mill-bloop:$bloopVersion` ``` to the build.sc of a project (it's probably possible to add it to a `~/.mill/ammonite/predef.sc` or a similar file instead)

2. run `mill bloop.integrations.mill.BloopModule/install` from the directory of the mill project.

## NB : 

Due to some [obscure bug](https://gitter.im/scalacenter/bloop?at=5b1ba015144c8c6fea8223c9) that prevents me from safely running non-brewed bloop, I'm only able to run `1.0.0-M10`, which fails to run the tests on my machine due to a bug in nuprocess.  