### PR TITLE
Terminate processes gracefully

### DIFF
--- a/bridges/scalajs-1.0/src/main/scala/bloop/scalajs/jsenv/NodeJsEnv.scala
+++ b/bridges/scalajs-1.0/src/main/scala/bloop/scalajs/jsenv/NodeJsEnv.scala
@@ -177,7 +177,8 @@ object NodeJSEnv {
         // Make sure we only destroy the process once, the test adapter can call this several times!
         if (!isClosed.getAndSet(true)) {
           logger.debug(s"Destroying process...")
-          process.destroy(true)
+          process.destroy(false)
+          process.waitFor(400, _root_.java.util.concurrent.TimeUnit.MILLISECONDS)
           // Make sure that no matter what happens the `onExit` callback is invoked
           handler.cancel()
         }

--- a/bridges/scalajs-1.0/src/main/scala/bloop/scalajs/jsenv/NodeJsEnv.scala
+++ b/bridges/scalajs-1.0/src/main/scala/bloop/scalajs/jsenv/NodeJsEnv.scala
@@ -179,6 +179,7 @@ object NodeJSEnv {
           logger.debug(s"Destroying process...")
           process.destroy(false)
           process.waitFor(400, _root_.java.util.concurrent.TimeUnit.MILLISECONDS)
+          process.destroy(true)
           // Make sure that no matter what happens the `onExit` callback is invoked
           handler.cancel()
         }

--- a/frontend/src/main/scala/bloop/exec/Forker.scala
+++ b/frontend/src/main/scala/bloop/exec/Forker.scala
@@ -195,8 +195,8 @@ object Forker {
           gobbleInput.cancel()
           try process.closeStdin(true)
           finally {
-            process.destroy(true)
-            process.waitFor(200, _root_.java.util.concurrent.TimeUnit.MILLISECONDS)
+            process.destroy(false)
+            process.waitFor(400, _root_.java.util.concurrent.TimeUnit.MILLISECONDS)
             if (process.isRunning) {
               val msg = s"The cancellation could not destroy process ${process.getPID}"
               opts.ngout.println(msg)

--- a/frontend/src/main/scala/bloop/exec/Forker.scala
+++ b/frontend/src/main/scala/bloop/exec/Forker.scala
@@ -197,6 +197,7 @@ object Forker {
           finally {
             process.destroy(false)
             process.waitFor(400, _root_.java.util.concurrent.TimeUnit.MILLISECONDS)
+            process.destroy(true)
             if (process.isRunning) {
               val msg = s"The cancellation could not destroy process ${process.getPID}"
               opts.ngout.println(msg)


### PR DESCRIPTION
To-do:
- [ ] `stdout` is disconnected immediately when pressing Ctrl-C. The user does not see any log messages triggered by termination.
- [ ] Write test case

Closes #719.