### PR TITLE
Guarantee cancellation upon sudden client dropouts

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -367,6 +367,9 @@ object Compiler {
       cancelPromise.synchronized {
         // Avoid illegal state exception if client cancellation promise is completed
         if (!cancelPromise.isCompleted) {
+          logger.debug(
+            s"Cancelling compilation from ${readOnlyClassesDirPath} to ${newClassesDirPath}"
+          )
           compileInputs.cancelPromise.success(())
         }
       }

--- a/frontend/src/main/scala/bloop/bsp/BloopLanguageClient.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopLanguageClient.scala
@@ -1,0 +1,125 @@
+package bloop.bsp
+
+import scala.meta.jsonrpc.Response
+import scala.meta.jsonrpc.RequestId
+import scala.meta.jsonrpc.CancelParams
+import scala.meta.jsonrpc.Notification
+import scala.meta.jsonrpc.JsonRpcClient
+import scala.meta.jsonrpc.MessageWriter
+import scala.meta.jsonrpc.MonixEnrichments._
+
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.syntax._
+import java.io.OutputStream
+import java.nio.ByteBuffer
+
+import monix.eval.Task
+import monix.eval.Callback
+import monix.execution.Ack
+import monix.reactive.Observer
+import monix.execution.Cancelable
+import monix.execution.atomic.Atomic
+import monix.execution.atomic.AtomicInt
+
+import scala.concurrent.Future
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration.FiniteDuration
+
+import scribe.LoggerSupport
+
+/**
+ * A copy of `LanguageClient` defined in `lsp4s` with a few critical fixes
+ * required to get cancellation of server and handling of client crash
+ * correctly. The new
+ */
+final class BloopLanguageClient(out: Observer[ByteBuffer], logger: LoggerSupport)
+    extends JsonRpcClient {
+  def this(out: OutputStream, logger: LoggerSupport) =
+    this(Observer.fromOutputStream(out, logger), logger)
+
+  private val writer = new MessageWriter(out, logger)
+  private val counter: AtomicInt = Atomic(1)
+  private val activeServerRequests =
+    TrieMap.empty[RequestId, Callback[Response]]
+
+  def notify[A: Encoder](method: String, notification: A): Future[Ack] =
+    writer.write(Notification(method, Some(notification.asJson)))
+
+  def serverRespond(response: Response): Future[Ack] = response match {
+    case Response.Empty => Ack.Continue
+    case x: Response.Success => writer.write(x)
+    case x: Response.Error =>
+      logger.error(s"Response error: $x")
+      writer.write(x)
+  }
+
+  def clientRespond(response: Response): Unit = {
+    for {
+      id <- response match {
+        case Response.Empty => None
+        case Response.Success(_, requestId) => Some(requestId)
+        case Response.Error(_, requestId) => Some(requestId)
+      }
+      callback <- activeServerRequests.get(id).orElse {
+        logger.error(s"Response to unknown request: $response")
+        None
+      }
+    } {
+      activeServerRequests.remove(id)
+      callback.onSuccess(response)
+    }
+  }
+
+  def request[A: Encoder, B: Decoder](
+      method: String,
+      request: A
+  ): Task[Either[Response.Error, B]] = {
+    val nextId = RequestId(counter.incrementAndGet())
+    val response = Task.create[Response] { (out, cb) =>
+      import java.util.concurrent.TimeUnit
+      val scheduled = out.scheduleOnce(FiniteDuration(0, TimeUnit.MILLISECONDS)) {
+        import scala.meta.jsonrpc.Request
+        val json = Request(method, Some(request.asJson), nextId)
+        activeServerRequests.put(nextId, cb)
+        writer.write(json)
+        ()
+      }
+      Cancelable { () =>
+        scheduled.cancel()
+        this.notify("$/cancelRequest", CancelParams(nextId.value))
+        ()
+      }
+    }
+
+    response.map {
+      case Response.Empty =>
+        Left(Response.invalidParams(s"Got empty response for request $request", nextId))
+      case err: Response.Error => Left(err)
+      case Response.Success(result, _) =>
+        import cats.syntax.either._
+        result.as[B].leftMap { err =>
+          Response.invalidParams(err.toString, nextId)
+        }
+    }
+  }
+
+  // Addition compared to lsp4s so that our tests can request something but forget about its result
+  def requestAndForget[A: Encoder](
+      method: String,
+      request: A
+  ): Task[Unit] = {
+    Task {
+      val nextId = RequestId(counter.incrementAndGet())
+      import scala.meta.jsonrpc.Request
+      val json = Request(method, Some(request.asJson), nextId)
+      writer.write(json)
+      ()
+    }
+  }
+}
+
+object BloopLanguageClient {
+  def fromOutputStream(out: OutputStream, logger: LoggerSupport) =
+    new BloopLanguageClient(Observer.fromOutputStream(out, logger), logger)
+}

--- a/frontend/src/main/scala/bloop/bsp/BloopLanguageServer.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopLanguageServer.scala
@@ -1,0 +1,156 @@
+package bloop.bsp
+
+import io.circe.Json
+import io.circe.jawn.parseByteBuffer
+import io.circe.syntax._
+
+import java.nio.ByteBuffer
+
+import monix.eval.Task
+import monix.execution.Cancelable
+import monix.execution.Scheduler
+import monix.reactive.Observable
+import monix.execution.CancelableFuture
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.util.control.NonFatal
+import scribe.LoggerSupport
+
+import scala.meta.jsonrpc.Message
+import scala.meta.jsonrpc.Request
+import scala.meta.jsonrpc.Response
+import scala.meta.jsonrpc.Service
+import scala.meta.jsonrpc.Services
+import scala.meta.jsonrpc.CancelParams
+import scala.meta.jsonrpc.Notification
+import scala.meta.jsonrpc.NamedJsonRpcService
+import scala.meta.jsonrpc.BaseProtocolMessage
+
+final class BloopLanguageServer(
+    in: Observable[BaseProtocolMessage],
+    client: BloopLanguageClient,
+    services: Services,
+    requestScheduler: Scheduler,
+    logger: LoggerSupport
+) {
+  private val activeClientRequests: TrieMap[Json, CancelableFuture[_]] = TrieMap.empty
+  private val cancelNotification =
+    Service.notification[CancelParams]("$/cancelRequest", logger) {
+      new Service[CancelParams, Unit] {
+        def handle(params: CancelParams): Task[Unit] = {
+          val id = params.id
+          activeClientRequests.get(id) match {
+            case None =>
+              Task {
+                logger.warn(s"Can't cancel request $id, no active request found.")
+                () // Response.empty
+              }
+            case Some(request) =>
+              Task {
+                logger.info(s"Cancelling request $id")
+                request.cancel()
+                () // Response.cancelled(id)
+              }
+          }
+        }
+      }
+    }
+
+  private val handlersByMethodName: Map[String, NamedJsonRpcService] =
+    services.addService(cancelNotification).byMethodName
+
+  def cancelAllRequests(): Unit = {
+    activeClientRequests.values.foreach { cancelable =>
+      cancelable.cancel()
+    }
+  }
+
+  def awaitRunningTasks: Task[Unit] = {
+    val futures = activeClientRequests.values.map(fut => Task.fromFuture(fut))
+    // Await until completion and ignore task results
+    Task.gatherUnordered(futures).materialize.map(_ => ())
+  }
+
+  def handleValidMessage(message: Message): Task[Response] = message match {
+    case response: Response =>
+      Task {
+        client.clientRespond(response)
+        Response.empty
+      }
+    case Notification(method, _) =>
+      handlersByMethodName.get(method) match {
+        case None =>
+          Task {
+            // Can't respond to invalid notifications
+            logger.error(s"Unknown method '$method'")
+            Response.empty
+          }
+
+        case Some(handler) =>
+          handler
+            .handle(message)
+            .map {
+              case Response.Empty => Response.empty
+              case nonEmpty =>
+                logger.error(
+                  s"Obtained non-empty response $nonEmpty for notification $message. " +
+                    s"Expected Response.empty"
+                )
+                Response.empty
+            }
+            .onErrorRecover {
+              case NonFatal(e) =>
+                logger.error(s"Error handling notification $message", e)
+                Response.empty
+            }
+      }
+
+    case request @ Request(method, _, id) =>
+      handlersByMethodName.get(method) match {
+        case None =>
+          Task {
+            logger.info(s"Method not found '$method'")
+            Response.methodNotFound(method, id)
+          }
+
+        case Some(handler) =>
+          val jsonId = request.id.asJson
+          val unregisterUponCompletion = Task { activeClientRequests.remove(jsonId); () }
+          val response = handler
+            .handle(request)
+            .doOnFinish(_ => unregisterUponCompletion)
+            .onErrorRecover {
+              case NonFatal(e) =>
+                logger.error(s"Unhandled error handling request $request", e)
+                Response.internalError(e.getMessage, request.id)
+            }
+
+          val runningResponse = response.runAsync(requestScheduler)
+          activeClientRequests.put(jsonId, runningResponse)
+          Task.fromFuture(runningResponse)
+      }
+
+  }
+
+  def handleMessage(message: BaseProtocolMessage): Task[Response] =
+    parseByteBuffer(ByteBuffer.wrap(message.content)) match {
+      case Left(err) => Task.now(Response.parseError(err.toString))
+      case Right(json) =>
+        json.as[Message] match {
+          case Left(err) => Task.now(Response.invalidRequest(err.toString))
+          case Right(msg) => handleValidMessage(msg)
+        }
+    }
+
+  def startTask: Task[Unit] = {
+    in.foreachL { msg =>
+      handleMessage(msg)
+        .map(client.serverRespond)
+        .onErrorRecover { case NonFatal(e) => logger.error("Unhandled error", e) }
+        .runAsync(requestScheduler)
+      ()
+    }
+  }
+}

--- a/frontend/src/main/scala/bloop/bsp/BspServer.scala
+++ b/frontend/src/main/scala/bloop/bsp/BspServer.scala
@@ -1,5 +1,6 @@
 package bloop.bsp
 
+import java.net.Socket
 import java.net.ServerSocket
 import java.util.Locale
 
@@ -8,13 +9,20 @@ import bloop.data.ClientInfo
 import bloop.engine.{ExecutionContext, State}
 import bloop.io.{AbsolutePath, RelativePath}
 import bloop.logging.{BspClientLogger, DebugFilter}
-import com.martiansoftware.nailgun.{NGUnixDomainServerSocket, NGWin32NamedPipeServerSocket}
+import bloop.sockets.UnixDomainServerSocket
+import bloop.sockets.Win32NamedPipeServerSocket
 
 import monix.eval.Task
+import monix.execution.Ack
 import monix.execution.Scheduler
+import monix.execution.Cancelable
 import monix.execution.atomic.Atomic
-import monix.reactive.{Observer}
+import monix.execution.misc.NonFatal
+import monix.reactive.observers.Subscriber
+import monix.reactive.{Observer, Observable}
+import monix.reactive.observables.ObservableLike
 
+import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.meta.jsonrpc.{BaseProtocolMessage, LanguageClient, LanguageServer}
 
@@ -34,11 +42,11 @@ object BspServer {
   private def initServer(cmd: ValidatedBsp, state: State): Task[ConnectionHandle] = {
     cmd match {
       case Commands.WindowsLocalBsp(pipeName, _) =>
-        val server = new NGWin32NamedPipeServerSocket(pipeName)
+        val server = new Win32NamedPipeServerSocket(pipeName)
         state.logger.debug(s"Waiting for a connection at pipe $pipeName...")
         Task(WindowsLocal(pipeName, server)).doOnCancel(Task(server.close()))
       case Commands.UnixLocalBsp(socketFile, _) =>
-        val server = new NGUnixDomainServerSocket(socketFile.toString)
+        val server = new UnixDomainServerSocket(socketFile.toString)
         state.logger.debug(s"Waiting for a connection at $socketFile...")
         Task(UnixLocal(socketFile, server)).doOnCancel(Task(server.close()))
       case Commands.TcpBsp(address, portNumber, _) =>
@@ -54,10 +62,11 @@ object BspServer {
       state: State,
       config: RelativePath,
       promiseWhenStarted: Option[Promise[Unit]],
-      obs: Option[Observer.Sync[State]],
+      externalObserver: Option[Observer.Sync[State]],
       scheduler: Scheduler,
       ioScheduler: Scheduler
   ): Task[State] = {
+    import state.logger
     def uri(handle: ConnectionHandle): String = {
       handle match {
         case w: WindowsLocal => s"local:${w.pipeName}"
@@ -66,94 +75,182 @@ object BspServer {
       }
     }
 
-    import state.logger
     def startServer(handle: ConnectionHandle): Task[State] = {
       val connectionURI = uri(handle)
-      // WARNING: Do NOT change this log, it's used by clients and bsp launcher to know when to start a connection
+
+      // Do NOT change this log, it's used by clients to know when to start a connection
       logger.info(s"The server is listening for incoming connections at $connectionURI...")
       promiseWhenStarted.foreach(_.success(()))
+
       val socket = handle.serverSocket.accept()
       logger.info(s"Accepted incoming BSP client connection at $connectionURI")
 
       val status = Atomic(0)
       val in = socket.getInputStream
       val out = socket.getOutputStream
+
+      // FORMAT: OFF
       val bspLogger = new BspClientLogger(logger)
-      val client = new LanguageClient(out, bspLogger)
-      val provider =
-        new BloopBspServices(state, client, config, in, status, obs, scheduler, ioScheduler)
-      val bloopServices = provider.services
+      val client = new BloopLanguageClient(out, bspLogger)
       val messages = BaseProtocolMessage.fromInputStream(in, bspLogger)
-      val server = new LanguageServer(messages, client, bloopServices, ioScheduler, bspLogger)
+      val provider = new BloopBspServices(state, client, config, in, status, externalObserver, scheduler, ioScheduler)
+      val server = new BloopLanguageServer(messages, client, provider.services, ioScheduler, bspLogger)
+      // FORMAT: ON
 
       def error(msg: String): Unit = provider.stateAfterExecution.logger.error(msg)
 
-      // Only consume requests in batches of 4 per client
-      val consumer = messages.consumeWith(monix.reactive.Consumer.foreachParallelAsync(4) { msg =>
-        server
-          .handleMessage(msg)
-          .flatMap(msg => Task.fromFuture(client.serverRespond(msg)).map(_ => ()))
-          .onErrorRecover {
-            case monix.execution.misc.NonFatal(e) =>
-              bspLogger.error("Unhandled error", e)
-              ()
-          }
-      })
+      import bloop.util.monix.FoldLeftAsyncConsumer
 
-      def closeCommunication(): Unit = {
-        import bloop.io.Paths
-        val latestState = provider.stateAfterExecution
-        val deleteExternalDirsTask = latestState.build.projects.map { project =>
-          val externalClientClassesDir = latestState.client.getUniqueClassesDirFor(project)
-          import java.io.IOException
-          if (externalClientClassesDir == project.genericClassesDir) Task.now(())
-          else {
-            Task {
-              Paths.delete(externalClientClassesDir)
-            }
-          }
-        }
-
-        // Run deletion of client external classes directories in IO pool
-        Task
-          .gatherUnordered(deleteExternalDirsTask)
-          .materialize
-          .map(_ => ())
-          .runAsync(ExecutionContext.ioScheduler)
-
-        // Close any socket communication asap
-        try socket.close()
-        finally handle.serverSocket.close()
+      val consumer = FoldLeftAsyncConsumer.consume[Unit, BaseProtocolMessage](()) {
+        case (state, msg) =>
+          import scala.meta.jsonrpc.Response.Empty
+          import scala.meta.jsonrpc.Response.Success
+          server
+            .handleMessage(msg)
+            .flatMap(msg => Task.fromFuture(client.serverRespond(msg)).map(_ => ()))
+            .onErrorRecover { case NonFatal(e) => bspLogger.error("Unhandled error", e); () }
       }
 
-      consumer
-        .doOnCancel {
-          Task {
-            error(s"BSP server cancelled, closing socket...")
-            closeCommunication()
+      /* This implementation of starting a server relies on two observables:
+       *
+       *   1. An observable with a publish strategy that gets protocol messages
+       *      and forwards them to the bloop server and services implementation.
+       *   2. An observable that pumps input from the socket `InputStream`,
+       *      parses it into BSP messages and forwards it to the previous
+       *      observable.
+       *
+       * We use two observables instead of one because if the client crashes or
+       * disconnects, we want to cancel all tasks triggered by the first
+       * observable as soon as possible. If we were using only one observable,
+       * we would not receive RST or FIN socket messages because the next
+       * `read` call would not happen until the spawn server tasks are
+       * finished. In our case, as soon as we have parsed a successful message,
+       * we will call `read` and wait on a read result, EOF or a connection
+       * reset/IO exception.
+       */
+
+      import monix.reactive.Observable
+      import monix.reactive.MulticastStrategy
+      val (bufferedObserver, endObservable) =
+        Observable.multicast(MulticastStrategy.publish[BaseProtocolMessage])(ioScheduler)
+
+      val isCommunicationActive = Atomic(true)
+      def onFinishOrCancel[T](cancelled: Boolean, result: Option[Throwable]) = Task {
+        if (isCommunicationActive.getAndSet(false)) {
+          if (cancelled) error(s"BSP server cancelled, closing socket...")
+          else result.foreach(t => error(s"BSP server stopped by ${t.getMessage}"))
+          server.cancelAllRequests()
+          val latestState = provider.stateAfterExecution
+          closeCommunication(externalObserver, latestState, socket, handle.serverSocket)
+        }
+      }
+
+      val consumingTask = endObservable
+        .consumeWith(consumer)
+        .doOnCancel(onFinishOrCancel(true, None))
+        .doOnFinish(result => onFinishOrCancel(false, result))
+        .flatMap(_ => server.awaitRunningTasks.map(_ => provider.stateAfterExecution))
+      val consumerFuture = consumingTask.runAsync(ioScheduler)
+
+      /*
+       * Cancel any ongoing tasks if the socket `InputStream` completed but the
+       * provider did not receive the appropriate shutdown mechanism.
+       *
+       * This can happen when clients suddently crash or exit with the Unix
+       * domain and Windows named pipe implementation, because in these
+       * implementations there are no special protocol messages to signal
+       * closing, unlike TCP that has `FIN` and `RST`. Unfortunately with
+       * Domain Socket and Windows named pipes, `socket.isClosed()` will always
+       * be false from the server side because of this reason.
+       */
+      val cancelIfAwaitingExit: Task[Unit] = Task {
+        if (!provider.exited.get) {
+          consumerFuture.cancel()
+        }
+      }
+
+      messages
+        .liftByOperator(new PumpOperator(bufferedObserver, consumerFuture))
+        .completedL
+        .doOnFinish(_ => cancelIfAwaitingExit)
+        .flatMap { _ =>
+          Task.fromFuture(consumerFuture).map { latestState =>
+            // Complete the states observable to signal exit on consumers
+            externalObserver.foreach(_.onComplete())
+            // Return the latest state
+            latestState
           }
         }
-        .doOnFinish { result =>
-          Task {
-            result.foreach(t => error(s"BSP server stopped by ${t.getMessage}"))
-            closeCommunication()
-          }
-        }
-        .map(_ => provider.stateAfterExecution)
+        .executeOn(ioScheduler)
     }
 
     initServer(cmd, state).materialize.flatMap {
       case scala.util.Success(handle: ConnectionHandle) =>
         startServer(handle).onErrorRecoverWith {
-          case t: Throwable =>
-            Task.now(state.withError(s"BSP server failed to start with ${t.getMessage}", t))
+          case t => Task.now(state.withError(s"Exiting BSP server with ${t.getMessage}", t))
         }
       case scala.util.Failure(t: Throwable) =>
-        promiseWhenStarted.foreach { p =>
-          if (!p.isCompleted) p.failure(t)
-        }
-
+        promiseWhenStarted.foreach(p => if (!p.isCompleted) p.failure(t))
         Task.now(state.withError(s"BSP server failed to open a socket: '${t.getMessage}'", t))
     }
+  }
+
+  def closeCommunication(
+      externalObserver: Option[Observer[State]],
+      latestState: State,
+      socket: Socket,
+      serverSocket: ServerSocket
+  ): Unit = {
+    val deleteExternalDirsTask = latestState.build.projects.map { project =>
+      import bloop.io.Paths
+      import java.io.IOException
+      val externalClientClassesDir = latestState.client.getUniqueClassesDirFor(project)
+      if (externalClientClassesDir == project.genericClassesDir) Task.now(())
+      else Task.eval(Paths.delete(externalClientClassesDir)).executeWithFork
+    }
+
+    // Run deletion of client external classes directories in IO pool
+    val groups = deleteExternalDirsTask.grouped(4).map(group => Task.gatherUnordered(group))
+    Task
+      .sequence(groups)
+      .map(_.flatten)
+      .materialize
+      .map(_ => ())
+      .runAsync(ExecutionContext.ioScheduler)
+
+    // Close any socket communication asap
+    try socket.close()
+    finally serverSocket.close()
+  }
+
+  final class PumpOperator[A](pumpTarget: Observer.Sync[A], runningFuture: Cancelable)
+      extends ObservableLike.Operator[A, A] {
+    def apply(out: Subscriber[A]): Subscriber[A] =
+      new Subscriber[A] { self =>
+        implicit val scheduler = out.scheduler
+        private[this] val isActive = Atomic(true)
+
+        def onNext(elem: A): Future[Ack] =
+          out.onNext(elem).syncOnContinue {
+            // Forward and ignore ack; safe because observer is sync
+            pumpTarget.onNext(elem)
+            ()
+          }
+
+        def onComplete(): Unit = {
+          if (isActive.getAndSet(false))
+            out.onComplete()
+        }
+
+        def onError(ex: Throwable): Unit = {
+          if (isActive.getAndSet(false)) {
+            // Complete instead of forwarding error so that completeL finishes
+            out.onComplete()
+            runningFuture.cancel()
+          } else {
+            scheduler.reportFailure(ex)
+          }
+        }
+      }
   }
 }

--- a/frontend/src/main/scala/bloop/cli/Validate.scala
+++ b/frontend/src/main/scala/bloop/cli/Validate.scala
@@ -36,7 +36,7 @@ object Validate {
     }
 
     def validatePipeName = cmd.pipeName match {
-      case Some(PipeName(pipeName)) => Run(Commands.WindowsLocalBsp(pipeName, cliOptions))
+      case Some(pipeName @ PipeName(_)) => Run(Commands.WindowsLocalBsp(pipeName, cliOptions))
       case Some(wrong) => cliError(Feedback.unexpectedPipeFormat(wrong), commonOptions)
       case None => cliError(Feedback.MissingPipeName, commonOptions)
     }

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -310,7 +310,7 @@ object CompileTask {
               )
             case _ => Nil
           }
-        }
+        }.executeOn(ExecutionContext.ioScheduler)
 
         // Block on all background task operations to fully populate classes directories
         backgroundTasks.map(_ => newState).doOnFinish(_ => Task(rootTracer.terminate()))

--- a/frontend/src/main/scala/bloop/io/SourceWatcher.scala
+++ b/frontend/src/main/scala/bloop/io/SourceWatcher.scala
@@ -97,6 +97,7 @@ final class SourceWatcher private (
       FoldLeftAsyncConsumer.consume[State, EventStream](state0) {
         case (state, stream) =>
           stream match {
+            // Ignore overflow for now, though we could restart run if changes are found
             case EventStream.Overflow => Task.now(state)
             case EventStream.SourceChanges(events) =>
               val eventsThatForceAction = events.collect { event =>

--- a/frontend/src/test/scala/bloop/CompileSpec.scala
+++ b/frontend/src/test/scala/bloop/CompileSpec.scala
@@ -705,7 +705,7 @@ object CompileSpec extends bloop.testing.BaseSuite {
               |""".stripMargin
         } else {
           s"""|[E1] ${targetFoo}:3
-              |      error: cannot access symbol Bar
+              |      error: cannot access Bar
               |${targetFoo}: L3 [E1]
               |""".stripMargin
         }

--- a/frontend/src/test/scala/bloop/CompileSpec.scala
+++ b/frontend/src/test/scala/bloop/CompileSpec.scala
@@ -705,7 +705,7 @@ object CompileSpec extends bloop.testing.BaseSuite {
               |""".stripMargin
         } else {
           s"""|[E1] ${targetFoo}:3
-              |      error: cannot find symbol Bar
+              |      error: cannot access symbol Bar
               |${targetFoo}: L3 [E1]
               |""".stripMargin
         }

--- a/frontend/src/test/scala/bloop/DeduplicationSpec.scala
+++ b/frontend/src/test/scala/bloop/DeduplicationSpec.scala
@@ -733,17 +733,38 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
             |}
           """.stripMargin
 
+        // Sleep in independent files to force compiler to check for cancelled status
         val `B2.scala` =
           """/B.scala
             |object B {
-            |  macros.SleepMacro.sleep()
-            |  macros.SleepMacro.sleep()
-            |  macros.SleepMacro.sleep()
-            |  macros.SleepMacro.sleep()
-            |  macros.SleepMacro.sleep()
-            |  macros.SleepMacro.sleep()
             |  def foo(s: String): String = s.toString
+            |  macros.SleepMacro.sleep()
             |}
+          """.stripMargin
+
+        val `Extra.scala` =
+          """/Extra.scala
+            |object Extra { def foo(s: String): String = s.toString; macros.SleepMacro.sleep() }
+          """.stripMargin
+
+        val `Extra2.scala` =
+          """/Extra2.scala
+            |object Extra2 { def foo(s: String): String = s.toString; macros.SleepMacro.sleep() }
+          """.stripMargin
+
+        val `Extra3.scala` =
+          """/Extra3.scala
+            |object Extra3 { def foo(s: String): String = s.toString; macros.SleepMacro.sleep() }
+          """.stripMargin
+
+        val `Extra4.scala` =
+          """/Extra4.scala
+            |object Extra4 { def foo(s: String): String = s.toString; macros.SleepMacro.sleep() }
+          """.stripMargin
+
+        val `Extra5.scala` =
+          """/Extra5.scala
+            |object Extra5 { def foo(s: String): String = s.toString; macros.SleepMacro.sleep() }
           """.stripMargin
       }
 
@@ -758,6 +779,11 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
       val compiledState = state.compile(`B`)
 
       writeFile(`B`.srcFor("B.scala"), Sources.`B2.scala`)
+      writeFile(`B`.srcFor("Extra.scala", exists = false), Sources.`Extra.scala`)
+      writeFile(`B`.srcFor("Extra2.scala", exists = false), Sources.`Extra2.scala`)
+      writeFile(`B`.srcFor("Extra3.scala", exists = false), Sources.`Extra3.scala`)
+      writeFile(`B`.srcFor("Extra4.scala", exists = false), Sources.`Extra4.scala`)
+      writeFile(`B`.srcFor("Extra5.scala", exists = false), Sources.`Extra5.scala`)
 
       loadBspState(workspace, projects, bspLogger) { bspState =>
         val firstDelay = Some(random(300, 500))
@@ -796,7 +822,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
           firstCompiledState.lastDiagnostics(`B`),
           s"""
              |#1: task start 2
-             |  -> Msg: Compiling b (1 Scala source)
+             |  -> Msg: Compiling b (6 Scala sources)
              |  -> Data kind: compile-task
              |#1: task finish 2
              |  -> errors 0, warnings 0

--- a/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
@@ -414,7 +414,6 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
       // This task closes the streams to simulate a client dropping out,
       // but doesn't properly close the server. This happens on purpose.
       val closeStreamsForcibly = () => {
-        //socket.setSoLinger(true, 0)
         socket.close()
       }
 

--- a/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
@@ -23,7 +23,6 @@ import monix.reactive.{Observable, MulticastStrategy, Observer}
 import monix.execution.{ExecutionModel, Scheduler, CancelableFuture}
 import monix.execution.atomic.AtomicInt
 
-import org.scalasbt.ipcsocket.Win32NamedPipeSocket
 import sbt.internal.util.MessageOnlyException
 
 import java.nio.file.Files
@@ -43,10 +42,21 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
       closeStreamsForcibly: () => Unit,
       currentCompileIteration: AtomicInt,
       diagnostics: ConcurrentHashMap[bsp.BuildTargetIdentifier, StringBuilder],
-      implicit val client: LanguageClient,
+      implicit val client: BloopLanguageClient,
       private val serverStates: Observable[State]
   ) {
     val status = state.status
+
+    def toUnsafeManagedState: ManagedBspTestState = {
+      new ManagedBspTestState(
+        state,
+        bsp.StatusCode.Ok,
+        currentCompileIteration,
+        diagnostics,
+        client,
+        serverStates
+      )
+    }
 
     def withinSession(f: ManagedBspTestState => Unit): Unit = {
       try f(
@@ -72,8 +82,8 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
       lastBspStatus: bsp.StatusCode,
       currentCompileIteration: AtomicInt,
       diagnostics: ConcurrentHashMap[bsp.BuildTargetIdentifier, StringBuilder],
-      implicit val client0: LanguageClient,
-      private val serverStates: Observable[State]
+      implicit val client0: BloopLanguageClient,
+      val serverStates: Observable[State]
   ) {
     val underlying = state
     val client = state.client
@@ -363,12 +373,14 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
         ()
       }
 
-      implicit val lsClient = new LanguageClient(out, logger)
+      implicit val lsClient = new BloopLanguageClient(out, logger)
       val messages = BaseProtocolMessage.fromInputStream(in, logger)
       val addDiagnosticsHandler =
         addServicesTest(configDirectory, () => compileIteration.get, addToStringReport)
       val services = addDiagnosticsHandler(TestUtil.createTestServices(false, logger))
-      val lsServer = new LanguageServer(messages, lsClient, services, ioScheduler, logger)
+      import bloop.bsp.BloopLanguageServer
+
+      val lsServer = new BloopLanguageServer(messages, lsClient, services, ioScheduler, logger)
       val runningClientServer = lsServer.startTask.runAsync(ioScheduler)
 
       val cwd = configDirectory.underlying.getParent
@@ -402,6 +414,7 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
       // This task closes the streams to simulate a client dropping out,
       // but doesn't properly close the server. This happens on purpose.
       val closeStreamsForcibly = () => {
+        //socket.setSoLinger(true, 0)
         socket.close()
       }
 

--- a/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
@@ -183,7 +183,6 @@ trait BspClientTest {
   }
 
   def establishClientConnection(cmd: Commands.ValidatedBsp): me.Task[java.net.Socket] = {
-    // Very important we use the socket implementations from ipcsocket for correctness
     import bloop.sockets.UnixDomainSocket
     import bloop.sockets.Win32NamedPipeSocket
     val connectToServer = me.Task {

--- a/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
@@ -184,13 +184,13 @@ trait BspClientTest {
 
   def establishClientConnection(cmd: Commands.ValidatedBsp): me.Task[java.net.Socket] = {
     // Very important we use the socket implementations from ipcsocket for correctness
-    import org.scalasbt.ipcsocket.UnixDomainSocket
-    import org.scalasbt.ipcsocket.Win32NamedPipeSocket
+    import bloop.sockets.UnixDomainSocket
+    import bloop.sockets.Win32NamedPipeSocket
     val connectToServer = me.Task {
       cmd match {
-        case cmd: Commands.WindowsLocalBsp => new Win32NamedPipeSocket(cmd.pipeName)
-        case cmd: Commands.UnixLocalBsp => new UnixDomainSocket(cmd.socket.syntax)
         case cmd: Commands.TcpBsp => new java.net.Socket(cmd.host, cmd.port)
+        case cmd: Commands.UnixLocalBsp => new UnixDomainSocket(cmd.socket.syntax)
+        case cmd: Commands.WindowsLocalBsp => new Win32NamedPipeSocket(cmd.pipeName)
       }
     }
     retryBackoff(connectToServer, 3, FiniteDuration(1, "s"))

--- a/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
@@ -640,6 +640,26 @@ class BspCompileSpec(
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report""".stripMargin
         )
+
+        import java.nio.file.Files
+        Files.delete(`A`.srcFor("main/scala/App.scala").underlying)
+
+        // Test that deleting a file with a warning doesn't make bloop send clear diagnostics
+        val secondCompiledState = compiledState.compile(`A`)
+        assert(secondCompiledState.status == ExitStatus.Ok)
+        assertValidCompilationState(secondCompiledState, projects)
+
+        assertNoDiff(
+          secondCompiledState.lastDiagnostics(`A`),
+          """|#2: task start 2
+             |  -> Msg: Compiling a (1 Scala source)
+             |  -> Data kind: compile-task
+             |#2: task finish 2
+             |  -> errors 0, warnings 0
+             |  -> Msg: Compiled 'a'
+             |  -> Data kind: compile-report
+             |""".stripMargin
+        )
       }
     }
   }

--- a/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
@@ -654,6 +654,9 @@ class BspCompileSpec(
           """|#2: task start 2
              |  -> Msg: Compiling a (1 Scala source)
              |  -> Data kind: compile-task
+             |#2: a/src/main/scala/App.scala
+             |  -> List()
+             |  -> reset = true
              |#2: task finish 2
              |  -> errors 0, warnings 0
              |  -> Msg: Compiled 'a'

--- a/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
@@ -152,33 +152,53 @@ class BspConnectionSpec(
             |  def sleep(): Unit = macro sleepImpl
             |  def sleepImpl(c: Context)(): c.Expr[Unit] = {
             |    import c.universe._
-            |    Thread.sleep(500)
+            |    Thread.sleep(1000)
             |    reify { () }
             |  }
             |}""".stripMargin
 
         val `B.scala` =
           """/B.scala
-            |object B {
-            |  macros.SleepMacro.sleep()
-            |  macros.SleepMacro.sleep()
-            |  macros.SleepMacro.sleep()
-            |  macros.SleepMacro.sleep()
-            |  macros.SleepMacro.sleep()
-            |  macros.SleepMacro.sleep()
-            |  macros.SleepMacro.sleep()
-            |  macros.SleepMacro.sleep()
-            |  macros.SleepMacro.sleep()
-            |  macros.SleepMacro.sleep()
-            |  macros.SleepMacro.sleep()
-            |  macros.SleepMacro.sleep()
-            |  def foo(s: String): String = s.toString
-            |}
+            |object B { def foo(s: String): String = s.toString; macros.SleepMacro.sleep() }
+          """.stripMargin
+
+        val `B2.scala` =
+          """/B2.scala
+            |object B2 { def foo(s: String): String = s.toString; macros.SleepMacro.sleep() }
+          """.stripMargin
+
+        val `B3.scala` =
+          """/B3.scala
+            |object B3 { def foo(s: String): String = s.toString; macros.SleepMacro.sleep() }
+          """.stripMargin
+
+        val `B4.scala` =
+          """/B4.scala
+            |object B4 { def foo(s: String): String = s.toString; macros.SleepMacro.sleep() }
+          """.stripMargin
+
+        val `B5.scala` =
+          """/B5.scala
+            |object B5 { def foo(s: String): String = s.toString; macros.SleepMacro.sleep() }
+          """.stripMargin
+
+        val `B6.scala` =
+          """/B6.scala
+            |object B6 { def foo(s: String): String = s.toString; macros.SleepMacro.sleep() }
           """.stripMargin
       }
 
       val `A` = TestProject(workspace, "a", List(Sources.`A.scala`))
-      val `B` = TestProject(workspace, "b", List(Sources.`B.scala`), List(`A`))
+      val sourcesB = List(
+        Sources.`B.scala`,
+        Sources.`B2.scala`,
+        Sources.`B3.scala`,
+        Sources.`B4.scala`,
+        Sources.`B5.scala`,
+        Sources.`B6.scala`
+      )
+
+      val `B` = TestProject(workspace, "b", sourcesB, List(`A`))
 
       val projects = List(`A`, `B`)
       val configDir = TestProject.populateWorkspace(workspace, projects)
@@ -242,11 +262,7 @@ class BspConnectionSpec(
       // of compilation, which would take more than 6 seconds as there are 12 sleeps
       val safeDelay = FiniteDuration(5, "s")
       import java.util.concurrent.TimeoutException
-      try TestUtil.await(safeDelay, poolFor1Client)(createHangingCompilationViaBsp)
-      catch {
-        case t: TimeoutException => //logger.dump(); throw t
-          throw t
-      }
+      TestUtil.await(safeDelay, poolFor1Client)(createHangingCompilationViaBsp)
     }
   }
 }

--- a/launcher/src/main/scala/bloop/launcher/bsp/BspBridge.scala
+++ b/launcher/src/main/scala/bloop/launcher/bsp/BspBridge.scala
@@ -8,6 +8,7 @@ import java.nio.file.Path
 import bloop.launcher.core.{Feedback, Shell}
 import bloop.launcher.util.Environment
 import bloop.launcher.{printError, printQuoted, println}
+import bloop.sockets.UnixDomainSocket
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Promise
@@ -151,7 +152,6 @@ final class BspBridge(
   def connectToOpenSession(serverConnection: BspConnection): Option[Socket] = {
     import scala.util.Try
     def establishSocketConnection(connection: BspConnection): Try[Socket] = {
-      import org.scalasbt.ipcsocket.UnixDomainSocket
       Try {
         connection match {
           case BspConnection.Tcp(host, port) => new Socket(host, port)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,6 +42,7 @@ object Dependencies {
   val difflibVersion = "1.3.0"
   val braveVersion = "5.6.1"
   val zipkinSenderVersion = "2.7.15"
+  val jnaVersion = "4.5.0"
 
   import sbt.librarymanagement.syntax.stringToOrganization
   val zinc = "ch.epfl.scala" %% "zinc" % zincVersion
@@ -83,9 +84,7 @@ object Dependencies {
   val gradleToolingApi = "org.gradle" % "gradle-tooling-api" % gradleVersion % Provided
   val groovy = "org.codehaus.groovy" % "groovy" % groovyVersion % Provided
 
-  val ipcsocket = "ch.epfl.scala" % "ipcsocket" % ipcsocketVersion
   val monix = "io.monix" %% "monix" % monixVersion
-
   val circeDerivation = "io.circe" %% "circe-derivation" % "0.9.0-M3"
   val circeParser = "io.circe" %% "circe-parser" % circeVersion
   val circeCore = "io.circe" %% "circe-core" % circeVersion
@@ -112,4 +111,7 @@ object Dependencies {
   val brave = "io.zipkin.brave" % "brave" % braveVersion
   val zipkinSender = "io.zipkin.reporter2" % "zipkin-sender-urlconnection" % zipkinSenderVersion
   val zipkinOkHttp = "io.zipkin.reporter2" % "zipkin-sender-okhttp3" % zipkinSenderVersion
+
+  val jna = "net.java.dev.jna" % "jna" % jnaVersion
+  val jnaPlatform = "net.java.dev.jna" % "jna-platform" % jnaVersion
 }

--- a/sockets/src/main/java/bloop/sockets/ReferenceCountedFileDescriptor.java
+++ b/sockets/src/main/java/bloop/sockets/ReferenceCountedFileDescriptor.java
@@ -1,0 +1,80 @@
+/*
+
+ Copyright 2004-2019, Martian Software, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+package bloop.sockets;
+
+import com.sun.jna.LastErrorException;
+
+import java.io.IOException;
+
+/**
+ * Encapsulates a file descriptor plus a reference count to ensure close requests
+ * only close the file descriptor once the last reference to the file descriptor
+ * is released.
+ *
+ * If not explicitly closed, the file descriptor will be closed when
+ * this object is finalized.
+ */
+public class ReferenceCountedFileDescriptor {
+  private int fd;
+  private int fdRefCount;
+  private boolean closePending;
+
+  public ReferenceCountedFileDescriptor(int fd) {
+    this.fd = fd;
+    this.fdRefCount = 0;
+    this.closePending = false;
+  }
+
+  protected void finalize() throws IOException {
+    close();
+  }
+
+  public synchronized int acquire() {
+    fdRefCount++;
+    return fd;
+  }
+
+  public synchronized void release() throws IOException {
+    fdRefCount--;
+    if (fdRefCount == 0 && closePending && fd != -1) {
+      doClose();
+    }
+  }
+
+  public synchronized void close() throws IOException {
+    if (fd == -1 || closePending) {
+      return;
+    }
+
+    if (fdRefCount == 0) {
+      doClose();
+    } else {
+      // Another thread has the FD. We'll close it when they release the reference.
+      closePending = true;
+    }
+  }
+
+  private void doClose() throws IOException {
+    try {
+      UnixDomainSocketLibrary.close(fd);
+      fd = -1;
+    } catch (LastErrorException e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/sockets/src/main/java/bloop/sockets/UnixDomainServerSocket.java
+++ b/sockets/src/main/java/bloop/sockets/UnixDomainServerSocket.java
@@ -1,0 +1,177 @@
+/*
+
+ Copyright 2004-2019, Martian Software, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+package bloop.sockets;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.sun.jna.LastErrorException;
+import com.sun.jna.ptr.IntByReference;
+
+/**
+ * Implements a {@link ServerSocket} which binds to a local Unix domain socket
+ * and returns instances of {@link UnixDomainSocket} from
+ * {@link #accept()}.
+ */
+public class UnixDomainServerSocket extends ServerSocket {
+  private static final int DEFAULT_BACKLOG = 50;
+
+  // We use an AtomicInteger to prevent a race in this situation which
+  // could happen if fd were just an int:
+  //
+  // Thread 1 -> UnixDomainServerSocket.accept()
+  //          -> lock this
+  //          -> check isBound and isClosed
+  //          -> unlock this
+  //          -> descheduled while still in method
+  // Thread 2 -> UnixDomainServerSocket.close()
+  //          -> lock this
+  //          -> check isClosed
+  //          -> UnixDomainSocketLibrary.close(fd)
+  //          -> now fd is invalid
+  //          -> unlock this
+  // Thread 1 -> re-scheduled while still in method
+  //          -> UnixDomainSocketLibrary.accept(fd, which is invalid and maybe re-used)
+  //
+  // By using an AtomicInteger, we'll set this to -1 after it's closed, which
+  // will cause the accept() call above to cleanly fail instead of possibly
+  // being called on an unrelated fd (which may or may not fail).
+  private final AtomicInteger fd;
+
+  private final int backlog;
+  private boolean isBound;
+  private boolean isClosed;
+
+  public static class UnixDomainServerSocketAddress extends SocketAddress {
+    private final String path;
+
+    public UnixDomainServerSocketAddress(String path) {
+      this.path = path;
+    }
+
+    public String getPath() {
+      return path;
+    }
+  }
+
+  /**
+   * Constructs an unbound Unix domain server socket.
+   */
+  public UnixDomainServerSocket() throws IOException {
+    this(DEFAULT_BACKLOG, null);
+  }
+
+  /**
+   * Constructs an unbound Unix domain server socket with the specified listen backlog.
+   */
+  public UnixDomainServerSocket(int backlog) throws IOException {
+    this(backlog, null);
+  }
+
+  /**
+   * Constructs and binds a Unix domain server socket to the specified path.
+   */
+  public UnixDomainServerSocket(String path) throws IOException {
+    this(DEFAULT_BACKLOG, path);
+  }
+
+  /**
+   * Constructs and binds a Unix domain server socket to the specified path
+   * with the specified listen backlog.
+   */
+  public UnixDomainServerSocket(int backlog, String path) throws IOException {
+    try {
+      fd = new AtomicInteger(
+          UnixDomainSocketLibrary.socket(
+              UnixDomainSocketLibrary.PF_LOCAL,
+              UnixDomainSocketLibrary.SOCK_STREAM,
+              0));
+      this.backlog = backlog;
+      if (path != null) {
+        bind(new UnixDomainServerSocketAddress(path));
+      }
+    } catch (LastErrorException e) {
+      throw new IOException(e);
+    }
+  }
+
+  public synchronized void bind(SocketAddress endpoint) throws IOException {
+    if (!(endpoint instanceof UnixDomainServerSocketAddress)) {
+      throw new IllegalArgumentException(
+          "endpoint must be an instance of UnixDomainServerSocketAddress");
+    }
+    if (isBound) {
+      throw new IllegalStateException("Socket is already bound");
+    }
+    if (isClosed) {
+      throw new IllegalStateException("Socket is already closed");
+    }
+    UnixDomainServerSocketAddress unEndpoint = (UnixDomainServerSocketAddress) endpoint;
+    UnixDomainSocketLibrary.SockaddrUn address =
+        new UnixDomainSocketLibrary.SockaddrUn(unEndpoint.getPath());
+    try {
+      int socketFd = fd.get();
+      UnixDomainSocketLibrary.bind(socketFd, address, address.size());
+      UnixDomainSocketLibrary.listen(socketFd, backlog);
+      isBound = true;
+    } catch (LastErrorException e) {
+      e.printStackTrace();
+      throw new IOException(e);
+    }
+  }
+
+  public Socket accept() throws IOException {
+    // We explicitly do not make this method synchronized, since the
+    // call to UnixDomainSocketLibrary.accept() will block
+    // indefinitely, causing another thread's call to close() to deadlock.
+    synchronized (this) {
+      if (!isBound) {
+        throw new IllegalStateException("Socket is not bound");
+      }
+      if (isClosed) {
+        throw new IllegalStateException("Socket is already closed");
+      }
+    }
+    try {
+      UnixDomainSocketLibrary.SockaddrUn sockaddrUn =
+          new UnixDomainSocketLibrary.SockaddrUn();
+      IntByReference addressLen = new IntByReference();
+      addressLen.setValue(sockaddrUn.size());
+      int clientFd = UnixDomainSocketLibrary.accept(fd.get(), sockaddrUn, addressLen);
+      return new UnixDomainSocket(clientFd);
+    } catch (LastErrorException e) {
+      throw new IOException(e);
+    }
+  }
+
+  public synchronized void close() throws IOException {
+    if (isClosed) {
+      throw new IllegalStateException("Socket is already closed");
+    }
+    try {
+      // Ensure any pending call to accept() fails.
+      UnixDomainSocketLibrary.close(fd.getAndSet(-1));
+      isClosed = true;
+    } catch (LastErrorException e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/sockets/src/main/java/bloop/sockets/UnixDomainSocket.java
+++ b/sockets/src/main/java/bloop/sockets/UnixDomainSocket.java
@@ -1,0 +1,213 @@
+/*
+
+ Copyright 2004-2019, Martian Software, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+package bloop.sockets;
+
+import com.sun.jna.LastErrorException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import java.nio.ByteBuffer;
+
+import java.net.Socket;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Implements a {@link Socket} backed by a native Unix domain socket.
+ *
+ * Instances of this class always return {@code null} for
+ * {@link Socket#getInetAddress()}, {@link Socket#getLocalAddress()},
+ * {@link Socket#getLocalSocketAddress()}, {@link Socket#getRemoteSocketAddress()}.
+ */
+public class UnixDomainSocket extends Socket {
+  private final ReferenceCountedFileDescriptor fd;
+  private boolean isClosed = false;
+  private final InputStream is;
+  private final OutputStream os;
+
+  /**
+   * Creates a Unix domain socket backed by a file path.
+   */
+  public UnixDomainSocket(String path) throws IOException {
+    try {
+      AtomicInteger fd = new AtomicInteger(
+        UnixDomainSocketLibrary.socket(
+        UnixDomainSocketLibrary.PF_LOCAL,
+          UnixDomainSocketLibrary.SOCK_STREAM,
+          0));
+      UnixDomainSocketLibrary.SockaddrUn address =
+        new UnixDomainSocketLibrary.SockaddrUn(path);
+      int socketFd = fd.get();
+      UnixDomainSocketLibrary.connect(socketFd, address, address.size());
+      this.fd = new ReferenceCountedFileDescriptor(socketFd);
+      this.is = new UnixDomainSocketInputStream();
+      this.os = new UnixDomainSocketOutputStream();
+    } catch (LastErrorException e) {
+      throw new IOException(e);
+    }
+  }
+
+  /**
+   * Creates a Unix domain socket backed by a native file descriptor.
+   */
+  public UnixDomainSocket(int fd) {
+    this.fd = new ReferenceCountedFileDescriptor(fd);
+    this.is = new UnixDomainSocketInputStream();
+    this.os = new UnixDomainSocketOutputStream();
+  }
+
+  public InputStream getInputStream() {
+    return is;
+  }
+
+  public OutputStream getOutputStream() {
+    return os;
+  }
+
+  public void shutdownInput() throws IOException {
+    doShutdown(UnixDomainSocketLibrary.SHUT_RD);
+  }
+
+  public void shutdownOutput() throws IOException {
+    doShutdown(UnixDomainSocketLibrary.SHUT_WR);
+  }
+
+  private void doShutdown(int how) throws IOException {
+    try {
+      int socketFd = fd.acquire();
+      if (socketFd != -1) {
+        UnixDomainSocketLibrary.shutdown(socketFd, how);
+      }
+    } catch (LastErrorException e) {
+      throw new IOException(e);
+    } finally {
+      fd.release();
+    }
+  }
+
+  @Override
+  public boolean isInputShutdown() {
+    return super.isInputShutdown();
+  }
+
+  @Override
+  public boolean isOutputShutdown() {
+    return super.isOutputShutdown();
+  }
+
+  @Override
+  public boolean isClosed() {
+    return this.isClosed;
+  }
+
+  public void close() throws IOException {
+    shutdownInput();
+    shutdownOutput();
+    super.close();
+
+    try {
+      // This might not close the FD right away. In case we are about
+      // to read or write on another thread, it will delay the close
+      // until the read or write completes, to prevent the FD from
+      // being re-used for a different purpose and the other thread
+      // reading from a different FD.
+      fd.close();
+      this.isClosed = true;
+    } catch (LastErrorException e) {
+      throw new IOException(e);
+    }
+  }
+
+  private class UnixDomainSocketInputStream extends InputStream {
+    public int read() throws IOException {
+      ByteBuffer buf = ByteBuffer.allocate(1);
+      int result;
+      if (doRead(buf) == 0) {
+        result = -1;
+      } else {
+        // Make sure to & with 0xFF to avoid sign extension
+        result = 0xFF & buf.get();
+      }
+      return result;
+    }
+
+    public int read(byte[] b, int off, int len) throws IOException {
+      if (len == 0) {
+        return 0;
+      }
+      ByteBuffer buf = ByteBuffer.wrap(b, off, len);
+      int result = doRead(buf);
+      if (result == 0) {
+        result = -1;
+      }
+      return result;
+    }
+
+    private int doRead(ByteBuffer buf) throws IOException {
+      try {
+        int fdToRead = fd.acquire();
+        if (fdToRead == -1) {
+          return -1;
+        }
+        return UnixDomainSocketLibrary.read(fdToRead, buf, buf.remaining());
+      } catch (LastErrorException e) {
+        throw new IOException(e);
+      } finally {
+        fd.release();
+      }
+    }
+  }
+
+  private class UnixDomainSocketOutputStream extends OutputStream {
+
+    public void write(int b) throws IOException {
+      ByteBuffer buf = ByteBuffer.allocate(1);
+      buf.put(0, (byte) (0xFF & b));
+      doWrite(buf);
+    }
+
+    public void write(byte[] b, int off, int len) throws IOException {
+      if (len == 0) {
+        return;
+      }
+      ByteBuffer buf = ByteBuffer.wrap(b, off, len);
+      doWrite(buf);
+    }
+
+    private void doWrite(ByteBuffer buf) throws IOException {
+      try {
+        int fdToWrite = fd.acquire();
+        if (fdToWrite == -1) {
+          return;
+        }
+        int ret = UnixDomainSocketLibrary.write(fdToWrite, buf, buf.remaining());
+        if (ret != buf.remaining()) {
+          // This shouldn't happen with standard blocking Unix domain sockets.
+          throw new IOException("Could not write " + buf.remaining() + " bytes as requested " +
+                                "(wrote " + ret + " bytes instead)");
+        }
+      } catch (LastErrorException e) {
+        throw new IOException(e);
+      } finally {
+        fd.release();
+      }
+    }
+  }
+}

--- a/sockets/src/main/java/bloop/sockets/UnixDomainSocketLibrary.java
+++ b/sockets/src/main/java/bloop/sockets/UnixDomainSocketLibrary.java
@@ -1,0 +1,140 @@
+/*
+
+ Copyright 2004-2019, Martian Software, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+package bloop.sockets;
+
+import com.sun.jna.LastErrorException;
+import com.sun.jna.Native;
+import com.sun.jna.Platform;
+import com.sun.jna.Structure;
+import com.sun.jna.Union;
+import com.sun.jna.ptr.IntByReference;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Utility class to bridge native Unix domain socket calls to Java using JNA.
+ */
+public class UnixDomainSocketLibrary {
+  public static final int PF_LOCAL = 1;
+  public static final int AF_LOCAL = 1;
+  public static final int SOCK_STREAM = 1;
+
+  public static final int SHUT_RD = 0;
+  public static final int SHUT_WR = 1;
+
+  // Utility class, do not instantiate.
+  private UnixDomainSocketLibrary() { }
+
+  // BSD platforms write a length byte at the start of struct sockaddr_un.
+  private static final boolean HAS_SUN_LEN =
+      Platform.isMac() || Platform.isFreeBSD() || Platform.isNetBSD() ||
+      Platform.isOpenBSD() || Platform.iskFreeBSD();
+
+  /**
+   * Bridges {@code struct sockaddr_un} to and from native code.
+   */
+  public static class SockaddrUn extends Structure implements Structure.ByReference {
+    /**
+     * On BSD platforms, the {@code sun_len} and {@code sun_family} values in
+     * {@code struct sockaddr_un}.
+     */
+    public static class SunLenAndFamily extends Structure {
+      public byte sunLen;
+      public byte sunFamily;
+
+      protected List getFieldOrder() {
+        return Arrays.asList(new String[] { "sunLen", "sunFamily" });
+      }
+    }
+
+    /**
+     * On BSD platforms, {@code sunLenAndFamily} will be present.
+     * On other platforms, only {@code sunFamily} will be present.
+     */
+    public static class SunFamily extends Union {
+      public SunLenAndFamily sunLenAndFamily;
+      public short sunFamily;
+    }
+
+    public SunFamily sunFamily = new SunFamily();
+    public byte[] sunPath = new byte[104];
+
+    /**
+     * Constructs an empty {@code struct sockaddr_un}.
+     */
+    public SockaddrUn() {
+      if (HAS_SUN_LEN) {
+        sunFamily.sunLenAndFamily = new SunLenAndFamily();
+        sunFamily.setType(SunLenAndFamily.class);
+      } else {
+        sunFamily.setType(Short.TYPE);
+      }
+      allocateMemory();
+    }
+
+    /**
+     * Constructs a {@code struct sockaddr_un} with a path whose bytes are encoded
+     * using the default encoding of the platform.
+     */
+    public SockaddrUn(String path) throws IOException {
+      byte[] pathBytes = path.getBytes();
+      if (pathBytes.length > sunPath.length - 1) {
+        throw new IOException("Cannot fit name [" + path + "] in maximum unix domain socket length");
+      }
+      System.arraycopy(pathBytes, 0, sunPath, 0, pathBytes.length);
+      sunPath[pathBytes.length] = (byte) 0;
+      if (HAS_SUN_LEN) {
+        int len = fieldOffset("sunPath") + pathBytes.length;
+        sunFamily.sunLenAndFamily = new SunLenAndFamily();
+        sunFamily.sunLenAndFamily.sunLen = (byte) len;
+        sunFamily.sunLenAndFamily.sunFamily = AF_LOCAL;
+        sunFamily.setType(SunLenAndFamily.class);
+      } else {
+        sunFamily.sunFamily = AF_LOCAL;
+        sunFamily.setType(Short.TYPE);
+      }
+      allocateMemory();
+    }
+
+    protected List getFieldOrder() {
+      return Arrays.asList(new String[] { "sunFamily", "sunPath" });
+    }
+  }
+
+  static {
+    Native.register(Platform.C_LIBRARY_NAME);
+  }
+
+  public static native int socket(int domain, int type, int protocol) throws LastErrorException;
+  public static native int bind(int fd, SockaddrUn address, int addressLen)
+    throws LastErrorException;
+  public static native int listen(int fd, int backlog) throws LastErrorException;
+  public static native int accept(int fd, SockaddrUn address, IntByReference addressLen)
+    throws LastErrorException;
+  public static native int connect(int fd, SockaddrUn address, int addressLen)
+    throws LastErrorException;
+  public static native int read(int fd, ByteBuffer buffer, int count)
+    throws LastErrorException;
+  public static native int write(int fd, ByteBuffer buffer, int count)
+    throws LastErrorException;
+  public static native int close(int fd) throws LastErrorException;
+  public static native int shutdown(int fd, int how) throws LastErrorException;
+}

--- a/sockets/src/main/java/bloop/sockets/Win32NamedPipeLibrary.java
+++ b/sockets/src/main/java/bloop/sockets/Win32NamedPipeLibrary.java
@@ -1,0 +1,94 @@
+/*
+
+ Copyright 2004-2019, Martian Software, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+package bloop.sockets;
+
+import java.nio.ByteBuffer;
+
+import com.sun.jna.*;
+import com.sun.jna.platform.win32.WinNT;
+import com.sun.jna.ptr.IntByReference;
+
+import com.sun.jna.win32.W32APIOptions;
+
+public interface Win32NamedPipeLibrary extends Library, WinNT {
+    int PIPE_ACCESS_DUPLEX = 3;
+    int PIPE_UNLIMITED_INSTANCES = 255;
+    int FILE_FLAG_FIRST_PIPE_INSTANCE = 524288;
+
+    Win32NamedPipeLibrary INSTANCE =
+            (Win32NamedPipeLibrary) Native.loadLibrary(
+                    "kernel32",
+                    Win32NamedPipeLibrary.class,
+                    W32APIOptions.UNICODE_OPTIONS);
+
+    HANDLE CreateNamedPipe(
+            String lpName,
+            int dwOpenMode,
+            int dwPipeMode,
+            int nMaxInstances,
+            int nOutBufferSize,
+            int nInBufferSize,
+            int nDefaultTimeOut,
+            SECURITY_ATTRIBUTES lpSecurityAttributes);
+    HANDLE CreateFile(
+            String lpFileName,
+            int dwDesiredAccess,
+            int dwSharedMode,
+            SECURITY_ATTRIBUTES lpSecurityAttributes,
+            int dwCreationDisposition,
+            int dwFlagsAndAttributes,
+            HANDLE hTemplateFile);
+    boolean ConnectNamedPipe(
+            HANDLE hNamedPipe,
+            Pointer lpOverlapped);
+    boolean DisconnectNamedPipe(
+            HANDLE hObject);
+    boolean ReadFile(
+            HANDLE hFile,
+            Memory lpBuffer,
+            int nNumberOfBytesToRead,
+            IntByReference lpNumberOfBytesRead,
+            Pointer lpOverlapped);
+    boolean WriteFile(
+            HANDLE hFile,
+            ByteBuffer lpBuffer,
+            int nNumberOfBytesToWrite,
+            IntByReference lpNumberOfBytesWritten,
+            Pointer lpOverlapped);
+    boolean CloseHandle(
+            HANDLE hObject);
+    boolean GetOverlappedResult(
+            HANDLE hFile,
+            Pointer lpOverlapped,
+            IntByReference lpNumberOfBytesTransferred,
+            boolean wait);
+    boolean CancelIoEx(
+            HANDLE hObject,
+            Pointer lpOverlapped);
+    HANDLE CreateEvent(
+            SECURITY_ATTRIBUTES lpEventAttributes,
+            boolean bManualReset,
+            boolean bInitialState,
+            String lpName);
+    int WaitForSingleObject(
+            HANDLE hHandle,
+            int dwMilliseconds
+    );
+
+    int GetLastError();
+}

--- a/sockets/src/main/java/bloop/sockets/Win32NamedPipeServerSocket.java
+++ b/sockets/src/main/java/bloop/sockets/Win32NamedPipeServerSocket.java
@@ -1,0 +1,199 @@
+/*
+
+ Copyright 2004-2019, Martian Software, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+package bloop.sockets;
+
+import com.sun.jna.platform.win32.WinBase;
+import com.sun.jna.platform.win32.WinError;
+import com.sun.jna.platform.win32.WinNT;
+import com.sun.jna.platform.win32.WinNT.HANDLE;
+import com.sun.jna.platform.win32.WinBase.SECURITY_ATTRIBUTES;
+import com.sun.jna.ptr.IntByReference;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class Win32NamedPipeServerSocket extends ServerSocket {
+    private static final Win32NamedPipeLibrary API = Win32NamedPipeLibrary.INSTANCE;
+    private static final String WIN32_PIPE_PREFIX = "\\\\.\\pipe\\";
+    private static final int BUFFER_SIZE = 65535;
+    private final LinkedBlockingQueue<HANDLE> openHandles;
+    private final LinkedBlockingQueue<HANDLE> connectedHandles;
+    private final Win32NamedPipeSocket.CloseCallback closeCallback;
+    private final String path;
+    private final int maxInstances;
+    private final HANDLE lockHandle;
+    private final boolean requireStrictLength;
+
+    public Win32NamedPipeServerSocket(String path) throws IOException {
+        this(Win32NamedPipeLibrary.PIPE_UNLIMITED_INSTANCES, path);
+    }
+
+    /**
+     * The doc for InputStream#read(byte[] b, int off, int len) states that
+     * "An attempt is made to read as many as len bytes, but a smaller number may be read."
+     * However, using requireStrictLength, Win32NamedPipeSocketInputStream can require that
+     * len matches up exactly the number of bytes to read.
+     */
+    public Win32NamedPipeServerSocket(String path, boolean requireStrictLength) throws IOException {
+        this(Win32NamedPipeLibrary.PIPE_UNLIMITED_INSTANCES, path, requireStrictLength);
+    }
+
+    public Win32NamedPipeServerSocket(int maxInstances, String path) throws IOException {
+        this(maxInstances, path, Win32NamedPipeSocket.DEFAULT_REQUIRE_STRICT_LENGTH);
+    }
+
+    /**
+     * The doc for InputStream#read(byte[] b, int off, int len) states that
+     * "An attempt is made to read as many as len bytes, but a smaller number may be read."
+     * However, using requireStrictLength, NGWin32NamedPipeSocketInputStream can require that
+     * len matches up exactly the number of bytes to read.
+     */
+    public Win32NamedPipeServerSocket(
+            int maxInstances,
+            String path,
+            boolean requireStrictLength) throws IOException {
+        this.openHandles = new LinkedBlockingQueue<>();
+        this.connectedHandles = new LinkedBlockingQueue<>();
+        this.closeCallback = handle -> {
+            if (connectedHandles.remove(handle)) {
+                closeConnectedPipe(handle, false);
+            }
+            if (openHandles.remove(handle)) {
+                closeOpenPipe(handle);
+            }
+        };
+        this.maxInstances = maxInstances;
+        this.requireStrictLength = requireStrictLength;
+        if (!path.startsWith(WIN32_PIPE_PREFIX)) {
+            this.path = WIN32_PIPE_PREFIX + path;
+        } else {
+            this.path = path;
+        }
+        String lockPath = this.path + "_lock";
+        SECURITY_ATTRIBUTES sa = Win32SecurityLibrary.createSecurityWithLogonDacl(WinNT.FILE_GENERIC_READ);
+        lockHandle = API.CreateNamedPipe(
+                lockPath,
+                Win32NamedPipeLibrary.FILE_FLAG_FIRST_PIPE_INSTANCE | Win32NamedPipeLibrary.PIPE_ACCESS_DUPLEX,
+                0,
+                1,
+                BUFFER_SIZE,
+                BUFFER_SIZE,
+                0,
+                sa);
+        if (lockHandle == Win32NamedPipeLibrary.INVALID_HANDLE_VALUE) {
+            throw new IOException(String.format("Could not create lock for %s, error %d", lockPath, API.GetLastError()));
+        } else {
+            if (!API.DisconnectNamedPipe(lockHandle)) {
+                throw new IOException(String.format("Could not disconnect lock %d", API.GetLastError()));
+            }
+        }
+
+    }
+
+    public void bind(SocketAddress endpoint) throws IOException {
+        throw new IOException("Win32 named pipes do not support bind(), pass path to constructor");
+    }
+
+    public Socket accept() throws IOException {
+        SECURITY_ATTRIBUTES sa = Win32SecurityLibrary.createSecurityWithLogonDacl(WinNT.FILE_ALL_ACCESS);
+        HANDLE handle = API.CreateNamedPipe(
+                path,
+                Win32NamedPipeLibrary.PIPE_ACCESS_DUPLEX | WinNT.FILE_FLAG_OVERLAPPED,
+                0,
+                maxInstances,
+                BUFFER_SIZE,
+                BUFFER_SIZE,
+                0,
+                sa);
+        if (handle == Win32NamedPipeLibrary.INVALID_HANDLE_VALUE) {
+            throw new IOException(String.format("Could not create named pipe, error %d", API.GetLastError()));
+        }
+        openHandles.add(handle);
+
+        HANDLE connWaitable = API.CreateEvent(null, true, false, null);
+        WinBase.OVERLAPPED olap = new WinBase.OVERLAPPED();
+        olap.hEvent = connWaitable;
+        olap.write();
+
+        boolean immediate = API.ConnectNamedPipe(handle, olap.getPointer());
+        if (immediate) {
+            openHandles.remove(handle);
+            connectedHandles.add(handle);
+            return new Win32NamedPipeSocket(handle, closeCallback, requireStrictLength);
+        }
+
+        int connectError = API.GetLastError();
+        if (connectError == WinError.ERROR_PIPE_CONNECTED) {
+            openHandles.remove(handle);
+            connectedHandles.add(handle);
+            return new Win32NamedPipeSocket(handle, closeCallback, requireStrictLength);
+        } else if (connectError == WinError.ERROR_NO_DATA) {
+            // Client has connected and disconnected between CreateNamedPipe() and ConnectNamedPipe()
+            // connection is broken, but it is returned it avoid loop here.
+            // Actual error will happen for NGSession when it will try to read/write from/to pipe
+            return new Win32NamedPipeSocket(handle, closeCallback, requireStrictLength);
+        } else if (connectError == WinError.ERROR_IO_PENDING) {
+            if (!API.GetOverlappedResult(handle, olap.getPointer(), new IntByReference(), true)) {
+                openHandles.remove(handle);
+                closeOpenPipe(handle);
+                throw new IOException("GetOverlappedResult() failed for connect operation: " + API.GetLastError());
+            }
+            openHandles.remove(handle);
+            connectedHandles.add(handle);
+            return new Win32NamedPipeSocket(handle, closeCallback, requireStrictLength);
+        } else {
+            throw new IOException("ConnectNamedPipe() failed with: " + connectError);
+        }
+    }
+
+    public void close() throws IOException {
+        try {
+            List<HANDLE> handlesToClose = new ArrayList<>();
+            openHandles.drainTo(handlesToClose);
+            for (HANDLE handle : handlesToClose) {
+                closeOpenPipe(handle);
+            }
+
+            List<HANDLE> handlesToDisconnect = new ArrayList<>();
+            connectedHandles.drainTo(handlesToDisconnect);
+            for (HANDLE handle : handlesToDisconnect) {
+                closeConnectedPipe(handle, true);
+            }
+        } finally {
+            API.CloseHandle(lockHandle);
+        }
+    }
+
+    private void closeOpenPipe(HANDLE handle) throws IOException {
+        API.CancelIoEx(handle, null);
+        API.CloseHandle(handle);
+    }
+
+    private void closeConnectedPipe(HANDLE handle, boolean shutdown) throws IOException {
+        if (!shutdown) {
+            API.WaitForSingleObject(handle, 10000);
+        }
+        API.DisconnectNamedPipe(handle);
+        API.CloseHandle(handle);
+    }
+}

--- a/sockets/src/main/java/bloop/sockets/Win32NamedPipeSocket.java
+++ b/sockets/src/main/java/bloop/sockets/Win32NamedPipeSocket.java
@@ -1,0 +1,225 @@
+/*
+
+ Copyright 2004-2019, Martian Software, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+package bloop.sockets;
+
+import com.sun.jna.Memory;
+import com.sun.jna.platform.win32.WinBase;
+import com.sun.jna.platform.win32.WinError;
+import com.sun.jna.platform.win32.WinNT;
+import com.sun.jna.platform.win32.WinNT.HANDLE;
+import com.sun.jna.ptr.IntByReference;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+
+public class Win32NamedPipeSocket extends Socket {
+    private static final Win32NamedPipeLibrary API = Win32NamedPipeLibrary.INSTANCE;
+    private static HANDLE createFile(String pipeName) {
+        return API.CreateFile(
+            pipeName,
+            WinNT.GENERIC_READ | WinNT.GENERIC_WRITE,
+            0,     // no sharing
+            null,  // default security attributes
+            WinNT.OPEN_EXISTING,
+            WinNT.FILE_FLAG_OVERLAPPED,     // need overlapped for true asynchronous read/write access
+            null); // no template file
+    }
+    private static CloseCallback emptyCallback() {
+        return new CloseCallback() {
+            public void onNamedPipeSocketClose(HANDLE handle) throws IOException {
+            }
+        };
+    }
+
+    static final boolean DEFAULT_REQUIRE_STRICT_LENGTH = false;
+    private final HANDLE handle;
+    private final CloseCallback closeCallback;
+    private boolean isClosed = false;
+    private final boolean requireStrictLength;
+    private final InputStream is;
+    private final OutputStream os;
+    private final HANDLE readerWaitable;
+    private final HANDLE writerWaitable;
+
+    interface CloseCallback {
+        void onNamedPipeSocketClose(HANDLE handle) throws IOException;
+    }
+
+    /**
+     * The doc for InputStream#read(byte[] b, int off, int len) states that
+     * "An attempt is made to read as many as len bytes, but a smaller number may be read."
+     * However, using requireStrictLength, NGWin32NamedPipeSocketInputStream can require that
+     * len matches up exactly the number of bytes to read.
+     */
+    public Win32NamedPipeSocket(
+            HANDLE handle,
+            CloseCallback closeCallback,
+            boolean requireStrictLength) throws IOException {
+        this.handle = handle;
+        this.closeCallback = closeCallback;
+        this.requireStrictLength = requireStrictLength;
+        this.readerWaitable = API.CreateEvent(null, true, false, null);
+        if (readerWaitable == null) {
+            throw new IOException("CreateEvent() failed ");
+        }
+        writerWaitable = API.CreateEvent(null, true, false, null);
+        if (writerWaitable == null) {
+            throw new IOException("CreateEvent() failed ");
+        }
+        this.is = new Win32NamedPipeSocketInputStream(handle);
+        this.os = new Win32NamedPipeSocketOutputStream(handle);
+    }
+
+    public Win32NamedPipeSocket(
+            HANDLE handle,
+            CloseCallback closeCallback) throws IOException {
+        this(handle, closeCallback, DEFAULT_REQUIRE_STRICT_LENGTH);
+    }
+
+    public Win32NamedPipeSocket(String pipeName) throws IOException {
+        this(createFile(pipeName), emptyCallback(), DEFAULT_REQUIRE_STRICT_LENGTH);
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return is;
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+        return os;
+    }
+
+    @Override
+    public boolean isClosed() {
+        return this.isClosed;
+    }
+
+    @Override
+    public void close() throws IOException {
+        // Follow shutdown procedure in pynailgun.py
+        shutdownInput();
+        shutdownOutput();
+        API.CloseHandle(handle);
+
+        this.isClosed = true;
+        closeCallback.onNamedPipeSocketClose(handle);
+    }
+
+    @Override
+    public void shutdownInput() throws IOException {
+        API.CloseHandle(readerWaitable);
+    }
+
+    @Override
+    public void shutdownOutput() throws IOException {
+        API.CloseHandle(writerWaitable);
+    }
+
+    private class Win32NamedPipeSocketInputStream extends InputStream {
+        private final HANDLE handle;
+
+        Win32NamedPipeSocketInputStream(HANDLE handle) {
+            this.handle = handle;
+        }
+
+        @Override
+        public int read() throws IOException {
+            int result;
+            byte[] b = new byte[1];
+            if (read(b) == 0) {
+                result = -1;
+            } else {
+                result = 0xFF & b[0];
+            }
+            return result;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            Memory readBuffer = new Memory(len);
+
+            WinBase.OVERLAPPED olap = new WinBase.OVERLAPPED();
+            olap.hEvent = readerWaitable;
+            olap.write();
+
+            boolean immediate = API.ReadFile(handle, readBuffer, len, null, olap.getPointer());
+            if (!immediate) {
+                int lastError = API.GetLastError();
+                if (lastError != WinError.ERROR_IO_PENDING) {
+                    throw new IOException("ReadFile() failed: " + lastError);
+                }
+            }
+
+            IntByReference r = new IntByReference();
+            if (!API.GetOverlappedResult(handle, olap.getPointer(), r, true)) {
+                int lastError = API.GetLastError();
+                throw new IOException("GetOverlappedResult() failed for read operation: " + lastError);
+            }
+            int actualLen = r.getValue();
+            if (requireStrictLength && (actualLen != len)) {
+                throw new IOException("ReadFile() read less bytes than requested: expected " +
+                    len + " bytes, but read " + actualLen + " bytes");
+            }
+            byte[] byteArray = readBuffer.getByteArray(0, actualLen);
+            System.arraycopy(byteArray, 0, b, off, actualLen);
+            return actualLen;
+        }
+    }
+
+    private class Win32NamedPipeSocketOutputStream extends OutputStream {
+        private final HANDLE handle;
+
+        Win32NamedPipeSocketOutputStream(HANDLE handle) {
+            this.handle = handle;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            write(new byte[]{(byte) (0xFF & b)});
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            ByteBuffer data = ByteBuffer.wrap(b, off, len);
+
+            WinBase.OVERLAPPED olap = new WinBase.OVERLAPPED();
+            olap.hEvent = writerWaitable;
+            olap.write();
+
+            boolean immediate = API.WriteFile(handle, data, len, null, olap.getPointer());
+            if (!immediate) {
+                int lastError = API.GetLastError();
+                if (lastError != WinError.ERROR_IO_PENDING) {
+                    throw new IOException("WriteFile() failed: " + lastError);
+                }
+            }
+            IntByReference written = new IntByReference();
+            if (!API.GetOverlappedResult(handle, olap.getPointer(), written, true)) {
+                int lastError = API.GetLastError();
+                throw new IOException("GetOverlappedResult() failed for write operation: " + lastError);
+            }
+            if (written.getValue() != len) {
+                throw new IOException("WriteFile() wrote less bytes than requested");
+            }
+        }
+    }
+}

--- a/sockets/src/main/java/bloop/sockets/Win32SecurityLibrary.java
+++ b/sockets/src/main/java/bloop/sockets/Win32SecurityLibrary.java
@@ -1,0 +1,116 @@
+/*
+
+ Copyright 2004-2019, Martian Software, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+package bloop.sockets;
+
+import com.sun.jna.platform.win32.WinNT;
+import com.sun.jna.platform.win32.WinNT.SECURITY_DESCRIPTOR;
+import com.sun.jna.platform.win32.WinNT.PSID;
+import com.sun.jna.platform.win32.WinNT.PSIDByReference;
+import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
+import com.sun.jna.platform.win32.WinNT.HANDLE;
+import com.sun.jna.platform.win32.WinNT.SID_AND_ATTRIBUTES;
+import com.sun.jna.platform.win32.WinNT.ACL;
+import com.sun.jna.platform.win32.WinNT.ACCESS_ALLOWED_ACE;
+import com.sun.jna.platform.win32.WinDef.DWORD;
+import com.sun.jna.platform.win32.WinBase.SECURITY_ATTRIBUTES;
+import com.sun.jna.platform.win32.Advapi32;
+import com.sun.jna.platform.win32.Advapi32Util;
+import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.platform.win32.Kernel32Util;
+import com.sun.jna.platform.win32.W32Errors;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.Native;
+
+public class Win32SecurityLibrary {
+	private static final long SE_GROUP_LOGON_ID = 0xC0000000L;
+
+	public static SECURITY_ATTRIBUTES createSecurityWithLogonDacl(int accessMask) {
+		SECURITY_DESCRIPTOR sd = new SECURITY_DESCRIPTOR(64 * 1024);
+		Advapi32.INSTANCE.InitializeSecurityDescriptor(sd, WinNT.SECURITY_DESCRIPTOR_REVISION);
+		Native.getLastError();
+
+		ACL pAcl;
+		int cbAcl = 0;
+		PSIDByReference psid = new PSIDByReference();
+		getLogonSID(psid);
+		int sidLength = Advapi32.INSTANCE.GetLengthSid(psid.getValue());
+		cbAcl = Native.getNativeSize(ACL.class, null);
+		cbAcl += Native.getNativeSize(ACCESS_ALLOWED_ACE.class, null);
+		cbAcl += (sidLength - DWORD.SIZE);
+		cbAcl = Advapi32Util.alignOnDWORD(cbAcl);
+		pAcl = new ACL(cbAcl);
+		Advapi32.INSTANCE.InitializeAcl(pAcl, cbAcl, WinNT.ACL_REVISION);
+		Native.getLastError();
+		Advapi32.INSTANCE.AddAccessAllowedAce(pAcl, WinNT.ACL_REVISION, accessMask, psid.getValue());
+		Native.getLastError();
+		Advapi32.INSTANCE.SetSecurityDescriptorDacl(sd, true, pAcl, false);
+		Native.getLastError();
+
+		SECURITY_ATTRIBUTES sa = new SECURITY_ATTRIBUTES();
+		sa.dwLength = new DWORD(sd.size());
+		sa.lpSecurityDescriptor = sd.getPointer();
+		sa.bInheritHandle = false;
+
+		return sa;
+	}
+
+	public static void getOwnerSID(PSIDByReference psid) {
+		HANDLEByReference phToken = new HANDLEByReference();
+		try {
+			Advapi32.INSTANCE.OpenProcessToken(Kernel32.INSTANCE.GetCurrentProcess(), WinNT.TOKEN_QUERY, phToken);
+			Native.getLastError();
+			IntByReference tokenInformationLength = new IntByReference();
+			Advapi32.INSTANCE.GetTokenInformation(phToken.getValue(),
+				WinNT.TOKEN_INFORMATION_CLASS.TokenOwner, null, 0, tokenInformationLength);
+			WinNT.TOKEN_OWNER owner = new WinNT.TOKEN_OWNER(tokenInformationLength.getValue());
+			Advapi32.INSTANCE.GetTokenInformation(phToken.getValue(),
+				WinNT.TOKEN_INFORMATION_CLASS.TokenOwner, owner,
+				tokenInformationLength.getValue(), tokenInformationLength);
+			Native.getLastError();
+			psid.setValue(owner.Owner);
+		} finally {
+			Kernel32Util.closeHandleRef(phToken);
+		}
+	}
+
+	public static void getLogonSID(PSIDByReference psid) {
+		HANDLEByReference phToken = new HANDLEByReference();
+		try {
+			Advapi32.INSTANCE.OpenProcessToken(Kernel32.INSTANCE.GetCurrentProcess(), WinNT.TOKEN_QUERY, phToken);
+			Native.getLastError();
+			IntByReference tokenInformationLength = new IntByReference();
+			Advapi32.INSTANCE.GetTokenInformation(phToken.getValue(),
+				WinNT.TOKEN_INFORMATION_CLASS.TokenGroups, null, 0, tokenInformationLength);
+			WinNT.TOKEN_GROUPS groups = new WinNT.TOKEN_GROUPS(tokenInformationLength.getValue());
+			Advapi32.INSTANCE.GetTokenInformation(phToken.getValue(),
+				WinNT.TOKEN_INFORMATION_CLASS.TokenGroups, groups,
+				tokenInformationLength.getValue(), tokenInformationLength);
+			Native.getLastError();
+
+			for (SID_AND_ATTRIBUTES sidAndAttribute: groups.getGroups()) {
+				if ((sidAndAttribute.Attributes & SE_GROUP_LOGON_ID) == SE_GROUP_LOGON_ID) {
+					psid.setValue(sidAndAttribute.Sid);
+					return;
+				}
+			}
+			throw new RuntimeException("LogonSID was not found.");
+		} finally {
+			Kernel32Util.closeHandleRef(phToken);
+		}
+	}
+}


### PR DESCRIPTION
The nitty-gritty is described in the commits. The diff is large because we add the sources of the sockets logic and some of the core lsp4s classes. This migration is useful to implement cancellation correctly and to fix some ongoing problems in future PRs (like local connections not working on Windows).