### PR TITLE
Remove default dependency between test sources

### DIFF
--- a/build-integrations/global/plugins.sbt
+++ b/build-integrations/global/plugins.sbt
@@ -12,10 +12,17 @@ unmanagedSourceDirectories in Compile ++= {
   val bloopBaseDir = root.getParentFile.getParentFile.getAbsoluteFile
   val integrationsMainDir = bloopBaseDir / "integrations"
   val pluginMainDir = integrationsMainDir / "sbt-bloop" / "src" / "main"
+  val scalaDependentDir = {
+    val scalaVersion = Keys.scalaBinaryVersion.value
+    if (scalaVersion == "2.10")
+      bloopBaseDir / "config" / "src" / "main" / s"scala-${Keys.scalaBinaryVersion.value}"
+    else bloopBaseDir / "config" / "src" / "main" / s"scala-2.11-12"
+  }
+
   List(
     root / "src" / "main" / "scala",
     bloopBaseDir / "config" / "src" / "main" / "scala",
-    bloopBaseDir / "config" / "src" / "main" / s"scala-${Keys.scalaBinaryVersion.value}",
+    scalaDependentDir,
     pluginMainDir / "scala",
     pluginMainDir / s"scala-sbt-${Keys.sbtBinaryVersion.value}"
   )

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -367,7 +367,9 @@ object BloopDefaults {
             logger.warn(Feedback.unknownConfigurations(project, unknown, ref))
             s"${ref.project}-test"
         }
-      case None => projectNameFromString(ref.project, configuration)
+      case None =>
+        // If no configuration, default is `Compile` dependency (see scripted tests `cross-compile-test-configuration`)
+        projectNameFromString(ref.project, Compile)
     }
   }
 
@@ -615,6 +617,9 @@ object BloopDefaults {
             project.dependencies.map(d => projectDependencyName(d, configuration, project, logger))
           val configDependencies =
             eligibleDepsFromConfig.value.map(c => projectNameFromString(project.id, c))
+          /*println(s"[${projectName}] Classpath dependencies ${classpathProjectDependencies}")
+            println(s"[${projectName}] Dependencies from configurations ${configDependencies}")*/
+
           // The distinct here is important to make sure that there are no repeated project deps
           (classpathProjectDependencies ++ configDependencies).distinct.toList
         }

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/test
@@ -1,6 +1,7 @@
 > bar/test:compile
 > baz/compile
 > woo/test:compile
+-> yay/test:compile
 > bloopInstall
 > checkBloopFile
 $ copy-file changes/export-jars.sbt export-jars.sbt

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/yay/src/test/scala/D.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/yay/src/test/scala/D.scala
@@ -1,0 +1,5 @@
+package woo
+
+import foo.{A, ATest}
+
+class D extends ATest


### PR DESCRIPTION
Fixes https://github.com/scalacenter/bloop/issues/599.

The fix is just obvious: it doesn't use `configuration` when no
configuration is used, and instead relies on the default `Compile`.