### PR TITLE
Update URL for installation instructions in bloop frontend missingConfigDirectory error message

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Feedback.scala
+++ b/frontend/src/main/scala/bloop/engine/Feedback.scala
@@ -70,7 +70,7 @@ object Feedback {
        |     If so, change your current directory or point directly to your `.bloop` directory via `--config-dir`.
        |
        |  2. Did you forget to generate configuration files for your build?
-       |     Check the installation instructions https://scalacenter.github.io/bloop/docs/installation/
+       |     Check the installation instructions https://scalacenter.github.io/bloop/setup
     """.stripMargin
 
   val MissingPipeName = "Missing pipe name to establish a local connection in Windows"


### PR DESCRIPTION
<img width="1555" alt="Screen Shot 2019-04-09 at 19 38 45" src="https://user-images.githubusercontent.com/20543481/55822190-59b97f00-5aff-11e9-81d1-c4f370ceabe0.png">

https://scalacenter.github.io/bloop/docs/installation/ is returning a 404 HTTP status code and it looks like that it was updated to https://scalacenter.github.io/bloop/setup