### PR TITLE
Fix aggressive deduplication of diagnostics

### DIFF
--- a/backend/src/main/scala/bloop/reporter/Reporter.scala
+++ b/backend/src/main/scala/bloop/reporter/Reporter.scala
@@ -33,7 +33,7 @@ abstract class Reporter(
     val _problems: mutable.Buffer[ProblemPerPhase] = mutable.ArrayBuffer.empty
 ) extends xsbti.Reporter
     with ConfigurableReporter {
-  case class PositionId(sourcePath: String, pointer: Int)
+  case class PositionId(sourcePath: String, offset: Int)
   private val _severities = TrieMap.empty[PositionId, Severity]
   private val _messages = TrieMap.empty[PositionId, List[String]]
 
@@ -81,9 +81,9 @@ abstract class Reporter(
       supress
     }
 
-    (InterfaceUtil.toOption(pos.sourcePath()), InterfaceUtil.toOption(pos.pointer())) match {
-      case (Some(sourcePath), Some(pointer)) =>
-        val positionId = PositionId(sourcePath, pointer)
+    (InterfaceUtil.toOption(pos.sourcePath()), InterfaceUtil.toOption(pos.offset())) match {
+      case (Some(sourcePath), Some(offset)) =>
+        val positionId = PositionId(sourcePath, offset)
         _severities.get(positionId) match {
           case Some(xsbti.Severity.Error) => processNewPosition(positionId, true)
           case Some(severity) if severity == problem.severity =>

--- a/frontend/src/test/scala/bloop/CompileSpec.scala
+++ b/frontend/src/test/scala/bloop/CompileSpec.scala
@@ -491,6 +491,24 @@ class CompileSpec {
   }
 
   @Test
+  def avoidAggressiveDiagnosticDeduplication(): Unit = {
+    object Sources {
+      val `A.scala` =
+        """object Dep {
+          |  val a1: Int = ""
+          |  val a2: Int = ""
+          |}""".stripMargin
+    }
+
+    val deps = Map.empty[String, Set[String]]
+    val logger = new RecordingLogger(ansiCodesSupported = false)
+    val structure = Map(RootProject -> Map("A.scala" -> Sources.`A.scala`))
+    checkAfterCleanCompilation(structure, deps, useSiteLogger = Some(logger)) { (state: State) =>
+      assertEquals(logger.errors.size.toLong, 4.toLong)
+    }
+  }
+
+  @Test
   def compileWithErrorAndRollbackToNoOp(): Unit = {
     // This test checks that we're using a transactional class file manager
     object Sources {

--- a/notes/v1.2.4.md
+++ b/notes/v1.2.4.md
@@ -1,0 +1,47 @@
+# bloop `v1.2.4` :surfer:
+
+## Upgrade guide :electric_plug:
+
+This section describes the upgrade steps. If you don't have bloop installed, please read
+the [installation instructions][] instead.
+
+If you're on macOS, **upgrade** to the latest version with:
+
+```sh
+$ brew upgrade scalacenter/bloop/bloop
+$ brew services restart bloop
+```
+
+If you're on Windows using `scoop`, **upgrade** to the latest version with:
+
+```sh
+$ scoop upgrade bloop
+$ bloop ng-stop
+$ // Start the server as you usually do (via systemd, manually, desktop services)
+```
+
+Otherwise, run:
+
+```
+$ curl -L https://github.com/scalacenter/bloop/releases/download/v1.2.4/install.py | python
+$ bloop ng-stop
+$ // Start the server as you usually do (via systemd, manually, desktop services)
+```
+
+Read the complete installation instructions in our [Installation page][installation instructions].
+
+## Highlights :books:
+
+`v1.2.4` is only a bugfix release.
+
+### Don't deduplicate diagnostics too aggressively
+
+Fix an error where the deduplication logic of diagnostics to avoid duplicated scalac errors
+relied on `pointer` instead of `offset`.
+
+## Contributors :busts_in_silhouette:
+
+According to `git shortlog -sn --no-merges v1.2.3..v1.2.4`, 1 people contributed to this `v1.2.4`
+release: Jorge Vicente Cantero.
+
+[installation instructions]: https://scalacenter.github.io/bloop/setup


### PR DESCRIPTION
Use `offset` instead of `pointer` (which is a short for column
position) to deduplicate error messages.