### PR TITLE
Use bsp 1.0.0 and implements its new methods

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -6,14 +6,15 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import bloop.{Compiler, ScalaInstance}
 import bloop.cli.{Commands, ExitStatus}
+import bloop.config.Config.Platform
 import bloop.data.Project
-import bloop.engine.tasks.Tasks
+import bloop.engine.tasks.{ScalaJsToolchain, ScalaNativeToolchain, Tasks}
 import bloop.engine.{Action, Dag, Exit, Interpreter, Run, State}
 import bloop.io.{AbsolutePath, RelativePath}
 import bloop.logging.BspServerLogger
-import bloop.testing.{BspLoggingEventHandler, LoggingEventHandler, TestInternals}
+import bloop.testing.{BspLoggingEventHandler, TestInternals}
 import monix.eval.Task
-import ch.epfl.scala.bsp.{BuildTargetIdentifier, ScalaTestClassesItem, ScalaTestClassesParams, endpoints}
+import ch.epfl.scala.bsp.{BuildTargetIdentifier, endpoints}
 
 import scala.meta.jsonrpc.{JsonRpcClient, Response => JsonRpcResponse, Services => JsonRpcServices}
 import xsbti.Problem
@@ -46,6 +47,7 @@ final class BloopBspServices(
     .requestAsync(endpoints.BuildTarget.scalacOptions)(scalacOptions(_))
     .requestAsync(endpoints.BuildTarget.compile)(compile(_))
     .requestAsync(endpoints.BuildTarget.test)(test(_))
+    .requestAsync(endpoints.BuildTarget.run)(run(_))
 
   // Internal state, think how to make this more elegant.
   @volatile private var currentState: State = null
@@ -118,23 +120,23 @@ final class BloopBspServices(
       }
   }
 
+  def mapToProject(target: bsp.BuildTargetIdentifier): Either[ProtocolError, ProjectMapping] = {
+    val uri = target.uri
+    ProjectUris.getProjectDagFromUri(uri.value, currentState) match {
+      case Left(errorMsg) => Left(JsonRpcResponse.parseError(errorMsg))
+      case Right(Some(project)) => Right((target, project))
+      case Right(None) => Left(JsonRpcResponse.invalidRequest(s"No project associated with $uri"))
+    }
+  }
+
   type ProjectMapping = (bsp.BuildTargetIdentifier, Project)
   private def mapToProjects(
       targets: Seq[bsp.BuildTargetIdentifier]): Either[ProtocolError, Seq[ProjectMapping]] = {
-    def getProject(target: bsp.BuildTargetIdentifier): Either[ProtocolError, ProjectMapping] = {
-      val uri = target.uri
-      ProjectUris.getProjectDagFromUri(uri.value, currentState) match {
-        case Left(errorMsg) => Left(JsonRpcResponse.parseError(errorMsg))
-        case Right(Some(project)) => Right((target, project))
-        case Right(None) => Left(JsonRpcResponse.invalidRequest(s"No project associated with $uri"))
-      }
-    }
-
     targets.headOption match {
       case Some(head) =>
-        val init = getProject(head).map(m => m :: Nil)
+        val init = mapToProject(head).map(m => m :: Nil)
         targets.tail.foldLeft(init) {
-          case (acc, t) => acc.flatMap(ms => getProject(t).map(m => m :: ms))
+          case (acc, t) => acc.flatMap(ms => mapToProject(t).map(m => m :: ms))
         }
       case None =>
         Left(
@@ -224,6 +226,73 @@ final class BloopBspServices(
                   case Right(state) =>
                     currentState = state
                     Right(bsp.TestResult(None, None))
+                }
+
+              case Left(error) => Task.now(Left(error))
+            }
+          }
+      }
+    }
+  }
+
+  def run(params: bsp.RunParams): BspResponse[bsp.RunResult] = {
+    def run(
+        id: BuildTargetIdentifier,
+        project: Project,
+        state: State
+    ): Task[State] = {
+      import Interpreter.{linkWithScalaJs, linkWithScalaNative}
+      val cwd = state.commonOptions.workingPath
+      val cmd = Commands.Run(project.name)
+      Interpreter.getMainClass(state, project, cmd.main) match {
+        case Left(state) =>
+          Task.now(sys.error(s"Failed to run main class in ${project.name}"))
+        case Right(mainClass) =>
+          project.platform match {
+            case Platform.Native(config, _) =>
+              val target = ScalaNativeToolchain.linkTargetFrom(config, project.out)
+              linkWithScalaNative(cmd, project, state, mainClass, target, config).flatMap { state =>
+                val args = (target.syntax +: cmd.args).toArray
+                if (!state.status.isOk) Task.now(state)
+                else Tasks.runNativeOrJs(state, project, cwd, mainClass, args)
+              }
+            case Platform.Js(config, _) =>
+              val target = ScalaJsToolchain.linkTargetFrom(config, project.out)
+              linkWithScalaJs(cmd, project, state, mainClass, target, config).flatMap { state =>
+                // We use node to run the program (is this a special case?)
+                val args = ("node" +: target.syntax +: cmd.args).toArray
+                if (!state.status.isOk) Task.now(state)
+                else Tasks.runNativeOrJs(state, project, cwd, mainClass, args)
+              }
+            case Platform.Jvm(_, _) =>
+              Tasks.runJVM(state, project, cwd, mainClass, cmd.args.toArray)
+          }
+      }
+    }
+
+    ifInitialized {
+      mapToProject(params.target) match {
+        case Left(error) => Task.now(Left(error))
+        case Right((tid, project)) =>
+          compileProjects(List((tid, project))).flatMap { compileResult =>
+            compileResult match {
+              case Right(result) =>
+                var isCancelled: Boolean = false
+                val runTask = run(tid, project, currentState)
+                  .doOnCancel(Task { isCancelled = true; () })
+
+                runTask.materialize.map(_.toEither).map {
+                  case Left(e) =>
+                    Left(JsonRpcResponse.internalError(s"Failed test execution: ${e.getMessage}"))
+                  case Right(state) =>
+                    currentState = state
+                    val status = {
+                      val exitStatus = state.status
+                      if (isCancelled) bsp.ExitStatus.Cancelled
+                      else if (exitStatus.isOk) bsp.ExitStatus.Ok
+                      else bsp.ExitStatus.Error
+                    }
+                    Right(bsp.RunResult(None, status))
                 }
 
               case Left(error) => Task.now(Left(error))

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -9,7 +9,7 @@ import bloop.cli.{Commands, ExitStatus}
 import bloop.data.Project
 import bloop.engine.{Action, Dag, Exit, Interpreter, Run, State}
 import bloop.io.{AbsolutePath, RelativePath}
-import bloop.logging.BspLogger
+import bloop.logging.BspServerLogger
 import monix.eval.Task
 import ch.epfl.scala.bsp.endpoints
 
@@ -32,8 +32,8 @@ final class BloopBspServices(
   private type BspResponse[T] = Task[Either[ProtocolError, T]]
 
   // Disable ansii codes for now so that the BSP clients don't get unescaped color codes
-  private val bspForwarderLogger = BspLogger(callSiteState, client, false)
-  final val services = JsonRpcServices.empty
+  private val bspForwarderLogger = BspServerLogger(callSiteState, client, false)
+  final val services = JsonRpcServices.empty(bspForwarderLogger)
     .requestAsync(endpoints.Build.initialize)(initialize(_))
     .notification(endpoints.Build.initialized)(initialized(_))
     .request(endpoints.Build.shutdown)(shutdown(_))

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -295,7 +295,7 @@ object Interpreter {
     }
   }
 
-  private def linkWithScalaJs(
+  private[bloop] def linkWithScalaJs(
       cmd: LinkingCommand,
       project: Project,
       state: State,
@@ -324,7 +324,7 @@ object Interpreter {
     }
   }
 
-  private def linkWithScalaNative(
+  private[bloop] def linkWithScalaNative(
       cmd: LinkingCommand,
       project: Project,
       state: State,
@@ -365,7 +365,7 @@ object Interpreter {
     }
   }
 
-  private def link(cmd: Commands.Link, state: State, sequential: Boolean): Task[State] = {
+  private[bloop] def link(cmd: Commands.Link, state: State, sequential: Boolean): Task[State] = {
     def doLink(project: Project)(state: State): Task[State] = {
       compileAnd(cmd, state, project, false, sequential, "`link`") { state =>
         getMainClass(state, project, cmd.main) match {
@@ -444,7 +444,7 @@ object Interpreter {
       .mergeStatus(ExitStatus.InvalidCommandLineOption)
   }
 
-  private def getMainClass(
+  private[bloop] def getMainClass(
       state: State,
       project: Project,
       cliMainClass: Option[String]

--- a/frontend/src/main/scala/bloop/engine/tasks/CompilationTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompilationTask.scala
@@ -5,7 +5,7 @@ import bloop.data.Project
 import bloop.engine._
 import bloop.engine.tasks.compilation._
 import bloop.io.AbsolutePath
-import bloop.logging.{BspLogger, Logger}
+import bloop.logging.{BspServerLogger, Logger}
 import bloop.reporter._
 import bloop.{CompileInputs, CompileMode, Compiler}
 import monix.eval.Task
@@ -211,7 +211,7 @@ object CompilationTask {
       logger: Logger
   ): Reporter = {
     logger match {
-      case bspLogger: BspLogger =>
+      case bspLogger: BspServerLogger =>
         // Disable reverse order to show errors as they come for BSP clients
         new BspReporter(project, bspLogger, cwd, identity, config.copy(reverseOrder = false))
       case _ => new LogReporter(logger, cwd, identity, config)

--- a/frontend/src/main/scala/bloop/logging/BspClientLogger.scala
+++ b/frontend/src/main/scala/bloop/logging/BspClientLogger.scala
@@ -1,0 +1,37 @@
+package bloop.logging
+
+import scribe.LogRecord
+
+/** Creates a logger that extends scribe's `LoggerSupport` for BSP's `LanguageClient`. */
+final class BspClientLogger[L <: Logger](val underlying: L)
+    extends Logger
+    with scribe.LoggerSupport {
+
+  override val name: String = underlying.name
+  override def isVerbose: Boolean = underlying.isVerbose
+  override def asDiscrete: Logger = new BspClientLogger(underlying.asDiscrete)
+  override def asVerbose: Logger = new BspClientLogger(underlying.asVerbose)
+
+  override def ansiCodesSupported: Boolean = underlying.ansiCodesSupported()
+  override def debug(msg: String): Unit = underlying.debug(msg)
+  override def trace(t: Throwable): Unit = underlying.trace(t)
+  override def error(msg: String): Unit = underlying.error(msg)
+  override def warn(msg: String): Unit = underlying.warn(msg)
+  override def info(msg: String): Unit = underlying.info(msg)
+
+  override def log[M](record: LogRecord[M]): Unit = {
+    import scribe.Level
+    val msg = record.message
+    record.level match {
+      case Level.Info => info(msg)
+      case Level.Error => error(msg)
+      case Level.Warn => warn(msg)
+      case Level.Debug => debug(msg)
+      case Level.Trace =>
+        record.throwable match {
+          case Some(t) => trace(t)
+          case None => error(record.message)
+        }
+    }
+  }
+}

--- a/frontend/src/main/scala/bloop/reporter/BspReporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/BspReporter.scala
@@ -2,14 +2,14 @@ package bloop.reporter
 
 import bloop.data.Project
 import bloop.io.AbsolutePath
-import bloop.logging.BspLogger
+import bloop.logging.BspServerLogger
 import xsbti.Position
 
 import scala.collection.mutable
 
 final class BspReporter(
     val project: Project,
-    override val logger: BspLogger,
+    override val logger: BspServerLogger,
     override val cwd: AbsolutePath,
     sourcePositionMapper: Position => Position,
     override val config: ReporterConfig,

--- a/frontend/src/test/scala/bloop/ClasspathHashingTest.scala
+++ b/frontend/src/test/scala/bloop/ClasspathHashingTest.scala
@@ -7,12 +7,11 @@ import bloop.logging.RecordingLogger
 import bloop.tasks.TestUtil
 import org.junit.Test
 import org.junit.experimental.categories.Category
-import sbt.internal.inc.bloop.ClasspathHashing
 
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.duration.FiniteDuration
 
 @Category(Array(classOf[bloop.FastTests]))
-class ClasspathHashing {
+class ClasspathHashingTest {
   @Test
   def detectsMacrosInClasspath(): Unit = {
     val logger = new RecordingLogger()
@@ -20,6 +19,7 @@ class ClasspathHashing {
       .resolve("ch.epfl.scala", "zinc_2.12", "1.2.1+97-636ca091", logger)
       .filter(_.syntax.endsWith(".jar"))
 
+    import sbt.internal.inc.bloop.ClasspathHashing
     Timer.timed(logger) {
       val duration = FiniteDuration(7, TimeUnit.SECONDS)
       TestUtil.await(duration) {

--- a/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
@@ -4,7 +4,7 @@ import java.nio.file.Files
 
 import bloop.cli.Commands
 import bloop.io.AbsolutePath
-import bloop.logging.{RecordingLogger, Slf4jAdapter}
+import bloop.logging.{BspClientLogger, RecordingLogger, Slf4jAdapter}
 import bloop.tasks.TestUtil
 import ch.epfl.scala.bsp
 import ch.epfl.scala.bsp.endpoints
@@ -13,11 +13,10 @@ import monix.{eval => me}
 import org.scalasbt.ipcsocket.Win32NamedPipeSocket
 
 import scala.concurrent.duration.FiniteDuration
-import scala.meta.jsonrpc.{BaseProtocolMessage, Response, Services}
-import scala.meta.lsp.{LanguageClient, LanguageServer}
+import scala.meta.jsonrpc.{BaseProtocolMessage, LanguageClient, LanguageServer, Response, Services}
 
 object BspClientTest {
-  def cleanUpLastResources(cmd: Commands.ValidatedBsp) = {
+  def cleanUpLastResources(cmd: Commands.ValidatedBsp): Unit = {
     cmd match {
       case cmd: Commands.WindowsLocalBsp => ()
       case cmd: Commands.UnixLocalBsp =>
@@ -44,9 +43,8 @@ object BspClientTest {
   val scheduler: Scheduler = Scheduler(java.util.concurrent.Executors.newFixedThreadPool(4),
                                        ExecutionModel.AlwaysAsyncExecution)
 
-  import com.typesafe.scalalogging.{Logger => ScalaLogger}
-  def createServices(logger: ScalaLogger): Services = {
-    Services.empty
+  def createServices(logger: BspClientLogger[_]): Services = {
+    Services.empty(logger)
       .notification(endpoints.Build.showMessage) {
         case bsp.ShowMessageParams(bsp.MessageType.Log, _, _, msg) => logger.debug(msg)
         case bsp.ShowMessageParams(bsp.MessageType.Info, _, _, msg) => logger.info(msg)
@@ -77,13 +75,12 @@ object BspClientTest {
   def runTest[T](
       cmd: Commands.ValidatedBsp,
       configDirectory: AbsolutePath,
-      logger0: TestLogger,
-      customServices: Services => Services = identity[Services],
+      logger: BspClientLogger[_],
+      customServices: Services => Services = identity[Services]
   )(runEndpoints: LanguageClient => me.Task[Either[Response.Error, T]]): Unit = {
-    val logger = ScalaLogger.apply(logger0)
     val workingPath = cmd.cliOptions.common.workingPath
     val projectName = workingPath.underlying.getFileName().toString()
-    val state = TestUtil.loadTestProject(projectName).copy(logger = logger0.underlying)
+    val state = TestUtil.loadTestProject(projectName).copy(logger = logger)
 
     // Clean all the project results to avoid reusing previous compiles.
     state.results.cleanSuccessful(state.build.projects)
@@ -95,7 +92,7 @@ object BspClientTest {
       val out = socket.getOutputStream
 
       implicit val lsClient = new LanguageClient(out, logger)
-      val messages = BaseProtocolMessage.fromInputStream(in)
+      val messages = BaseProtocolMessage.fromInputStream(in, logger)
       val services = customServices(createServices(logger))
       val lsServer = new LanguageServer(messages, lsClient, services, scheduler, logger)
       val runningClientServer = lsServer.startTask.runAsync(scheduler)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
 
   val nailgunVersion = "0c8b937b"
   val zincVersion = "1.2.1+104-55d3c3d5"
-  val bspVersion = "1.0.0-M4"
+  val bspVersion = "1.0.0"
   val scalazVersion = "7.2.20"
   val coursierVersion = "1.1.0-M3"
   val lmVersion = "1.0.0"


### PR DESCRIPTION
This pull request upgrades to 1.0.0 to implements its new methods, which we didn't implement because Intellij didn't implement us yet. However, as they start to be implemented in IntelliJ and other clients, we add the implementations so that the existing clients, like IntelliJ or [Metals](https://github.com/scalameta/metals/), can start benefiting from them.
  
We miss the following items to be fully implementing BSP 1.0.0:
  
- [x] `buildTarget/test`
- [x] `buildTarget/run`
- [ ] `buildTarget/scalaTestClasses` 
- [ ] `buildTarget/scalaMainClasses`
- [ ] Notifications on build target modification
- [ ] Change of namespace to be compliant with 1.0.0
  
Alongside these missing items, I'd like to implement request buffering in bloop so that the clients can indiscriminately send request without taking into account whether they finished or not. I suspect this is not going to be easy.
  
I'm not sure yet how I'm going to organize my work to implement the missing entrypoints, but it's likely I will not do everything in this PR. I'm mostly trying to prioritize for the most important things.