### PR TITLE
[DOCS] add git clone instructions to 'Opening up our sbt build' section

### DIFF
--- a/website/content/docs/developer-documentation.md
+++ b/website/content/docs/developer-documentation.md
@@ -30,13 +30,20 @@ process.
 
 ## Opening up our sbt build
 
-Bloop builds with sbt. Run sbt in the base directory to load the project.
+Bloop builds with sbt and uses git submodules. To avoid getting cryptic errors like
+"No project 'compilation' in 'file:///Users/ashwinraja/Development/bloop/benchmark-bridge/'"
+you need to clone the repository and initialize the submodules *before* you run sbt.
+
+If you haven't yet cloned bloop, run the following commands:
 
 ```sh
 $ git clone --recursive https://github.com/scalacenter/bloop.git
 $ cd bloop
 $ sbt
 ```
+
+If you forgot to initialize git submodules, run `git submodule update --init` in the bloop
+repository.
 
 ## Building Bloop locally
 

--- a/website/content/docs/developer-documentation.md
+++ b/website/content/docs/developer-documentation.md
@@ -32,6 +32,12 @@ process.
 
 Bloop builds with sbt. Run sbt in the base directory to load the project.
 
+```sh
+$ git clone --recursive https://github.com/scalacenter/bloop.git
+$ cd bloop
+$ sbt
+```
+
 ## Building Bloop locally
 
 The following sequence of commands is sufficient to build Bloop, publish it


### PR DESCRIPTION
Just making it very explicit that you need to `git clone --recursive https://github.com/scalacenter/bloop.git` in this section, since it tripped me up.

