### PR TITLE
fix scalatest arg construction order

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ contributing to Bloop by [reading the CONTRIBUTING guide][contributing].
 follows the [Scala Code of Conduct][coc]. We are committed to providing a safe
 environment for all contributors.
 
-[gitter]: https://github.com/scalacenter/bloop
+[gitter]: https://gitter.im/scalacenter/bloop
 [contributing]: https://scalacenter.github.io/bloop/docs/developer-documentation/
 [scalacenter]: https://scala.epfl.ch
 [coc]: https://www.scala-lang.org/conduct/


### PR DESCRIPTION
Repo with reproduction: https://github.com/tkroman/berror

Reason: args are constructed in reverse right now (e.g. instead of `-l Label` order is `Label -l`).

With this built locally tests pass.

Also fixes a bug in `-h` flag handling, where a file was created instead of directory previously.