### PR TITLE
Implement test autocompletion for bash/zsh/fish

### DIFF
--- a/etc/bash/bloop
+++ b/etc/bash/bloop
@@ -96,6 +96,11 @@ _bloop() {
             command=${COMP_WORDS[1]}
 
             case "${prev}" in
+                --only|-o)
+                if [ "$command" == "test" ]; then
+                    _testsfqcn
+                fi
+                ;;
                 -*)
                 flag="$prev"
                 _callCompletionForCommandAndFlag "$command" "$flag"

--- a/etc/fish/bloop.fish
+++ b/etc/fish/bloop.fish
@@ -48,6 +48,19 @@ function __assert_args_at_least_count -a count
     test (count $cmd) -ge $count
 end
 
+function __assert_prev_arg_in
+    set -l tokens (commandline -poc)
+    if not __assert_args_at_least_count 1
+        return 0
+    end
+    for arg in $argv
+        if string match -q -- $tokens[-1] $argv[0]
+            return 1
+        end
+    end
+    return 0
+end
+
 function _project_commands
     bloop autocomplete --format bash --mode project-commands 2> /dev/null
 end
@@ -82,6 +95,7 @@ complete -c bloop -f -n "__assert_args_count 0" -a '(_commands)'
 # Only a project command has been provided
 complete -c bloop -f -n "__assert_args_count 1; and __fish_seen_subcommand_from_project_commands" -a '(_projects)'
 
+complete -c bloop -x -n "__fish_seen_subcommand_from test; and __assert_prev_arg_in --only -o" -a '(_testsfqcn)'
 
 for cmd in (_commands)
     set -l minTokens (_is_project_command $cmd)

--- a/etc/zsh/_bloop
+++ b/etc/zsh/_bloop
@@ -52,6 +52,16 @@ _flags_for_cmd() {
     return 0
 }
 
+_tests_or_flags() {
+    local prev=${words[CURRENT-1]}
+    local cmd=${words[1]}
+    if [[ $prev = '--only' || $prev = '-o' ]] && [[ $cmd = 'test' ]] then
+        _testsfqcn
+    else
+        _flags
+    fi
+}
+
 _project_or_flags() {
     local project_cmd=($(bloop autocomplete --format zsh --mode project-commands))
     local cmd=${words[2]}
@@ -74,6 +84,6 @@ _project_or_flags() {
 _arguments \
     ":command:_commands" \
     ":project_or_flags:_project_or_flags" \
-    "*::flags:_flags"
+    "*::flags:_tests_or_flags"
 
 return 0

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -8,7 +8,7 @@ import bloop.cli.completion.{Case, Mode}
 import bloop.io.{AbsolutePath, RelativePath, SourceWatcher}
 import bloop.logging.DebugFilter
 import bloop.testing.{LoggingEventHandler, TestInternals}
-import bloop.engine.tasks.{CompilationTask, LinkTask, Tasks}
+import bloop.engine.tasks.{CompilationTask, LinkTask, Tasks, TestTask}
 import bloop.cli.Commands.CompilingCommand
 import bloop.cli.validation.Validate
 import bloop.data.{Platform, Project}
@@ -300,10 +300,13 @@ object Interpreter {
           completion <- cmd.format.showMainName(main)
         } state.logger.info(completion)
       case Mode.TestsFQCN =>
+        import ExecutionContext.scheduler
         for {
           projectName <- cmd.project
-          placeholder <- List.empty[String]
-          completion <- cmd.format.showTestName(placeholder)
+          project <- Tasks.pickTestProject(projectName, state)
+          testsFQCN <- TestTask.findTestsFQCN(project, state)
+          testFQCN <- testsFQCN
+          completion <- cmd.format.showTestName(testFQCN)
         } state.logger.info(completion)
     }
 

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -261,15 +261,15 @@ object TestTask {
   }
 
   /**
-    * Finds testsFQCN in `project`.
-    *
-    * @param state   The current state of Bloop.
-    * @param project The project for which to find the testsFQCN.
-    * @return An array containing all the testsFQCN that were detected.
-    */
-  private[bloop] def findTestsFQCN(
-    project: Project,
-    state: State
+   * Finds the fully qualified names of the test names discovered in a project.
+   *
+   * @param state   The current state of Bloop.
+   * @param project The project for which to find tests.
+   * @return An array containing all the testsFQCN that were detected.
+   */
+  private[bloop] def findFullyQualifiedTestNames(
+      project: Project,
+      state: State
   ): Task[List[String]] = {
     import state.logger
     TestTask.discoverTestFrameworks(project, state).map {
@@ -278,17 +278,17 @@ object TestTask {
         val frameworks = found.frameworks
         val lastCompileResult = state.results.lastSuccessfulResultOrEmpty(project)
         val analysis = lastCompileResult.analysis().toOption.getOrElse {
-          logger.warn(
-            s"TestsFQCN was triggered, but no compilation detected for ${project.name}")
+          logger.warn(s"TestsFQCN was triggered, but no compilation detected for ${project.name}")
           Analysis.empty
         }
         val tests = discoverTests(analysis, frameworks)
-        tests.toList.flatMap {
-          case (framework, tasks) => tasks.map(t => (framework, t))
-        }.map(_._2.fullyQualifiedName)
+        tests.toList
+          .flatMap {
+            case (framework, tasks) => tasks.map(t => (framework, t))
+          }
+          .map(_._2.fullyQualifiedName)
     }
   }
-
 
   /**
    * Fixes the test arguments for a given framework.

--- a/frontend/src/test/scala/bloop/tasks/JsTestSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/JsTestSpec.scala
@@ -222,4 +222,20 @@ class JsTestSpec(
       ()
     }
   }
+
+  @Test
+  def testsFQCNAreDetected(): Unit = {
+    TestUtil.quietIfSuccess(testState.logger) { logger =>
+      val testsFQCNTask = TestTask.findTestsFQCN(testProject, testState).map { testsFQCN =>
+        targetFrameworks.foreach { framework =>
+          assertTrue(
+            s"hello.${framework}Test not detected.",
+            testsFQCN.contains(s"hello.${framework}Test")
+          )
+        }
+      }
+      TestUtil.blockOnTask(testsFQCNTask, 10)
+      ()
+    }
+  }
 }

--- a/frontend/src/test/scala/bloop/tasks/JsTestSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/JsTestSpec.scala
@@ -224,9 +224,9 @@ class JsTestSpec(
   }
 
   @Test
-  def testsFQCNAreDetected(): Unit = {
+  def discoverFullyQualifiedTestNames(): Unit = {
     TestUtil.quietIfSuccess(testState.logger) { logger =>
-      val testsFQCNTask = TestTask.findTestsFQCN(testProject, testState).map { testsFQCN =>
+      val task = TestTask.findFullyQualifiedTestNames(testProject, testState).map { testsFQCN =>
         targetFrameworks.foreach { framework =>
           assertTrue(
             s"hello.${framework}Test not detected.",
@@ -234,7 +234,7 @@ class JsTestSpec(
           )
         }
       }
-      TestUtil.blockOnTask(testsFQCNTask, 10)
+      TestUtil.blockOnTask(task, 10)
       ()
     }
   }

--- a/frontend/src/test/scala/bloop/tasks/JvmTestSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/JvmTestSpec.scala
@@ -211,9 +211,9 @@ class JvmTestSpec(
   }
 
   @Test
-  def testsFQCNAreDetected(): Unit = {
+  def discoverFullyQualifiedTestNames(): Unit = {
     TestUtil.quietIfSuccess(testState.logger) { logger =>
-      val testsFQCNTask = TestTask.findTestsFQCN(testProject, testState).map { testsFQCN =>
+      val task = TestTask.findFullyQualifiedTestNames(testProject, testState).map { testsFQCN =>
         targetFrameworks.foreach { framework =>
           assertTrue(
             s"hello.${framework}Test not detected.",
@@ -221,7 +221,7 @@ class JvmTestSpec(
           )
         }
       }
-      TestUtil.blockOnTask(testsFQCNTask, 5)
+      TestUtil.blockOnTask(task, 5)
       ()
     }
   }

--- a/frontend/src/test/scala/bloop/tasks/JvmTestSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/JvmTestSpec.scala
@@ -209,4 +209,20 @@ class JvmTestSpec(
       ()
     }
   }
+
+  @Test
+  def testsFQCNAreDetected(): Unit = {
+    TestUtil.quietIfSuccess(testState.logger) { logger =>
+      val testsFQCNTask = TestTask.findTestsFQCN(testProject, testState).map { testsFQCN =>
+        targetFrameworks.foreach { framework =>
+          assertTrue(
+            s"hello.${framework}Test not detected.",
+            testsFQCN.contains(s"hello.${framework}Test")
+          )
+        }
+      }
+      TestUtil.blockOnTask(testsFQCNTask, 5)
+      ()
+    }
+  }
 }


### PR DESCRIPTION
This PR enables

- bloop server to respond tests FQCN in a project to a testsfqcn autocomplete request like `bloop autocomplete --format <shell> --mode testsfqcn --project <project>`
- bash/zsh/fish to autocomplete test names after `bloop test <project> --only`

<details>
<summary>Here are demos</summary>

### zsh
[![asciicast](https://asciinema.org/a/NaRcg4vNckhD2pYrvmo114hhi.svg)](https://asciinema.org/a/NaRcg4vNckhD2pYrvmo114hhi)

(in this video, autocompletion transformed the command from `bloop` to `blobloop`, but this is not actually happening..., I think this is a problem of `asciinema` and my zsh configuration...)

### bash
[![asciicast](https://asciinema.org/a/89AAwTmMzW9gbEILMXnCtBveZ.svg)](https://asciinema.org/a/89AAwTmMzW9gbEILMXnCtBveZ)

### fish
[![asciicast](https://asciinema.org/a/rhypFT5yCDGMk5lurkot1zuGh.svg)](https://asciinema.org/a/rhypFT5yCDGMk5lurkot1zuGh)

</details>

---

test is failing, but I'm not sure how the test related to this PR.