### PR TITLE
Interpreter: Allow to run externally-defined main classes

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Feedback.scala
+++ b/frontend/src/main/scala/bloop/engine/Feedback.scala
@@ -6,12 +6,10 @@ object Feedback {
   private final val eol = System.lineSeparator
   def listMainClasses(mainClasses: List[String]): String =
     s"Use the following main classes:\n${mainClasses.mkString(" * ", s"$eol * ", "")}"
-  def missingMainClass(project: Project, mainClass: String = ""): String =
-    s"Missing main class $mainClass in project '${project.name}'"
-  def missingDefaultMainClass(project: Project, mainClass: String): String =
-    s"Missing default main class $mainClass in project '${project.name}'"
-  def expectedMainClass(project: Project): String =
-    s"Expected a main class via command-line or in the configuration of project '${project.name}'"
+  def missingMainClass(project: Project): String =
+    s"No main classes defined in project '${project.name}'"
+  def expectedDefaultMainClass(project: Project): String =
+    s"Multiple main classes found. Expected a default main class via command-line or in the configuration of project '${project.name}'"
 
   def missingScalaInstance(project: Project): String =
     s"Failed to compile project '${project.name}': found Scala sources but project is missing Scala configuration."


### PR DESCRIPTION
Currently, the following error is triggered when specifying a valid
class that is not defined in the project:

```shell
$ bloop run root -m play.core.server.ProdServerStart
[E] Missing main class  in project 'root'
```

Simplify the logic of `findMainClasses()`. The validation logic is
redundant since specifying an invalid main class will be caught at a
later point:

```shell
 $ bloop run root -m test
[E] Error: Could not find or load main class test
```