### PR TITLE
Reload and save state during BSP actions

### DIFF
--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -46,7 +46,8 @@ object Bloop extends CaseApp[CliOptions] {
     val input = reader.readLine()
     input.split(" ") match {
       case Array("exit") =>
-        waitForState(Exit(ExitStatus.Ok), Tasks.persist(state).map(_ => state))
+        val persistOut = (msg: String) => state.commonOptions.ngout.println(msg)
+        waitForState(Exit(ExitStatus.Ok), Tasks.persist(state, persistOut).map(_ => state))
         ()
 
       case Array("projects") =>

--- a/frontend/src/main/scala/bloop/bsp/BspServer.scala
+++ b/frontend/src/main/scala/bloop/bsp/BspServer.scala
@@ -93,10 +93,10 @@ object BspServer {
       val server = new LanguageServer(messages, client, bloopServices, scheduler, bspLogger)
 
       server.startTask
-        .map(_ => servicesProvider.latestState)
+        .map(_ => servicesProvider.stateAfterExecution)
         .onErrorHandleWith { t =>
           Task.now(
-            servicesProvider.latestState.withError(s"BSP server stopped by ${t.getMessage}")
+            servicesProvider.stateAfterExecution.withError(s"BSP server stopped by ${t.getMessage}")
           )
         }
         .doOnFinish(_ => Task { handle.serverSocket.close() })

--- a/frontend/src/main/scala/bloop/engine/Build.scala
+++ b/frontend/src/main/scala/bloop/engine/Build.scala
@@ -19,7 +19,7 @@ final case class Build private (
     Dag.dagFor(dags, project).getOrElse(sys.error(s"Project $project does not have a DAG!"))
 
   /**
-   * Has this build definition changed since it was loaded?
+   * Detect changes in the build definition since the last time it was loaded.
    *
    * @param logger A logger that receives errors, if any.
    * @return The status of the directory from which the build was loaded.

--- a/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
@@ -90,7 +90,7 @@ object ResultsCache {
   private[ResultsCache] final val EmptyResult: PreviousResult =
     PreviousResult.of(Optional.empty[CompileAnalysis], Optional.empty[MiniSetup])
 
-  private[bloop] val forTests: ResultsCache =
+  private[bloop] val emptyForTests: ResultsCache =
     new ResultsCache(Map.empty, Map.empty)
 
   def load(build: Build, cwd: AbsolutePath, logger: Logger): ResultsCache = {

--- a/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
+++ b/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
@@ -1,5 +1,6 @@
 package bloop.logging
 
+import java.io.PrintStream
 import java.util.concurrent.atomic.AtomicInteger
 
 import bloop.engine.State

--- a/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
@@ -3,6 +3,8 @@ package bloop.bsp
 import java.nio.file.Files
 
 import bloop.cli.Commands
+import bloop.engine.State
+import bloop.engine.caches.{ResultsCache, StateCache}
 import bloop.io.AbsolutePath
 import bloop.logging.{BspClientLogger, DebugFilter, RecordingLogger, Slf4jAdapter}
 import bloop.tasks.TestUtil
@@ -86,13 +88,22 @@ object BspClientTest {
       logger: BspClientLogger[_],
       customServices: Services => Services = identity[Services],
       allowError: Boolean = false,
+      reusePreviousState: Boolean = false,
   )(runEndpoints: LanguageClient => me.Task[Either[Response.Error, T]]): Unit = {
     val workingPath = cmd.cliOptions.common.workingPath
     val projectName = workingPath.underlying.getFileName().toString()
-    val state = TestUtil.loadTestProject(projectName).copy(logger = logger)
+
+    // Set an empty results cache and update the state globally
+    val state = {
+      val state0 = TestUtil.loadTestProject(projectName).copy(logger = logger)
+      if (reusePreviousState) state0
+      else {
+        val state = state0.copy(results = ResultsCache.emptyForTests)
+        State.stateCache.updateBuild(state)
+      }
+    }
 
     // Clean all the project results to avoid reusing previous compiles.
-    state.results.cleanSuccessful(state.build.projects)
     val configPath = configDirectory.toRelative(workingPath)
     val bspServer = BspServer.run(cmd, state, configPath, scheduler).runAsync(scheduler)
 

--- a/frontend/src/test/scala/bloop/exec/ForkerSpec.scala
+++ b/frontend/src/test/scala/bloop/exec/ForkerSpec.scala
@@ -51,7 +51,7 @@ class ForkerSpec {
       val wait = Duration.apply(15, TimeUnit.SECONDS)
       val exitCode =
         TestUtil.await(wait)(config.runMain(cwdPath, mainClass, args, logger.asVerbose, opts))
-      val messages = logger.getMessages
+      val messages = logger.getMessages()
       op(exitCode, messages)
     }
 

--- a/frontend/src/test/scala/bloop/tasks/CleanSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/CleanSpec.scala
@@ -55,7 +55,7 @@ class CleanSpec {
         case (project, deps) => dummyProject(buildPath, project, deps, logger)
       }
       val build = Build(buildPath, projects.toList)
-      val results = projects.foldLeft(ResultsCache.forTests) { (cache, project) =>
+      val results = projects.foldLeft(ResultsCache.emptyForTests) { (cache, project) =>
         cache.addResult(project, Compiler.Result.Empty)
       }
       val state = State.forTests(build, CompilationHelpers.getCompilerCache(logger), logger)

--- a/frontend/src/test/scala/bloop/tasks/CompileSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/CompileSpec.scala
@@ -479,7 +479,8 @@ class CompileSpec {
     val state = TestUtil.loadTestProject(testProject).copy(logger = logger)
     val action = Run(Commands.Compile(testProject))
     val compiledState = TestUtil.blockingExecute(action, state)
-    val t = Tasks.persist(compiledState)
+    val persistOut = (msg: String) => compiledState.commonOptions.ngout.println(msg)
+    val t = Tasks.persist(compiledState, persistOut)
 
     try TestUtil.await(FiniteDuration(7, TimeUnit.SECONDS))(t)
     catch { case t: Throwable => logger.dump(); throw t }


### PR DESCRIPTION
1. Persist analysis files so that new BSP sessions don't trigger full
   compile.
2. Synchronize the state globally so that other clients can reuse the
   state produced by BSP actions.