### PR TITLE
Cancel deduplication if ongoing compilation looks dead

### DIFF
--- a/backend/src/main/scala/bloop/logging/Logger.scala
+++ b/backend/src/main/scala/bloop/logging/Logger.scala
@@ -30,6 +30,9 @@ abstract class Logger extends xsbti.Logger with BaseSbtLogger {
 
   def report(msg: String, t: Throwable): Unit = { error(msg); trace(t) }
   def handleCompilationEvent(event: CompilationEvent): Unit = ()
+
+  /** Display a message as a warning to user using `showMessage` in BSP-based loggers and `warn` otherwise. */
+  def displayWarningToUser(msg: String): Unit = warn(msg)
 }
 
 /**

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
@@ -15,6 +15,7 @@ import java.io.File
 import java.nio.file.Path
 
 import scala.collection.mutable
+import scala.concurrent.Promise
 
 import monix.eval.Task
 import monix.reactive.Observable
@@ -47,6 +48,7 @@ import xsbti.compile.PreviousResult
  * @param scalaSources A list of Scala sources in the project.
  * @param oracleInputs The compiler oracle inputs are the main input to the
  * compilation task called by [[CompileGraph]].
+ * @param cancelCompilation A promise that can be completed to cancel the compilation.
  * @param reporter A reporter instance that will register every reporter action
  * produced by the compilation started by this compile bundle.
  * @param logger A logger instance that will register every logger action
@@ -65,6 +67,7 @@ final case class CompileBundle(
     javaSources: List[AbsolutePath],
     scalaSources: List[AbsolutePath],
     oracleInputs: CompilerOracle.Inputs,
+    cancelCompilation: Promise[Unit],
     reporter: ObservedReporter,
     logger: ObservedLogger[Logger],
     mirror: Observable[Either[ReporterAction, LoggerAction]],
@@ -126,6 +129,7 @@ object CompileBundle {
       reporter: ObservedReporter,
       lastSuccessful: LastSuccessfulResult,
       lastResult: Compiler.Result,
+      cancelCompilation: Promise[Unit],
       logger: ObservedLogger[Logger],
       mirror: Observable[Either[ReporterAction, LoggerAction]],
       tracer: BraveTracer
@@ -188,6 +192,7 @@ object CompileBundle {
           javaSources,
           scalaSources,
           inputs,
+          cancelCompilation,
           reporter,
           logger,
           mirror,

--- a/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
+++ b/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
@@ -51,6 +51,17 @@ final class BspServerLogger private (
     ()
   }
 
+  override def displayWarningToUser(msg: String): Unit = {
+    // Log warning too despite the `logMessage`
+    warn(msg)
+    // Metals and other clients should be showing `showMessage` to users
+    import ch.epfl.scala.bsp.MessageType
+    import ch.epfl.scala.bsp.ShowMessageParams
+    val showParams = ShowMessageParams(MessageType.Warning, None, None, msg)
+    bsp.endpoints.Build.showMessage.notify(showParams)
+    ()
+  }
+
   override def warn(msg: String): Unit = {
     Build.logMessage.notify(bsp.LogMessageParams(bsp.MessageType.Warning, None, None, msg))
     ()

--- a/frontend/src/main/scala/bloop/util/SystemProperties.scala
+++ b/frontend/src/main/scala/bloop/util/SystemProperties.scala
@@ -1,0 +1,40 @@
+package bloop.util
+
+import bloop.logging.Logger
+
+import scala.concurrent.duration.FiniteDuration
+
+object SystemProperties {
+  private def parseLong(repr: String): Option[Long] = {
+    try Some(java.lang.Long.parseLong(repr))
+    catch { case _: NumberFormatException => None }
+  }
+
+  def getCompileDisconnectionTime(logger: Logger): FiniteDuration = {
+    val disconnectionTime = System.getProperty(Keys.SecondsBeforeDisconnectionKey)
+    import java.util.concurrent.TimeUnit
+    val secondsBeforeDisconnection = {
+      if (disconnectionTime == null) Defaults.SecondsBeforeDisconnection
+      else {
+        parseLong(disconnectionTime).getOrElse {
+          logger.warn(
+            s"Ignoring non-numeric value for ${Keys.SecondsBeforeDisconnectionKey}, defaulting to ${Defaults.SecondsBeforeDisconnection}"
+          )
+          Defaults.SecondsBeforeDisconnection
+        }
+      }
+    }
+
+    FiniteDuration(secondsBeforeDisconnection, TimeUnit.SECONDS)
+  }
+
+  private[bloop] object Keys {
+    val SecondsBeforeDisconnectionKey =
+      "bloop.compilation.seconds-before-disconnection"
+  }
+
+  private[bloop] object Defaults {
+    val SecondsBeforeDisconnection: Long = 30L
+
+  }
+}


### PR DESCRIPTION
This PR adds a new system property to configure a disconnection time
from a deduplicated compilation process as well as the machinery
required to implement the cancellation.

When a deduplication takes place and an ongoing compilation has not
registered any kind of progress update for a particular time slot (no
log or reporter action, including scalac progress updates), then Bloop
will disconnect the deduplication, cancel the ongoing compilation and
attempt to schedule another fresh compile. This mechanism is done to
avoid any kind of issues that could occur during compilation.

In all the time of testing this feature, I've never encountered a case
where this is necessary. However, it's a safety mechanism that will
allow us to debug misbehaviours if compilations go awry.

Users can modify the disconnection time via a System property. By
default, 30 seconds need to pass with no progress update before a
disconnection takes place.