### PR TITLE
Remove `--isolated` and add `--propagate` / `--include-dependencies`

### DIFF
--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -73,8 +73,9 @@ object Commands {
       @ExtraName("p")
       @HelpMessage("The projects to clean.")
       project: List[String] = Nil,
-      @HelpMessage("Do not run clean for dependencies. By default, false.")
-      isolated: Boolean = false,
+      @ExtraName("propagate")
+      @HelpMessage("Run clean for the project's dependencies. By default, false.")
+      includeDependencies: Boolean = false,
       @Recurse cliOptions: CliOptions = CliOptions.default,
   ) extends RawCommand
 
@@ -116,8 +117,9 @@ object Commands {
       @ExtraName("p")
       @HelpMessage("The project to test (will be inferred from remaining cli args).")
       project: String = "",
-      @HelpMessage("Do not run tests for dependencies. By default, false.")
-      isolated: Boolean = false,
+      @ExtraName("propagate")
+      @HelpMessage("Run tests for the project dependencies. By default, false.")
+      includeDependencies: Boolean = false,
       @ExtraName("o")
       @HelpMessage("The list of test suite filters to test for only.")
       only: List[String] = Nil,

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -198,7 +198,7 @@ object Interpreter {
           val cwd = cmd.cliOptions.common.workingPath
           compileAnd(state, project, reporterConfig, false, sequential, "`test`") { state =>
             val testEventHandler = new LoggingEventHandler(state.logger)
-            Tasks.test(state, project, cwd, cmd.isolated, cmd.args, testFilter, testEventHandler)
+            Tasks.test(state, project, cwd, cmd.includeDependencies, cmd.args, testFilter, testEventHandler)
           }
         }
         if (cmd.watch) watch(project, state, doTest _)
@@ -394,7 +394,7 @@ object Interpreter {
   private def clean(cmd: Commands.Clean, state: State): Task[State] = {
     val (projects, missing) = lookupProjects(cmd.project, state)
     if (missing.isEmpty)
-      Tasks.clean(state, projects, cmd.isolated).map(_.mergeStatus(ExitStatus.Ok))
+      Tasks.clean(state, projects, cmd.includeDependencies).map(_.mergeStatus(ExitStatus.Ok))
     else Task.now(reportMissing(missing, state))
   }
 


### PR DESCRIPTION
Fixes https://github.com/scalacenter/bloop/issues/578.

This commit does not implement `--cascade`, a new ticket is open for
that and will be added in 1.1.0
https://github.com/scalacenter/bloop/issues/589.