### PR TITLE
Print error if download fails in install.py

### DIFF
--- a/bin/install.py
+++ b/bin/install.py
@@ -66,7 +66,7 @@ ZSH_COMPLETION_DIR = join(BLOOP_INSTALLATION_TARGET, "zsh")
 BASH_COMPLETION_DIR = join(BLOOP_INSTALLATION_TARGET, "bash")
 SYSTEMD_SERVICE_DIR = join(BLOOP_INSTALLATION_TARGET, "systemd")
 XDG_DIR = join(BLOOP_INSTALLATION_TARGET, "xdg")
-COURSIER_URL = "https://github.com/alexarchambault/coursier/raw/v" + args.coursier + "/coursier"
+COURSIER_URL = "https://github.com/coursier/coursier/raw/v" + args.coursier + "/coursier"
 
 # If this is not a released version of Bloop, we need to extract the commit SHA
 # to know how to download the completion and startup scripts.

--- a/bin/install.py
+++ b/bin/install.py
@@ -106,7 +106,8 @@ def download(url, target):
         with open(target, "wb") as file:
             copyfileobj(socket, file, BUFFER_SIZE)
         socket.close()
-    except IOError:
+    except IOError as e:
+        print(e)
         print("Couldn't download %s, please try again." % url)
         sys.exit(1)
 


### PR DESCRIPTION
Hopefully this will make it easier to diagnose issues such as #650 in the future.

Also update `COURSIER_URL`: both http://get-coursier.io and https://github.com/alexarchambault/coursier redirect to https://github.com/coursier/coursier.