### PR TITLE
Ensure mill config uses generated sources too

### DIFF
--- a/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
+++ b/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
@@ -98,7 +98,7 @@ object Bloop extends ExternalModule {
       Config.Project(
         name = name(module),
         directory = module.millSourcePath.toNIO,
-        sources = module.sources().map(_.path.toNIO).toList,
+        sources = module.allSources().map(_.path.toNIO).toList,
         dependencies = module.moduleDeps.map(name).toList,
         classpath = classpath().map(_.toNIO).toList,
         out = out(module).toNIO,


### PR DESCRIPTION
At the moment source generators (for example ScalaPB) do not run when doing bloopInstall in mill and since mill and bloop do not share output directories, there are a lot of spurious errors when compiling with bloop caused by the compilation output for the generated sources being missing. 

This changes the mill Config.Project so that it contains the generated sources too.

I have tested this with Metals + VS Code on [this project](https://github.com/DavidGregory084/inc) and the references to the `proto` module in the `common` module seem to work with this change.