### PR TITLE
Array indices in fish start from 1

### DIFF
--- a/etc/fish/bloop.fish
+++ b/etc/fish/bloop.fish
@@ -54,7 +54,7 @@ function __assert_prev_arg_in
         return 0
     end
     for arg in $argv
-        if string match -q -- $tokens[-1] $argv[0]
+        if string match -q -- $tokens[-1] $argv[1]
             return 1
         end
     end


### PR DESCRIPTION
Was getting the following fish error:

```
/usr/share/fish/vendor_completions.d/bloop.fish (line 57): array indices start at 1, not 0.
        if string match -q -- $tokens[-1] $argv[0]
                                                ^
in function “__assert_prev_arg_in”
        called on standard input
        with parameter list “--only -o”

in command substitution
        called on standard input
```

when trying to autocomplete project name in `bloop test`.