### PR TITLE
Cache compiler plugins with a whitelist by default

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,7 +33,7 @@ matrix:
           "sbtBloop013/publishLocal" \
           "sbtBloop10/publishLocal" \
           "integrationSetUpBloop" \
-          "frontend/testOnly bloop.tasks.IntegrationTestSuite"
+          "frontend/testOnly bloop.IntegrationTestSuite"
 
   RUN_BENCHMARKS_AND_SCRIPTED:
     - bin/sbt-ci.sh \

--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -128,7 +128,7 @@ object Compiler {
         .withSources(sources.map(_.toFile))
         .withClasspath(classpath)
         .withStore(inputs.store)
-        .withScalacOptions(inputs.scalacOptions ++ Array("-Ycache-plugin-class-loader:last-modified"))
+        .withScalacOptions(inputs.scalacOptions)
         .withJavacOptions(inputs.javacOptions)
         .withClasspathOptions(inputs.classpathOptions)
         .withOrder(inputs.compileOrder)

--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -128,7 +128,7 @@ object Compiler {
         .withSources(sources.map(_.toFile))
         .withClasspath(classpath)
         .withStore(inputs.store)
-        .withScalacOptions(inputs.scalacOptions)
+        .withScalacOptions(inputs.scalacOptions ++ Array("-Ycache-plugin-class-loader:last-modified"))
         .withJavacOptions(inputs.javacOptions)
         .withClasspathOptions(inputs.classpathOptions)
         .withOrder(inputs.compileOrder)

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginWhitelist.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginWhitelist.scala
@@ -1,0 +1,124 @@
+package bloop.engine.tasks.compilation
+
+import java.net.URI
+import java.nio.file.{FileSystems, Files, Path, Paths}
+import java.nio.file.attribute.{BasicFileAttributes, FileTime}
+import java.util.concurrent.ConcurrentHashMap
+
+import bloop.logging.{DebugFilter, Logger}
+import monix.eval.Task
+
+import scala.util.control.NonFatal
+import scala.xml.XML
+
+object CompilerPluginWhitelist {
+
+  /**
+   * A list of compiler plugin names (as specified in their scalac-plugin.xml
+   * whose classloaders are safe to be cached. The plugin sources of every plugin
+   * have been checked to ensure there is no global state and this is a requirement
+   * to adding new names in the list.
+   */
+  val whitelistedPluginNames: List[String] = List(
+    "bloop-test-plugin", // Plugin we use in tests
+    "clippy",
+    "scalajs",
+    "nir", // scala-native
+    "macro-paradise-plugin",
+    "semanticdb",
+    "wartremover",
+    "silencer",
+    "scapegoat",
+    "acyclic",
+    "scoverage",
+    "kind-projector",
+    "scalac-profiling",
+    "classpath-shrinker",
+    "bm4", // better-monadic-for
+    "splain",
+    "deriving",
+  )
+
+  /** A sequence of versions that are known not to support compiler plugin classloading. */
+  val scalaVersionBlacklist = List("2.10.", "2.11.", "2.12.1", "2.12.2", "2.12.3", "2.12.4", "0.")
+
+  private implicit val debug = DebugFilter.Compilation
+  private val emptyMap = java.util.Collections.emptyMap[String, String]()
+  private[this] val cachePluginJar = new ConcurrentHashMap[Path, (FileTime, Boolean)]()
+  def enablePluginCaching(
+      scalaVersion: String,
+      scalacOptions: List[String],
+      logger: Logger
+  ): Task[List[String]] = {
+    def isPluginWhitelisted(pluginPath: Path): Boolean = {
+      val uriZipFile = URI.create("jar:file:" + pluginPath.toUri.getRawPath)
+      try {
+        val fs = FileSystems.newFileSystem(uriZipFile, emptyMap)
+        try {
+          val pluginDeclarationFile = fs.getPath("/scalac-plugin.xml")
+          val xml = XML.load(Files.newInputStream(pluginDeclarationFile))
+          val pluginName = (xml \ "name").text
+          val cache = whitelistedPluginNames.contains(pluginName)
+          if (cache) logger.debug(s"Compiler plugin ${pluginName} is whitelisted")
+          else logger.debug(s"Disabling plugin caching because ${pluginName} is not whitelisted")
+          cache
+        } finally {
+          fs.close()
+        }
+      } catch {
+        case NonFatal(t) =>
+          logger.trace(t)
+          logger.debug(s"Disable plugin caching because ${pluginPath} couldn't be read")
+          false
+      }
+    }
+
+    scalaVersionBlacklist.find(v => scalaVersion.startsWith(v)) match {
+      case Some(blacklistedVersion) =>
+        logger.debug(
+          s"Disabling compiler plugin classloading, unsupported in Scala ${blacklistedVersion}"
+        )
+        Task.now(scalacOptions)
+      case None =>
+        if (scalacOptions.contains("-Ycache-plugin-class-loader:none")) Task.now(scalacOptions)
+        else {
+          val pluginCompilerFlags = scalacOptions.filter(_.startsWith("-Xplugin:"))
+          val shouldCachePlugins = pluginCompilerFlags.map { flag =>
+            Task {
+              val jarList = flag.stripPrefix("-Xplugin:")
+              jarList.split(java.io.File.pathSeparator).headOption match {
+                case Some(mainPluginJar) =>
+                  val pluginPath = Paths.get(mainPluginJar)
+                  if (!Files.exists(pluginPath)) {
+                    logger.debug(s"Disable plugin caching because ${pluginPath} doesn't exist")
+                    false
+                  } else {
+                    val attrs = Files.readAttributes(pluginPath, classOf[BasicFileAttributes])
+                    val lastModifiedTime = attrs.lastModifiedTime()
+                    Option(cachePluginJar.get(pluginPath)) match {
+                      case Some((prevLastModifiedTime, cacheClassloader))
+                          if prevLastModifiedTime == lastModifiedTime =>
+                        logger.debug(s"Cache hit ${cacheClassloader} for plugin ${pluginPath}")
+                        cacheClassloader
+                      case _ =>
+                        logger.debug(s"Cache miss for plugin ${pluginPath}")
+                        val shouldCache = isPluginWhitelisted(pluginPath)
+                        cachePluginJar.put(pluginPath, (lastModifiedTime, shouldCache))
+                        shouldCache
+                    }
+                  }
+                case None =>
+                  logger.debug(s"Expecting at least one jar in '$flag'")
+                  false // The -Xplugin flag is misconstructed, don't cache
+              }
+            }
+          }
+
+          Task.gatherUnordered(shouldCachePlugins).map(_.forall(_ == true)).map { enableCacheFlag =>
+            if (!enableCacheFlag) scalacOptions
+            else "-Ycache-plugin-class-loader:last-modified" :: scalacOptions
+          }
+        }
+    }
+  }
+}

--- a/frontend/src/test/resources/compiler-plugin-whitelist/bloop-test-plugin/src/main/resources/scalac-plugin.xml
+++ b/frontend/src/test/resources/compiler-plugin-whitelist/bloop-test-plugin/src/main/resources/scalac-plugin.xml
@@ -1,0 +1,4 @@
+<plugin>
+  <name>bloop-test-plugin</name>
+  <classname>bloop.test.BloopTestPlugin</classname>
+</plugin>

--- a/frontend/src/test/resources/compiler-plugin-whitelist/bloop-test-plugin/src/main/scala/BloopTestPlugin.scala
+++ b/frontend/src/test/resources/compiler-plugin-whitelist/bloop-test-plugin/src/main/scala/BloopTestPlugin.scala
@@ -1,0 +1,25 @@
+package bloop.test
+
+import scala.tools.nsc.{ Global, Phase }
+import scala.tools.nsc.plugins.{ Plugin, PluginComponent }
+
+class BloopTestPlugin(val global: Global) extends Plugin {
+  val name = "bloop-test-plugin"
+  val description = "Just prints whenever it's initialized"
+  val components = List[PluginComponent](BloopTestComponent)
+  global.reporter.echo(
+    global.NoPosition,
+    s"Bloop test plugin classloader: ${this.getClass.getClassLoader}"
+  )
+
+  private object BloopTestComponent extends PluginComponent {
+    val global = BloopTestPlugin.this.global
+    import global._
+    override val runsAfter = List("erasure")
+    val phaseName = "BloopTest"
+
+    override def newPhase(prev: Phase): StdPhase = new StdPhase(prev) {
+      override def apply(unit: CompilationUnit): Unit = ()
+    }
+  }
+}

--- a/frontend/src/test/resources/compiler-plugin-whitelist/build.sbt
+++ b/frontend/src/test/resources/compiler-plugin-whitelist/build.sbt
@@ -1,0 +1,41 @@
+bloopExportJarClassifiers in Global := Some(Set("sources"))
+bloopConfigDir in Global := baseDirectory.value / "bloop-config"
+import _root_.sbtcrossproject.CrossPlugin.autoImport.{crossProject => crossProjects}
+
+val silencerVersion = "1.3.1"
+val derivingVersion = "1.0.0"
+lazy val whitelist = crossProjects(JVMPlatform, JSPlatform)
+  .settings(
+    scalaVersion := "2.12.8",
+    wartremoverErrors ++= Warts.unsafe,
+    addCompilerPlugin(scalafixSemanticdb),
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
+    libraryDependencies ++= Seq(
+      compilerPlugin("com.github.ghik" %% "silencer-plugin" % silencerVersion),
+      "com.github.ghik" %% "silencer-lib" % silencerVersion % Provided
+    ),
+    addCompilerPlugin("com.sksamuel.scapegoat" %% "scalac-scapegoat-plugin" % "1.3.8"),
+    // Required to add as normal libdep too to work around https://github.com/sksamuel/scapegoat/issues/98
+    libraryDependencies += "com.sksamuel.scapegoat" %% "scalac-scapegoat-plugin" % "1.3.8",
+    libraryDependencies += "com.lihaoyi" %% "acyclic" % "0.1.7" % "provided",
+    autoCompilerPlugins := true,
+    addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.7"),
+    scalacOptions in Compile += "-P:scapegoat:dataDir:./target/scapegoat",
+    addCompilerPlugin("org.scoverage" %% "scalac-scoverage-plugin" % "1.3.1"),
+    libraryDependencies += "org.scoverage" %%% "scalac-scoverage-runtime" % "1.3.1",
+    scalacOptions in Compile += {
+      val scapegoatDataDir = (bloopConfigDir in Global).value / "whitelistJS" / "scapegoat"
+      java.nio.file.Files.createDirectories(scapegoatDataDir.toPath)
+      s"-P:scoverage:dataDir:${scapegoatDataDir}"
+    },
+    addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.8"),
+    resolvers += Resolver.bintrayRepo("scalacenter", "releases"),
+    addCompilerPlugin("ch.epfl.scala" %% "classpath-shrinker" % "0.1.1"),
+    addCompilerPlugin("ch.epfl.scala" %% "scalac-profiling" % "1.0.0"),
+    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0-M4"),
+    addCompilerPlugin("io.tryp" % "splain" % "0.3.5" cross CrossVersion.patch),
+    libraryDependencies ++= List(
+      "org.scalaz" %% "deriving-macro" % derivingVersion,
+      compilerPlugin("org.scalaz" %% "deriving-plugin" % derivingVersion),
+    )
+  )

--- a/frontend/src/test/resources/compiler-plugin-whitelist/project/build.properties
+++ b/frontend/src/test/resources/compiler-plugin-whitelist/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.6

--- a/frontend/src/test/resources/compiler-plugin-whitelist/project/plugins.sbt
+++ b/frontend/src/test/resources/compiler-plugin-whitelist/project/plugins.sbt
@@ -1,0 +1,37 @@
+val typesafeConfig = "com.typesafe" % "config" % "1.3.2"
+val metaconfigCore = "com.geirsson" %% "metaconfig-core" % "0.6.0"
+val metaconfigConfig = "com.geirsson" %% "metaconfig-typesafe-config" % "0.6.0"
+val metaconfigDocs = "com.geirsson" %% "metaconfig-docs" % "0.6.0"
+val circeDerivation = "io.circe" %% "circe-derivation" % "0.9.0-M3"
+
+// Let's add our sbt plugin to the sbt too ;)
+unmanagedSourceDirectories in Compile ++= {
+  val baseDir =
+    baseDirectory.value.getParentFile.getParentFile.getParentFile.getParentFile.getParentFile.getParentFile
+  val integrationsMainDir = baseDir / "integrations"
+  if (!integrationsMainDir.exists()) Nil
+  else {
+    val pluginMainDir = integrationsMainDir / "sbt-bloop" / "src" / "main"
+    List(
+      baseDir / "config" / "src" / "main" / "scala",
+      baseDir / "config" / "src" / "main" / "scala-2.11-12",
+      pluginMainDir / "scala",
+      pluginMainDir / s"scala-sbt-${sbt.Keys.sbtBinaryVersion.value}"
+    )
+  }
+}
+
+libraryDependencies ++= List(
+  typesafeConfig,
+  metaconfigCore,
+  metaconfigDocs,
+  metaconfigConfig,
+  circeDerivation
+)
+
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.26")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.3.7")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.1")
+addSbtPlugin("com.softwaremill.clippy" % "plugin-sbt" % "0.5.3")

--- a/frontend/src/test/resources/compiler-plugin-whitelist/project/project/build.properties
+++ b/frontend/src/test/resources/compiler-plugin-whitelist/project/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.6

--- a/frontend/src/test/resources/compiler-plugin-whitelist/sandbox/src/main/scala/hello/App.scala
+++ b/frontend/src/test/resources/compiler-plugin-whitelist/sandbox/src/main/scala/hello/App.scala
@@ -1,0 +1,7 @@
+package hello
+
+object App {
+  def main(args: Array[String]): Unit = {
+    println("Whitelist application was compiled successfully")
+  }
+}

--- a/frontend/src/test/resources/compiler-plugin-whitelist/whitelist/shared/src/main/scala/hello/App.scala
+++ b/frontend/src/test/resources/compiler-plugin-whitelist/whitelist/shared/src/main/scala/hello/App.scala
@@ -1,0 +1,7 @@
+package hello
+
+object App {
+  def main(args: Array[String]): Unit = {
+    println("Whitelist application was compiled successfully")
+  }
+}

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -426,7 +426,7 @@ object TestUtil {
           .generateUnifiedDiff(
             "expected",
             "obtained",
-            obtainedLines,
+            expectedLines,
             patch,
             1
           )


### PR DESCRIPTION
A few months ago, I made [a change to cache compiler plugin classloaders in scala/scala](https://github.com/scala/scala/pull/6314)
via a compiler flag. The compiler flag, when enabled in projects that
make a heavy use of compiler plugins and macros, would yield great
compilation performance improvements. In the analyzed projects, around
15-35% faster compilation.

However, this feature was not enabled by default because caching
compiler plugin classloaders or macro libraries is dangerous when they
are stateful (for example, they define a map/set in a top-level object
but never clear its contents at the end of a compiler plugin). As there
is no way to know a priori if they are stateful or not, we agreed the
best default was to ask users to enable the flag manually.

As the compilation flag is not well-known and most users don't even know
they are using macros/compiler plugins in their projects, it's been
largely unused. This pull request tries to change the current situation
by enabling the flag for compiler plugins that have been checked to be
stateless. With this guarantee, we can enable the flag by default and
provide out-of-the-box the best compilation performance we know we can
provide without any user intervention.

The stateless plugins I've curated are the following: scala-js/scala-js,
scala-native/scala-native, wartremover/wartremover,
scalameta/semanticdb, scalamacros/paradise, ghik/silencer,
sksamuel/scapegoat, scoverage/scalac-scoverage-plugin, lihaoyi/acyclic,
non/kind-projector, scalacenter/classpath-shrinker,
scalacenter/scalac-profiling, softwaremill/scala-clippy,
oleg-py/better-monadic-for, tek/splain, scalaz/scalaz-deriving. They
represent a big chunk of all the compiler plugins used in the Scala
community.

All the analyzed compiler plugins were stateless, partly because the
cake pattern in the scala compiler forces everything to be initialized
only when the `Plugin` is. However, it's possible for other plugins to
be stateful, so to err on the conservative side we keep using the
current whitelist strategy to cache compiler plugin classloaders.

To test the correctness of our solution, the pull request adds a test
where we add the whitelisted compiler plugins to a project and then we
compile the project twice. We test the first time bloop should
initialize the compiler plugin classloader, the second time should not.
Then we make some more tests to ensure that disabling the cache via
"-Ycache-plugin-class-loader:none" works.

This change will be a big deal for bloop users, but specially for Metals
users. Metals enables the semanticdb compiler plugin by default and that
is known to hit compilation times particularly bad. This work was
motivated by [this Metals ticket](https://github.com/scalameta/metals/issues/455).
  
Note that compiler plugin caching will only work in 2.12.5 or greater.