### PR TITLE
Correct socks uri parsing

### DIFF
--- a/frontend/src/main/scala/bloop/util/ProxySetup.scala
+++ b/frontend/src/main/scala/bloop/util/ProxySetup.scala
@@ -1,6 +1,6 @@
 package bloop.util
 
-import java.net.URL
+import java.net.URI
 import java.net.MalformedURLException
 
 import bloop.logging.Logger
@@ -142,7 +142,7 @@ object ProxySetup {
   ): Option[ProxySettings] = {
     env.get(key).flatMap { proxyVar =>
       try {
-        val url = new URL(proxyVar)
+        val url = new URI(proxyVar)
         val maybeNoProxy = env.get("no_proxy").map(_.replace(',', '|'))
         Some(ProxySettings(url.getHost(), url.getPort(), maybeNoProxy))
       } catch {


### PR DESCRIPTION
URL refuse to parse socks protocol.  So replace it by URI.