### PR TITLE
fixing brew instructions after failed installation

### DIFF
--- a/docs/tools/homebrew/install.md
+++ b/docs/tools/homebrew/install.md
@@ -1,4 +1,5 @@
 ```bash
+$ brew tap scalacenter/bloop
 $ brew install scalacenter/bloop/bloop
 ```
 


### PR DESCRIPTION
Hi guys,

I was using Linuxbrew (brew 2.0) to install bloop on linux using brew. 
The command above didn't work by default so I had to figure out how to make it work.
Here is the result of what helped to fix the issue and to finally install bloop. Hope it will help somebody else ;)

### console output of problem and solution
```
[18:09:31] (exit code 0)
> brew tap scalacenter/bloop/bloop
Error: Invalid tap name 'scalacenter/bloop/bloop'
[18:09:39] (exit code 1)
> brew install scalacenter/bloop
Error: No available formula with the name "scalacenter/bloop" 
==> Searching for a previously deleted formula (in the last month)...
Warning: homebrew/core is shallow clone. To get complete history run:
  git -C "$(brew --repo homebrew/core)" fetch --unshallow

Error: No previously deleted formula found.
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
[18:12:46] (exit code 1)
> brew tap scalacenter/bloop
==> Tapping scalacenter/bloop
Cloning into '/home/user/.linuxbrew/Homebrew/Library/Taps/scalacenter/homebrew-bloop'...
remote: Enumerating objects: 6, done.
remote: Counting objects: 100% (6/6), done.
remote: Compressing objects: 100% (6/6), done.
remote: Total 6 (delta 0), reused 6 (delta 0), pack-reused 0
Unpacking objects: 100% (6/6), done.
Tapped 1 formula (33 files, 121.8KB).
[18:13:00] (exit code 0)
> brew install scalacenter/bloop
Error: No available formula with the name "scalacenter/bloop" 
==> Searching for a previously deleted formula (in the last month)...
Warning: homebrew/core is shallow clone. To get complete history run:
  git -C "$(brew --repo homebrew/core)" fetch --unshallow

Error: No previously deleted formula found.
==> Searching for similarly named formulae...
This similarly named formula was found:
scalacenter/bloop/bloop
To install it, run:
  brew install scalacenter/bloop/bloop
[18:13:13] (exit code 1)
> brew install scalacenter/bloop/bloop
==> Installing bloop from scalacenter/bloop
```