### PR TITLE
Allow customization of cores via system property

### DIFF
--- a/frontend/src/main/scala/bloop/engine/ExecutionContext.scala
+++ b/frontend/src/main/scala/bloop/engine/ExecutionContext.scala
@@ -13,7 +13,15 @@ import monix.execution.{ExecutionModel, UncaughtExceptionReporter}
 import monix.execution.schedulers.ExecutorScheduler
 
 object ExecutionContext {
-  private[bloop] val nCPUs = Runtime.getRuntime.availableProcessors()
+  private[bloop] val nCPUs = {
+    val default = Runtime.getRuntime.availableProcessors()
+    Option(System.getProperty("bloop.computation.cores")) match {
+      case Some(value) =>
+        try Integer.parseInt(value)
+        catch { case scala.util.control.NonFatal(_) => default }
+      case None => default
+    }
+  }
 
   import monix.execution.Scheduler
   implicit lazy val bspScheduler: Scheduler = Scheduler {


### PR DESCRIPTION
Note that we can only customize the number of cores dedicated to the
computation thread pool, which is the main thread pool where all
compilation takes place. We usually want to be this pool to have roughly
the same amount of threads as cores supported in the running machine.