### PR TITLE
Add bloop-specific compile progress

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -45,8 +45,8 @@ matrix:
           "show version" \
           "set pgpPublicRing in Global := file(\"/drone/.gnupg/pubring.asc\")" \
           "set pgpSecretRing in Global := file(\"/drone/.gnupg/secring.asc\")" \
-          "frontend/runMain bloop.util.CommandsDocGenerator --out ../docs/cli-reference.md" \
           "releaseBloop" \
+          "frontend/runMain bloop.util.CommandsDocGenerator --out ../docs/cli-reference.md" \
           "docs/docusaurusPublishGhpages"
 
   UPDATE_GITHUB_AND_INSTALLERS:

--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -46,6 +46,12 @@ object Compiler {
     }
   }
 
+  private final class BloopProgress(reporter: Reporter) extends CompileProgress {
+    override def startUnit(phase: String, unitPath: String): Unit =
+      reporter.reportCompilationProgress(phase, unitPath)
+    override def advance(current: Int, total: Int): Boolean = true
+  }
+
   sealed trait Result
   object Result {
     final case object Empty extends Result with CacheHashCode
@@ -126,7 +132,7 @@ object Compiler {
         if (!compileInputs.scalaInstance.isDotty) opts
         else Ecosystem.supportDotty(opts)
       }
-      val progress = Optional.empty[CompileProgress]
+      val progress = Optional.of[CompileProgress](new BloopProgress(reporter))
       val setup =
         Setup.create(lookup, skip, cacheFile, compilerCache, incOptions, reporter, progress, empty)
       // We only set the pickle promise here, but the java signal is set in `BloopHighLevelCompiler`

--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -15,6 +15,8 @@ import bloop.util.CacheHashCode
 import sbt.internal.inc.bloop.internal.StopPipelining
 import sbt.util.InterfaceUtil
 
+import scala.concurrent.Promise
+
 case class CompileInputs(
     scalaInstance: ScalaInstance,
     compilerCache: CompilerCache,
@@ -31,7 +33,8 @@ case class CompileInputs(
     previousCompilerResult: Compiler.Result,
     reporter: Reporter,
     mode: CompileMode,
-    dependentResults: Map[File, PreviousResult]
+    dependentResults: Map[File, PreviousResult],
+    cancelPromise: Promise[Unit]
 )
 
 object Compiler {
@@ -46,10 +49,21 @@ object Compiler {
     }
   }
 
-  private final class BloopProgress(reporter: Reporter) extends CompileProgress {
-    override def startUnit(phase: String, unitPath: String): Unit =
-      reporter.reportCompilationProgress(phase, unitPath)
-    override def advance(current: Int, total: Int): Boolean = true
+  private final class BloopProgress(
+      reporter: Reporter,
+      cancelPromise: Promise[Unit]
+  ) extends CompileProgress {
+    private var current = 0.toLong
+    private var total = 26.toLong
+    override def startUnit(phase: String, unitPath: String): Unit = {
+      reporter.reportCompilationProgress(current, total, phase, unitPath)
+    }
+
+    override def advance(current0: Int, total0: Int): Boolean = {
+      current = current0.toLong
+      total = total0.toLong
+      !cancelPromise.isCompleted
+    }
   }
 
   sealed trait Result
@@ -132,7 +146,8 @@ object Compiler {
         if (!compileInputs.scalaInstance.isDotty) opts
         else Ecosystem.supportDotty(opts)
       }
-      val progress = Optional.of[CompileProgress](new BloopProgress(reporter))
+      val progress =
+        Optional.of[CompileProgress](new BloopProgress(reporter, compileInputs.cancelPromise))
       val setup =
         Setup.create(lookup, skip, cacheFile, compilerCache, incOptions, reporter, progress, empty)
       // We only set the pickle promise here, but the java signal is set in `BloopHighLevelCompiler`
@@ -156,6 +171,16 @@ object Compiler {
     import scala.util.{Success, Failure}
     val reporter = compileInputs.reporter
 
+    def cancel(): Unit = {
+      // Avoid illegal state exception if client cancellation promise is completed
+      if (!compileInputs.cancelPromise.isCompleted) {
+        compileInputs.cancelPromise.success(())
+      }
+
+      // Always report the compilation of a project no matter if it's completed
+      reporter.reportCancelledCompilation()
+    }
+
     val previousAnalysis = InterfaceUtil.toOption(compileInputs.previousResult.analysis())
     val previousProblems: List[Problem] = compileInputs.previousCompilerResult match {
       case f: Compiler.Result.Failed => f.problems
@@ -172,6 +197,7 @@ object Compiler {
     BloopZincCompiler
       .compile(inputs, compileInputs.mode, reporter)
       .materialize
+      .doOnCancel(Task(cancel()))
       .map {
         case Success(result) =>
           // Report end of compilation only after we have reported all warnings from previous runs

--- a/backend/src/main/scala/bloop/reporter/Reporter.scala
+++ b/backend/src/main/scala/bloop/reporter/Reporter.scala
@@ -65,6 +65,9 @@ abstract class Reporter(
   private def hasWarnings(problems: Seq[Problem]): Boolean =
     problems.exists(_.severity == Severity.Warn)
 
+  /** Report the progress from the compiler. */
+  def reportCompilationProgress(phase: String, sourceFile: String): Unit
+
   /** A function called *always* at the very beginning of compilation. */
   def reportStartCompilation(previousProblems: List[xsbti.Problem]): Unit
 

--- a/backend/src/main/scala/bloop/reporter/Reporter.scala
+++ b/backend/src/main/scala/bloop/reporter/Reporter.scala
@@ -66,7 +66,15 @@ abstract class Reporter(
     problems.exists(_.severity == Severity.Warn)
 
   /** Report the progress from the compiler. */
-  def reportCompilationProgress(phase: String, sourceFile: String): Unit
+  def reportCompilationProgress(
+      progress: Long,
+      total: Long,
+      phase: String,
+      sourceFile: String
+  ): Unit
+
+  /** Report the compile cancellation of this project. */
+  def reportCancelledCompilation(): Unit
 
   /** A function called *always* at the very beginning of compilation. */
   def reportStartCompilation(previousProblems: List[xsbti.Problem]): Unit

--- a/backend/src/test/scala/bloop/logging/RecordingLogger.scala
+++ b/backend/src/test/scala/bloop/logging/RecordingLogger.scala
@@ -16,6 +16,8 @@ final class RecordingLogger(
   def clear(): Unit = messages.clear()
 
   def infos: List[String] = getMessagesAt(Some("info"))
+  def warnings: List[String] = getMessagesAt(Some("warn"))
+  def errors: List[String] = getMessagesAt(Some("error"))
   def getMessagesAt(level: Option[String]): List[String] = getMessages(level).map(_._2)
   def getMessages(): List[(String, String)] = getMessages(None)
   private def getMessages(level: Option[String]): List[(String, String)] = {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -136,6 +136,7 @@ sidebar_label: CLI --help
 #### Examples
 
   * <samp>bloop compile foobar</samp>
+  * <samp>bloop compile foobar baz</samp>
   * <samp>bloop compile foobar -w</samp>
   * <samp>bloop compile foobar --reporter bloop</samp>
   * <samp>bloop compile foobar --reporter scalac</samp>
@@ -311,7 +312,7 @@ sidebar_label: CLI --help
 #### Examples
 
   * <samp>bloop run foobar</samp>
-  * <samp>bloop run foobar -m com.acme.Main -- arg1 arg2</samp>
+  * <samp>bloop run foobar -m com.acme.Main -- -J-Xmx4g arg1 arg2</samp>
   * <samp>bloop run foobar -O debug -- arg1</samp>
   * <samp>bloop run foobar -m com.acme.Main -O release -w</samp>
 
@@ -353,7 +354,9 @@ sidebar_label: CLI --help
 #### Examples
 
   * <samp>bloop test foobar</samp>
+  * <samp>bloop test foobar baz</samp>
   * <samp>bloop test foobar -w</samp>
   * <samp>bloop test foobar --propagate</samp>
   * <samp>bloop test foobar --propagate -w</samp>
   * <samp>bloop test foobar --only com.acme.StringSpecification</samp>
+  * <samp>bloop test foobar --only com.acme.StringSpecification -- -J-Xmx4g</samp>

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -17,6 +17,8 @@ import bloop.engine.tasks.toolchains.{ScalaJsToolchain, ScalaNativeToolchain}
 import caseapp.core.CommandMessages
 import monix.eval.Task
 
+import scala.concurrent.Promise
+
 object Interpreter {
   // This is stack-safe because of Monix's trampolined execution
   def execute(action: Action, stateTask: Task[State]): Task[State] = {
@@ -146,7 +148,8 @@ object Interpreter {
         createReporter,
         compilerMode,
         cmd.pipeline,
-        excludeRoot
+        excludeRoot,
+        Promise[Unit]()
       )
     }
 

--- a/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
+++ b/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
@@ -123,12 +123,12 @@ final class BspServerLogger private (
    *
    * The following fields of the progress notification are not populated:
    *
-   * 1. total: Option[Long] -- there seems to be no way of detecting total compilation units.
    * 1. data: Option[Json] -- there is no additional metadata we want to share with the client.
    */
   def publishCompileProgress(
       taskId: bsp.TaskId,
-      id: Long,
+      progress: Long,
+      total: Long,
       phase: String,
       sourceFile: String
   ): Unit = {
@@ -138,8 +138,8 @@ final class BspServerLogger private (
         taskId,
         Some(System.currentTimeMillis()),
         Some(msg),
-        None,
-        Some(id),
+        Some(progress),
+        Some(total),
         Some("phase/file"),
         Some("compile"),
         None

--- a/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
+++ b/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
@@ -119,6 +119,36 @@ final class BspServerLogger private (
   private def now: Long = System.currentTimeMillis()
 
   /**
+   * Publish a compile progress notification to the client via BSP.
+   *
+   * The following fields of the progress notification are not populated:
+   *
+   * 1. total: Option[Long] -- there seems to be no way of detecting total compilation units.
+   * 1. data: Option[Json] -- there is no additional metadata we want to share with the client.
+   */
+  def publishCompileProgress(
+      taskId: bsp.TaskId,
+      id: Long,
+      phase: String,
+      sourceFile: String
+  ): Unit = {
+    val msg = s"Compiling ${sourceFile} (phase ${phase})"
+    Build.taskProgress.notify(
+      bsp.TaskProgressParams(
+        taskId,
+        Some(System.currentTimeMillis()),
+        Some(msg),
+        None,
+        Some(id),
+        Some("phase/file"),
+        Some("compile"),
+        None
+      )
+    )
+    ()
+  }
+
+  /**
    * Publish a compile start notification to the client via BSP.
    *
    * The compile start notification must always have a corresponding
@@ -132,7 +162,7 @@ final class BspServerLogger private (
       bsp.CompileTask(bsp.BuildTargetIdentifier(project.bspUri))
     )
 
-    val ack = Build.taskStart.notify(
+    Build.taskStart.notify(
       bsp.TaskStartParams(
         taskId,
         Some(now),

--- a/frontend/src/main/scala/bloop/reporter/BspProjectReporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/BspProjectReporter.scala
@@ -7,6 +7,7 @@ import bloop.io.AbsolutePath
 import bloop.logging.BspServerLogger
 import xsbti.Position
 import ch.epfl.scala.bsp
+import monix.execution.atomic.AtomicLong
 import sbt.util.InterfaceUtil
 import xsbti.compile.CompileAnalysis
 
@@ -42,6 +43,12 @@ final class BspProjectReporter(
 
   // Report summary manually via `reportEndCompilation` for BSP clients
   override def printSummary(): Unit = ()
+
+  val compileProgressCounter = AtomicLong(0)
+  override def reportCompilationProgress(phase: String, sourceFile: String): Unit = {
+    val id = compileProgressCounter.addAndGet(1)
+    logger.publishCompileProgress(taskId, id, phase, sourceFile)
+  }
 
   // Includes problems of both successful and failed compilations
   private var previouslyReportedProblems: List[xsbti.Problem] = Nil

--- a/frontend/src/main/scala/bloop/reporter/BspProjectReporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/BspProjectReporter.scala
@@ -45,9 +45,18 @@ final class BspProjectReporter(
   override def printSummary(): Unit = ()
 
   val compileProgressCounter = AtomicLong(0)
-  override def reportCompilationProgress(phase: String, sourceFile: String): Unit = {
+  override def reportCompilationProgress(
+      progress: Long,
+      total: Long,
+      phase: String,
+      sourceFile: String
+  ): Unit = {
     val id = compileProgressCounter.addAndGet(1)
-    logger.publishCompileProgress(taskId, id, phase, sourceFile)
+    logger.publishCompileProgress(taskId, progress, total, phase, sourceFile)
+  }
+
+  override def reportCancelledCompilation(): Unit = {
+    ()
   }
 
   // Includes problems of both successful and failed compilations

--- a/frontend/src/main/scala/bloop/reporter/LogReporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/LogReporter.scala
@@ -43,6 +43,8 @@ final class LogReporter(
     }
   }
 
+  override def reportCompilationProgress(phase: String, sourceFile: String): Unit = ()
+
   override def reportStartIncrementalCycle(sources: Seq[File], outputDirs: Seq[File]): Unit = {
     // TODO(jvican): Fix https://github.com/scalacenter/bloop/issues/386 here
     require(sources.size > 0) // This is an invariant enforced in the call-site

--- a/frontend/src/main/scala/bloop/reporter/LogReporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/LogReporter.scala
@@ -3,7 +3,7 @@ import java.io.File
 
 import bloop.data.Project
 import bloop.io.AbsolutePath
-import bloop.logging.Logger
+import bloop.logging.{DebugFilter, Logger}
 import xsbti.compile.CompileAnalysis
 import xsbti.{Position, Severity}
 import ch.epfl.scala.bsp
@@ -43,7 +43,17 @@ final class LogReporter(
     }
   }
 
-  override def reportCompilationProgress(phase: String, sourceFile: String): Unit = ()
+  override def reportCompilationProgress(
+      progress: Long,
+      total: Long,
+      phase: String,
+      sourceFile: String
+  ): Unit = ()
+
+  override def reportCancelledCompilation(): Unit = {
+    logger.warn(s"Cancelling compilation of ${project.name}")
+    ()
+  }
 
   override def reportStartIncrementalCycle(sources: Seq[File], outputDirs: Seq[File]): Unit = {
     // TODO(jvican): Fix https://github.com/scalacenter/bloop/issues/386 here

--- a/frontend/src/test/scala/bloop/JsTestSpec.scala
+++ b/frontend/src/test/scala/bloop/JsTestSpec.scala
@@ -23,7 +23,7 @@ import sbt.testing.Framework
 import xsbti.compile.CompileAnalysis
 
 import scala.collection.mutable.ListBuffer
-import scala.concurrent.Await
+import scala.concurrent.{Await, Promise}
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 
@@ -44,7 +44,7 @@ object JsTestSpec {
       CompilationTask.toReporter(project, cwd, format, state0.logger)
     val dag = state0.build.getDagFor(project)
     val compileTask =
-      CompilationTask.compile(state0, dag, createReporter, order, false, false)
+      CompilationTask.compile(state0, dag, createReporter, order, false, false, Promise[Unit]())
     val state = Await.result(compileTask.runAsync(ExecutionContext.scheduler), Duration.Inf)
     val result = state.results.lastSuccessfulResultOrEmpty(project).analysis().toOption
     val analysis = result.getOrElse(sys.error(s"$target lacks analysis after compilation!?"))

--- a/frontend/src/test/scala/bloop/JvmTestSpec.scala
+++ b/frontend/src/test/scala/bloop/JvmTestSpec.scala
@@ -21,7 +21,7 @@ import org.junit.{Assert, Test}
 import sbt.testing.Framework
 import xsbti.compile.CompileAnalysis
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, Promise}
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 
@@ -40,7 +40,7 @@ object JvmTestSpec {
       CompilationTask.toReporter(project, cwd, format, state0.logger)
     val dag = state0.build.getDagFor(project)
     val compileTask =
-      CompilationTask.compile(state0, dag, createReporter, order, false, false)
+      CompilationTask.compile(state0, dag, createReporter, order, false, false, Promise[Unit]())
     val state = Await.result(compileTask.runAsync(ExecutionContext.scheduler), Duration.Inf)
     val result = state.results.lastSuccessfulResultOrEmpty(project).analysis().toOption
     val analysis = result.getOrElse(sys.error(s"$target lacks analysis after compilation!?"))

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -54,7 +54,7 @@ object TestUtil {
     }
   }
 
-  final val scalaInstance: ScalaInstance = {
+  final lazy val scalaInstance: ScalaInstance = {
     val logger = new RecordingLogger
     ScalaInstance.resolve(
       "org.scala-lang",

--- a/notes/v1.2.0.md
+++ b/notes/v1.2.0.md
@@ -79,6 +79,15 @@ possibly affected by a change in a project. As this is a common use case, `--cas
 simplify its use. This feature is fully documented by the
 [Quickstart](https://scalacenter.github.io/bloop/docs/usage) page.
 
+### Cancel compilation
+
+Compile cancellation was not yet supported by bloop and `v1.2.0` fixes it. Just as the cancellation
+of `test` or `run`, every time the user presses <kbd>Ctrl</kbd>+<kbd>C</kbd> in the middle of a
+compilation command or a bsp client sends a cancel request, bloop will cancel the compilation
+gracefully.
+
+> It's highly recommended to be on the last Scala 2.12.8 release to get more predictable and quick
+cancellations.
 
 ### Pass jvm options to `test` and `run` ([#769](https://github.com/scalacenter/bloop/pull/769))
 


### PR DESCRIPTION
For two reasons:

1. Get compilation progress notifications.
2. Implement and test compile cancellation.