### PR TITLE
Change SCOOP env variable to avoid conflict

### DIFF
--- a/bin/install.py
+++ b/bin/install.py
@@ -281,7 +281,7 @@ if is_windows:
         output_file.write(generate_bat(BLOOP_CLIENT_TARGET))
     make_executable(target)
 
-    if not "SCOOP" in os.environ:
+    if not "BLOOP_IN_SCOOP" in os.environ:
         print("You can run `bloop` in Windows with " + target)
         print("Recommended: Add " + BLOOP_INSTALLATION_TARGET + " to the Windows $PATH")
 

--- a/project/ReleaseUtils.scala
+++ b/project/ReleaseUtils.scala
@@ -190,7 +190,7 @@ object ReleaseUtils {
        |  "env_add_path": "$$dir",
        |  "env_set": {
        |    "HOME": "$$dir",
-       |    "SCOOP": "true"
+       |    "BLOOP_IN_SCOOP": "true"
        |  },
        |  "installer": {
        |    "script": "python $$dir/install.py --dest $$dir"


### PR DESCRIPTION
Avoid conflict with Scoop's own SCOOP env variable by renaming to BLOOP_IN_SCOOP