### PR TITLE
Fix installation bugs and add Windows installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ website/build/
 website/build/bloop-gh-pages/
 node_modules/
 package-lock.json
+.metals/

--- a/bin/install.py
+++ b/bin/install.py
@@ -141,7 +141,7 @@ def macos_launch_script_contents(is_local):
 def generate_bat(bloop_client_target):
     contents = """
     @echo off
-    python %%~dp0%s %%*
+    python %%%s %%*
     """ % bloop_client_target
     return textwrap.dedent(contents)
 

--- a/bin/install.py
+++ b/bin/install.py
@@ -10,6 +10,7 @@ from subprocess import CalledProcessError, check_call
 import platform
 import sys
 import re
+import textwrap
 from shutil import copyfileobj, copyfile
 
 IS_PY2 = sys.version[0] == '2'
@@ -115,19 +116,25 @@ BLOOP_ARTIFACT = "ch.epfl.scala:bloop-frontend_2.12:%s" % BLOOP_VERSION
 
 BUFFER_SIZE = 4096
 
-MACOS_LAUNCH_SCRIPT_CONTENTS = """
-#!/usr/bin/env sh
+def macos_launch_script_contents(is_local):
+    configuration_ivy_home = " "
+    if is_local:
+        configuration_ivy_home = "-Divy.home=%s " % args.ivy_home
 
-BASE_BIN_DIR=$(dirname "$0")
-COURSIER_BIN="$BASE_BIN_DIR/%s"
-/usr/libexec/java_home -v 1.8 -F -R --exec java \
-     -Divy.home=%s -jar "$COURSIER_BIN" launch %s \
-     -r bintray:scalameta/maven \
-     -r bintray:scalacenter/releases \
-     -r https://oss.sonatype.org/content/repositories/staging \
-     --main bloop.Server
-""" % (BLOOP_COURSIER_BINARY_NAME, args.ivy_home, BLOOP_ARTIFACT)
+    contents = """
+    #!/usr/bin/env sh
 
+    BASE_BIN_DIR=$(dirname "$0")
+    COURSIER_BIN="$BASE_BIN_DIR/%s"
+    /usr/libexec/java_home -v 1.8 -F -R --exec java \
+      %s-jar "$COURSIER_BIN" launch %s \
+      -r bintray:scalameta/maven \
+      -r bintray:scalacenter/releases \
+      -r https://oss.sonatype.org/content/repositories/staging \
+      --main bloop.Server
+    """ % (BLOOP_COURSIER_BINARY_NAME, configuration_ivy_home, BLOOP_ARTIFACT)
+
+    return textwrap.dedent(contents)
 
 def download(url, target):
     try:
@@ -187,15 +194,23 @@ def coursier_bootstrap(target, main):
     try:
         # Use own script if Mac OS system to avoid launchd problems with java environment variables
         if platform.system() == "Darwin":
-            # Resolve first so that `coursier launch` in script doesn't
-            check_call(["java"] + http + https + ["-Divy.home=" + args.ivy_home, "-jar", BLOOP_COURSIER_TARGET, "fetch", BLOOP_ARTIFACT,
-                "-r", "bintray:scalameta/maven",
-                "-r", "bintray:scalacenter/releases"
-            ])
+            if is_local:
+                # Resolve first so that `coursier launch` in script doesn't
+                check_call(["java"] + http + https + ["-Divy.home=" + args.ivy_home, "-jar", BLOOP_COURSIER_TARGET, "fetch", BLOOP_ARTIFACT,
+                    "-r", "bintray:scalameta/maven",
+                    "-r", "bintray:scalacenter/releases"
+                ])
+            else:
+                # Resolve first so that `coursier launch` in script doesn't
+                check_call(["java"] + http + https + ["-jar", BLOOP_COURSIER_TARGET, "fetch", BLOOP_ARTIFACT,
+                    "-r", "bintray:scalameta/maven",
+                    "-r", "bintray:scalacenter/releases",
+                    "-r", "https://oss.sonatype.org/content/repositories/staging"
+                ])
 
             # Write the script in blp-server path so that it works
             with open(target, 'w') as output_file:
-                output_file.write(MACOS_LAUNCH_SCRIPT_CONTENTS)
+                output_file.write(macos_launch_script_contents(is_local))
 
             make_executable(target)
         else:

--- a/build.sbt
+++ b/build.sbt
@@ -338,7 +338,8 @@ addCommandAlias(
     s"${nativeBridge.id}/$publishLocalCmd",
     s"${jsBridge06.id}/$publishLocalCmd",
     s"${jsBridge10.id}/$publishLocalCmd",
-    "createLocalHomebrewFormula"
+    "createLocalHomebrewFormula",
+    "createLocalScoopFormula",
   ).mkString(";", ";", "")
 )
 

--- a/docs/tools/scoop/install.md
+++ b/docs/tools/scoop/install.md
@@ -1,0 +1,27 @@
+Add the bloop bundle to [scoop](https://github.com/lukesampson/scoop):
+
+```bash
+$ scoop bucket add bloop-stable https://github.com/scalacenter/scoop-bloop.git
+```
+
+Check that the bucket is correctly configured:
+
+```bash
+$ scoop bucket list
+$ scoop search bloop
+// You should see the bloop scoop package listed here
+```
+
+Then, install it with:
+
+```bash
+$ scoop install bloop
+```
+
+### Requirements
+
+1. **Python 2 or 3**. The installation script is written in Python.
+1. **Java 8**. The incremental compiler does not yet support Java 11.
+
+> You must ensure that Java 8 is installed manually (as well as ensuring that you run bloop with
+Java 8). The python dependency is automatically installed by scoop.

--- a/docs/tools/scoop/usage.md
+++ b/docs/tools/scoop/usage.md
@@ -1,0 +1,37 @@
+The installation script installs the build server and the bloop command-line application (CLI).
+The build server **must be started** before the command-line application is used. Start it with:
+
+```bash
+$ bloop server
+```
+
+This process can take a while to run the first time is executed. When the nailgun logs show up,
+verify your installation by running the command-line application:
+
+```
+$ bloop about
+bloop v1.1.1
+
+Running on Scala v2.12.7 and Zinc v1.1.1
+Maintained by the Scala Center (Martin Duhem, Jorge Vicente Cantero)
+```
+
+### Running the server in the background
+
+Bloop's build server is a long-running process designed to provide the fastest compilation possible
+to users. As such, users are responsible for managing its lifecycle and minimizing the amount of
+times it's restarted.
+
+Bloop does not have a service file for Windows so you have to start and stop the bloop server
+manually. It is recommended to have the bloop server running in a long-lived terminal session.
+
+### Command-line completions
+
+Bloop does not support Powershell completions at the moment. However, it does support Bash/Zsh
+command-line completions which are installed by default in the bloop installation directory (under
+`/etc`).
+
+There are several projects that allow you to use Bash style completions in your Powershell:
+
+1. [PSReadLine](https://github.com/lzybkr/PSReadLine), a plugin that improves the Powershell experience and supports bash completions.
+1. [`ps-bash-completions`](https://github.com/tillig/ps-bash-completions), a single Powershell module to install bash completions.

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -83,7 +83,9 @@ object BuildKeys {
   val bloopName = Def.settingKey[String]("The name to use in build info generated code")
   val nailgunClientLocation = Def.settingKey[sbt.File]("Where to find the python nailgun client")
   val updateHomebrewFormula = Def.taskKey[Unit]("Update Homebrew formula")
+  val updateScoopFormula = Def.taskKey[Unit]("Update Scoop formula")
   val createLocalHomebrewFormula = Def.taskKey[Unit]("Create local Homebrew formula")
+  val createLocalScoopFormula = Def.taskKey[Unit]("Create local Scoop formula")
 
   val gradleIntegrationDirs = sbt.AttributeKey[List[File]]("gradleIntegrationDirs")
   val fetchGradleApi = Def.taskKey[Unit]("Fetch Gradle API artifact")
@@ -124,7 +126,9 @@ object BuildKeys {
     GHReleaseKeys.ghreleaseRepoName := "bloop",
     GHReleaseKeys.ghreleaseAssets += ReleaseUtils.versionedInstallScript.value,
     createLocalHomebrewFormula := ReleaseUtils.createLocalHomebrewFormula.value,
-    updateHomebrewFormula := ReleaseUtils.updateHomebrewFormula.value
+    createLocalScoopFormula := ReleaseUtils.createLocalScoopFormula.value,
+    updateHomebrewFormula := ReleaseUtils.updateHomebrewFormula.value,
+    updateScoopFormula := ReleaseUtils.updateScoopFormula.value,
   )
 
   import sbtbuildinfo.{BuildInfoKey, BuildInfoKeys}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
 
   val nailgunVersion = "6992a3bf"
   // Used to download the python client instead of resolving
-  val nailgunCommit = "6992a3bf"
+  val nailgunCommit = "dc1dd806"
 
   val zincVersion = "1.2.1+106-0dad4a69"
   val bspVersion = "2.0.0-M1" 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,9 @@ object Dependencies {
   val Scala212Version = "2.12.7"
 
   val nailgunVersion = "6992a3bf"
+  // Used to download the python client instead of resolving
+  val nailgunCommit = "6992a3bf"
+
   val zincVersion = "1.2.1+106-0dad4a69"
   val bspVersion = "2.0.0-M1" 
   val scalazVersion = "7.2.20"

--- a/project/ReleaseUtils.scala
+++ b/project/ReleaseUtils.scala
@@ -21,7 +21,7 @@ object ReleaseUtils {
    * the version of Bloop that we're releasing.
    */
   val versionedInstallScript = Def.task {
-    val nailgun = Dependencies.nailgunVersion
+    val nailgun = Dependencies.nailgunCommit
     val coursier = Dependencies.coursierVersion
     val version = Keys.version.value
     val target = Keys.target.value

--- a/project/ReleaseUtils.scala
+++ b/project/ReleaseUtils.scala
@@ -170,7 +170,7 @@ object ReleaseUtils {
   def generateScoopFormulaContents(version: String, origin: FormulaOrigin): String = {
     val url = {
       origin match {
-        case Left(f) => s"""file://${f.getAbsolutePath}"""
+        case Left(f) => s"""${f.toPath.toUri.toString.replace("\\", "\\\\")}"""
         case Right(tag) => s"https://github.com/scalacenter/bloop/releases/download/$tag/install.py"
       }
     }

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -83,6 +83,12 @@
       "tools/nix/usage": {
         "title": "tools/nix/usage"
       },
+      "tools/scoop/install": {
+        "title": "tools/scoop/install"
+      },
+      "tools/scoop/usage": {
+        "title": "tools/scoop/usage"
+      },
       "tools/universal/install": {
         "title": "tools/universal/install"
       },

--- a/website/static/scripts/build-tools.js
+++ b/website/static/scripts/build-tools.js
@@ -34,6 +34,12 @@
     }
   }
 
+
+  previouslyBuildActive = null;
+  if (typeof(Storage) !== "undefined") {
+    previouslyBuildActive = sessionStorage.getItem("previouslyBuildActive");
+  }
+
   const buttons = document.querySelectorAll(".build-tools-group .build-tools-button");
   for (let i = 0; i < buttons.length; i++) {
     const button = buttons[i];
@@ -43,10 +49,15 @@
       } else {
         reset();
       }
+
       currentNav = this;
-      addClass(currentNav, "active");
       const name = currentNav.attributes["data-title"].value;
-      location.hash = name;
+
+      if (typeof(Storage) !== "undefined") {
+        sessionStorage.setItem("previouslyBuildActive", name);
+      }
+
+      addClass(currentNav, "active");
       currentItem = document.querySelectorAll(
         "[data-title=" + name + "]:not(.build-tools-button)"
       );
@@ -56,6 +67,14 @@
       for (let i = 0; i < stepHidden.length; i++) {
         $(stepHidden[i]).show();
       }
+
     };
+
+    const dataTitle = $(button).data("title");
+    if (dataTitle) {
+      if (dataTitle === previouslyBuildActive) {
+        button.click();
+      }
+    }
   }
 })();

--- a/website/static/scripts/tools.js
+++ b/website/static/scripts/tools.js
@@ -34,6 +34,11 @@
     }
   }
 
+  previouslyActive = null;
+  if (typeof(Storage) !== "undefined") {
+    previouslyActive = sessionStorage.getItem("previouslyActive");
+  }
+
   const buttons = document.querySelectorAll(".tools-group .tools-button");
   for (let i = 0; i < buttons.length; i++) {
     const button = buttons[i];
@@ -44,8 +49,13 @@
         reset();
       }
       currentNav = this;
-      addClass(currentNav, "active");
       const name = currentNav.attributes["data-title"].value;
+
+      if (typeof(Storage) !== "undefined") {
+        sessionStorage.setItem("previouslyActive", name);
+      }
+
+      addClass(currentNav, "active");
       location.hash = name;
       currentItem = document.querySelectorAll(
         "[data-title=" + name + "]:not(.tools-button)"
@@ -57,5 +67,16 @@
         $(stepHidden[i]).show();
       }
     };
+
+    const dataTitle = $(button).data("title");
+    if (dataTitle) {
+      if (("#" + dataTitle) === location.hash) {
+        button.click();
+      } else {
+        if (dataTitle === previouslyActive) {
+          button.click();
+        }
+      }
+    }
   }
 })();

--- a/website/tools.yml
+++ b/website/tools.yml
@@ -1,7 +1,8 @@
-- name: Universal installation
+- name: Universal Installation
   items:
-    universal: curl
-- name: Package managers
+    universal: curl (Default)
+- name: Package Managers
   items:
-    homebrew: Homebrew
+    homebrew: Homebrew (Mac OS)
+    scoop: Scoop (Windows)
     nix: Nix


### PR DESCRIPTION
1. Configure a scoop-based installation for Windows Powershell users.
2. Improve the ergonomics of Windows CMD users.
3. Fix several bugs with the installation script and the nailgun script.
4. Fix a bug in the build when running gradle in Windows.
5. Improve the UX of the installation page by persisting the choices to
   the session storage.

The fixed tickets are linked in the commit messages.