### PR TITLE
Allow reflective bloop invocation with cancellation

### DIFF
--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -1,6 +1,8 @@
 package bloop
 
+import java.io.{InputStream, PrintStream}
 import java.nio.file.{Files, Path}
+import java.util.concurrent.CompletableFuture
 
 import bloop.bsp.BspServer
 import bloop.cli.validation.Validate
@@ -20,6 +22,31 @@ object Cli {
     val action = parse(args, CommonOptions.default)
     val exitStatus = run(action, NoPool, args)
     sys.exit(exitStatus.code)
+  }
+
+  def reflectMain(
+      args: Array[String],
+      cwd: Path,
+      in: InputStream,
+      out: PrintStream,
+      err: PrintStream,
+      props: java.util.Properties,
+      cancel: CompletableFuture[Boolean]
+  ): Int = {
+    val env = CommonOptions.PrettyProperties.from(props)
+    val nailgunOptions = CommonOptions(
+      in = in,
+      out = out,
+      err = err,
+      ngout = out,
+      ngerr = err,
+      workingDirectory = cwd.toAbsolutePath.toString,
+      env = env
+    )
+
+    val cmd = parse(args, nailgunOptions)
+    val exitStatus = run(cmd, NoPool, args, cancel)
+    exitStatus.code
   }
 
   def nailMain(ngContext: NGContext): Unit = {
@@ -211,6 +238,17 @@ object Cli {
   }
 
   def run(action: Action, pool: ClientPool, userArgs: Array[String]): ExitStatus = {
+    val cancel = new CompletableFuture[Boolean]()
+    cancel.complete(false)
+    run(action, pool, userArgs, cancel)
+  }
+
+  private def run(
+      action: Action,
+      pool: ClientPool,
+      userArgs: Array[String],
+      cancel: CompletableFuture[Boolean]
+  ): ExitStatus = {
     import bloop.io.AbsolutePath
     def getConfigDir(cliOptions: CliOptions): AbsolutePath = {
       val cwd = AbsolutePath(cliOptions.common.workingDirectory)
@@ -239,7 +277,8 @@ object Cli {
     val currentState = State.loadActiveStateFor(configDirectory, pool, cliOptions.common, logger)
 
     if (Files.exists(configDirectory.underlying)) {
-      waitUntilEndOfWorld(action, cliOptions, pool, configDirectory.underlying, logger, userArgs) {
+      val dir = configDirectory.underlying
+      waitUntilEndOfWorld(action, cliOptions, pool, dir, logger, userArgs, cancel) {
         Interpreter.execute(action, currentState).map { newState =>
           State.stateCache.updateBuild(newState.copy(status = ExitStatus.Ok))
           // Persist successful result on the background for the new state -- it doesn't block!
@@ -261,7 +300,8 @@ object Cli {
       pool: ClientPool,
       configDirectory: Path,
       logger: Logger,
-      userArgs: Array[String]
+      userArgs: Array[String],
+      cancel: CompletableFuture[Boolean]
   )(taskState: Task[State]): ExitStatus = {
     val ngout = cliOptions.common.ngout
     def logElapsed(since: Long): Unit = {
@@ -278,8 +318,23 @@ object Cli {
         .dematerialize
         .runAsync(ExecutionContext.scheduler)
 
+    if (!cancel.isDone) {
+      // Add support for a client to cancel bloop via Java's completable future
+      import bloop.monix.Java8Compat.JavaCompletableFutureUtils
+      val cancelCliClient = Task.deferFutureAction(cancel.asScala(_)).map { cancel =>
+        if (cancel) {
+          cliOptions.common.out.println(
+            s"Client in $configDirectory triggered cancellation. Cancelling tasks...")
+          handle.cancel()
+        } else ()
+      }.runAsync(ExecutionContext.scheduler)
+    }
+
+
     def handleException(t: Throwable) = {
       handle.cancel()
+      if (!cancel.isDone)
+        cancel.complete(false)
       if (t.getMessage != null)
         logger.error(t.getMessage)
       logger.trace(t)
@@ -294,6 +349,8 @@ object Cli {
             ngout.println(
               s"Client in $configDirectory disconnected with a '$e' event. Cancelling tasks...")
             handle.cancel()
+            if (!cancel.isDone)
+              cancel.complete(false)
           }
       }
 

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -14,6 +14,7 @@ import bloop.config.Config
 import bloop.data.Project
 import bloop.engine.Feedback.XMessageString
 import monix.eval.Task
+
 object Interpreter {
   // This is stack-safe because of Monix's trampolined execution
   def execute(action: Action, stateTask: Task[State]): Task[State] = {


### PR DESCRIPTION
1. Add a `reflectMain` method that exposes a Java-only API to run
   Bloop's CLI (usually for executing a long-running process like `bloop
   bsp`).
2. Add support for cancellation. Whenever the user feels like quitting,
   it can complete the `cancel: CompletableFuture[Boolean]` with a `true`
   to force the cancellation. If it completes it with a `false`, the
   cancellation will not happen.