### PR TITLE
Upgrade to latest bsp version

### DIFF
--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -131,7 +131,7 @@ class BspProtocolSpec {
           endpoints.BuildTarget.dependencySources.request(bsp.DependencySourcesParams(btis)).map {
             case Left(error) => Left(error)
             case Right(sources) =>
-              val fetchedSources = sources.items.flatMap(i => i.uris.map(_.value))
+              val fetchedSources = sources.items.flatMap(i => i.sources.map(_.value))
               val expectedSources = BuildLoader
                 .loadSynchronously(configDir, logger.underlying)
                 .flatMap(_.sources.map(s => bsp.Uri(s.underlying.toUri).value))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
 
   val nailgunVersion = "0c8b937b"
   val zincVersion = "1.2.1+104-55d3c3d5"
-  val bspVersion = "1.0.0"
+  val bspVersion = "1.0.1-M1"
   val scalazVersion = "7.2.20"
   val coursierVersion = "1.1.0-M3"
   val lmVersion = "1.0.0"
@@ -38,7 +38,7 @@ object Dependencies {
 
   import sbt.librarymanagement.syntax.stringToOrganization
   val zinc = "ch.epfl.scala" %% "zinc" % zincVersion
-  val bsp = "ch.epfl.scala" %% "bsp" % bspVersion
+  val bsp = "ch.epfl.scala" %% "bsp4s" % bspVersion
   val nailgun = "ch.epfl.scala" % "nailgun-server" % nailgunVersion
 
   val configDirectories = "io.github.soc" % "directories" % configDirsVersion


### PR DESCRIPTION
With the introduction of bsp4j, we've realized that the dependency sources params didn't have the correct name for one of the fields, causing an error at runtime. By upgrading to a version of bsp4s that fixes it, we can keep on with our lives.