### PR TITLE
Handle build load errors gracefully in the server

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Feedback.scala
+++ b/frontend/src/main/scala/bloop/engine/Feedback.scala
@@ -19,10 +19,10 @@ object Feedback {
     missing match {
       case Nil => None
       case missing :: Nil =>
-        Some(s"Detected missing dependency '$missing' in project '${project.name}' may cause compilation issues")
+        Some(s"Missing project '$missing', may cause compilation issues in project '${project.name}'")
       case xs =>
         val deps = missing.map(m => s"'$m'").mkString(", ")
-        Some(s"Detected missing dependencies $deps in project '${project.name}' may cause compilation issues")
+        Some(s"Missing projects $deps, may cause compilation issues in project '${project.name}'")
     }
   }
 

--- a/frontend/src/main/scala/bloop/engine/Feedback.scala
+++ b/frontend/src/main/scala/bloop/engine/Feedback.scala
@@ -15,6 +15,16 @@ object Feedback {
     s"Failed to compile project '${project.name}': found Scala sources but project is missing Scala configuration."
   def missingInstanceForJavaCompilation(project: Project): String =
     s"Failed to compile Java sources in ${project.name}: default Zinc Scala instance couldn't be created!"
+  def detectMissingDependencies(project: Project, missing: List[String]): Option[String] = {
+    missing match {
+      case Nil => None
+      case missing :: Nil =>
+        Some(s"Detected missing dependency '$missing' in project '${project.name}' may cause compilation issues")
+      case xs =>
+        val deps = missing.map(m => s"'$m'").mkString(", ")
+        Some(s"Detected missing dependencies $deps in project '${project.name}' may cause compilation issues")
+    }
+  }
 
   def failedToLink(project: Project, linker: String, t: Throwable): String =
     s"Failed to link $linker project '${project.name}': '${t.getMessage}'"

--- a/frontend/src/test/scala/bloop/engine/LoadProjectSpec.scala
+++ b/frontend/src/test/scala/bloop/engine/LoadProjectSpec.scala
@@ -24,7 +24,7 @@ class LoadProjectSpec {
 
     val t = BuildLoader
       .load(configDir, logger)
-      .map(ps => Dag.fromMap(ps.map(p => p.name -> p).toMap))
+      .map(ps => Dag.fromMap(ps.map(p => p.name -> p).toMap).dags)
     try TestUtil.await(FiniteDuration(5, TimeUnit.SECONDS))(t)
     catch { case t: Throwable => logger.dump(); throw t }
     ()


### PR DESCRIPTION
Imagine that `bloopInstall` fails to successfully complete. The process
did complete for a subset of the build graph, but not all of it. And now
imagine that the errors are not relevant and the user is willing to
ignore them temporarily. Isn't it frustrating that bloop will fail to do
anything with a `NoSuchElementException` because the build load fails?

This commit tries to improve on this situation by not making it an
all-or-nothing situation. Bloop can now handle missing dependencies in a
configuration file gracefully. To let the user know that there's
something off, though, we emit a warning every time we compile a module
that has a missing dependency (in case, for example, there's a failure
in compilation). However, we do not emit such warning if the user
compiles other modules in the build and therefore give more freedom to
the user.

Fixes https://github.com/scalacenter/bloop/issues/708