### PR TITLE
Remove command prompt for one-line commands

### DIFF
--- a/docs/tools/homebrew/install.md
+++ b/docs/tools/homebrew/install.md
@@ -1,5 +1,5 @@
 ```bash
-$ brew install scalacenter/bloop/bloop
+brew install scalacenter/bloop/bloop
 ```
 
 ### Requirements

--- a/docs/tools/nix/usage.md
+++ b/docs/tools/nix/usage.md
@@ -2,7 +2,7 @@ The installation script installs the build server and the bloop command-line app
 The build server **must be started** before the command-line application is used. Start it with:
 
 ```bash
-$ blp-server
+blp-server
 ```
 
 Then, verify your installation by running the command-line application:

--- a/docs/tools/scoop/install.md
+++ b/docs/tools/scoop/install.md
@@ -1,21 +1,21 @@
 Add the bloop bundle to [scoop](https://github.com/lukesampson/scoop):
 
 ```bash
-$ scoop bucket add bloop-stable https://github.com/scalacenter/scoop-bloop.git
+scoop bucket add bloop-stable https://github.com/scalacenter/scoop-bloop.git
 ```
 
 Check that the bucket is correctly configured:
 
 ```bash
-$ scoop bucket list
-$ scoop search bloop
+scoop bucket list
+scoop search bloop
 // You should see the bloop scoop package listed here
 ```
 
 Then, install it with:
 
 ```bash
-$ scoop install bloop
+scoop install bloop
 ```
 
 ### Requirements

--- a/docs/tools/scoop/usage.md
+++ b/docs/tools/scoop/usage.md
@@ -2,7 +2,7 @@ The installation script installs the build server and the bloop command-line app
 The build server **must be started** before the command-line application is used. Start it with:
 
 ```bash
-$ bloop server
+bloop server
 ```
 
 This process can take a while to run the first time is executed. When the nailgun logs show up,

--- a/docs/tools/universal/usage.md
+++ b/docs/tools/universal/usage.md
@@ -2,7 +2,7 @@ The installation script installs the build server and the bloop command-line app
 The build server **must be started** before the command-line application is used. Start it with:
 
 ```bash
-$ bloop server
+bloop server
 ```
 
 <blockquote>
@@ -67,7 +67,7 @@ Symlink the fish completions file in the Bloop installation directory to your lo
 directory (usually `~/.config/fish/completions`).
 
 ```sh
-$ ln -s $HOME/.bloop/fish/bloop.fish ~/.config/fish/completions/bloop.fish
+ln -s $HOME/.bloop/fish/bloop.fish ~/.config/fish/completions/bloop.fish
 ```
 
 > Make sure that the target fish completions directory already exists.
@@ -78,11 +78,11 @@ Make sure that, before reloading the fish shell, the build server is started.
 If you still experience problems, reload the completion script:
 
 ```bash
-$ source $HOME/.bloop/fish/bloop.fish bloop.fish
+source $HOME/.bloop/fish/bloop.fish bloop.fish
 ```
 
 Or, if you use [Oh My Fish](https://github.com/oh-my-fish/oh-my-fish):
 
 ```bash
-$ omf reload
+omf reload
 ```


### PR DESCRIPTION
The dollar sign should not be copied when I click a "copy" button. At least for one-line commands.
__
Example page with "copy" button" - [link](https://scalacenter.github.io/bloop/setup#scoop).