### PR TITLE
Synchronize CLI clients to the same build

### DIFF
--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -20,6 +20,7 @@ import jline.console.ConsoleReader
 import _root_.monix.eval.Task
 
 import scala.annotation.tailrec
+import scala.concurrent.Promise
 
 object Bloop extends CaseApp[CliOptions] {
   private val reader = consoleReader()
@@ -46,7 +47,8 @@ object Bloop extends CaseApp[CliOptions] {
     val config = origin.underlying
     def waitForState(a: Action, t: Task[State]): State = {
       // Ignore the exit status here, all we want is the task to finish execution or fail.
-      Cli.waitUntilEndOfWorld(a, options, state.pool, config, state.logger, Array("from-shell")) {
+      val p = Promise[Unit]().success(())
+      Cli.waitUntilEndOfWorld(a, options, state.pool, config, state.logger, p) {
         t.map(s => { State.stateCache.updateBuild(s.copy(status = ExitStatus.Ok)); s })
       }
 


### PR DESCRIPTION

Bloop does not support concurrent access of projects in the same
build by two different CLI clients. It does, however, support it for
one CLI client and as many BSP clients as they connect to the build
server. For this reason, this commit implements a way to prevent two CLI
clients from running operations concurrently in the same build.