### PR TITLE
Fix test resource behavior for source-based projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ contributing to Bloop by [reading the CONTRIBUTING guide][contributing].
 follows the [Scala Code of Conduct][coc]. We are committed to providing a safe
 environment for all contributors.
 
-[gitter]: https://github.com/scalacenter/bloop
+[gitter]: https://gitter.im/scalacenter/bloop
 [contributing]: https://scalacenter.github.io/bloop/docs/developer-documentation/
 [scalacenter]: https://scala.epfl.ch
 [coc]: https://www.scala-lang.org/conduct/

--- a/config/src/main/scala/bloop/config/util/ConfigUtil.scala
+++ b/config/src/main/scala/bloop/config/util/ConfigUtil.scala
@@ -1,26 +1,14 @@
 package bloop.config.util
 
-import java.nio.file.{Path, Files}
+import java.nio.file.Path
 
 object ConfigUtil {
   def pathsOutsideRoots(roots: Seq[Path], paths: Seq[Path]): Seq[Path] = {
-    paths.filterNot { path =>
-      roots.exists { root =>
-        var found: Boolean = false
-        val rootDirSize = root.toString.size
-        var currentTarget = (if (Files.isRegularFile(path)) path.getParent else path).toAbsolutePath
-        while (!found &&
-               currentTarget != null &&
-               // Use a heuristic to know if we should short-circuit and return false
-               currentTarget.toString.size >= rootDirSize) {
-          if (currentTarget == root) {
-            found = true
-          }
-
-          currentTarget = currentTarget.getParent
-        }
-        found
-      }
+    for {
+      path <- paths
+      root <- roots if !path.toAbsolutePath.startsWith(root)
+    } yield {
+      path
     }
   }
 }

--- a/config/src/main/scala/bloop/config/util/ConfigUtil.scala
+++ b/config/src/main/scala/bloop/config/util/ConfigUtil.scala
@@ -6,7 +6,7 @@ object ConfigUtil {
   def pathsOutsideRoots(roots: Seq[Path], paths: Seq[Path]): Seq[Path] = {
     for {
       path <- paths
-      root <- roots if !path.toAbsolutePath.startsWith(root)
+      root <- roots if !path.toAbsolutePath.startsWith(root.toAbsolutePath)
     } yield {
       path
     }

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -868,14 +868,10 @@ object BloopDefaults {
           .map(_.toPath)
           .distinct
 
-      println("resd " + resourceDirs)
-
       val allResourceFiles: Seq[File] = Keys
         .resources
         .all(sf).value.flatten
         .distinct
-
-      println("resf " + resourceDirs)
 
       val additionalResources: Seq[Path] =
         ConfigUtil.pathsOutsideRoots(

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -714,7 +714,6 @@ object BloopDefaults {
         val binaryModules = configModules(Keys.update.value)
         val sourceModules = updateClassifiers.value.toList.flatMap(configModules)
         val allModules = mergeModules(binaryModules, sourceModules)
-
         val resolution = {
           val modules = onlyCompilationModules(allModules, classpath).toList
           if (modules.isEmpty) None else Some(Config.Resolution(modules))


### PR DESCRIPTION
Fixes #738.

**Issue** 
having the following project structure:

```
-toplevel
  |-src/test/resources/application.conf
-modules/foo
  |-src/test/resources/application.conf
```

where `toplevel` depends on `foo`, default (sbt/intellij/...) behavior is to have both `toplevel` and `foo` resources on classpath. Bloop only uses `toplevel` which leads to eg test errors when `modules` projects declare some shared/default configuration keys in configs, which are normally expected to be merged with `toplevel` configs.

**Fix**
include resources for all aggregated projects.
