### PR TITLE
Enable old project in benchmarks again

### DIFF
--- a/bin/run-benchmarks.sh
+++ b/bin/run-benchmarks.sh
@@ -60,14 +60,14 @@ main() {
 
     SBT_BLOOP_BENCHMARKS=(
       "$BLOOP_MEDIUM_JMH_OPTIONS -p project=sbt -p projectName=sbtRoot"
-      "$BLOOP_LARGE_JMH_OPTIONS -p project=scala -p projectName=compiler"
+      "$BLOOP_LARGE_JMH_OPTIONS -p project=frontend -p projectName=root"
+      "$BLOOP_LARGE_JMH_OPTIONS -p project=akka -p projectName=akka"
+      "$BLOOP_LARGE_JMH_OPTIONS -p project=spark -p projectName=examples"
+      # "$BLOOP_LARGE_JMH_OPTIONS -p project=scala -p projectName=compiler"
       "$BLOOP_SMALL_JMH_OPTIONS -p project=utest -p projectName=root"
       "$BLOOP_SMALL_JMH_OPTIONS -p project=versions -p projectName=versions"
       "$BLOOP_SMALL_JMH_OPTIONS -p project=with-tests -p projectName=with-tests"
-      "$BLOOP_LARGE_JMH_OPTIONS -p project=frontend -p projectName=root"
-      "$BLOOP_LARGE_JMH_OPTIONS -p project=akka -p projectName=akka"
       # "$BLOOP_LARGE_JMH_OPTIONS -p project=lichess -p projectName=lila-test"
-      "$BLOOP_LARGE_JMH_OPTIONS -p project=spark -p projectName=examples"
     )
 
     for benchmark in "${SBT_BLOOP_BENCHMARKS[@]}"; do

--- a/bin/run-benchmarks.sh
+++ b/bin/run-benchmarks.sh
@@ -37,7 +37,7 @@ main() {
     # This ensures we cannot run benchmarks concurrently (& there are no stale benchmark processes)
     (
       set -o pipefail
-      (ps -C java -o pid && echo "A java process was found running.") | tee "$LOG_FILE"
+      ((ps -C java -o pid && echo "A java process was found running.") | tee "$LOG_FILE") || exit 1
     )
 
     # Delete the directory to start afresh (mkdir it)
@@ -58,7 +58,7 @@ main() {
     git submodule update --init --recursive
 
     echo "Setting up the machine before benchmarks..."
-    /bin/bash "$BLOOP_HOME/benchmark-bridge/scripts/benv" set
+    /bin/bash "$BLOOP_HOME/benchmark-bridge/scripts/benv" set || exit 1
 
     SBT_COMMANDS="$SBT_COMMANDS;integrationSetUpBloop"
 

--- a/bin/run-benchmarks.sh
+++ b/bin/run-benchmarks.sh
@@ -81,7 +81,7 @@ main() {
       "$BLOOP_MEDIUM_JMH_OPTIONS -p project=sbt -p projectName=sbtRoot"
       "$BLOOP_LARGE_JMH_OPTIONS -p project=frontend -p projectName=root"
       "$BLOOP_GIGANTIC_JMH_OPTIONS -p project=akka -p projectName=akka"
-      "$BLOOP_LARGE_JMH_OPTIONS -p project=spark -p projectName=examples"
+      "$BLOOP_GIGANTIC_JMH_OPTIONS -p project=spark -p projectName=examples"
       # "$BLOOP_LARGE_JMH_OPTIONS -p project=scala -p projectName=compiler"
       "$BLOOP_SMALL_JMH_OPTIONS -p project=utest -p projectName=root"
       "$BLOOP_SMALL_JMH_OPTIONS -p project=versions -p projectName=versions"

--- a/bin/run-benchmarks.sh
+++ b/bin/run-benchmarks.sh
@@ -63,7 +63,7 @@ main() {
     git submodule update --init --recursive
 
     echo "Setting up the machine before benchmarks..."
-    /bin/bash "$BLOOP_HOME/benchmark-bridge/scripts/benv" set || exit 1
+    /bin/bash "$BLOOP_HOME/benchmark-bridge/scripts/benv" check || exit 1
 
     SBT_COMMANDS="$SBT_COMMANDS;integrationSetUpBloop"
 

--- a/bin/run-benchmarks.sh
+++ b/bin/run-benchmarks.sh
@@ -63,7 +63,7 @@ main() {
     git submodule update --init --recursive
 
     echo "Setting up the machine before benchmarks..."
-    /bin/bash "$BLOOP_HOME/benchmark-bridge/scripts/benv" check || exit 1
+    /bin/bash "$BLOOP_HOME/benchmark-bridge/scripts/benv" set -nb -ns -nf -nl -ni || exit 1
 
     SBT_COMMANDS="$SBT_COMMANDS;integrationSetUpBloop"
 

--- a/bin/run-benchmarks.sh
+++ b/bin/run-benchmarks.sh
@@ -60,13 +60,13 @@ main() {
 
     SBT_BLOOP_BENCHMARKS=(
       "$BLOOP_MEDIUM_JMH_OPTIONS -p project=sbt -p projectName=sbtRoot"
-      #"$BLOOP_LARGE_JMH_OPTIONS -p project=scala -p projectName=compiler"
-      #"$BLOOP_SMALL_JMH_OPTIONS -p project=utest -p projectName=root"
-      #"$BLOOP_SMALL_JMH_OPTIONS -p project=versions -p projectName=versions"
-      #"$BLOOP_SMALL_JMH_OPTIONS -p project=with-tests -p projectName=with-tests"
+      "$BLOOP_LARGE_JMH_OPTIONS -p project=scala -p projectName=compiler"
+      "$BLOOP_SMALL_JMH_OPTIONS -p project=utest -p projectName=root"
+      "$BLOOP_SMALL_JMH_OPTIONS -p project=versions -p projectName=versions"
+      "$BLOOP_SMALL_JMH_OPTIONS -p project=with-tests -p projectName=with-tests"
       "$BLOOP_LARGE_JMH_OPTIONS -p project=frontend -p projectName=root"
       "$BLOOP_LARGE_JMH_OPTIONS -p project=akka -p projectName=akka"
-      "$BLOOP_LARGE_JMH_OPTIONS -p project=lichess -p projectName=lila-test"
+      # "$BLOOP_LARGE_JMH_OPTIONS -p project=lichess -p projectName=lila-test"
       "$BLOOP_LARGE_JMH_OPTIONS -p project=spark -p projectName=examples"
     )
 


### PR DESCRIPTION
The previous projects were not being benchmarked after the experiments with
pipelined compilation. Let's get a solid baseline with these projects and then
improve bloop from there.