### PR TITLE
Don't fail in builds of single sbt plugins

### DIFF
--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/sbt-plugin-build/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/sbt-plugin-build/build.sbt
@@ -1,0 +1,20 @@
+name := "sbt-plugin-foobar"
+sbtPlugin := true
+
+import java.nio.file.Files
+
+val checkMetaBuildInfo = taskKey[Unit]("Check sbt meta build info is not generated")
+checkMetaBuildInfo in ThisBuild := {
+  def readBareFile(p: java.nio.file.Path): String =
+    new String(Files.readAllBytes(p)).replaceAll("\\s", "")
+
+  def check(f: File): Unit = {
+    val metaContents = readBareFile(f.toPath)
+    assert(metaContents.contains("\"autoImports\":[\""), "Missing auto imports.")
+    assert(metaContents.contains("\"sbtVersion\":\""), "Missing sbt version.")
+  }
+
+  val bloopMetaDir = Keys.baseDirectory.value./("project")./(".bloop")
+  val metaBuildConfig = bloopMetaDir./("sbt-plugin-build.json")
+  check(metaBuildConfig)
+}

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/sbt-plugin-build/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/sbt-plugin-build/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))
+

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/sbt-plugin-build/project/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/sbt-plugin-build/project/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))
+

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/sbt-plugin-build/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/sbt-plugin-build/test
@@ -1,0 +1,1 @@
+> bloopInstall


### PR DESCRIPTION
I knew about the possibility of failing in builds of single sbt plugins,
but however didn't protect us against them because I hoped sbt would
expose an entry point to know for real if a project is a meta build or
not. As this hasn't been the case, I've implemented a simple heuristic
to know whether a build is a meta-project or not: check if the cwd is
the same as the root of the build.

Kudos to @olafurpg for finding this bug in sbt-scalafix.