### PR TITLE
Make compile watch clear screen before first run

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -109,6 +109,8 @@ object Interpreter {
         State.stateCache.updateBuild(state)
     }
 
+    if (!BspServer.isWindows)
+      state.logger.info("\u001b[H\u001b[2J")
     // Force the first execution before relying on the file watching task
     fg(state).flatMap(newState => watcher.watch(newState, fg))
   }


### PR DESCRIPTION
Adding a clear screen just before forcing the first execution of file watch task