### PR TITLE
Invalidate symbols with forked and local javac

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -183,8 +183,9 @@ object Compiler {
           // Add to the blacklist so that we never copy them
           allInvalidatedClassFilesForProject.++=(classes)
           val invalidatedExtraCompileProducts = classes.flatMap { classFile =>
+            val prefixClassName = classFile.getName().stripSuffix(".class")
             supportedCompileProducts.flatMap { supportedProductSuffix =>
-              val productName = classFile.getName().stripSuffix(".class") + supportedProductSuffix
+              val productName = prefixClassName + supportedProductSuffix
               val productAssociatedToClassFile = new File(classFile.getParentFile, productName)
               if (!productAssociatedToClassFile.exists()) Nil
               else List(productAssociatedToClassFile)

--- a/backend/src/main/scala/bloop/CompilerCache.scala
+++ b/backend/src/main/scala/bloop/CompilerCache.scala
@@ -1,14 +1,38 @@
 package bloop
 
+import java.io.File
+import java.lang.Iterable
+import java.io.PrintWriter
 import java.util.concurrent.ConcurrentHashMap
+import javax.tools.JavaFileManager.Location
+import javax.tools.JavaFileObject.Kind
+import javax.tools.{
+  FileObject,
+  ForwardingJavaFileManager,
+  StandardJavaFileManager,
+  ForwardingJavaFileObject,
+  JavaFileManager,
+  JavaFileObject,
+  JavaCompiler => JavaxCompiler
+}
 
 import bloop.io.{AbsolutePath, Paths}
 import bloop.logging.Logger
-import sbt.internal.inc.bloop.ZincInternals
-import sbt.internal.inc.{AnalyzingCompiler, ZincUtil}
+
 import sbt.librarymanagement.Resolver
+
 import xsbti.ComponentProvider
 import xsbti.compile.Compilers
+import xsbti.compile.{JavaCompiler => XJavaCompiler, JavaTool => XJavaTool}
+import xsbti.compile.ClassFileManager
+import xsbti.{Logger => XLogger, Reporter => XReporter}
+
+import sbt.internal.inc.bloop.ZincInternals
+import sbt.internal.inc.{AnalyzingCompiler, ZincUtil}
+import sbt.internal.inc.javac.JavaTools
+import sbt.internal.inc.javac.{JavaCompiler, Javadoc, ForkedJava}
+import sbt.internal.util.LoggerWriter
+import sbt.internal.inc.javac.DiagnosticsReporter
 
 final class CompilerCache(
     componentProvider: ComponentProvider,
@@ -22,9 +46,26 @@ final class CompilerCache(
   def get(scalaInstance: ScalaInstance): Compilers =
     cache.computeIfAbsent(scalaInstance, newCompilers)
 
+  private[bloop] def duplicateWith(logger: Logger): CompilerCache =
+    new CompilerCache(componentProvider, retrieveDir, logger, userResolvers)
+
+  private val compileJavaHomeKey = "bloop.compilation.java-home"
+  private val compileJavaHome = Option(System.getProperty(compileJavaHomeKey))
   private def newCompilers(scalaInstance: ScalaInstance): Compilers = {
-    val compiler = getScalaCompiler(scalaInstance, componentProvider)
-    ZincUtil.compilers(scalaInstance, None, compiler)
+    val scalaCompiler = getScalaCompiler(scalaInstance, componentProvider)
+    val javaCompiler = {
+      compileJavaHome
+        .flatMap(javaHome => getForkedJavaCompiler(javaHome))
+        .orElse {
+          Option(javax.tools.ToolProvider.getSystemJavaCompiler)
+            .map(compiler => new BloopJavaCompiler(compiler))
+        }
+        .getOrElse(new BloopForkedJavaCompiler(None))
+    }
+
+    val javaDoc = Javadoc.local.getOrElse(Javadoc.fork())
+    val javaTools = JavaTools(javaCompiler, javaDoc)
+    ZincUtil.compilers(javaTools, scalaCompiler)
   }
 
   def getScalaCompiler(
@@ -37,15 +78,201 @@ final class CompilerCache(
       case Array(jar) => ZincUtil.scalaCompiler(scalaInstance, jar)
       case _ =>
         ZincUtil.scalaCompiler(
-          /* scalaInstance        = */ scalaInstance,
-          /* globalLock           = */ BloopComponentsLock,
-          /* componentProvider    = */ componentProvider,
-          /* secondaryCacheDir    = */ Some(Paths.getCacheDirectory("bridge-cache").toFile),
-          /* dependencyResolution = */ DependencyResolution.getEngine(userResolvers),
-          /* compilerBridgeSource = */ bridgeSources,
-          /* scalaJarsTarget      = */ retrieveDir.toFile,
-          /* log                  = */ logger
+          scalaInstance,
+          BloopComponentsLock,
+          componentProvider,
+          Some(Paths.getCacheDirectory("bridge-cache").toFile),
+          DependencyResolution.getEngine(userResolvers),
+          bridgeSources,
+          retrieveDir.toFile,
+          logger
         )
+    }
+  }
+
+  def getForkedJavaCompiler(javaHome: String): Option[xsbti.compile.JavaCompiler] = {
+    val homeFile = new java.io.File(javaHome)
+    if (homeFile.exists()) {
+      import bloop.logging.DebugFilter
+      logger.debug(s"Instantiating a Java compiler from $javaHome")(DebugFilter.Compilation)
+      Some(new BloopForkedJavaCompiler(Some(homeFile)))
+    } else {
+      logger.warn(s"Ignoring non-existing Java home $compileJavaHome, using default")
+      None
+    }
+  }
+
+  /**
+   * A Java compiler that will invalidate class files from a forked java
+   * compiler by adding a new classes directory to the begining of the
+   * `-classpath` compiler option where we will write an empty class file for
+   * every invalidated class file. This empty class file will force the javac
+   * compiler to output an error similar to:
+   *
+   *  ```
+   *  /path/to/File.java:1
+   *    error: cannot access Bar
+   *
+   *  bad class file: ./B.class
+   *  class file contains wrong class: java.lang.Object
+   *  Please remove or make sure it appears in the correct subdirectory of the classpath.
+   *  ```
+   *
+   * Fortunately, the last bit is not parsed by Zinc's `JavacParser` and
+   * doesn't show up as a reported Zinc problem. The first bit does show up and
+   * it's a good enough error to intuit that the symbol might not exist, so we
+   * leave it there. We cannot replace that error with a custom one because it
+   * would be confusing if the accessibility error is real and not caused by
+   * our invalidation trick.
+   */
+  final class BloopForkedJavaCompiler(javaHome: Option[File]) extends XJavaCompiler {
+    import xsbti.compile.IncToolOptions
+
+    def run(
+        sources: Array[File],
+        options: Array[String],
+        topts: IncToolOptions,
+        reporter: XReporter,
+        log: XLogger
+    ): Boolean = {
+      val classpathIndex = options.indexOf("-classpath")
+      if (classpathIndex == -1) {
+        logger.error("Missing classpath option for forked Java compiler")
+        false
+      } else {
+        import sbt.util.InterfaceUtil
+        InterfaceUtil.toOption(topts.classFileManager()) match {
+          case None => logger.error("Missing class file manager for forked Java compiler"); false
+          case Some(classFileManager) =>
+            import java.nio.file.Files
+            val newInvalidatedEntry = AbsolutePath(
+              Files.createTempDirectory("invalidated-forked-javac")
+            )
+
+            val invalidatedPaths =
+              classFileManager.invalidatedClassFiles().map(_.getAbsolutePath())
+            val classpathValueIndex = classpathIndex + 1
+            val classpathValue = options.apply(classpathValueIndex)
+            val classpathEntries = classpathValue.split(File.pathSeparator)
+
+            invalidatedPaths.foreach { invalidatedPath =>
+              val relativePath = classpathEntries.collectFirst {
+                case classpathEntry if invalidatedPath.startsWith(classpathEntry) =>
+                  invalidatedPath.stripPrefix(classpathEntry)
+              }
+
+              relativePath.foreach { relative =>
+                val relativeParts = relative.split(File.separator)
+                val invalidatedClassFile = relativeParts.foldLeft(newInvalidatedEntry) {
+                  case (path, relativePart) => path.resolve(relativePart)
+                }
+
+                val invalidatedClassFilePath = invalidatedClassFile.underlying
+                Files.createDirectories(invalidatedClassFilePath.getParent)
+                Files.write(invalidatedClassFilePath, "".getBytes())
+              }
+            }
+
+            val newClasspathValue = newInvalidatedEntry.toFile + File.pathSeparator + classpathValue
+            options(classpathValueIndex) = newClasspathValue
+
+            try {
+              import sbt.internal.inc.javac.BloopForkedJavaUtils
+              BloopForkedJavaUtils.launch(javaHome, "javac", sources, options, log, reporter)
+            } finally {
+              Paths.delete(newInvalidatedEntry)
+            }
+        }
+      }
+    }
+  }
+
+  /**
+   * A Java compiler that will invalidate class files using the local JDK Java
+   * compiler API. The invalidated class files are invalidated programmatically
+   * because they cannot be deleted from the classes directories because they
+   * are read-only.
+   */
+  final class BloopJavaCompiler(compiler: JavaxCompiler) extends XJavaCompiler {
+    import java.io.File
+    import xsbti.compile.IncToolOptions
+    import xsbti.Reporter
+    override def run(
+        sources: Array[File],
+        options: Array[String],
+        incToolOptions: IncToolOptions,
+        reporter: Reporter,
+        log0: xsbti.Logger
+    ): Boolean = {
+      val log: sbt.util.Logger = log0
+      import collection.JavaConverters._
+      val logger = new LoggerWriter(log)
+      val logWriter = new PrintWriter(logger)
+      log.debug("Attempting to call " + compiler + " directly...")
+      val diagnostics = new DiagnosticsReporter(reporter)
+      val fileManager0 = compiler.getStandardFileManager(diagnostics, null, null)
+
+      /* Local Java compiler doesn't accept `-J<flag>` options, strip them. */
+      val (invalidOptions, cleanedOptions) = options partition (_ startsWith "-J")
+      if (invalidOptions.nonEmpty) {
+        log.warn("Javac is running in 'local' mode. These flags have been removed:")
+        log.warn(invalidOptions.mkString("\t", ", ", ""))
+      }
+
+      var compileSuccess = false
+      import sbt.internal.inc.javac.WriteReportingFileManager
+      val zincFileManager = incToolOptions.classFileManager().get()
+      val fileManager = new BloopInvalidatingFileManager(fileManager0, zincFileManager)
+      val jfiles = fileManager0.getJavaFileObjectsFromFiles(sources.toList.asJava)
+      try {
+        val newJavacOptions = cleanedOptions.toList.asJava
+        val success = compiler
+          .getTask(logWriter, fileManager, diagnostics, newJavacOptions, null, jfiles)
+          .call()
+
+        /* Double check success variables for the Java compiler.
+         * The local compiler may report successful compilations even though
+         * there have been errors (e.g. encoding problems in sources). To stick
+         * to javac's behaviour, we report fail compilation from diagnostics. */
+        compileSuccess = success && !diagnostics.hasErrors
+      } finally {
+        import sbt.util.Level
+        logger.flushLines(if (compileSuccess) Level.Warn else Level.Error)
+      }
+      compileSuccess
+    }
+
+    final class BloopInvalidatingFileManager(
+        fileManager: JavaFileManager,
+        zincManager: ClassFileManager
+    ) extends ForwardingJavaFileManager[JavaFileManager](fileManager) {
+      import scala.collection.JavaConverters._
+      override def getJavaFileForOutput(
+          location: Location,
+          className: String,
+          kind: Kind,
+          sibling: FileObject
+      ): JavaFileObject = {
+        val output = super.getJavaFileForOutput(location, className, kind, sibling)
+        import sbt.internal.inc.javac.WriteReportingJavaFileObject
+        new WriteReportingJavaFileObject(output, zincManager)
+      }
+
+      import java.{util => ju}
+      override def list(
+          location: Location,
+          packageName: String,
+          kinds: ju.Set[Kind],
+          recurse: Boolean
+      ): Iterable[JavaFileObject] = {
+        val invalidated = zincManager.invalidatedClassFiles().map(_.getAbsolutePath()).toSet
+        val ls = super.list(location, packageName, kinds, recurse)
+        ls.asScala.filter { o =>
+          !invalidated.exists { invalidatedPath =>
+            o.getName().contains(invalidatedPath)
+          }
+        }.asJava
+      }
     }
   }
 }

--- a/backend/src/main/scala/sbt/internal/inc/javac/BloopForkedJavaUtils.scala
+++ b/backend/src/main/scala/sbt/internal/inc/javac/BloopForkedJavaUtils.scala
@@ -1,0 +1,16 @@
+package sbt.internal.inc.javac
+
+import java.io.File
+import xsbti.Logger
+import xsbti.Reporter
+
+object BloopForkedJavaUtils {
+  def launch(
+      javaHome: Option[File],
+      program: String,
+      sources: Seq[File],
+      options: Seq[String],
+      log: Logger,
+      reporter: Reporter
+  ): Boolean = ForkedJava.launch(javaHome, "javac", sources, options, log, reporter)
+}

--- a/frontend/src/test/scala/bloop/testing/BaseSuite.scala
+++ b/frontend/src/test/scala/bloop/testing/BaseSuite.scala
@@ -295,14 +295,32 @@ class BaseSuite extends TestSuite with BloopHelpers {
   }
 
   import bloop.io.RelativePath
+  def assertCompileProduct(
+      state: TestState,
+      project: TestProject,
+      classFile: RelativePath,
+      existing: Boolean
+  ): Unit = {
+    val buildProject = state.build.getProjectFor(project.config.name).get
+    val externalClassesDir = state.client.getUniqueClassesDirFor(buildProject)
+    if (existing) assert(externalClassesDir.resolve(classFile).exists)
+    else assert(!externalClassesDir.resolve(classFile).exists)
+  }
+
   def assertNonExistingCompileProduct(
       state: TestState,
       project: TestProject,
       classFile: RelativePath
   ): Unit = {
-    val buildProject = state.build.getProjectFor(project.config.name).get
-    val externalClassesDir = state.client.getUniqueClassesDirFor(buildProject)
-    assert(!externalClassesDir.resolve(classFile).exists)
+    assertCompileProduct(state, project, classFile, false)
+  }
+
+  def assertExistingCompileProduct(
+      state: TestState,
+      project: TestProject,
+      classFile: RelativePath
+  ): Unit = {
+    assertCompileProduct(state, project, classFile, true)
   }
 
   def assertExistingInternalClassesDir(lastState: TestState)(

--- a/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
+++ b/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
@@ -247,6 +247,9 @@ trait BloopHelpers {
     def withLogger(logger: Logger): TestState =
       new TestState(state.copy(logger = logger))
 
+    def withNewCompilerCache: TestState =
+      new TestState(state.copy(compilerCache = state.compilerCache.duplicateWith(state.logger)))
+
     def backup: TestState = {
       import java.nio.file.Files
       val logger = this.state.logger


### PR DESCRIPTION
Java compilation requires a mechanism to invalidate symbols that does
not depend on deleting class files from the classes directories. The
following commit implements that mechanism for both local and forked
javac compilation.

The mechanism becomes complex when supporting forked javac compilation
since we depend on the javac CLI and we cannot access any public API.
This forces us to implement a clever trick to get the compiler to fail
when a file has been invalidated.