### PR TITLE
Use a guaranteed-unique name for temporary directories

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -3,6 +3,7 @@ package bloop
 import xsbti.compile._
 import xsbti.T2
 import java.util.Optional
+import java.util.UUID
 import java.io.File
 
 import bloop.internal.Ecosystem
@@ -110,7 +111,7 @@ object Compiler {
 
   def compile(compileInputs: CompileInputs): Task[Result] = {
     val classesDir = compileInputs.classesDir.toFile
-    val classesDirBak = compileInputs.classesDir.getParent.resolve("classes.bak").toFile
+    val classesDirBak = compileInputs.classesDir.getParent.resolve(UUID.randomUUID().toString).toFile
     def getInputs(compilers: Compilers): Inputs = {
       val options = getCompilationOptions(compileInputs)
       val setup = getSetup(compileInputs)


### PR DESCRIPTION
This is an attempt to correct race-conditions relating to concurrent
access of a temporary directory called `classes.bak`. The change chooses
a different, unique name (a UUID) for the temporary directory.

Bloop's build is currently failing, so I can't test this change, but
it's very simple. But I'm relying on a review, or some evidence of
passing tests, to confirm that this is the right thing to do.

Hopefully fixes #812.