### PR TITLE
Add resources to the configuration file

### DIFF
--- a/bridges/scala-native/src/main/scala/bloop/scalanative/NativeBridge.scala
+++ b/bridges/scala-native/src/main/scala/bloop/scalanative/NativeBridge.scala
@@ -15,7 +15,7 @@ object NativeBridge {
     if (workdir.isDirectory) Paths.delete(workdir)
     Files.createDirectories(workdir.underlying)
 
-    val classpath = project.classpath.map(_.underlying)
+    val classpath = project.compilationClasspath.map(_.underlying)
     val nativeLogger = NativeLogger(logger.debug _, logger.info _, logger.warn _, logger.error _)
     val config = setUpNativeConfig(project, config0)
     val nativeMode = config.mode match {
@@ -66,7 +66,7 @@ object NativeBridge {
       if (config.nativelib.toString.nonEmpty) config.nativelib
       else {
         Discover
-          .nativelib(project.classpath.map(_.underlying))
+          .nativelib(project.compilationClasspath.map(_.underlying))
           .getOrElse(sys.error("Fatal: nativelib is missing and could not be found."))
       }
     }

--- a/bridges/scalajs-0.6/src/main/scala/bloop/scalajs/JsBridge.scala
+++ b/bridges/scalajs-0.6/src/main/scala/bloop/scalajs/JsBridge.scala
@@ -57,7 +57,7 @@ object JsBridge {
       target: Path,
       logger: BloopLogger
   ): Unit = {
-    val classpath = project.classpath.map(_.underlying)
+    val classpath = project.compilationClasspath.map(_.underlying)
     val classpathIrFiles = classpath
       .filter(Files.isDirectory(_))
       .flatMap(findIrFiles)

--- a/bridges/scalajs-1.0/src/main/scala/bloop/scalajs/JsBridge.scala
+++ b/bridges/scalajs-1.0/src/main/scala/bloop/scalajs/JsBridge.scala
@@ -59,7 +59,7 @@ object JsBridge {
     }
 
     val cache = new IRFileCache().newCache
-    val irClasspath = FileScalaJSIRContainer.fromClasspath(project.classpath.map(_.toFile))
+    val irClasspath = FileScalaJSIRContainer.fromClasspath(project.compilationClasspath.map(_.toFile))
     val irFiles = cache.cached(irClasspath)
 
     val moduleInitializers = mainClass match {

--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -183,6 +183,7 @@ object Config {
       classpath: List[Path],
       out: Path,
       classesDir: Path,
+      resources: Option[List[Path]],
       `scala`: Option[Scala],
       java: Option[Java],
       sbt: Option[Sbt],
@@ -193,7 +194,7 @@ object Config {
 
   object Project {
     // FORMAT: OFF
-    private[bloop] val empty: Project = Project("", emptyPath, List(), List(), List(), emptyPath, emptyPath, None, None, None, None, None, None)
+    private[bloop] val empty: Project = Project("", emptyPath, List(), List(), List(), emptyPath, emptyPath, None, None, None, None, None, None, None)
     // FORMAT: ON
 
     def analysisFileName(projectName: String) = s"$projectName-analysis.bin"
@@ -201,7 +202,7 @@ object Config {
 
   case class File(version: String, project: Project)
   object File {
-    final val LatestVersion = "1.1.0-M1"
+    final val LatestVersion = "1.1.0-M2"
 
     private[bloop] val empty = File(LatestVersion, Project.empty)
 
@@ -237,6 +238,7 @@ object Config {
         List(scalaLibraryJar),
         outDir,
         classesDir,
+        Some(List(outDir.resolve("resource1.xml"))),
         Some(
           Scala(
             "org.scala-lang",

--- a/config/src/main/scala/bloop/config/util/ConfigUtil.scala
+++ b/config/src/main/scala/bloop/config/util/ConfigUtil.scala
@@ -1,0 +1,26 @@
+package bloop.config.util
+
+import java.nio.file.{Path, Files}
+
+object ConfigUtil {
+  def pathsOutsideRoots(roots: Seq[Path], paths: Seq[Path]): Seq[Path] = {
+    paths.filterNot { path =>
+      roots.exists { root =>
+        var found: Boolean = false
+        val rootDirSize = root.toString.size
+        var currentTarget = (if (Files.isRegularFile(path)) path.getParent else path).toAbsolutePath
+        while (!found &&
+               currentTarget != null &&
+               // Use a heuristic to know if we should short-circuit and return false
+               currentTarget.toString.size >= rootDirSize) {
+          if (currentTarget == root) {
+            found = true
+          }
+
+          currentTarget = currentTarget.getParent
+        }
+        found
+      }
+    }
+  }
+}

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -498,7 +498,7 @@ final class BloopBspServices(
             bsp.ScalacOptionsItem(
               target = target,
               options = project.scalacOptions.toList,
-              classpath = project.classpath.map(e => bsp.Uri(e.toBspUri)).toList,
+              classpath = project.compilationClasspath.map(e => bsp.Uri(e.toBspUri)).toList,
               classDirectory = bsp.Uri(project.classesDir.toBspUri)
             )
         }.toList

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -76,7 +76,7 @@ final case class Project(
       if (index == -1) {
         p.resources.foreach(r => cp.append(r))
       }
-      else cp.insertAll(index + 1, p.resources)
+      else cp.insertAll(index, p.resources)
     }
     cp.toArray
   }

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -10,6 +10,7 @@ import xsbti.compile.{ClasspathOptions, CompileOrder}
 import bloop.ScalaInstance
 import bloop.bsp.ProjectUris
 import bloop.config.{Config, ConfigEncoderDecoders}
+import bloop.engine.Dag
 import bloop.engine.tasks.toolchains.{JvmToolchain, ScalaJsToolchain, ScalaNativeToolchain}
 import ch.epfl.scala.{bsp => Bsp}
 
@@ -19,6 +20,7 @@ final case class Project(
     dependencies: List[String],
     scalaInstance: Option[ScalaInstance],
     rawClasspath: List[AbsolutePath],
+    resources: List[AbsolutePath],
     compileSetup: Config.CompileSetup,
     classesDir: AbsolutePath,
     scalacOptions: List[String],
@@ -33,11 +35,12 @@ final case class Project(
     resolution: Option[Config.Resolution],
     origin: Origin
 ) {
+
   /** The bsp uri associated with this project. */
   val bspUri: Bsp.Uri = Bsp.Uri(ProjectUris.toURI(baseDirectory, name))
 
   /** This project's full classpath (classes directory and raw classpath) */
-  val classpath: Array[AbsolutePath] = (classesDir :: rawClasspath).toArray
+  val compilationClasspath: Array[AbsolutePath] = (classesDir :: rawClasspath).toArray
 
   val classpathOptions: ClasspathOptions = {
     ClasspathOptions.of(
@@ -62,6 +65,20 @@ final case class Project(
       case other: Project => this.hashCode == other.hashCode
       case _ => false
     }
+  }
+
+  def fullClasspathFor(dag: Dag[Project]): Array[AbsolutePath] = {
+    val cp = compilationClasspath.toBuffer
+    // Add the resources right after the classes directory if found in the classpath
+    Dag.dfs(dag).foreach { p =>
+      val index = cp.indexOf(p.classesDir)
+      // If there is an anomaly and the classes dir of a dependency is missing, add resource at end
+      if (index == -1) {
+        p.resources.foreach(r => cp.append(r))
+      }
+      else cp.insertAll(index + 1, p.resources)
+    }
+    cp.toArray
   }
 }
 
@@ -113,6 +130,7 @@ object Project {
     val analysisOut = scala
       .flatMap(_.analysis.map(AbsolutePath.apply))
       .getOrElse(out.resolve(Config.Project.analysisFileName(project.name)))
+    val resources = project.resources.toList.flatten.map(AbsolutePath.apply)
 
     Project(
       project.name,
@@ -120,6 +138,7 @@ object Project {
       project.dependencies,
       instance,
       project.classpath.map(AbsolutePath.apply),
+      resources,
       setup,
       AbsolutePath(project.classesDir),
       scala.map(_.options).getOrElse(Nil),

--- a/frontend/src/main/scala/bloop/engine/tasks/CompilationTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompilationTask.scala
@@ -85,7 +85,7 @@ object CompilationTask {
             instance,
             compilerCache,
             sources.toArray,
-            project.classpath,
+            project.compilationClasspath,
             graphInputs.store,
             project.classesDir,
             project.out,

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -54,7 +54,7 @@ object Tasks {
     import state.logger
     project.scalaInstance match {
       case Some(instance) =>
-        val classpath = project.classpath
+        val classpath = project.fullClasspathFor(state.build.getDagFor(project))
         val entries = classpath.map(_.underlying.toFile).toSeq
         logger.debug(s"Setting up the console classpath with ${entries.mkString(", ")}")(
           DebugFilter.All)
@@ -182,7 +182,7 @@ object Tasks {
       fqn: String,
       args: Array[String]
   ): Task[State] = {
-    val classpath = project.classpath
+    val classpath = project.fullClasspathFor(state.build.getDagFor(project))
     val processConfig = Forker(javaEnv, classpath)
     val runTask = processConfig.runMain(cwd, fqn, args, state.logger, state.commonOptions)
     runTask.map { exitCode =>

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -3,7 +3,7 @@ package bloop.engine.tasks
 import bloop.cli.ExitStatus
 import bloop.config.Config
 import bloop.data.{Platform, Project}
-import bloop.engine.{Feedback, State}
+import bloop.engine.{Dag, Feedback, State}
 import bloop.engine.tasks.toolchains.ScalaJsToolchain
 import bloop.exec.Forker
 import bloop.io.AbsolutePath
@@ -129,7 +129,8 @@ object TestTask {
     implicit val logContext: DebugFilter = DebugFilter.Test
     project.platform match {
       case Platform.Jvm(env, _, _) =>
-        val forker = Forker(env, project.classpath)
+        val classpath = project.fullClasspathFor(state.build.getDagFor(project))
+        val forker = Forker(env, classpath)
         val testLoader = forker.newClassLoader(Some(TestInternals.filteredLoader))
         val frameworks = project.testFrameworks.flatMap(f =>
           TestInternals.loadFramework(testLoader, f.names, logger))

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
@@ -214,7 +214,7 @@ object CompileGraph {
 
                   // Let's order the IRs exactly in the same order as provided in the classpath!
                   // Required for symbol clashes in dependencies (`AppLoader` in guardian/frontend)
-                  val indexDirs = project.classpath.iterator.filter(_.isDirectory).zipWithIndex.toMap
+                  val indexDirs = project.compilationClasspath.iterator.filter(_.isDirectory).zipWithIndex.toMap
                   val dependentStore = {
                     val transitiveStores =
                       results.flatMap(r => indexDirs.get(r.bundle.project.classesDir).iterator.map(i => i -> r.store))

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -317,7 +317,7 @@ class BspProtocolSpec {
                   Assert.assertEquals(obtainedUri, expectedUri)
                   val obtainedOptions =
                     stringifyOptions(opts.options, opts.classpath, opts.classDirectory)
-                  val classpath = p.classpath.iterator.map(i => bsp.Uri(i.toBspUri)).toList
+                  val classpath = p.compilationClasspath.iterator.map(i => bsp.Uri(i.toBspUri)).toList
                   val classesDir = bsp.Uri(p.classesDir.toBspUri)
                   val expectedOptions =
                     stringifyOptions(p.scalacOptions.toList, classpath, classesDir)

--- a/frontend/src/test/scala/bloop/engine/DagSpec.scala
+++ b/frontend/src/test/scala/bloop/engine/DagSpec.scala
@@ -21,8 +21,8 @@ class DagSpec {
   // format: OFF
   def dummyOrigin = TestUtil.syntheticOriginFor(dummyPath)
   def dummyProject(name: String, dependencies: List[String]): Project =
-    Project(name, dummyPath, dependencies, Some(dummyInstance), Nil, compileOptions, dummyPath, Nil,
-      Nil, Nil, Nil, Config.TestOptions.empty, dummyPath, dummyPath,
+    Project(name, dummyPath, dependencies, Some(dummyInstance), Nil, Nil, compileOptions,
+      dummyPath, Nil, Nil, Nil, Nil, Config.TestOptions.empty, dummyPath, dummyPath,
       Project.defaultPlatform(logger), None, None, dummyOrigin)
   // format: ON
 

--- a/frontend/src/test/scala/bloop/exec/ForkerSpec.scala
+++ b/frontend/src/test/scala/bloop/exec/ForkerSpec.scala
@@ -43,7 +43,7 @@ class ForkerSpec {
       val cwdPath = AbsolutePath(cwd)
       val project = TestUtil.getProject(TestUtil.RootProject, state)
       val env = JavaEnv.default
-      val classpath = project.classpath
+      val classpath = project.fullClasspathFor(state.build.getDagFor(project))
       val config = Forker(env, classpath)
       val logger = new RecordingLogger
       val opts = state.commonOptions.copy(env = TestUtil.runAndTestProperties)

--- a/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
+++ b/frontend/src/test/scala/bloop/tasks/IntegrationTestSuite.scala
@@ -79,6 +79,7 @@ class IntegrationTestSuite(testDirectory: Path) {
           dependencies = previousProjects.map(_.name),
           scalaInstance = previousProjects.head.scalaInstance,
           rawClasspath = Nil,
+          resources = Nil,
           compileSetup = Config.CompileSetup.empty,
           classesDir = classesDir,
           scalacOptions = Nil,

--- a/frontend/src/test/scala/bloop/tasks/JsTestSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/JsTestSpec.scala
@@ -181,7 +181,8 @@ class JsTestSpec(
   @Test
   def testsAreDetected(): Unit = {
     // Load the project's classpath by filtering out unwanted FQNs to create the test loader
-    val classpathEntries = testProject.classpath.map(_.underlying.toUri.toURL)
+    val classpath = testProject.fullClasspathFor(testState.build.getDagFor(testProject))
+    val classpathEntries = classpath.map(_.underlying.toUri.toURL)
     val testLoader = new URLClassLoader(classpathEntries, Some(TestInternals.filteredLoader).orNull)
     def frameworks(classLoader: ClassLoader): List[Framework] = {
       testProject.testFrameworks.flatMap(f =>

--- a/frontend/src/test/scala/bloop/tasks/JvmTestSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/JvmTestSpec.scala
@@ -82,7 +82,8 @@ class JvmTestSpec(
 
   private val processRunnerConfig: Forker = {
     val javaEnv = JavaEnv.default
-    val classpath = testProject.classpath
+    val classpath = testProject.fullClasspathFor(testState.build.getDagFor(testProject))
+    val classpathEntries = classpath.map(_.underlying.toUri.toURL)
     Forker(javaEnv, classpath)
   }
 

--- a/frontend/src/test/scala/bloop/tasks/TestResourcesSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestResourcesSpec.scala
@@ -1,13 +1,11 @@
 package bloop.tasks
 
 import org.junit.Test
-import org.junit.Assert.assertEquals
 import org.junit.experimental.categories.Category
 
 import sbt.internal.util.EscHelpers.removeEscapeSequences
 
 import bloop.cli.Commands
-import bloop.exec.JavaEnv
 import bloop.tasks.TestUtil.{loadTestProject, runAndCheck}
 
 @Category(Array(classOf[bloop.FastTests]))

--- a/frontend/src/test/scala/bloop/tasks/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestUtil.scala
@@ -289,6 +289,7 @@ object TestUtil {
       dependencies = dependencies.toList,
       scalaInstance = scalaInstance,
       rawClasspath = classpath,
+      resources = Nil,
       compileSetup = Config.CompileSetup.empty.copy(order = compileOrder),
       classesDir = AbsolutePath(target),
       scalacOptions = Nil,

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -94,6 +94,7 @@ final class BloopConverter(parameters: BloopParameters) {
         classpath = classpath,
         out = project.getBuildDir.toPath,
         classesDir = classesDir,
+        resources = Some(getResources(sourceSet)),
         `scala` = scalaConfig,
         java = getJavaConfig(project, sourceSet),
         sbt = None,
@@ -117,6 +118,9 @@ final class BloopConverter(parameters: BloopParameters) {
 
   private def getSources(sourceSet: SourceSet): List[Path] =
     sourceSet.getAllSource.getSrcDirs.asScala.map(_.toPath).toList
+
+  private def getResources(sourceSet: SourceSet): List[Path] =
+    sourceSet.getResources.getSrcDirs.asScala.map(_.toPath).toList
 
   private def isProjectDependency(
       projectDependencies: List[ProjectDependency],

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -267,7 +267,7 @@ object BuildImplementation {
 
   final val globalSettings: Seq[Def.Setting[_]] = Seq(
     Keys.cancelable := true,
-    BuildKeys.schemaVersion := "4.0",
+    BuildKeys.schemaVersion := "4.2",
     Keys.testOptions in Test += sbt.Tests.Argument("-oD"),
     Keys.onLoadMessage := Header.intro,
     Keys.onLoad := BuildDefaults.bloopOnLoad.value,


### PR DESCRIPTION
Resources are files that are used at runtime, either when testing or
running an application. These files can be generated by the build tool
or be present in a resource directory of a project.

Resource files have been supported in bloop since 1.0, where in sbt and
other build tools we were relying on the resources to be copied by the
build tool to the classes directory. This approach had a problem:
whenever a change is done in an unmanaged resource file (a file that is
controlled by the user, like a `log4j2.properties` file), bloop would
not pick it up until there's a new `bloopInstall` invocation.

This is a known limitation that this commit fixes. The approach to
support resources has changed:

1. A new `resources` field has been added to the JSON file.
2. Resources are not copied to the class file, they are instead added to
   the test and run classpaths.

The second item makes a subtle but important point. The fact that we
don't copy the resources means two things:

1. We don't care about the relative path with regards to the root
   resource directory where a resource lives.
2. We rely on the contents of the `resources` field, which should
   contain only those directories which are either considered roots (e.g.
   files from where the application can use relative paths to look for
   resources) or single files.

We support this treatment of resources in all build tools. Sbt requires
a special case in the plugin because the source of truth is `resources`,
which contains all the contained files in the resource directories + any
other file the user may have added. As a consequence, we filter the
paths until we get either root resource directories or single source
files. Note that removing directories that are already contained in a
root resource directory is really important because it dictates the way
the resource will be accessible at runtime (where the lookup relative
paths play an important role).

Fixes https://github.com/scalacenter/bloop/issues/586