### PR TITLE
Log to the user a deduplication is happening

### DIFF
--- a/frontend/src/main/scala/bloop/data/ClientInfo.scala
+++ b/frontend/src/main/scala/bloop/data/ClientInfo.scala
@@ -26,6 +26,8 @@ object ClientInfo {
       // we don't support concurrent CLI client executions for the same build
       AbsolutePath(Files.createDirectories(project.genericClassesDir.underlying).toRealPath())
     }
+
+    override def toString(): String = s"cli client '$id'"
   }
 
   final case class BspClientInfo(
@@ -50,5 +52,7 @@ object ClientInfo {
         }
       )
     }
+
+    override def toString(): String = s"bsp client '$name $version'"
   }
 }

--- a/frontend/src/test/scala/bloop/DeduplicationSpec.scala
+++ b/frontend/src/test/scala/bloop/DeduplicationSpec.scala
@@ -27,7 +27,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
   }
 
   private def checkDeduplication(logger: RecordingLogger, isDeduplicated: Boolean): Unit = {
-    val deduplicated = logger.debugs.exists(_.startsWith("Deduplicating compilation"))
+    val deduplicated = logger.infos.exists(_.startsWith("Deduplicating compilation"))
     if (isDeduplicated) assert(deduplicated) else assert(!deduplicated)
   }
 
@@ -934,6 +934,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
                |Compiled a ???
                |Compiling b (1 Scala source)
                |Compiled b ???
+               |Deduplicating compilation of b from bsp client 'test-bloop-client 1.0.0'
                |Compiling b (1 Scala source)
                |Compiling b (1 Scala source)
                |Compiled b ???


### PR DESCRIPTION

Making more visible the cases where bloop performs a deduplication is better for debugging purposes and will inform users better about what work is the build server doing.