### PR TITLE
Clean all projects by default

### DIFF
--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -79,7 +79,7 @@ object Commands {
 
   case class Clean(
       @ExtraName("p")
-      @HelpMessage("The projects to clean.")
+      @HelpMessage("The projects to clean (you can specify multiple). By default, all.")
       project: List[String] = Nil,
       @ExtraName("propagate")
       @HelpMessage("Run clean for the project's dependencies. By default, false.")

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -293,10 +293,14 @@ object Interpreter {
   }
 
   private def clean(cmd: Commands.Clean, state: State): Task[State] = {
-    val (projects, missing) = lookupProjects(cmd.project, state)
-    if (missing.isEmpty)
-      Tasks.clean(state, projects, cmd.includeDependencies).map(_.mergeStatus(ExitStatus.Ok))
-    else Task.now(reportMissing(missing, state))
+    if (cmd.project.isEmpty)
+      Tasks.clean(state, state.build.projects, cmd.includeDependencies).map(_.mergeStatus(ExitStatus.Ok))
+    else {
+      val (projects, missing) = lookupProjects(cmd.project, state)
+      if (missing.isEmpty)
+        Tasks.clean(state, projects, cmd.includeDependencies).map(_.mergeStatus(ExitStatus.Ok))
+      else Task.now(reportMissing(missing, state))
+    }
   }
 
   private def linkWithScalaJs(

--- a/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
@@ -90,6 +90,9 @@ object ResultsCache {
   private[ResultsCache] final val EmptyResult: PreviousResult =
     PreviousResult.of(Optional.empty[CompileAnalysis], Optional.empty[MiniSetup])
 
+  private[bloop] def forTests(logger: Logger): ResultsCache =
+    new ResultsCache(Map.empty, Map.empty, logger)
+
   def load(build: Build, cwd: AbsolutePath, logger: Logger): ResultsCache = {
     val handle = loadAsync(build, cwd, logger).runAsync(ExecutionContext.ioScheduler)
     Await.result(handle, Duration.Inf)

--- a/frontend/src/test/scala/bloop/tasks/CleanTaskSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/CleanTaskSpec.scala
@@ -104,6 +104,17 @@ class CleanTaskSpec {
     )
 
   @Test
+  def cleansAllProjectsByDefault: Unit =
+    cleanAndCheck(
+      Set(
+        "foo" -> Set.empty,
+        "bar" -> Set.empty
+      ),
+      Commands.Clean(Nil),
+      Set("foo", "bar")
+    )
+
+  @Test
   def errorsOnMissingProjects: Unit =
     cleanAndCheck(
       Set(

--- a/frontend/src/test/scala/bloop/tasks/CleanTaskSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/CleanTaskSpec.scala
@@ -50,7 +50,7 @@ class CleanTaskSpec {
         case (project, deps) => dummyProject(buildPath, project, deps)
       }
       val build = Build(buildPath, projects.toList)
-      val results = projects.foldLeft(ResultsCache.forTests(logger)) { (cache, project) =>
+      val results = projects.foldLeft(ResultsCache.forTests) { (cache, project) =>
         cache.addResult(project, Compiler.Result.Empty)
       }
       val state = State.forTests(build, CompilationHelpers.getCompilerCache(logger), logger)

--- a/frontend/src/test/scala/bloop/tasks/CleanTaskSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/CleanTaskSpec.scala
@@ -1,0 +1,118 @@
+package bloop.tasks
+
+import bloop.Compiler
+import bloop.cli.{Commands, ExitStatus}
+import bloop.data.Project
+import bloop.engine.{Build, Run, State}
+import bloop.engine.caches.ResultsCache
+import bloop.exec.JavaEnv
+import bloop.io.AbsolutePath
+import bloop.logging.BloopLogger
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.experimental.categories.Category
+
+@Category(Array(classOf[bloop.FastTests]))
+class CleanTaskSpec {
+
+  private def dummyProject(
+    buildPath: AbsolutePath,
+    name: String,
+    dependencies: Set[String]
+  ): Project =
+    TestUtil.makeProject(
+      buildPath.underlying,
+      name,
+      sources = Map.empty,
+      dependencies = dependencies,
+      scalaInstance = None,
+      javaEnv = JavaEnv.default
+    )
+
+  /**
+   * Executes the given `command` and checks if it cleaned `expected` projects.
+   *
+   * @param projectsWithDeps The projects contained in this build along with their dependencies.
+   * @param command          The command to execute.
+   * @param expectedProjects The projects expected to be cleaned by `command`.
+   * @param expectedStatus   The exit status expected to be set by `command`.
+   */
+  private def cleanAndCheck(
+    projectsWithDeps: Set[(String, Set[String])],
+    command: Commands.Clean,
+    expectedProjects: Set[String],
+    expectedStatus: ExitStatus = ExitStatus.Ok
+  ): Unit = {
+    TestUtil.withTemporaryDirectory { temp =>
+      val buildPath = AbsolutePath(temp)
+      val logger = BloopLogger.default("test-logger")
+      val projects = projectsWithDeps.map {
+        case (project, deps) => dummyProject(buildPath, project, deps)
+      }
+      val build = Build(buildPath, projects.toList)
+      val results = projects.foldLeft(ResultsCache.forTests(logger)) { (cache, project) =>
+        cache.addResult(project, Compiler.Result.Empty)
+      }
+      val state = State.forTests(build, CompilationHelpers.getCompilerCache(logger), logger)
+        .copy(results = results)
+
+      val cleanState = TestUtil.blockingExecute(Run(command), state)
+
+      val projectsLeft = cleanState.results.allSuccessful.map {
+        case (project, _) => project.name
+      }.toSet
+      val projectsCleaned = projectsWithDeps.map(_._1).toSet -- projectsLeft
+      assertEquals(expectedProjects, projectsCleaned)
+      assertEquals(expectedStatus, cleanState.status)
+    }
+  }
+
+  @Test
+  def cleansSingleProject: Unit =
+    cleanAndCheck(
+      Set(
+        "foo" -> Set("bar"),
+        "bar" -> Set.empty,
+        "baz" -> Set.empty
+      ),
+      Commands.Clean(List("foo")),
+      Set("foo")
+    )
+
+  @Test
+  def cleansMultipleProjects: Unit =
+    cleanAndCheck(
+      Set(
+        "foo" -> Set.empty,
+        "bar" -> Set.empty,
+        "baz" -> Set.empty
+      ),
+      Commands.Clean(List("foo", "bar")),
+      Set("foo", "bar")
+    )
+
+  @Test
+  def cleansDependentProjects: Unit =
+    cleanAndCheck(
+      Set(
+        "foo" -> Set("bar"),
+        "bar" -> Set.empty,
+        "baz" -> Set.empty
+      ),
+      Commands.Clean(List("foo"), includeDependencies = true),
+      Set("foo", "bar")
+    )
+
+  @Test
+  def errorsOnMissingProjects: Unit =
+    cleanAndCheck(
+      Set(
+        "foo" -> Set("bar"),
+        "bar" -> Set.empty,
+      ),
+      Commands.Clean(List("baz")),
+      Set(),
+      ExitStatus.merge(ExitStatus.UnexpectedError, ExitStatus.InvalidCommandLineOption)
+    )
+
+}

--- a/frontend/src/test/scala/bloop/tasks/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestUtil.scala
@@ -54,7 +54,6 @@ object TestUtil {
         // Check that this is a clean compile!
         val projects = state.build.projects
         assert(projects.forall(p => noPreviousAnalysis(p, state)))
-        val project = getProject(rootProjectName, state)
         val action = Run(Commands.Compile(rootProjectName, incremental = true))
         val compiledState = TestUtil.blockingExecute(action, state)
         afterCompile(compiledState)
@@ -206,10 +205,8 @@ object TestUtil {
   def runAndCheck(state: State, cmd: Commands.CompilingCommand)(
       check: List[(String, String)] => Unit): Unit = {
     val recordingLogger = new RecordingLogger
-    val recordingStream = ProcessLogger.toOutputStream(recordingLogger.info _)
     val commonOptions = state.commonOptions.copy(env = runAndTestProperties)
     val recordingState = state.copy(logger = recordingLogger).copy(commonOptions = commonOptions)
-    val project = getProject(cmd.project, recordingState)
     TestUtil.blockingExecute(Run(cmd), recordingState)
     check(recordingLogger.getMessages)
   }

--- a/website/content/docs/commands-reference.md
+++ b/website/content/docs/commands-reference.md
@@ -76,7 +76,7 @@ toc = true
 
 <dl>
   <dt><code>--project</code> or <code>-p</code> (type: <code>string*</code>)</dt>
-  <dd><p>The projects to clean.</p></dd>
+  <dd><p>The projects to clean (you can specify multiple). By default, all.</p></dd>
   <dt><code>--include-dependencies</code> or <code>--propagate</code> (type: <code>bool</code>)</dt>
   <dd><p>Run clean for the project's dependencies. By default, false.</p></dd>
   <dt><code>--config-dir</code> or <code>-c</code> (type: <code>path?</code>)</dt>
@@ -91,7 +91,9 @@ toc = true
 
 ### Examples
 
+  * <samp>bloop clean</samp>
   * <samp>bloop clean foobar</samp>
+  * <samp>bloop clean foobar baz</samp>
   * <samp>bloop clean foobar --propagate</samp>
 
 ## `bloop compile`


### PR DESCRIPTION
Also add `CleanTaskSpec`, fix documentation and remove some unused variables/parameters.

Closes #593.