### PR TITLE
Fix `scalaInstanceFromBloop` in boostrapped server

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -81,7 +81,7 @@ object Compiler {
 
     object NotOk {
       def unapply(result: Result): Option[Result] = result match {
-        case f @ (Failed(_, _, _) | Cancelled(_, _) | Blocked(_)) => Some(f)
+        case f @ (Failed(_, _, _) | Cancelled(_, _) | Blocked(_) | GlobalError(_)) => Some(f)
         case _ => None
       }
     }

--- a/frontend/src/test/scala/bloop/tasks/CompileSpec.scala
+++ b/frontend/src/test/scala/bloop/tasks/CompileSpec.scala
@@ -12,7 +12,6 @@ import bloop.cli.Commands
 import bloop.config.Config
 import bloop.engine.tasks.Tasks
 import bloop.engine.{Feedback, Run, State}
-import bloop.exec.JavaEnv
 import bloop.logging.{Logger, RecordingLogger}
 import bloop.tasks.TestUtil.{
   RootProject,


### PR DESCRIPTION
When coursier bootstraps bloop, the code source location for the classes
has an unknown scheme that trips the creation of the scala instance.

This error only happens when coursier boostraps, as it inlines all jars
in a jar file that is inlined in a shell script, and there's no notion
of independent jars we can use to instantiate a scala instance. To fix
this problem, we detect this error and add a fallback mechanism where:

1. We get the scheme specific part and read the content stream.
2. Copy the content stream to an independent file that we then use to
   instantiate an scala instance.

We don't add tests for this improvement because it's a rare error enough
that would need a lot of test instrumentation to test reliably. Local
testing confirms that compiling java only projects with no scala
instance defined works now in systems where bloop is boostrapped.