### PR TITLE
Disable warnings logged by nuprocess library

### DIFF
--- a/launcher/src/main/scala/bloop/launcher/core/Shell.scala
+++ b/launcher/src/main/scala/bloop/launcher/core/Shell.scala
@@ -5,9 +5,11 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import java.util.concurrent.TimeUnit
+import java.util.logging.{Level, Logger}
 
 import bloop.launcher.bsp.BspConnection
 import bloop.launcher.util.Environment
+import com.zaxxer.nuprocess.internal.BasePosixProcess
 import com.zaxxer.nuprocess.{NuAbstractProcessHandler, NuProcess, NuProcessBuilder}
 
 import scala.collection.mutable.ListBuffer
@@ -162,6 +164,8 @@ final class Shell(runWithInterpreter: Boolean, detectPython: Boolean) {
 }
 
 object Shell {
+  Logger.getLogger(classOf[BasePosixProcess].getCanonicalName).setLevel(Level.SEVERE)
+
   def default: Shell = new Shell(false, true)
 
   def portNumberWithin(from: Int, to: Int): Int = {


### PR DESCRIPTION
When running launcher and `bloop` is not on the `PATH` we get the following error:

```
Starting the bsp launcher for bloop...
Jan 15, 2019 12:39:19 PM com.zaxxer.nuprocess.linux.LinuxProcess start
WARNING: Failed to start process
java.io.IOException: error=2, No such file or directory
	at com.zaxxer.nuprocess.internal.LibJava8.Java_java_lang_UNIXProcess_forkAndExec(Native Method)
	at com.zaxxer.nuprocess.linux.LinuxProcess.start(LinuxProcess.java:109)
	at com.zaxxer.nuprocess.linux.LinProcessFactory.createProcess(LinProcessFactory.java:40)
	at com.zaxxer.nuprocess.NuProcessBuilder.start(NuProcessBuilder.java:266)
	at bloop.launcher.core.Shell.runCommand(Shell.scala:87)
	at bloop.launcher.core.Shell.detectBloopInSystemPath(Shell.scala:153)
	at bloop.launcher.LauncherMain.detectServerState(Launcher.scala:232)
	at bloop.launcher.LauncherMain.connectToBloopBspServer(Launcher.scala:159)
	at bloop.launcher.LauncherMain.runLauncher(Launcher.scala:95)
	at bloop.launcher.LauncherMain.cli(Launcher.scala:78)
	at bloop.launcher.LauncherMain.main(Launcher.scala:59)
	at bloop.launcher.Launcher.main(Launcher.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at coursier.bootstrap.Bootstrap.main(Unknown Source)

A bloop installation has been detected either in the PATH or $HOME/.bloop
```

NuProcess library is using a logger, which always logs warning when it cannot start, but since `bloop` is reading the result of the command from the `exit code`, I am wondering how this (small, but annoying) issue could be addressed? Please, suggest/discuss better solution if you have one.

This PR is a simplest fix I could come up with: disabling warnings from `NuProcess` (the impact analysis is at the end of this message). It gives us more clear output:
```
Starting the bsp launcher for bloop...
A bloop installation has been detected either in the PATH or $HOME/.bloop
```
----
Analysis:
`NuProcess` is inconsistent... most of the time it just swallows the exception, but in three cases it also logs warnings, before doing nothing...

Those warnings are logged when exception happens while:
a) reading stdout/stderr
b) starting process
c) creating pipes - but this cases does not affect `launcher`, since the exception is actually propagated after being logged

I believe both a) and b) are of low impact, since `launcher` depends on exit codes anyway