### PR TITLE
Update Mill

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,7 +28,7 @@ object Dependencies {
   val scalaNativeVersion = "0.3.7"
   val scalaJs06Version = "0.6.23"
   val scalaJs10Version = "1.0.0-M3"
-  val millVersion = "0.2.3"
+  val millVersion = "0.2.6"
 
   import sbt.librarymanagement.syntax.stringToOrganization
   val zinc = "ch.epfl.scala" %% "zinc" % zincVersion

--- a/website/content/docs/installation.md
+++ b/website/content/docs/installation.md
@@ -272,6 +272,8 @@ Then run `bloopInstall` from the mill command-line:
 mill bloop.integrations.mill.Bloop/install
 ```
 
+Note that the plugin will always be built for the latest Mill version, older versions may not be supported.
+
 ### Start bloop
 
 Before using the bloop client, you need to start the Bloop server. There is usually only one bloop server running in a machine.


### PR DESCRIPTION
Newer Mill versions have a slightly different macro for expanding a Discovery,
so the current mill-bloop.jar doesn't work with newer Mill versions anymore