### PR TITLE
Scope javac options and scalac options in compile

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -786,9 +786,9 @@ object BloopDefaults {
           Config.Test(frameworks, options)
         }
 
-        val javacOptions = Keys.javacOptions.value.toList
+        val javacOptions = Keys.javacOptions.in(Keys.compile).in(configuration).value.toList
         val scalacOptions = {
-          val options = Keys.scalacOptions.value.toList
+          val options = Keys.scalacOptions.in(Keys.compile).in(configuration).value.toList
           val internalClasspath = BloopKeys.bloopInternalClasspath.value
           replaceScalacOptionsPaths(options, internalClasspath, logger)
         }


### PR DESCRIPTION
This will give us more precise scalac options than before because some
plugins/users might add specific options in these two scopes. This is
the scope that the `Keys.compile` task accesses when it calls for the
value of scalac options.

I hope that doing this does not force the compilation of inter-module
dependencies. It should not, at least by some local experimentation, but
if it does we could consider reverting the change.

This was discovered during the compilation of http4s, which after this
change is exported and compiled correctly.