### PR TITLE
Don't error on trace message

### DIFF
--- a/frontend/src/main/scala/bloop/logging/BspClientLogger.scala
+++ b/frontend/src/main/scala/bloop/logging/BspClientLogger.scala
@@ -30,7 +30,7 @@ final class BspClientLogger[L <: Logger](val underlying: L)
       case Level.Trace =>
         record.throwable match {
           case Some(t) => trace(t)
-          case None => error(record.message)
+          case None => debug(record.message)
         }
     }
   }


### PR DESCRIPTION
I assumed scribe loggers couldn't trace messages, as trace is only used
for exception in sbt loggers (which we implement in bloop). Now we
redirect to debug instead of error.