### PR TITLE
Improve handling of `-J` arguments and jvm options

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -44,7 +44,7 @@ matrix:
           "releaseBloop" \
           "docs/docusaurusPublishGhpages"
 
-  RELEASE_GITHUB_BREW:
+  UPDATE_GITHUB_AND_INSTALLERS:
     - bin/sbt-ci.sh \
           "frontend/updateHomebrewFormula" \
           "frontend/updateScoopFormula" \
@@ -195,7 +195,8 @@ pipeline:
       - export DRONE_DIR="/drone"
       - . bin/set-up-dodo.sh # Source it because it exports variables
       - echo "oauth = $BLOOPOID_GITHUB_TOKEN" > ~/.github
-      - ${RELEASE_GITHUB_BREW}
+      - ${UPDATE_GITHUB_AND_INSTALLERS}
+      - git status # Print to see what may be polluting the git state
 
   rebuild-cache:
     image: drillster/drone-volume-cache

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -1,7 +1,7 @@
 ---
 id: launcher-reference
-title: Launcher
-sidebar_label: Launcher Reference
+title: Launcher Reference
+sidebar_label: Built-in Launcher
 ---
 
 The launcher is a lightweight artifact (~122K) that installs and configures

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,0 +1,136 @@
+---
+id: server-reference
+title: Build Server Reference
+sidebar_label: Build Server
+---
+
+The build server is at the core of bloop. It runs in the background and is
+the responsible for scheduling and running client actions.
+
+Bloop's build server is a long-running process designed to provide the fastest
+compilation possible to users. As such, users are responsible for managing its
+lifecycle and minimizing the amount of times it's restarted.
+
+## Start the build server
+
+At the end of the day, the build server is an artifact in Maven Central. However,
+the recommended way of starting the server is via `bloop server`.
+
+`bloop server` is an OS-independent way of starting the server that abstracts over
+some of the messy details of running a JVM application with the right configuration.
+For example, `bloop server`:
+
+1. Finds the location of a bootstrapped jar automatically in the bloop installation
+   directory
+1. Runs the server with the jvm options in the `.jvmopts` file in the bloop installation
+   directory. The `.jvmopts` file can contain the flags separated by either a new line or
+   a whitespace.
+1. Provides a way to evolve the way the server is run and managed in the future, which
+   makes it especially compatibility-friendly.
+   
+The bloop installation directory is the directory where `bloop` is located. In Unix-based
+systems, the bloop installation directory can be found by running `which bloop`.
+
+<blockquote class="grab-attention">
+Do you want to install and start the server <i>automatically</i> in the background?
+The <a href="launcher-reference">Launcher</a> is a lightweight artifact that will
+provide clients an out-of-the-box bloop experience.
+</blockquote>
+
+### `bloop server`
+
+#### Usage
+
+**Synopsis**: `bloop [FLAGS...] server [JVM_OPTS...] NAILGUN_PORT`
+
+* `NAILGUN_PORT` must be a free TCP port. For now, only ports in the localhost is
+  supported.
+* `JVM_OPTS` must be valid JVM arguments prefixed with `-J`, used to pass in
+  temporary jvm options to the server. For a permanent solution, add the options in
+  `.jvmopts` file.
+  
+#### Flags
+
+<dl>
+  <dt><code>--server-location</code> (type: <code>path</code>)</dt>
+  <dd><p>Use the server jar or script in the given path</p></dd>
+</dl>
+
+## Automatic management of the server
+
+It is generally a good practice to have a way to manage the lifecycle of the server. 
+Depending on your operating system, there exist several solutions that allow you to
+start, stop, restart and inspect the status of the build server at any time.
+
+Bloop supports the following mechanisms out-of-the-box:
+
+1. `brew services` in OSX systems
+1. `systemd` in Linux systems
+1. Desktop Entries in systems that follow the [XDG Desktop Entry Specification](https://standards.freedesktop.org/desktop-entry-spec/latest/)
+
+> Windows users do not have a way of starting the server via Windows Services, so the
+> lifecycle management has to be manual. Do you want to help improve the situation?
+> Check this [ticket](https://github.com/scalacenter/bloop/issues/766).
+
+### via `brew services`
+
+Brew services are powered by `launchd` and need a macOS property list (`plist`) that explains how to
+start the Bloop server and under which conditions. The property list is installed by default in the
+[Homebrew](../setup#homebrew) installation and doesn't require any extra steps to use it.
+
+Command examples:
+
+1. `cat /usr/local/var/log/bloop/bloop.out.log`: check the build server logs via stdout.
+1. `cat /usr/local/var/log/bloop/bloop.err.log`: check the build server logs via stderr.
+1. `brew services start bloop`: starts up the bloop server.
+1. `brew services stop bloop`: stops the bloop server.
+1. `brew services restart bloop`: restarts the bloop server.
+
+### via `systemd`
+
+To have the Bloop server be automatically managed by systemd, install Bloop's systemd service:
+
+```bash
+$ systemctl --user enable $HOME/.bloop/systemd/bloop.service
+$ systemctl --user daemon-reload
+```
+
+The build server will be started whenever you log in your computer and killed whenever your session
+is closed.
+
+<blockquote>
+<p>
+It is also possible to only kill the build server when the machine is shut down. Please refer to <a
+href="https://wiki.archlinux.org/index.php/Systemd/Users">Systemd's documentation about user
+services</a> for advanced configuration.
+</p>
+</blockquote>
+
+Command examples:
+
+1. `journalctl --user-unit bloop`: check the build server logs.
+1. `systemctl --user status bloop`: checks the status of the build server.
+1. `systemctl --user start bloop`: starts up the bloop server.
+1. `systemctl --user stop bloop`: stops the bloop server.
+1. `systemctl --user restart bloop`: restarts the build server.
+
+### via Desktop Entries
+
+A desktop entry is a `bloop.desktop` file which your desktop environment recognizes as a launcher if
+it supports the [freedesktop.org Desktop Entry
+specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html).
+For example, Ubuntu recognizes and displays desktop entries in the application menu next to an icon.
+
+Install a desktop entry with:
+
+```bash
+$ mkdir -p $HOME/.local/share/applications
+$ ln -s $HOME/.bloop/xdg/bloop.desktop $HOME/.local/share/applications/
+```
+
+If you want to start the server automatically, add the desktop entry to `autostart`:
+
+```bash
+$ mkdir -p $HOME/.config/autostart
+$ ln -s $HOME/.bloop/xdg/bloop.desktop $HOME/.config/autostart/
+```

--- a/docs/src/main/scala/bloop/Docs.scala
+++ b/docs/src/main/scala/bloop/Docs.scala
@@ -22,7 +22,12 @@ object Docs {
       // it should work with mdoc when run inside bloop but it doesn't, let's wait until it's fixed
       .withIn(cwd.resolve("docs"))
       .withOut(cwd.resolve("out"))
-      .withStringModifiers(List(new ReleasesModifier, new LauncherReleasesModifier))
+      .withStringModifiers(
+        List(
+          new ReleasesModifier,
+          new LauncherReleasesModifier
+        )
+      )
 
     val exitCode = _root_.mdoc.Main.process(settings)
     if (exitCode != 0) sys.exit(exitCode)

--- a/docs/tools/homebrew/usage.md
+++ b/docs/tools/homebrew/usage.md
@@ -15,6 +15,9 @@ Command examples:
 1. `brew services stop bloop`: stops the bloop server.
 1. `brew services restart bloop`: restarts the bloop server.
 
+To learn more about `bloop server` and managing the server lifecycle automatically, head to the
+[Build Server Reference](docs/server-reference).
+
 ### Command-line completions
 
 The installation script will automatically install completions for bash, zsh and fish.

--- a/docs/tools/nix/usage.md
+++ b/docs/tools/nix/usage.md
@@ -21,64 +21,10 @@ Bloop's build server is a long-running process designed to provide the fastest c
 to users. As such, users are responsible for managing its lifecycle and minimizing the amount of
 times it's restarted.
 
-Depending on your setup, there are several mechanisms to start automatically the build server and
-manage its lifetime.
-
-<blockquote>
-  <p>
-    The following section is Unix only. If you're a Windows user, you will need to run the bloop
-    server manually in a long-running terminal session.
-  </p>
-</blockquote>
-
-#### Systemd
-
-To have the Bloop server be automatically managed by systemd, install Bloop's systemd service:
-
-```bash
-$ systemctl --user enable $HOME/.bloop/systemd/bloop.service
-$ systemctl --user daemon-reload
-```
-
-The build server will be started whenever you log in your computer and killed whenever your session
-is closed.
-
-<blockquote>
-<p>
-It is also possible to only kill the build server when the machine is shut down. Please refer to <a
-href="https://wiki.archlinux.org/index.php/Systemd/Users">Systemd's documentation about user
-services</a> for advanced configuration.
-</p>
-</blockquote>
-
-Command examples:
-
-1. `journalctl --user-unit bloop`: check the build server logs.
-1. `systemctl --user status bloop`: checks the status of the build server.
-1. `systemctl --user start bloop`: starts up the bloop server.
-1. `systemctl --user stop bloop`: stops the bloop server.
-1. `systemctl --user restart bloop`: restarts the build server.
-
-#### Desktop Entry
-
-A desktop entry is a `bloop.desktop` file which your desktop environment recognizes as a launcher if
-it supports the [freedesktop.org Desktop Entry
-specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html).
-For example, Ubuntu recognizes and displays desktop entries in the application menu next to an icon.
-
-Install a desktop entry with:
-
-```bash
-$ mkdir -p $HOME/.local/share/applications
-$ ln -s $HOME/.bloop/xdg/bloop.desktop $HOME/.local/share/applications/
-```
-
-If you want to start the server automatically, add the desktop entry to `autostart`:
-
-```bash
-$ mkdir -p $HOME/.config/autostart
-$ ln -s $HOME/.bloop/xdg/bloop.desktop $HOME/.config/autostart/
-```
+We have seen how to manually start the server with `bloop server`. However, you may prefer an
+automatic solution that starts the server in the background when you log in and allows you to
+quickly restart it. There are several mechanisms to do so, read the [Build Server
+Reference](docs/server-reference).
 
 ### Command-line completions
 

--- a/docs/tools/scoop/usage.md
+++ b/docs/tools/scoop/usage.md
@@ -25,6 +25,13 @@ times it's restarted.
 Bloop does not have a service file for Windows so you have to start and stop the bloop server
 manually. It is recommended to have the bloop server running in a long-lived terminal session.
 
+> If you want to improve this situation, check this
+[ticket](https://github.com/scalacenter/bloop/issues/766) which proposes a solution to this problem
+that is compatible with Windows Services.
+
+To learn more about `bloop server` and managing the server lifecycle automatically, head to the
+[Build Server Reference](docs/server-reference).
+
 ### Command-line completions
 
 Bloop does not support Powershell completions at the moment. However, it does support Bash/Zsh

--- a/docs/tools/universal/usage.md
+++ b/docs/tools/universal/usage.md
@@ -29,64 +29,10 @@ Bloop's build server is a long-running process designed to provide the fastest c
 to users. As such, users are responsible for managing its lifecycle and minimizing the amount of
 times it's restarted.
 
-Depending on your setup, there are several mechanisms to start automatically the build server and
-manage its lifetime (and they are all installed by default).
-
-<blockquote>
-  <p>
-    The following section is Unix only. If you're a Windows user, you will need to run the bloop
-    server manually in a long-running terminal session.
-  </p>
-</blockquote>
-
-#### Systemd
-
-To have the Bloop server be automatically managed by systemd, install Bloop's systemd service:
-
-```bash
-$ systemctl --user enable $HOME/.bloop/systemd/bloop.service
-$ systemctl --user daemon-reload
-```
-
-The build server will be started whenever you log in your computer and killed whenever your session
-is closed.
-
-<blockquote>
-<p>
-It is also possible to only kill the build server when the machine is shut down. Please refer to <a
-href="https://wiki.archlinux.org/index.php/Systemd/Users">Systemd's documentation about user
-services</a> for advanced configuration.
-</p>
-</blockquote>
-
-Command examples:
-
-1. `journalctl --user-unit bloop`: check the build server logs.
-1. `systemctl --user status bloop`: checks the status of the build server.
-1. `systemctl --user start bloop`: starts up the bloop server.
-1. `systemctl --user stop bloop`: stops the bloop server.
-1. `systemctl --user restart bloop`: restarts the build server.
-
-#### Desktop Entry
-
-A desktop entry is a `bloop.desktop` file which your desktop environment recognizes as a launcher if
-it supports the [freedesktop.org Desktop Entry
-specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html).
-For example, Ubuntu recognizes and displays desktop entries in the application menu next to an icon.
-
-Install a desktop entry with:
-
-```bash
-$ mkdir -p $HOME/.local/share/applications
-$ ln -s $HOME/.bloop/xdg/bloop.desktop $HOME/.local/share/applications/
-```
-
-If you want to start the server automatically, add the desktop entry to `autostart`:
-
-```bash
-$ mkdir -p $HOME/.config/autostart
-$ ln -s $HOME/.bloop/xdg/bloop.desktop $HOME/.config/autostart/
-```
+We have seen how to manually start the server with `bloop server`. However, you may prefer an
+automatic solution that starts the server in the background when you log in and allows you to
+quickly restart it. There are several mechanisms to do so, read the [Build Server
+Reference](docs/server-reference).
 
 ### Command-Line Completions
 

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -367,7 +367,7 @@ final class BloopBspServices(
         case Right(mainClass) =>
           project.platform match {
             case Platform.Jvm(javaEnv, _, _) =>
-              Tasks.runJVM(state, project, javaEnv, cwd, mainClass, cmd.args.toArray)
+              Tasks.runJVM(state, project, javaEnv, cwd, mainClass, cmd.args.toArray, false)
             case platform @ Platform.Native(config, _, _) =>
               val target = ScalaNativeToolchain.linkTargetFrom(project, config)
               linkMainWithNative(cmd, project, state, mainClass, target, platform).flatMap {

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -4,7 +4,6 @@ import java.net.InetAddress
 import java.nio.file.Path
 
 import bloop.cli.CliParsers.CommandsMessages
-import bloop.engine.ExecutionContext
 import bloop.io.AbsolutePath
 import caseapp.{CommandName, ExtraName, HelpMessage, Hidden, Recurse}
 import caseapp.core.CommandMessages
@@ -176,6 +175,8 @@ object Commands {
       @ExtraName("w")
       @HelpMessage("If set, run the command whenever projects' source files change.")
       watch: Boolean = false,
+      @HelpMessage("Ignore arguments starting with `-J` and forward them instead.")
+      skipJargs: Boolean = false,
       @ExtraName("O")
       @HelpMessage(
         "If an optimizer is used (e.g. Scala Native or Scala.js), run it in `debug` or `release` mode. Defaults to `debug`.")

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -367,7 +367,15 @@ object Interpreter {
                     else Tasks.runNativeOrJs(state, project, cwd, mainClass, args)
                 }
               case Platform.Jvm(javaEnv, _, _) =>
-                Tasks.runJVM(state, project, javaEnv, cwd, mainClass, cmd.args.toArray)
+                Tasks.runJVM(
+                  state,
+                  project,
+                  javaEnv,
+                  cwd,
+                  mainClass,
+                  cmd.args.toArray,
+                  cmd.skipJargs
+                )
             }
         }
       }

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -173,6 +173,7 @@ object Tasks {
    * @param cwd       The directory in which to start the forked JVM.
    * @param fqn       The fully qualified name of the main class.
    * @param args      The arguments to pass to the main class.
+   * @param skipJargs Skip the interpretation of `-J` options in `args`.
    */
   def runJVM(
       state: State,
@@ -180,11 +181,12 @@ object Tasks {
       javaEnv: JavaEnv,
       cwd: AbsolutePath,
       fqn: String,
-      args: Array[String]
+      args: Array[String],
+      skipJargs: Boolean
   ): Task[State] = {
     val classpath = project.fullClasspathFor(state.build.getDagFor(project))
     val processConfig = Forker(javaEnv, classpath)
-    val runTask = processConfig.runMain(cwd, fqn, args, state.logger, state.commonOptions)
+    val runTask = processConfig.runMain(cwd, fqn, args, skipJargs, state.logger, state.commonOptions)
     runTask.map { exitCode =>
       val exitStatus = Forker.exitStatus(exitCode)
       state.mergeStatus(exitStatus)

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -30,8 +30,8 @@ object TestTask {
    * @param project The project to test.
    * @param cwd The current working directory.
    * @param userTestOptions0 The test options that are passed by the user via CLI. If they
-    *                         contain arguments starting with `-J`, they will be interpreted
-    *                         as java options.
+   *                         contain arguments starting with `-J`, they will be interpreted
+   *                         as jvm options.
    * @param testFilter The test filter for test suites.
    * @param failureHandler The handler that will intervene if there's an error.
    * @return A status code that will signal success or failure.

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -29,7 +29,9 @@ object TestTask {
    * @param state The state with which to test.
    * @param project The project to test.
    * @param cwd The current working directory.
-   * @param userTestOptions The test options that are passed by the user via CLI.
+   * @param userTestOptions0 The test options that are passed by the user via CLI. If they
+    *                         contain arguments starting with `-J`, they will be interpreted
+    *                         as java options.
    * @param testFilter The test filter for test suites.
    * @param failureHandler The handler that will intervene if there's an error.
    * @return A status code that will signal success or failure.
@@ -38,7 +40,7 @@ object TestTask {
       state: State,
       project: Project,
       cwd: AbsolutePath,
-      userTestOptions: List[String],
+      rawTestOptions: List[String],
       testFilter: String => Boolean,
       failureHandler: LoggingEventHandler
   ): Task[Int] = {
@@ -50,6 +52,7 @@ object TestTask {
         if (frameworks.isEmpty) logger.error("No test frameworks found")
         else logger.debug(s"Found test frameworks: ${frameworks.map(_.name).mkString(", ")}")
 
+        val (userJvmOptions, userTestOptions) = rawTestOptions.partition(_.startsWith("-J"))
         val frameworkArgs = considerFrameworkArgs(frameworks, userTestOptions, logger)
         val args = fixTestOptions(project, project.testOptions.arguments ++ frameworkArgs)
         logger.debug(s"Running test suites with arguments: $args")
@@ -65,8 +68,17 @@ object TestTask {
         found match {
           case DiscoveredTestFrameworks.Jvm(_, forker, loader) =>
             val opts = state.commonOptions
-            TestInternals
-              .execute(cwd, forker, loader, discovered, args, failureHandler, logger, opts)
+            TestInternals.execute(
+              cwd,
+              forker,
+              loader,
+              discovered,
+              args,
+              userJvmOptions,
+              failureHandler,
+              logger,
+              opts
+            )
           case DiscoveredTestFrameworks.Js(_, closeResources) =>
             val cancelled: AtomicBoolean = AtomicBoolean(false)
             def cancel(): Unit = {

--- a/frontend/src/main/scala/bloop/testing/TestInternals.scala
+++ b/frontend/src/main/scala/bloop/testing/TestInternals.scala
@@ -125,7 +125,7 @@ object TestInternals {
 
     val listener = server.listenToTests
     val runner = {
-      val runTask = forker.runMain(cwd, forkMain, arguments, logger, opts, testAgentJars)
+      val runTask = forker.runMain(cwd, forkMain, arguments, false, logger, opts, testAgentJars)
       runTask.map(exitCode => Forker.exitStatus(exitCode).code)
     }
 

--- a/frontend/src/main/scala/bloop/testing/TestInternals.scala
+++ b/frontend/src/main/scala/bloop/testing/TestInternals.scala
@@ -94,6 +94,7 @@ object TestInternals {
    * @param classLoader      The class loader used for discovering the tests
    * @param discovered       The test tasks that were discovered, grouped by their `Framework`
    * @param args             The test arguments to pass to the framework
+   * @param userJvmOptions   The jvm options to run tests with.
    * @param testEventHandler Handler that reacts on messages from the testing frameworks
    * @param logger           Logger receiving test output
    * @param opts             The options to run the program with
@@ -104,6 +105,7 @@ object TestInternals {
       classLoader: ClassLoader,
       discovered: Map[Framework, List[TaskDef]],
       args: List[Config.TestArgument],
+      userJvmOptions: List[String],
       testEventHandler: TestSuiteEventHandler,
       logger: Logger,
       opts: CommonOptions
@@ -115,7 +117,7 @@ object TestInternals {
 
     val server = new TestServer(logger, testEventHandler, classLoader, discovered, args, opts)
     val forkMain = classOf[sbt.ForkMain].getCanonicalName
-    val arguments = Array(server.port.toString)
+    val arguments = userJvmOptions.toArray ++ Array(server.port.toString)
     val testAgentJars = agentFiles.filter(_.underlying.toString.endsWith(".jar"))
     logger.debug("Test agent JARs: " + testAgentJars.mkString(", "))
 

--- a/frontend/src/test/scala/bloop/exec/ForkerSpec.scala
+++ b/frontend/src/test/scala/bloop/exec/ForkerSpec.scala
@@ -51,7 +51,8 @@ class ForkerSpec {
       try {
         val wait = Duration.apply(25, TimeUnit.SECONDS)
         val exitCode =
-          TestUtil.await(wait)(config.runMain(cwdPath, mainClass, args, logger.asVerbose, opts))
+          TestUtil.await(wait)(
+            config.runMain(cwdPath, mainClass, args, false, logger.asVerbose, opts))
         val messages = logger.getMessages()
         op(exitCode, messages)
       } finally {

--- a/frontend/src/test/scala/bloop/tasks/JvmTestSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/JvmTestSpec.scala
@@ -122,6 +122,7 @@ class JvmTestSpec(
             classLoader,
             tests,
             Nil,
+            Nil,
             NoopEventHandler,
             logger,
             opts)
@@ -154,6 +155,7 @@ class JvmTestSpec(
             config,
             classLoader,
             tests,
+            Nil,
             Nil,
             NoopEventHandler,
             logger,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
 
   val nailgunVersion = "6992a3bf"
   // Used to download the python client instead of resolving
-  val nailgunCommit = "db48d66f"
+  val nailgunCommit = "933f482b"
 
   val zincVersion = "1.2.1+106-0dad4a69"
   val bspVersion = "2.0.0-M1" 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -62,11 +62,15 @@
         "sidebar_label": "Integration Guide"
       },
       "launcher-reference": {
-        "title": "Launcher",
-        "sidebar_label": "Launcher Reference"
+        "title": "Launcher Reference",
+        "sidebar_label": "Built-in Launcher"
       },
       "release-table": {
         "title": "release-table"
+      },
+      "server-reference": {
+        "title": "Build Server Reference",
+        "sidebar_label": "Build Server"
       },
       "target/scala-2.12/classes/LICENSE": {
         "title": "target/scala-2.12/classes/LICENSE"

--- a/website/pages/en/setup.js
+++ b/website/pages/en/setup.js
@@ -23,7 +23,7 @@ const SetupHeader = () => {
       </h1>
     <p style={{"justifyContent": "center", "marginLeft": "1.5em", "marginRight": "1.5em", "textAlign": "center", "maxWidth": "1024px"}}>
       The installation guide walks <b>users</b> through all the steps to install bloop and get any
-      of the supported build tools export their build definitions to Bloop's build server.
+      of the supported build tools to successfully export their build definitions.
     </p>
 
     <p style={{"justifyContent": "center", "marginLeft": "1.5em", "marginRight": "1.5em", "textAlign": "center"}}>

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -19,6 +19,7 @@
     ],
     "References": [
       "cli-reference",
+      "server-reference",
       "launcher-reference",
       "configuration-format"
     ]

--- a/website/static/css/index.css
+++ b/website/static/css/index.css
@@ -19,6 +19,11 @@ a .button {
   color: #primaryColor;
 }
 
+.grab-attention {
+  background-color: #fff8fc;
+  border-left: 8px solid #ffd6ff;
+}
+
 .button {
   border-radius: 8px;
 }


### PR DESCRIPTION
Information in the commit messages. In a nutshell:

1. Allow users to pass jvm options prefixed with `-J` for test and run as normal app arguments.
1. Support `-J` arguments in the `bloop server` invocations and document them.
1. Read jvm opts from a `.jvmopts` file in the bloop installation directory by default.

Fixes https://github.com/scalacenter/bloop/issues/761
Fixes https://github.com/scalacenter/bloop/issues/565