### PR TITLE
Send out server BSP responses/notifications in order

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopLanguageClient.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopLanguageClient.scala
@@ -6,7 +6,6 @@ import scala.meta.jsonrpc.CancelParams
 import scala.meta.jsonrpc.Notification
 import scala.meta.jsonrpc.JsonRpcClient
 import scala.meta.jsonrpc.MessageWriter
-import scala.meta.jsonrpc.MonixEnrichments._
 
 import io.circe.Decoder
 import io.circe.Encoder
@@ -29,14 +28,15 @@ import scala.concurrent.duration.FiniteDuration
 import scribe.LoggerSupport
 
 /**
- * A copy of `LanguageClient` defined in `lsp4s` with a few critical fixes
- * required to get cancellation of server and handling of client crash
- * correctly. The new
+ * A copy of `LanguageClient` defined in `lsp4s` with a few critical fixes.
  */
 final class BloopLanguageClient(out: Observer[ByteBuffer], logger: LoggerSupport)
     extends JsonRpcClient {
+
+  // ++ bloop
   def this(out: OutputStream, logger: LoggerSupport) =
-    this(Observer.fromOutputStream(out, logger), logger)
+    this(BloopLanguageClient.fromOutputStream(out, logger), logger)
+  // -- bloop
 
   private val writer = new MessageWriter(out, logger)
   private val counter: AtomicInt = Atomic(1)
@@ -120,6 +120,46 @@ final class BloopLanguageClient(out: Observer[ByteBuffer], logger: LoggerSupport
 }
 
 object BloopLanguageClient {
-  def fromOutputStream(out: OutputStream, logger: LoggerSupport) =
-    new BloopLanguageClient(Observer.fromOutputStream(out, logger), logger)
+
+  /**
+   * An observer implementation that writes messages to the underlying output
+   * stream. This class is copied over from lsp4s but has been modified to
+   * synchronize writing on the output stream. Synchronizing makes sure BSP
+   * clients see server responses in the order they were sent.
+   *
+   * If this is a bottleneck in the future, we can consider removing the
+   * synchronized blocks here and in the body of `BloopLanguageClient` and
+   * replace them with a ring buffer and an id generator to make sure all
+   * server interactions are sent out in order. As it's not a performance
+   * blocker for now, we opt for the synchronized approach.
+   */
+  def fromOutputStream(
+      out: OutputStream,
+      logger: LoggerSupport
+  ): Observer.Sync[ByteBuffer] = {
+    new Observer.Sync[ByteBuffer] {
+      private[this] var isClosed: Boolean = false
+      override def onNext(elem: ByteBuffer): Ack = out.synchronized {
+        if (isClosed) Ack.Stop
+        else {
+          try {
+            while (elem.hasRemaining) out.write(elem.get().toInt)
+            out.flush()
+            Ack.Continue
+          } catch {
+            case t: java.io.IOException =>
+              logger.trace("OutputStream closed!", t)
+              isClosed = true
+              Ack.Stop
+          }
+        }
+      }
+      override def onError(ex: Throwable): Unit = ()
+      override def onComplete(): Unit = {
+        out.synchronized {
+          out.close()
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Synchronize on the output stream that writes out the responses to make
sure that the client receives the BSP server interactions in the same
order they happened. This helps fighting critical violations of the
protocol where `taskFinish` notifications could get before `taskStart`
notifications to the client, or where out-of-order receptions in the
client could produce incorrect user behaviors.