### PR TITLE
Add a way to ignore annotation procesor and gradle 5.3.1 test suite

### DIFF
--- a/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
+++ b/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
@@ -22,8 +22,16 @@ import bloop.engine.BuildLoader
 
 import scala.collection.JavaConverters._
 
-class ConfigGenerationSuite {
-  private val gradleVersion: String = "4.8.1"
+class ConfigGenerationSuite481 extends ConfigGenerationSuite{
+  protected val gradleVersion: String = "4.8.1"
+}
+
+class ConfigGenerationSuite531 extends ConfigGenerationSuite{
+  protected val gradleVersion: String = "5.3.1"
+}
+
+abstract class ConfigGenerationSuite {
+  protected val gradleVersion: String
   private val testProjectDir_ = new TemporaryFolder()
   @Rule def testProjectDir: TemporaryFolder = testProjectDir_
 


### PR DESCRIPTION
In gradle 5 a default annotation processor was added and it causes java projects not to be built because of the missing directory. I added a manual step that checks for the flag (due to compatibility reasons couldn't use the proper API) and then:
- if the annotation processor is none we remove the whole option
- otherwise if the option for processor exists and it is not none we create the directory

I also added separate test suites for 4.8.1 and 5.3.1 (in 5.3.1 this was broken)