### PR TITLE
Updated mill version 0.2.6 -> 0.3.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -355,6 +355,7 @@ addCommandAlias(
     s"${backend.id}/$publishLocalCmd",
     s"${frontend.id}/$publishLocalCmd",
     s"${nativeBridge.id}/$publishLocalCmd",
+    s"${millBloop.id}/$publishLocalCmd",
     s"${jsBridge06.id}/$publishLocalCmd",
     s"${jsBridge10.id}/$publishLocalCmd",
     s"${launcher.id}/$publishLocalCmd",

--- a/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
+++ b/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
@@ -9,7 +9,7 @@ import bloop.config.util.ConfigUtil
 
 object Bloop extends ExternalModule {
 
-  def install(ev: Evaluator[Any]) = T.command {
+  def install(ev: Evaluator) = T.command {
     val bloopDir = pwd / ".bloop"
     mkdir(bloopDir)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
   val scalaNativeVersion = "0.3.7"
   val scalaJs06Version = "0.6.25"
   val scalaJs10Version = "1.0.0-M5"
-  val millVersion = "0.2.6"
+  val millVersion = "0.3.5"
   val xxHashVersion = "1.3.0"
   val ztVersion = "1.13"
   val difflibVersion = "1.3.0"


### PR DESCRIPTION
This bumps the mill dependency to the current version and adds the `publishLocal` step to the `"install"` alias.