### PR TITLE
Don't create and delete empty classes dirs

### DIFF
--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopLookup.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopLookup.scala
@@ -17,8 +17,10 @@ final class BloopLookup(
   override def changedClasspathHash: Option[Vector[FileHash]] = {
     if (classpathHash == previousClasspathHash) None
     else {
-      // Previous classpath hash may contain directories, discard them and check again
-      val newPreviousClasspathHash = previousClasspathHash.filterNot(fh => fh.file.isDirectory())
+      // Discard directories and known empty classes dirs and check if there's still a hash mismatch
+      val newPreviousClasspathHash = previousClasspathHash
+        .filterNot(fh => fh.file.isDirectory() || fh.file.getName().startsWith("classes-empty-"))
+
       if (classpathHash == newPreviousClasspathHash) None
       else {
         logger.debug("Classpath hash changed!")

--- a/frontend/src/main/scala/bloop/engine/caches/LastSuccessfulResult.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/LastSuccessfulResult.scala
@@ -19,21 +19,33 @@ case class LastSuccessfulResult(
     previous: PreviousResult,
     classesDir: AbsolutePath,
     populatingProducts: Task[Unit]
-)
+) {
+  def hasEmptyClassesDir: Boolean =
+    classesDir.underlying.getFileName().toString.startsWith("classes-empty-")
+}
 
 object LastSuccessfulResult {
   private final val EmptyPreviousResult =
     PreviousResult.of(Optional.empty[CompileAnalysis], Optional.empty[MiniSetup])
 
-  final def empty(project: Project): LastSuccessfulResult = {
-    val classesDir = Files.createDirectories(
-      project.genericClassesDir.getParent.resolve(s"classes-empty-${project.name}").underlying
-    )
+  def empty(project: Project): LastSuccessfulResult = {
+    /*
+     * An empty classes directory never exists on purpose. It is merely a
+     * placeholder until a non empty classes directory is used. There is only
+     * one single empty classes directory per project and can be shared by
+     * different projects, so to avoid problems across different compilations
+     * we never create this directory and special case Zinc logic to skip it.
+     *
+     * The prefix name 'classes-empty-` of this classes directory should not
+     * change without modifying `BloopLookup` defined in `backend`.
+     */
+    val classesDirName = s"classes-empty-${project.name}"
+    val classesDir = project.genericClassesDir.getParent.resolve(classesDirName).underlying
     LastSuccessfulResult(
       Vector.empty,
       Vector.empty,
       EmptyPreviousResult,
-      AbsolutePath(classesDir.toRealPath()),
+      AbsolutePath(classesDir),
       Task.now(())
     )
   }

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
@@ -390,7 +390,15 @@ object CompileGraph {
                           // Delete in background after running tasks which could be using this dir
                           .doOnFinish { _ =>
                             Task {
-                              BloopPaths.delete(toDeleteResult.classesDir)
+                              // Don't delete classes dir if it's an empty
+                              if (toDeleteResult.hasEmptyClassesDir) {
+                                // The empty classes dir should not exist in the
+                                // first place but we guarantee that even if it
+                                // does we don't delete it to avoid any conflicts
+                                logger.debug(s"Skipping delete for ${toDeleteResult.classesDir}")
+                              } else {
+                                BloopPaths.delete(toDeleteResult.classesDir)
+                              }
                             }.executeOn(ExecutionContext.ioScheduler)
                           }
                       }.memoize

--- a/frontend/src/test/scala/bloop/CompileSpec.scala
+++ b/frontend/src/test/scala/bloop/CompileSpec.scala
@@ -302,8 +302,8 @@ object CompileSpec extends bloop.testing.BaseSuite {
 
       // Check that initial classes directory doesn't exist either
       assertNonExistingInternalClassesDir(secondCompiledState)(compiledState, List(`A`))
-      // There should only be three classes dirs: empty-a, current classes dir and external
-      assert(list(workspace.resolve("target").resolve("a")).size == 3)
+      // There should only be 2 dirs: current classes dir and external (no empty classes dir)
+      assert(list(workspace.resolve("target").resolve("a")).size == 2)
     }
   }
 


### PR DESCRIPTION

Empty classes directories exist uniquely per project and can be shared by any compiler process. To avoid any conflicts, we neither create nor delete empty classes directories and just treat them as mere placeholders of future, valid classes directories.