### PR TITLE
Include resources in dependency classpath

### DIFF
--- a/bridges/scalajs-0.6/src/main/scala/bloop/scalajs/JsBridge.scala
+++ b/bridges/scalajs-0.6/src/main/scala/bloop/scalajs/JsBridge.scala
@@ -53,12 +53,12 @@ object JsBridge {
   def link(
       config: JsConfig,
       project: Project,
+      classpath: Array[Path],
       runMain: java.lang.Boolean,
       mainClass: Option[String],
       target: Path,
       logger: BloopLogger
   ): Unit = {
-    val classpath = project.compilationClasspath.map(_.underlying)
     val classpathIrFiles = classpath
       .filter(Files.isDirectory(_))
       .flatMap(findIrFiles)
@@ -137,7 +137,8 @@ object JsBridge {
       } else {
         new CustomDomNodeEnv(
           JSDOMNodeJSEnv.Config().withEnv(fullEnv).withExecutable(nodePath),
-          customScripts)
+          customScripts
+        )
       }
     }
 

--- a/bridges/scalajs-1.0/src/main/scala/bloop/scalajs/JsBridge.scala
+++ b/bridges/scalajs-1.0/src/main/scala/bloop/scalajs/JsBridge.scala
@@ -43,6 +43,7 @@ object JsBridge {
   def link(
       config: JsConfig,
       project: Project,
+      classpath: Array[Path],
       runMain: java.lang.Boolean,
       mainClass: Option[String],
       target: Path,
@@ -61,8 +62,7 @@ object JsBridge {
     }
 
     val cache = new IRFileCache().newCache
-    val irClasspath =
-      FileScalaJSIRContainer.fromClasspath(project.compilationClasspath.map(_.toFile))
+    val irClasspath = FileScalaJSIRContainer.fromClasspath(classpath.map(_.toFile))
     val irFiles = cache.cached(irClasspath)
 
     val moduleInitializers = mainClass match {

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -40,9 +40,6 @@ final case class Project(
   /** The bsp uri associated with this project. */
   val bspUri: Bsp.Uri = Bsp.Uri(ProjectUris.toURI(baseDirectory, name))
 
-  /** This project's full classpath (classes directory and raw classpath) */
-  val compilationClasspath: Array[AbsolutePath] = (classesDir :: rawClasspath).toArray
-
   val classpathOptions: ClasspathOptions = {
     ClasspathOptions.of(
       compileSetup.addLibraryToBootClasspath,
@@ -70,8 +67,8 @@ final case class Project(
     }
   }
 
-  def fullClasspathFor(dag: Dag[Project]): Array[AbsolutePath] = {
-    val cp = compilationClasspath.toBuffer
+  def dependencyClasspath(dag: Dag[Project]): Array[AbsolutePath] = {
+    val cp = (classesDir :: rawClasspath).toBuffer
     // Add the resources right before the classes directory if found in the classpath
     Dag.dfs(dag).foreach { p =>
       val index = cp.indexOf(p.classesDir)

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -72,11 +72,13 @@ final case class Project(
     // Add the resources right before the classes directory if found in the classpath
     Dag.dfs(dag).foreach { p =>
       val index = cp.indexOf(p.classesDir)
-      // If there is an anomaly and the classes dir of a dependency is missing, add resource at end
+      // Only add those resources that exist at the moment of creating the classpath
+      val resources = p.resources.filter(_.exists)
       if (index == -1) {
-        cp.appendAll(p.resources)
+        // If anomaly and classes dir of a dependency is missing, add resources at end
+        cp.appendAll(resources)
       } else {
-        cp.insertAll(index, p.resources)
+        cp.insertAll(index, resources)
       }
     }
     cp.toArray

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -54,7 +54,7 @@ object Tasks {
     import state.logger
     project.scalaInstance match {
       case Some(instance) =>
-        val classpath = project.fullClasspathFor(state.build.getDagFor(project))
+        val classpath = project.dependencyClasspath(state.build.getDagFor(project))
         val entries = classpath.map(_.underlying.toFile).toSeq
         logger.debug(s"Setting up the console classpath with ${entries.mkString(", ")}")(
           DebugFilter.All)
@@ -180,7 +180,7 @@ object Tasks {
       args: Array[String],
       skipJargs: Boolean
   ): Task[State] = {
-    val classpath = project.fullClasspathFor(state.build.getDagFor(project))
+    val classpath = project.dependencyClasspath(state.build.getDagFor(project))
     val processConfig = Forker(javaEnv, classpath)
     val runTask =
       processConfig.runMain(cwd, fqn, args, skipJargs, state.logger, state.commonOptions)

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
@@ -2,6 +2,7 @@ package bloop.engine.tasks.compilation
 
 import bloop.data.Project
 import bloop.engine.Feedback
+import bloop.engine.Dag
 import bloop.io.{AbsolutePath, Paths}
 import bloop.{Compiler, ScalaInstance}
 
@@ -27,8 +28,9 @@ import bloop.{Compiler, ScalaInstance}
  */
 final case class CompileBundle(
     project: Project,
+    classpath: Array[AbsolutePath],
     javaSources: List[AbsolutePath],
-    scalaSources: List[AbsolutePath],
+    scalaSources: List[AbsolutePath]
 ) {
   val isJavaOnly: Boolean = scalaSources.isEmpty && !javaSources.isEmpty
 
@@ -70,10 +72,11 @@ case class CompileSourcesAndInstance(
 )
 
 object CompileBundle {
-  def apply(project: Project): CompileBundle = {
+  def apply(project: Project, dag: Dag[Project]): CompileBundle = {
     val sources = project.sources.distinct
+    val classpath = project.dependencyClasspath(dag)
     val javaSources = sources.flatMap(src => Paths.pathFilesUnder(src, "glob:**.java")).distinct
     val scalaSources = sources.flatMap(src => Paths.pathFilesUnder(src, "glob:**.scala")).distinct
-    new CompileBundle(project, javaSources, scalaSources)
+    new CompileBundle(project, classpath, javaSources, scalaSources)
   }
 }

--- a/frontend/src/main/scala/bloop/engine/tasks/toolchains/ScalaJsToolchain.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/toolchains/ScalaJsToolchain.scala
@@ -35,6 +35,7 @@ final class ScalaJsToolchain private (bridgeClassLoader: ClassLoader) {
    * initializers instead of the main module initializers.
    *
    * @param project The project to link
+   * @param fullClasspath The full classpath to link with
    * @param config The configuration for Scala.js
    * @param runMain Whether the link process should install module initializers for main.
    * @param mainClass The main class if invoked via `link` or `run`.
@@ -45,6 +46,7 @@ final class ScalaJsToolchain private (bridgeClassLoader: ClassLoader) {
   def link(
       config: JsConfig,
       project: Project,
+      fullClasspath: Array[Path],
       runMain: java.lang.Boolean,
       mainClass: Option[String],
       target: AbsolutePath,
@@ -54,7 +56,7 @@ final class ScalaJsToolchain private (bridgeClassLoader: ClassLoader) {
     val method = bridgeClazz.getMethod("link", paramTypesLink: _*)
     val linkage = Task(
       method
-        .invoke(null, config, project, runMain, mainClass, target.underlying, logger)
+        .invoke(null, config, project, fullClasspath, runMain, mainClass, target.underlying, logger)
         .asInstanceOf[Unit]
     ).materialize
     linkage.map {
@@ -96,7 +98,7 @@ final class ScalaJsToolchain private (bridgeClassLoader: ClassLoader) {
   }
 
   // format: OFF
-  private val paramTypesLink = classOf[JsConfig] :: classOf[Project] :: classOf[java.lang.Boolean] :: classOf[Option[String]] :: classOf[Path] :: classOf[Logger] :: Nil
+  private val paramTypesLink = classOf[JsConfig] :: classOf[Project] :: classOf[Array[Path]] :: classOf[java.lang.Boolean] :: classOf[Option[String]] :: classOf[Path] :: classOf[Logger] :: Nil
   private val paramTypesTestFrameworks = classOf[List[List[String]]] :: classOf[String] :: classOf[Path] :: classOf[Path] :: classOf[Logger] :: classOf[java.lang.Boolean] :: classOf[Map[String, String]] :: Nil
   // format: ON
 }

--- a/frontend/src/main/scala/bloop/engine/tasks/toolchains/ScalaNativeToolchain.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/toolchains/ScalaNativeToolchain.scala
@@ -18,15 +18,17 @@ final class ScalaNativeToolchain private (classLoader: ClassLoader) {
   /**
    * Compile down to native binary using Scala Native's toolchain.
    *
-   * @param config    The native configuration to use.
-   * @param project   The project to link
-   * @param mainClass The fully qualified main class name
-   * @param logger    The logger to use
+   * @param config        The native configuration to use.
+   * @param project       The project to link
+   * @param fullClasspath The full classpath to link with
+   * @param mainClass     The fully qualified main class name
+   * @param logger        The logger to use
    * @return The absolute path to the native binary.
    */
   def link(
       config: NativeConfig,
       project: Project,
+      fullClasspath: Array[Path],
       mainClass: String,
       target: AbsolutePath,
       logger: Logger
@@ -38,7 +40,7 @@ final class ScalaNativeToolchain private (classLoader: ClassLoader) {
     val fullEntry = if (mainClass.endsWith("$")) mainClass else mainClass + "$"
     val linkage = Task {
       nativeLinkMeth
-        .invoke(null, config, project, fullEntry, target.underlying, logger)
+        .invoke(null, config, project, fullClasspath, fullEntry, target.underlying, logger)
         .asInstanceOf[Unit]
     }.materialize
 
@@ -53,7 +55,7 @@ final class ScalaNativeToolchain private (classLoader: ClassLoader) {
   }
 
   // format: OFF
-  private val paramTypes = classOf[NativeConfig] :: classOf[Project] :: classOf[String] :: classOf[Path] :: classOf[Logger] :: Nil
+  private val paramTypes = classOf[NativeConfig] :: classOf[Project] :: classOf[Array[Path]] :: classOf[String] :: classOf[Path] :: classOf[Logger] :: Nil
   // format: ON
 }
 

--- a/frontend/src/test/scala/bloop/ForkerSpec.scala
+++ b/frontend/src/test/scala/bloop/ForkerSpec.scala
@@ -44,7 +44,7 @@ class ForkerSpec {
     TestUtil.checkAfterCleanCompilation(runnableProject, dependencies) { state =>
       val project = TestUtil.getProject(TestUtil.RootProject, state)
       val env = JavaEnv.default
-      val classpath = project.fullClasspathFor(state.build.getDagFor(project))
+      val classpath = project.dependencyClasspath(state.build.getDagFor(project))
       val config = Forker(env, classpath)
       val logger = new RecordingLogger
       val opts = state.commonOptions.copy(env = TestUtil.runAndTestProperties)

--- a/frontend/src/test/scala/bloop/JsTestSpec.scala
+++ b/frontend/src/test/scala/bloop/JsTestSpec.scala
@@ -187,7 +187,7 @@ class JsTestSpec(
   @Test
   def testsAreDetected(): Unit = {
     // Load the project's classpath by filtering out unwanted FQNs to create the test loader
-    val classpath = testProject.fullClasspathFor(testState.build.getDagFor(testProject))
+    val classpath = testProject.dependencyClasspath(testState.build.getDagFor(testProject))
     val classpathEntries = classpath.map(_.underlying.toUri.toURL)
     val testLoader = new URLClassLoader(classpathEntries, Some(TestInternals.filteredLoader).orNull)
     def frameworks(classLoader: ClassLoader): List[Framework] = {

--- a/frontend/src/test/scala/bloop/JvmTestSpec.scala
+++ b/frontend/src/test/scala/bloop/JvmTestSpec.scala
@@ -87,7 +87,7 @@ class JvmTestSpec(
 
   private val processRunnerConfig: Forker = {
     val javaEnv = JavaEnv.default
-    val classpath = testProject.fullClasspathFor(testState.build.getDagFor(testProject))
+    val classpath = testProject.dependencyClasspath(testState.build.getDagFor(testProject))
     val classpathEntries = classpath.map(_.underlying.toUri.toURL)
     Forker(javaEnv, classpath)
   }

--- a/frontend/src/test/scala/bloop/RunSpec.scala
+++ b/frontend/src/test/scala/bloop/RunSpec.scala
@@ -133,7 +133,7 @@ class RunSpec {
     state.build.getProjectFor(target) match {
       case Some(rootWithAggregation) =>
         val dag = state.build.getDagFor(rootWithAggregation)
-        val fullClasspath = rootWithAggregation.fullClasspathFor(dag).toList
+        val fullClasspath = rootWithAggregation.dependencyClasspath(dag).toList
         val dependentResources = Dag.dfs(dag).flatMap(_.resources)
         Assert.assertFalse(dependentResources.isEmpty)
         dependentResources.foreach { r =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,14 +3,14 @@ package build
 object Dependencies {
   val Scala210Version = "2.10.7"
   val Scala211Version = "2.11.12"
-  val Scala212Version = "2.12.7"
+  val Scala212Version = "2.12.8"
 
   val nailgunVersion = "6992a3bf"
   // Used to download the python client instead of resolving
   val nailgunCommit = "af4d2e7f"
 
   val zincVersion = "1.2.1+106-0dad4a69"
-  val bspVersion = "2.0.0-M1" 
+  val bspVersion = "2.0.0-M1"
   val scalazVersion = "7.2.20"
   val coursierVersion = "1.1.0-M8"
   val lmVersion = "1.0.0"
@@ -100,7 +100,7 @@ object Dependencies {
   val scalaJsSbtTestAdapter10 = "org.scala-js" %% "scalajs-sbt-test-adapter" % scalaJs10Version
   val scalaJsLogging10 = "org.scala-js" %% "scalajs-logging" % scalaJs10Version
 
-  val mill = "com.lihaoyi" %% "mill-scalalib"	% millVersion % Provided
+  val mill = "com.lihaoyi" %% "mill-scalalib" % millVersion % Provided
   val xxHashLibrary = "net.jpountz.lz4" % "lz4" % xxHashVersion
   val zt = "org.zeroturnaround" % "zt-zip" % ztVersion
 }


### PR DESCRIPTION
In https://github.com/scalacenter/bloop/pull/730, I claimed:

> Resources are files that are used at runtime, either when testing or
running an application. These files can be generated by the build tool or
be present in a resource directory of a project.

However, this was not the full story, it turns out that resources are also
required by macros, which happen at compile time, and therefore resources
are required by `compile`.

This patch modifies bloop to use the classpath with resources as the
default from now on for any action in bloop, as all of them require it.

Fixes https://github.com/scalacenter/bloop/issues/763