### PR TITLE
Don't fail bloop if Java 11 installed in Mac OS

### DIFF
--- a/project/ReleaseUtils.scala
+++ b/project/ReleaseUtils.scala
@@ -99,8 +99,6 @@ object ReleaseUtils {
        |      bash_completion.install "bin/bash/bloop"
        |      fish_completion.install "bin/fish/bloop.fish"
        |
-       |      File.delete("bin/blp-coursier")
-       |
        |      # We need to create these files manually here, because otherwise launchd
        |      # will create them with owner set to `root` (see the plist file below).
        |      FileUtils.mkdir_p("log/bloop/")
@@ -125,9 +123,9 @@ object ReleaseUtils {
        |    <key>KeepAlive</key>
        |    <true/>
        |    <key>StandardOutPath</key>
-       |    <string>#{var}/log/bloop/bloop.out.log</string>
+       |    <string>#{prefix}/log/bloop/bloop.out.log</string>
        |    <key>StandardErrorPath</key>
-       |    <string>#{var}/log/bloop/bloop.err.log</string>
+       |    <string>#{prefix}/log/bloop/bloop.err.log</string>
        |</dict>
        |</plist>
        |          EOS


### PR DESCRIPTION
This fix uses the godsend `/usr/libexec/java_home` to detect the java
home for 1.8 and use that one to run `coursier launch` (failing with a
helpful error message if it doesn't find it). The main idea here comes
from @olafurpg and some of the discussion of the bug

In reality, this means that the server must be run with Java 1.8 or it
will fail. This is a good compromise for now until we can ensure that
we are as efficient and correct in other Java versions as we're in Java
1.8. I've tested this in my machine where Java 8 is installed via jenv
(which doesn't set the java home variable directly) and Java 11 was
installed via homebrew casks. I believe this scenario stresses this fix
enough to make it valid.

For now, we only use this approach in Mac OS because libexec/java_home
only exist in OSX.

Fixes https://github.com/scalacenter/bloop/issues/743