### PR TITLE
Updated mill version 0.3.5 -> 0.3.6

### DIFF
--- a/docs/build-tools/mill/export.md
+++ b/docs/build-tools/mill/export.md
@@ -8,7 +8,7 @@ import $ivy.`ch.epfl.scala::mill-bloop:@VERSION@`
 
 ### Requirements
 
-* `mill` >= 0.3.5.
+* `mill` >= 0.3.6.
 
 > bloop makes a best effort to support always the latest mill version. The current plugin may not
 work for older and newer versions due to breaking binary changes in mill's public API.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
   val scalaNativeVersion = "0.3.7"
   val scalaJs06Version = "0.6.25"
   val scalaJs10Version = "1.0.0-M5"
-  val millVersion = "0.3.5"
+  val millVersion = "0.3.6"
   val xxHashVersion = "1.3.0"
   val ztVersion = "1.13"
   val difflibVersion = "1.3.0"


### PR DESCRIPTION
With this version change, mill-bloop seems to work with mill 0.3.6-42-d1f1b6 also (latest published "unstable" mill version).