### PR TITLE
Handle recursive dependencies gracefully

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -85,7 +85,7 @@ pipeline:
       - ./frontend/src/test/resources/cross-test-build-1.0/target/generation-cache-file
     volumes:
       - /cache:/cache
-    cache_key: [ DRONE_REPO_OWNER, DRONE_REPO_NAME, DRONE_BRANCH ]
+    cache_key: [ DRONE_REPO_OWNER, DRONE_REPO_NAME ]
     when:
       ref: [ refs/heads/master, refs/tags/*, refs/pull/*/head ]
       matrix:
@@ -214,4 +214,4 @@ pipeline:
       - ./frontend/src/test/resources/cross-test-build-1.0/target/generation-cache-file
     volumes:
       - /cache:/cache
-    cache_key: [ DRONE_REPO_OWNER, DRONE_REPO_NAME, DRONE_BRANCH ]
+    cache_key: [ DRONE_REPO_OWNER, DRONE_REPO_NAME ]

--- a/.drone.yml
+++ b/.drone.yml
@@ -40,12 +40,13 @@ matrix:
           "show version" \
           "set pgpPublicRing in Global := file(\"/drone/.gnupg/pubring.asc\")" \
           "set pgpSecretRing in Global := file(\"/drone/.gnupg/secring.asc\")" \
-          "docs/docusaurusPublishGhpages" \
-          "releaseBloop"
+          "releaseBloop" \
+          "docs/docusaurusPublishGhpages"
 
   RELEASE_GITHUB_BREW:
     - bin/sbt-ci.sh \
           "frontend/updateHomebrewFormula" \
+          "frontend/updateScoopFormula" \
           "frontend/githubRelease"
   OS:
     - windows

--- a/backend/src/main/scala/bloop/io/Paths.scala
+++ b/backend/src/main/scala/bloop/io/Paths.scala
@@ -15,7 +15,7 @@ import java.nio.file.{
 }
 import java.util
 
-import bloop.logging.Logger
+import bloop.logging.{DebugFilter, Logger}
 import io.github.soc.directories.ProjectDirectories
 
 object Paths {
@@ -111,7 +111,7 @@ object Paths {
       }
 
       def visitFileFailed(t: Path, e: IOException): FileVisitResult = {
-        logger.error(s"Unexpected failure when visiting ${t}: '${e.getMessage}'")
+        logger.debug(s"Unexpected failure when visiting ${t}: '${e.getMessage}'")(DebugFilter.All)
         FileVisitResult.CONTINUE
       }
 

--- a/backend/src/main/scala/bloop/io/Paths.scala
+++ b/backend/src/main/scala/bloop/io/Paths.scala
@@ -111,7 +111,8 @@ object Paths {
       }
 
       def visitFileFailed(t: Path, e: IOException): FileVisitResult = {
-        logger.debug(s"Unexpected failure when visiting ${t}: '${e.getMessage}'")(DebugFilter.All)
+        logger.error(s"Unexpected failure when visiting ${t}: '${e.getMessage}'")
+        logger.trace(e)
         FileVisitResult.CONTINUE
       }
 
@@ -126,9 +127,12 @@ object Paths {
       ): FileVisitResult = FileVisitResult.CONTINUE
     }
 
-    val opts = util.EnumSet.of(FileVisitOption.FOLLOW_LINKS)
-    Files.walkFileTree(base.underlying, opts, maxDepth, visitor)
-    out.toList
+    if (!base.exists) Nil
+    else {
+      val opts = util.EnumSet.of(FileVisitOption.FOLLOW_LINKS)
+      Files.walkFileTree(base.underlying, opts, maxDepth, visitor)
+      out.toList
+    }
   }
 
   /**

--- a/bin/install.py
+++ b/bin/install.py
@@ -186,14 +186,14 @@ def coursier_bootstrap(target, main):
     http = []
     https = []
 
-    if "http_proxy" in os.environ:
+    if os.environ.get("http_proxy"):
         http_proxy = urlparse(os.environ['http_proxy'])
         http = [
             "-Dhttp.proxyHost="+http_proxy.hostname,
             "-Dhttp.proxyPort="+str(http_proxy.port)
         ]
 
-    if "https_proxy" in os.environ:
+    if os.environ.get("https_proxy"):
         https_proxy = urlparse(os.environ['https_proxy'])
         https = [
             "-Dhttps.proxyHost="+https_proxy.hostname,

--- a/build.sbt
+++ b/build.sbt
@@ -312,7 +312,8 @@ val bloop = project
   .settings(
     releaseEarly := { () },
     skip in publish := true,
-    crossSbtVersions := Seq("1.1.0", "0.13.16")
+    crossSbtVersions := Seq("1.1.0", "0.13.16"),
+    commands += BuildDefaults.exportProjectsInTestResourcesCmd
   )
 
 /***************************************************************************************************/

--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -240,8 +240,8 @@ object Config {
 
   case class File(version: String, project: Project)
   object File {
-    final val LatestVersion = "1.1.0-M2"
-
+    // We cannot have the version coming from the build tool
+    final val LatestVersion = "1.1.2"
     private[bloop] val empty = File(LatestVersion, Project.empty)
 
     private[bloop] def dummyForTests: File = {

--- a/docs/src/main/scala/bloop/docs/Sonatype.scala
+++ b/docs/src/main/scala/bloop/docs/Sonatype.scala
@@ -17,7 +17,7 @@ case class Release(version: String, lastModified: Date) {
 }
 
 object Sonatype {
-  lazy val release = Sonatype.fetchLatest("releases")
+  lazy val release = Sonatype.fetchLatest("staging")
 
   // Copy-pasted from https://github.com/scalameta/metals/blob/994e5e6746ad327ce727d688ad9831e0fbb69b3f/metals-docs/src/main/scala/docs/Snapshot.scala
   lazy val current: Release = Release(BuildInfo.version, new Date())

--- a/frontend/src/main/scala/bloop/cli/ExitStatus.scala
+++ b/frontend/src/main/scala/bloop/cli/ExitStatus.scala
@@ -21,7 +21,7 @@ object ExitStatus {
   }
 
   // FORMAT: OFF
-  val Ok, UnexpectedError, ParseError, InvalidCommandLineOption, CompilationError, LinkingError, TestExecutionError, RunError: ExitStatus = generateExitStatus
+  val Ok, UnexpectedError, ParseError, InvalidCommandLineOption, CompilationError, LinkingError, TestExecutionError, RunError, BuildDefinitionError: ExitStatus = generateExitStatus
   // FORMAT: ON
 
   // The initialization of all must come after the invocations to `generateExitStatus`

--- a/frontend/src/main/scala/bloop/engine/Build.scala
+++ b/frontend/src/main/scala/bloop/engine/Build.scala
@@ -12,7 +12,7 @@ final case class Build private (
     projects: List[Project]
 ) extends CacheHashCode {
   private val stringToProjects: Map[String, Project] = projects.map(p => p.name -> p).toMap
-  private[bloop] val DagResult(dags, missingDeps) = Dag.fromMap(stringToProjects)
+  private[bloop] val DagResult(dags, missingDeps, traces) = Dag.fromMap(stringToProjects)
 
   def getProjectFor(name: String): Option[Project] = stringToProjects.get(name)
 

--- a/frontend/src/main/scala/bloop/engine/Feedback.scala
+++ b/frontend/src/main/scala/bloop/engine/Feedback.scala
@@ -1,5 +1,8 @@
 package bloop.engine
+import java.nio.file.Path
+
 import bloop.data.Project
+import bloop.engine.Dag.RecursiveTrace
 import bloop.io.AbsolutePath
 
 object Feedback {
@@ -15,11 +18,21 @@ object Feedback {
     s"Failed to compile project '${project.name}': found Scala sources but project is missing Scala configuration."
   def missingInstanceForJavaCompilation(project: Project): String =
     s"Failed to compile Java sources in ${project.name}: default Zinc Scala instance couldn't be created!"
+
+  def reportRecursiveTrace(trace: RecursiveTrace): String = {
+    trace.visited.headOption match {
+      case Some(initialProject) =>
+        s"Fatal recursive dependency detected in '${initialProject}': ${trace.visited}"
+      case None => "The build has an undefined recursive trace. Please, report upstream."
+    }
+  }
+
   def detectMissingDependencies(project: Project, missing: List[String]): Option[String] = {
     missing match {
       case Nil => None
       case missing :: Nil =>
-        Some(s"Missing project '$missing', may cause compilation issues in project '${project.name}'")
+        Some(
+          s"Missing project '$missing', may cause compilation issues in project '${project.name}'")
       case xs =>
         val deps = missing.map(m => s"'$m'").mkString(", ")
         Some(s"Missing projects $deps, may cause compilation issues in project '${project.name}'")
@@ -58,6 +71,26 @@ object Feedback {
        |  2. Did you forget to generate configuration files for your build?
        |     Check the installation instructions https://scalacenter.github.io/bloop/docs/installation/
     """.stripMargin
+
+  val MissingPipeName = "Missing pipe name to establish a local connection in Windows"
+  val MissingSocket =
+    "A socket file is required to establish a local connection through Unix sockets"
+  def excessiveSocketLengthInMac(socket: Path): String =
+    s"The length of the socket path '${socket.toString}' exceeds 104 bytes in macOS"
+  def excessiveSocketLength(socket: Path): String =
+    s"The length of the socket path '${socket.toString}' exceeds 108 bytes"
+  def existingSocketFile(socket: Path): String =
+    s"Bloop bsp server cannot establish a connection with an existing socket file '${socket.toAbsolutePath}'"
+  def missingParentOfSocket(socket: Path): String =
+    s"'${socket.toAbsolutePath}' cannot be created because its parent does not exist"
+  def unexpectedPipeFormat(pipeName: String): String =
+    s"Pipe name '${pipeName}' does not start with '\\\\.\\pipe\\'"
+  def outOfRangePort(n: Int): String =
+    s"Port number '${n}' is either negative or bigger than 65535"
+  def reservedPortNumber(n: Int): String =
+    s"Port number '${n}' is reserved for the operating system. Use a port number bigger than 1024"
+  def unknownHostName(host: String): String =
+    s"Host name '$host' could not be either parsed or resolved"
 
   implicit class XMessageString(msg: String) {
     def suggest(suggestion: String): String = s"$msg\n$suggestion"

--- a/frontend/src/test/scala/bloop/cli/validation/ValidateSuite.scala
+++ b/frontend/src/test/scala/bloop/cli/validation/ValidateSuite.scala
@@ -4,7 +4,7 @@ import java.nio.file.Files
 
 import bloop.bsp.BspServer
 import bloop.cli.{BspProtocol, Commands, ExitStatus}
-import bloop.engine.{Action, Exit, Print, Run}
+import bloop.engine.{Action, Exit, Feedback, Print, Run}
 import org.junit.Test
 
 class ValidateSuite {

--- a/frontend/src/test/scala/bloop/engine/FileWatchingSpec.scala
+++ b/frontend/src/test/scala/bloop/engine/FileWatchingSpec.scala
@@ -169,7 +169,7 @@ class FileWatchingSpec {
     }
 
     val t = Task.zip2(Task.fromFuture(testFuture), checkTests).doOnCancel(Task(testFuture.cancel()))
-    TestUtil.blockOnTask(t, 20.toLong)
+    TestUtil.blockOnTask(t, 30.toLong)
     ()
   }
 

--- a/frontend/src/test/scala/bloop/exec/ForkerSpec.scala
+++ b/frontend/src/test/scala/bloop/exec/ForkerSpec.scala
@@ -48,11 +48,15 @@ class ForkerSpec {
       val logger = new RecordingLogger
       val opts = state.commonOptions.copy(env = TestUtil.runAndTestProperties)
       val mainClass = s"$packageName.$mainClassName"
-      val wait = Duration.apply(15, TimeUnit.SECONDS)
-      val exitCode =
-        TestUtil.await(wait)(config.runMain(cwdPath, mainClass, args, logger.asVerbose, opts))
-      val messages = logger.getMessages()
-      op(exitCode, messages)
+      try {
+        val wait = Duration.apply(25, TimeUnit.SECONDS)
+        val exitCode =
+          TestUtil.await(wait)(config.runMain(cwdPath, mainClass, args, logger.asVerbose, opts))
+        val messages = logger.getMessages()
+        op(exitCode, messages)
+      } finally {
+        logger.dump()
+      }
     }
 
   @Test

--- a/frontend/src/test/scala/bloop/tasks/CompileSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/CompileSpec.scala
@@ -4,7 +4,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 
-import org.junit.Test
+import org.junit.{Assert, Test}
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import org.junit.experimental.categories.Category
 import bloop.ScalaInstance
@@ -458,6 +458,7 @@ class CompileSpec {
         val projectB = getProject("B", state)
         val action = Run(Commands.Compile("B"), Run(Commands.Compile("C")))
         val compiledState = TestUtil.blockingExecute(action, state)
+        Assert.assertFalse("Sequential compilation didn't fail!", compiledState.status.isOk)
 
         // Check that A failed to compile and that `C` was skipped
         val msgs = logger.getMessages

--- a/frontend/src/test/scala/bloop/tasks/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/tasks/TestUtil.scala
@@ -12,7 +12,7 @@ import bloop.data.{Origin, Project}
 import bloop.engine.{Action, Build, BuildLoader, ExecutionContext, Interpreter, Run, State}
 import bloop.exec.JavaEnv
 import bloop.ScalaInstance
-import bloop.io.AbsolutePath
+import bloop.io.{AbsolutePath, RelativePath}
 import bloop.io.Paths.delete
 import bloop.internal.build.BuildInfo
 import bloop.logging.{BloopLogger, BufferedLogger, Logger, RecordingLogger}
@@ -369,5 +369,23 @@ object TestUtil {
     if (!diff.isEmpty) {
       Assert.fail("\n" + diff)
     }
+  }
+
+  def createSimpleRecursiveBuild(bloopDir: RelativePath): AbsolutePath = {
+    import bloop.config.Config
+    val baseDir = Files.createTempDirectory("bloop-recursive-project")
+    baseDir.toFile.deleteOnExit()
+    val configDir = AbsolutePath(baseDir).resolve(bloopDir)
+    Files.createDirectory(configDir.underlying)
+    val jsonTargetG = configDir.resolve("g.json").underlying
+    val outDir = Files.createDirectory(baseDir.resolve("out"))
+    val classesDir = Files.createDirectory(outDir.resolve("classes"))
+
+    // format: OFF
+    val configFileG = bloop.config.Config.File(Config.File.LatestVersion, Config.Project("g", baseDir, Nil, List("g"), Nil, outDir, classesDir, None, None, None, None, None, None, None))
+    bloop.config.write(configFileG, jsonTargetG)
+    // format: ON
+
+    configDir
   }
 }

--- a/notes/v1.1.2.md
+++ b/notes/v1.1.2.md
@@ -1,0 +1,46 @@
+# Install `v1.1.1` :candy:
+
+If you're on Mac OS X, **upgrade** to the latest version with:
+
+```sh
+$ brew upgrade scalacenter/bloop/bloop
+```
+
+Otherwise, run:
+
+```
+$ curl -L https://github.com/scalacenter/bloop/releases/download/v1.1.2/install.py | python
+```
+
+Read the complete installation instructions in our [Installation page][installation instructions].
+
+## Highlights :books:
+
+The v1.1.2 release is mostly a bugfix release fixing some installation problems.
+
+### Fixes in installation
+
+1. Configure a scoop-based installation for Windows Powershell users.
+1. Improve the ergonomics of Windows CMD users.
+1. Fix several bugs with the installation script and the nailgun script.
+1. Fix a bug in the build when running gradle in Windows.
+1. Improve the UX of the installation page by persisting the choices to the session storage.
+
+Check the PR introducing these changes [here](https://github.com/scalacenter/bloop/pull/755).
+
+### Handling recursive dependencies gracefully
+
+See scalameta/metals#396 for the issue that triggered work on this area. Even
+if recursive dependencies is a fatal error for bloop, we still handle
+gracefully and connect successfully during a bsp connection. Builds that have
+problems will get:
+
+1. An empty response to `workspace/buildTargets`.
+1. A `build/showMessage` per every error found.
+
+## Contributors :busts_in_silhouette:
+
+According to `git shortlog -sn --no-merges v1.1.1..v1.1.2`, 1 people contributed to this
+`v1.1.2` release: Jorge Vicente Cantero.
+
+[installation instructions]: https://scalacenter.github.io/bloop/setup

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -138,6 +138,7 @@ object BuildKeys {
     List(Keys.scalaVersion, Keys.scalaOrganization, scalaJarsKey)
   }
 
+
   import sbt.util.Logger.{Null => NullLogger}
   def bloopInfoKeys(
       nativeBridge: Reference,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.2.7


### PR DESCRIPTION
See https://github.com/scalameta/metals/issues/396 for the issue that
triggered work on this area. Even if recursive dependencies is a fatal
error for bloop, we still handle gracefully and connect successfully
during a bsp connection. Builds that have problems will get:

1. An empty response to `workspace/buildTargets`.
2. A `build/showMessage` per every error found.