### PR TITLE
Re-publish diagnostics for warnings

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -79,6 +79,10 @@ pipeline:
       - /drone/.coursier
       - /drone/.sbt
       - /drone/.dodo
+      - ./frontend/src/test/resources/cross-test-build-0.6/bloop-config
+      - ./frontend/src/test/resources/cross-test-build-0.6/target/generation-cache-file
+      - ./frontend/src/test/resources/cross-test-build-1.0/bloop-config
+      - ./frontend/src/test/resources/cross-test-build-1.0/target/generation-cache-file
     volumes:
       - /cache:/cache
     cache_key: [ DRONE_REPO_OWNER, DRONE_REPO_NAME, DRONE_BRANCH ]
@@ -196,6 +200,10 @@ pipeline:
       - /drone/.coursier
       - /drone/.sbt
       - /drone/.dodo
+      - ./frontend/src/test/resources/cross-test-build-0.6/bloop-config
+      - ./frontend/src/test/resources/cross-test-build-0.6/target/generation-cache-file
+      - ./frontend/src/test/resources/cross-test-build-1.0/bloop-config
+      - ./frontend/src/test/resources/cross-test-build-1.0/target/generation-cache-file
     volumes:
       - /cache:/cache
     cache_key: [ DRONE_REPO_OWNER, DRONE_REPO_NAME, DRONE_BRANCH ]

--- a/backend/src/main/scala/bloop/reporter/Reporter.scala
+++ b/backend/src/main/scala/bloop/reporter/Reporter.scala
@@ -98,4 +98,11 @@ object Reporter {
     val ps = sourceInfos.flatMap(_._2.getReportedProblems).map(Problem.fromZincProblem(_))
     new LogReporter(logger, cwd, identity, ReporterConfig.defaultFormat, ps)
   }
+/*
+  def getWarningsFromAnalysis(analysis: CompileAnalysis): List[xsbti.Problem] = {
+    import scala.collection.JavaConverters._
+    val sourceInfos = analysis.readSourceInfos.getAllSourceInfos.asScala.toBuffer
+    val ps = sourceInfos.flatMap(_._2.getReportedProblems).map(Problem.fromZincProblem(_))
+    ps.filter(_.)
+  }*/
 }

--- a/backend/src/main/scala/bloop/reporter/Reporter.scala
+++ b/backend/src/main/scala/bloop/reporter/Reporter.scala
@@ -98,11 +98,4 @@ object Reporter {
     val ps = sourceInfos.flatMap(_._2.getReportedProblems).map(Problem.fromZincProblem(_))
     new LogReporter(logger, cwd, identity, ReporterConfig.defaultFormat, ps)
   }
-/*
-  def getWarningsFromAnalysis(analysis: CompileAnalysis): List[xsbti.Problem] = {
-    import scala.collection.JavaConverters._
-    val sourceInfos = analysis.readSourceInfos.getAllSourceInfos.asScala.toBuffer
-    val ps = sourceInfos.flatMap(_._2.getReportedProblems).map(Problem.fromZincProblem(_))
-    ps.filter(_.)
-  }*/
 }

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -183,8 +183,9 @@ final class BloopBspServices(
     }
 
     def reportError(p: Project, problems: List[Problem], elapsedMs: Long): String = {
+      // Don't show warnings in this "final report", we're handling them in the reporter
       val count = bloop.reporter.Problem.count(problems)
-      s"${p.name} [${elapsedMs}ms] (errors ${count.errors}, warnings ${count.warnings})"
+      s"${p.name} [${elapsedMs}ms] (errors ${count.errors})"
     }
 
     Interpreter.execute(action, Task.now(state)).map { newState =>

--- a/frontend/src/test/resources/cross-test-build-0.6/build.sbt
+++ b/frontend/src/test/resources/cross-test-build-0.6/build.sbt
@@ -1,3 +1,4 @@
+bloopExportJarClassifiers in Global := Some(Set("sources"))
 bloopConfigDir in Global := baseDirectory.value / "bloop-config"
 
 import sbtcrossproject.{crossProject, CrossType}


### PR DESCRIPTION
Introduces the ability to diff the changed source files from one analysis to the other one and then use this information to know which warnings in previous runs should still be logged because new compilations have not compiled their origin source files.
  
See https://github.com/scalacenter/bloop/issues/696