### PR TITLE
Upgrade to NuProcess 1.2.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val ipcsocketVersion = "1.0.0"
   val monixVersion = "2.3.3"
   val circeVersion = "0.9.3"
-  val nuprocessVersion = "1.2.3"
+  val nuprocessVersion = "1.2.4"
   val shapelessVersion = "2.3.3-lower-priority-coproduct"
   val scalaNativeVersion = "0.3.7"
   val scalaJs06Version = "0.6.23"


### PR DESCRIPTION
The new version includes a fix for a linking error in JDK10.

Fixes #584.

/cc @rom1dep