### PR TITLE
Fallback to direct server invocation in nailgun client

### DIFF
--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -123,7 +123,8 @@ object BuildKeys {
     GHReleaseKeys.ghreleaseRepoOrg := "scalacenter",
     GHReleaseKeys.ghreleaseRepoName := "bloop",
     GHReleaseKeys.ghreleaseAssets += ReleaseUtils.versionedInstallScript.value,
-    createLocalHomebrewFormula := ReleaseUtils.createLocalHomebrewFormula.value
+    createLocalHomebrewFormula := ReleaseUtils.createLocalHomebrewFormula.value,
+    updateHomebrewFormula := ReleaseUtils.updateHomebrewFormula.value
   )
 
   import sbtbuildinfo.{BuildInfoKey, BuildInfoKeys}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val Scala211Version = "2.11.12"
   val Scala212Version = "2.12.7"
 
-  val nailgunVersion = "0c8b937b"
+  val nailgunVersion = "6992a3bf"
   val zincVersion = "1.2.1+106-0dad4a69"
   val bspVersion = "2.0.0-M1" 
   val scalazVersion = "7.2.20"


### PR DESCRIPTION
The python nailgun client allows to run the bloop server when it's an
executable (a script) and not a jar so that running `bloop server` in
systems such as Nix works and doesn't fail with an error.

This mechanism is only a fallback iff the invocation with `java -jar`
failed.