### PR TITLE
Initialize internal exit status list after sourcecode

### DIFF
--- a/frontend/src/main/scala/bloop/cli/ExitStatus.scala
+++ b/frontend/src/main/scala/bloop/cli/ExitStatus.scala
@@ -20,18 +20,19 @@ object ExitStatus {
     result
   }
 
-  private val all: List[ExitStatus] = allInternal.toList
-  private def codeToName(code: Int): String = {
+  // FORMAT: OFF
+  val Ok, UnexpectedError, ParseError, InvalidCommandLineOption, CompilationError, LinkingError, TestExecutionError, RunError: ExitStatus = generateExitStatus
+  // FORMAT: ON
+
+  // The initialization of all must come after the invocations to `generateExitStatus`
+  private lazy val all: List[ExitStatus] = allInternal.toList
+  private[bloop] def codeToName(code: Int): String = {
     if (code == 0) Ok.name
     else {
       val names = all.collect { case exit if (exit.code & code) != 0 => exit.name }
       names.mkString("+")
     }
   }
-
-  // FORMAT: OFF
-  val Ok, UnexpectedError, ParseError, InvalidCommandLineOption, CompilationError, LinkingError, TestExecutionError, RunError: ExitStatus = generateExitStatus
-  // FORMAT: ON
 
   def apply(code: Int): ExitStatus = {
     if (cache.contains(code)) cache.get(code)

--- a/frontend/src/test/scala/bloop/tasks/CompilationTaskTest.scala
+++ b/frontend/src/test/scala/bloop/tasks/CompilationTaskTest.scala
@@ -19,7 +19,8 @@ import bloop.tasks.TestUtil.{
   checkAfterCleanCompilation,
   getProject,
   hasPreviousResult,
-  noPreviousAnalysis
+  noPreviousAnalysis,
+  ensureCompilationInAllTheBuild
 }
 
 import scala.concurrent.duration.FiniteDuration
@@ -486,11 +487,5 @@ class CompilationTaskTest {
 
     val analysisOutFile = state.build.getProjectFor(testProject).get.analysisOut
     assertTrue(Files.exists(analysisOutFile.underlying))
-  }
-
-  def ensureCompilationInAllTheBuild(state: State): Unit = {
-    state.build.projects.foreach { p =>
-      assertTrue(s"${p.name} was not compiled", hasPreviousResult(p, state))
-    }
   }
 }

--- a/frontend/src/test/scala/bloop/tasks/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestUtil.scala
@@ -18,6 +18,7 @@ import bloop.io.Paths.delete
 import bloop.internal.build.BuildInfo
 import bloop.logging.{BloopLogger, BufferedLogger, Logger, ProcessLogger, RecordingLogger}
 import monix.eval.Task
+import org.junit.Assert
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -190,8 +191,7 @@ object TestUtil {
       noDependencies,
       rootProjectName = cmd.project,
       javaEnv = javaEnv,
-      quiet = true) { state =>
-      runAndCheck(state, cmd)(check)
+      quiet = true) { state => runAndCheck(state, cmd)(check)
     }
   }
 
@@ -293,6 +293,12 @@ object TestUtil {
     Files.createDirectories(srcs)
     Files.createDirectories(classes)
     (srcs, classes)
+  }
+
+  def ensureCompilationInAllTheBuild(state: State): Unit = {
+    state.build.projects.foreach { p =>
+      Assert.assertTrue(s"${p.name} was not compiled", hasPreviousResult(p, state))
+    }
   }
 
   def writeSources(srcDir: Path, sources: Map[String, String]): Unit = {


### PR DESCRIPTION
Fix an issue where bloop would run `test` or `run` even if `compile`
failed. This issue happened because of a bad initialization error in the
`ExitStatus` object that was causing `codeToName` not to work. This
affected the following logic in `Interpreter`:

```
runCompile(cmd, state, project, deduplicateFailures, excludeRoot).flatMap { compiled =>
  if (compiled.status != ExitStatus.CompilationError) next(compiled)
  else Task.now(state.withDebug(s"Failed compilation for $project. Skipping $nextAction..."))
}
```

After the change to the exit status, the test passes.