### PR TITLE
Use generic classes dir for the pipelined traversal

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -138,21 +138,21 @@ pipeline:
       - git log --oneline --graph | head -n 20
       - ${RUN_BENCHMARKS_AND_SCRIPTED}
 
-#  run_community_pipelined:
-#    image: scalacenter/scala-docs:1.4
-#    group: build
-#    when:
-#      ref: [ refs/heads/master, refs/tags/*, refs/pull/*/head ]
-#      matrix:
-#        OS: linux
-#        OPS: community-build
-#    commands:
-#      - export DRONE_DIR="/drone"
-#      - export PIPELINE_COMMUNITY_BUILD="true"
-#      - . bin/set-up-dodo.sh # Source it because it exports variables
-#      - git log --oneline --graph | head -n 20
-#      - . bin/detect-community-build.sh # Source it because it exports variables
-#      - ${RUN_COMMUNITY_BUILD_EXTRA}
+  run_community_pipelined:
+    image: scalacenter/scala-docs:1.4
+    group: build
+    when:
+      ref: [ refs/heads/master, refs/tags/*, refs/pull/*/head ]
+      matrix:
+        OS: linux
+        OPS: community-build
+    commands:
+      - export DRONE_DIR="/drone"
+      - export PIPELINE_COMMUNITY_BUILD="true"
+      - . bin/set-up-dodo.sh # Source it because it exports variables
+      - git log --oneline --graph | head -n 20
+      - . bin/detect-community-build.sh # Source it because it exports variables
+      - ${RUN_COMMUNITY_BUILD_EXTRA}
 
   build_windows:
     group: build

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,8 @@ matrix:
           "jsBridge10/publishLocal" \
           "frontend/runMain bloop.util.CommandsDocGenerator --test" \
           "frontend/runMain bloop.util.CommandsDocGenerator --out ../docs/cli-reference.md" \
-          "frontend/test" \
+          "frontend/testOnly -bloop.IntegrationTestSuite" \
+          "frontend/testOnly bloop.IntegrationTestSuite" \
           "gradleBloop212/test" \
           "docs/run"
 

--- a/backend/src/main/scala/bloop/io/Paths.scala
+++ b/backend/src/main/scala/bloop/io/Paths.scala
@@ -170,26 +170,31 @@ object Paths {
 
   def isDirectoryEmpty(path: AbsolutePath): Boolean = {
     var isEmpty: Boolean = true
-    Files.walkFileTree(
-      path.underlying,
-      new SimpleFileVisitor[Path] {
-        override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
-          isEmpty = false
-          FileVisitResult.TERMINATE
-        }
-
-        override def preVisitDirectory(
-            directory: Path,
-            attributes: BasicFileAttributes
-        ): FileVisitResult = {
-          if (path.underlying == directory) FileVisitResult.CONTINUE
-          else {
+    import java.nio.file.NoSuchFileException
+    try {
+      Files.walkFileTree(
+        path.underlying,
+        new SimpleFileVisitor[Path] {
+          override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
             isEmpty = false
             FileVisitResult.TERMINATE
           }
+
+          override def preVisitDirectory(
+              directory: Path,
+              attributes: BasicFileAttributes
+          ): FileVisitResult = {
+            if (path.underlying == directory) FileVisitResult.CONTINUE
+            else {
+              isEmpty = false
+              FileVisitResult.TERMINATE
+            }
+          }
         }
-      }
-    )
+      )
+    } catch {
+      case _: NoSuchFileException => isEmpty = true
+    }
     isEmpty
   }
 }

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -296,7 +296,14 @@ object CompileTask {
               case _ => () // Do nothing when the final compilation result is not an actual error
             }
 
-            failures.foreach(p => rawLogger.error(s"'${p.name}' failed to compile."))
+            val projectsFailedToCompile = failures.map(p => s"'${p.name}'")
+            val failureMessage =
+              if (failures.size <= 2) projectsFailedToCompile.mkString(",")
+              else {
+                s"${projectsFailedToCompile.take(2).mkString(", ")} and ${projectsFailedToCompile.size - 2} more projects"
+              }
+
+            rawLogger.error("Failed to compile " + failureMessage)
             stateWithResults.copy(status = ExitStatus.CompilationError)
           }
         }

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
@@ -783,11 +783,11 @@ object CompileGraph {
                   val bundleInputs = BundleInputs(project, dag, Map.empty)
                   setupAndDeduplicate(client, bundleInputs, computeBundle) { bundle =>
                     // Place IRs stores in same order as classes dirs show up in the raw classpath!
-                    val classpath = bundle.project.rawClasspath
-                    val indexDirs = classpath.iterator.filter(_.isDirectory).zipWithIndex.toMap
                     val dependencyStore = {
+                      val indexDirs =
+                        bundle.project.rawClasspath.filter(_.isDirectory).zipWithIndex.toMap
                       val transitive = results.flatMap { r =>
-                        val classesDir = client.getUniqueClassesDirFor(r.bundle.project)
+                        val classesDir = r.bundle.project.genericClassesDir
                         indexDirs.get(classesDir).iterator.map(i => i -> r.store)
                       }
                       SimpleIRStore(

--- a/frontend/src/test/scala/bloop/CompileSpec.scala
+++ b/frontend/src/test/scala/bloop/CompileSpec.scala
@@ -238,7 +238,7 @@ object CompileSpec extends bloop.testing.BaseSuite {
 
       val targetBPath = TestUtil.universalPath("b/src/B.scala")
       assertNoDiff(
-        logger.renderErrors(exceptContaining = "failed to compile"),
+        logger.renderErrors(exceptContaining = "Failed to compile"),
         s"""[E1] ${targetBPath}:2:17
            |     type mismatch;
            |      found   : String("")
@@ -527,7 +527,7 @@ object CompileSpec extends bloop.testing.BaseSuite {
            |                    ^
            |${targetBar}: L2 [E1], L2 [E2]
           """.stripMargin,
-        logger.renderErrors(exceptContaining = "failed to compile")
+        logger.renderErrors(exceptContaining = "Failed to compile")
       )
 
       assertIsFile(writeFile(`A`.srcFor("main/scala/Bar.scala"), Sources.`Bar2.scala`))
@@ -612,7 +612,7 @@ object CompileSpec extends bloop.testing.BaseSuite {
 
         val targetBar = TestUtil.universalPath("a/src/Bar.scala")
         assertNoDiff(
-          logger.renderErrors(exceptContaining = "failed to compile"),
+          logger.renderErrors(exceptContaining = "Failed to compile"),
           s"""|[E1] ${targetBar}:3:15
               |     value greeting is not a member of Foo
               |     L3:   println(foo.greeting())
@@ -712,7 +712,7 @@ object CompileSpec extends bloop.testing.BaseSuite {
       }
 
       assertNoDiff(
-        logger.renderErrors(exceptContaining = "failed to compile"),
+        logger.renderErrors(exceptContaining = "Failed to compile"),
         expectedMessage
       )
     }
@@ -791,7 +791,7 @@ object CompileSpec extends bloop.testing.BaseSuite {
            |                    ^
            |${targetBar}: L2 [E1], L2 [E2]
           """.stripMargin,
-        logger.renderErrors(exceptContaining = "failed to compile")
+        logger.renderErrors(exceptContaining = "Failed to compile")
       )
 
       assertIsFile(writeFile(`C`.srcFor("main/scala/Bar.scala"), Sources.`Bar2.scala`))
@@ -854,13 +854,13 @@ object CompileSpec extends bloop.testing.BaseSuite {
       import bloop.testing.DiffAssertions
       try {
         assertNoDiff(
-          logger.renderErrors(exceptContaining = "failed to compile"),
+          logger.renderErrors(exceptContaining = "Failed to compile"),
           cannotFindSymbolError
         )
       } catch {
         case _: DiffAssertions.TestFailedException =>
           assertNoDiff(
-            logger.renderErrors(exceptContaining = "failed to compile"),
+            logger.renderErrors(exceptContaining = "Failed to compile"),
             cannotFindSymbolError2
           )
       }
@@ -894,7 +894,7 @@ object CompileSpec extends bloop.testing.BaseSuite {
       val targetFoo = TestUtil.universalPath("a/src/Foo.scala")
       assertDiagnosticsResult(compiledState.getLastResultFor(`A`), 1)
       assertNoDiff(
-        logger.renderErrors(exceptContaining = "failed to compile"),
+        logger.renderErrors(exceptContaining = "Failed to compile"),
         s"""[E1] ${targetFoo}:2:18
            |     ';' expected but '=' found.
            |     L2:   al foo: String = 1
@@ -929,7 +929,7 @@ object CompileSpec extends bloop.testing.BaseSuite {
 
       assertDiagnosticsResult(compiledState.getLastResultFor(`A`), 1)
       assertNoDiff(
-        logger.renderErrors(exceptContaining = "failed to compile"),
+        logger.renderErrors(exceptContaining = "Failed to compile"),
         """bad option: '-Ytyper-degug'""".stripMargin
       )
     }
@@ -1149,7 +1149,7 @@ object CompileSpec extends bloop.testing.BaseSuite {
            |     L2:   "".lengthCompare("1".substring(0))
            |                            ^^^^^^^^^^^^^^^^
            |${targetA}: L2 [E1], L6 [E2]
-           |'a' failed to compile.""".stripMargin
+           |Failed to compile 'a'""".stripMargin
       )
     }
   }
@@ -1189,7 +1189,7 @@ object CompileSpec extends bloop.testing.BaseSuite {
            |     L2:   val a1: Int = ""
            |                         ^
            |${targetA}: L2 [E1], L3 [E2]
-           |'a' failed to compile.""".stripMargin
+           |Failed to compile 'a'""".stripMargin
       )
     }
   }

--- a/frontend/src/test/scala/bloop/DeduplicationSpec.scala
+++ b/frontend/src/test/scala/bloop/DeduplicationSpec.scala
@@ -548,7 +548,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
              |     L3:   def foo(i: Int): String = i
              |                                     ^
              |${TestUtil.universalPath("b/src/B.scala")}: L3 [E1]
-             |'b' failed to compile.""".stripMargin
+             |Failed to compile 'b'""".stripMargin
         )
 
         assertNoDiff(
@@ -569,7 +569,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
              |     L3:   def foo(i: Int): String = i
              |                                     ^
              |${targetB}: L3 [E1]
-             |'b' failed to compile.""".stripMargin
+             |Failed to compile 'b'""".stripMargin
         )
 
         /* Repeat the same but this time the CLI client runs the compilation first */
@@ -608,7 +608,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
              |     L3:   def foo(i: Int): String = i
              |                                     ^
              |${targetB}: L3 [E1]
-             |'b' failed to compile.""".stripMargin
+             |Failed to compile 'b'""".stripMargin
         )
 
         assertNoDiff(
@@ -628,7 +628,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
              |     L3:   def foo(i: Int): String = i
              |                                     ^
              |${targetB}: L3 [E1]
-             |'b' failed to compile.""".stripMargin
+             |Failed to compile 'b'""".stripMargin
         )
 
         assertNoDiff(

--- a/frontend/src/test/scala/bloop/IntegrationTestSuite.scala
+++ b/frontend/src/test/scala/bloop/IntegrationTestSuite.scala
@@ -128,17 +128,21 @@ class IntegrationTestSuite(testDirectory: Path) {
       )
     }
 
+    import bloop.cli.CliOptions
     val enablePipelining = isPipeliningEnabled
     val action = Run(
       Commands.Compile(
         List(projectToCompile.name),
         incremental = true,
         pipeline = isPipeliningEnabled
+        //cliOptions = CliOptions.default.copy(verbose = true)
       ),
       Exit(ExitStatus.Ok)
     )
 
-    val state1 = TestUtil.blockingExecute(action, state)
+    val verboseState = state //.copy(logger = state.logger.asVerbose)
+    val state1 = TestUtil.blockingExecute(action, verboseState)
+    assert(state1.status.isOk)
     reachable.foreach { p =>
       assertTrue(
         s"Project `$integrationTestName/${p.name}` has not been compiled.",


### PR DESCRIPTION

Pipelining was using the client classes directory instead of the generic classes directory, which meant that the IR stores were not put in the right order.

This change also fixes a bug that would show up if a project has several source directories that contain each other. Before this fix, the compiler would fail with repeated definition error.