### PR TITLE
Avoid duplication in `dependencies` section

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -790,7 +790,7 @@ object BloopDefaults {
         // Aggregates are considered to be dependencies too for the sake of user-friendliness
         val aggregates =
           project.aggregate.map(agg => projectNameFromString(agg.project, configuration, logger))
-        val dependenciesAndAggregates = dependencies ++ aggregates
+        val dependenciesAndAggregates = (dependencies ++ aggregates).distinct
 
         val bloopConfigDir = BloopKeys.bloopConfigDir.value
         val out = (bloopConfigDir / project.id).toPath.toAbsolutePath


### PR DESCRIPTION
Most projects that I've seen have the same entries in `dependsOn` and `aggregate`, which means we see these modules twice in the config files. This is just an OCD-induced change, I have no reasons to say it's impacting performance in any way :)