### PR TITLE
Add support for Ammonite REPL

### DIFF
--- a/bin/install.py
+++ b/bin/install.py
@@ -79,7 +79,7 @@ BASH_COMPLETION_DIR = join(BLOOP_INSTALLATION_TARGET, "bash")
 FISH_COMPLETION_DIR = join(BLOOP_INSTALLATION_TARGET, "fish")
 SYSTEMD_SERVICE_DIR = join(BLOOP_INSTALLATION_TARGET, "systemd")
 XDG_DIR = join(BLOOP_INSTALLATION_TARGET, "xdg")
-COURSIER_URL = "https://github.com/coursier/coursier/raw/v" + args.coursier + "/coursier"
+COURSIER_URL = "https://github.com/coursier/coursier/releases/download/v" + args.coursier + "/coursier"
 
 # If this is not a released version of Bloop, we need to extract the commit SHA
 # to know how to download the completion and startup scripts.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -177,6 +177,12 @@ sidebar_label: CLI --help
   <dd><p>Pick reporter to show compilation messages. By default, bloop's used.</p></dd>
   <dt><code>--exclude-root</code> (type: <code>bool</code>)</dt>
   <dd><p>Start up the console compiling only the target project's dependencies.</p></dd>
+  <dt><code>--repl</code> (type: <code>repl</code>)</dt>
+  <dd><p>Pick REPL to run console. The default is Ammonite, available REPLs are: scalac, ammonite</p></dd>
+  <dt><code>--ammonite-version</code> (type: <code>string?</code>)</dt>
+  <dd><p>The Ammonite version to use, it defaults to latest release. Ammonite REPL only.</p></dd>
+  <dt><code>--out-file</code> (type: <code>path?</code>)</dt>
+  <dd><p>The output file where the Ammonite command is written. Ammonite REPL only.</p></dd>
   <dt><code>--config-dir</code> or <code>-c</code> (type: <code>path?</code>)</dt>
   <dd><p>File path to the bloop config directory, defaults to `.bloop` in the current working directory.</p></dd>
   <dt><code>--version</code> or <code>-v</code> (type: <code>bool</code>)</dt>

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -155,10 +155,11 @@ object Commands {
       reporter: ReporterKind = BloopReporter,
       @HelpMessage("Start up the console compiling only the target project's dependencies.")
       excludeRoot: Boolean = false,
-      @HelpMessage(s"Pick REPL to use. By default, Ammonite is used. Available REPLs: ${ReplKind.repls.map(_.name).mkString(", ")}")
+      @HelpMessage(s"Pick REPL to run console. The default is Ammonite, available REPLs are: ${ReplKind.repls.map(_.name).mkString(", ")}")
       repl: ReplKind = AmmoniteRepl,
-      @HelpMessage("The Ammonite version to use. Defaults to latest release.")
+      @HelpMessage("The Ammonite version to use, it defaults to latest release. Ammonite REPL only.")
       ammoniteVersion: Option[String] = None,
+      @HelpMessage("The output file where the Ammonite command is written. Ammonite REPL only.")
       outFile: Option[Path] = None,
       @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends CompilingCommand

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -75,7 +75,7 @@ object Commands {
       includeDependencies: Boolean = false,
       @HelpMessage("Clean a project and all projects depending on it. By default, false.")
       cascade: Boolean = false,
-      @Recurse cliOptions: CliOptions = CliOptions.default,
+      @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends RawCommand
 
   @CommandName("bsp")
@@ -89,7 +89,8 @@ object Commands {
       @HelpMessage("A path to a socket file to communicate through Unix sockets (local only).")
       socket: Option[Path] = None,
       @HelpMessage(
-        "A path to a new existing socket file to communicate through Unix sockets (local only).")
+        "A path to a new existing socket file to communicate through Unix sockets (local only)."
+      )
       pipeName: Option[String] = None,
       @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends RawCommand
@@ -111,7 +112,7 @@ object Commands {
       watch: Boolean = false,
       @HelpMessage("Compile a project and all projects depending on it. By default, false.")
       cascade: Boolean = false,
-      @Recurse cliOptions: CliOptions = CliOptions.default,
+      @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends CompilingCommand
 
   case class Test(
@@ -154,6 +155,11 @@ object Commands {
       reporter: ReporterKind = BloopReporter,
       @HelpMessage("Start up the console compiling only the target project's dependencies.")
       excludeRoot: Boolean = false,
+      @HelpMessage(s"Pick REPL to use. By default, Ammonite is used. Available REPLs: ${ReplKind.repls.map(_.name).mkString(", ")}")
+      repl: ReplKind = AmmoniteRepl,
+      @HelpMessage("The Ammonite version to use. Defaults to latest release.")
+      ammoniteVersion: Option[String] = None,
+      outFile: Option[Path] = None,
       @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends CompilingCommand
 
@@ -180,7 +186,8 @@ object Commands {
       skipJargs: Boolean = false,
       @ExtraName("O")
       @HelpMessage(
-        "If an optimizer is used (e.g. Scala Native or Scala.js), run it in `debug` or `release` mode. Defaults to `debug`.")
+        "If an optimizer is used (e.g. Scala Native or Scala.js), run it in `debug` or `release` mode. Defaults to `debug`."
+      )
       optimize: Option[OptimizerConfig] = None,
       @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends LinkingCommand
@@ -204,7 +211,8 @@ object Commands {
       watch: Boolean = false,
       @ExtraName("O")
       @HelpMessage(
-        "Optimization level of the linker. Valid options: `debug` or `release` mode. Defaults to `debug`.")
+        "Optimization level of the linker. Valid options: `debug` or `release` mode. Defaults to `debug`."
+      )
       optimize: Option[OptimizerConfig] = None,
       @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends LinkingCommand

--- a/frontend/src/main/scala/bloop/cli/ReplKind.scala
+++ b/frontend/src/main/scala/bloop/cli/ReplKind.scala
@@ -1,0 +1,19 @@
+package bloop.cli
+import caseapp.core.ArgParser
+
+sealed abstract class ReplKind(val name: String)
+case object ScalacRepl extends ReplKind("scalac")
+case object AmmoniteRepl extends ReplKind("ammonite")
+
+object ReplKind {
+  val repls: List[ReplKind] = List(ScalacRepl, AmmoniteRepl)
+
+  implicit val replKindRead: ArgParser[ReplKind] = {
+    ArgParser.instance[ReplKind]("repl") { input =>
+      repls.find(_.name == input) match {
+        case Some(repl) => Right(repl)
+        case None => Left(s"Unrecognized repl: $input. Available: ${repls.map(_.name).mkString(", ")}")
+      }
+    }
+  }
+}

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -20,6 +20,12 @@ import caseapp.core.CommandMessages
 import monix.eval.Task
 
 import scala.concurrent.Promise
+import java.nio.file.Files
+import java.nio.charset.StandardCharsets
+import bloop.ScalaInstance
+import scala.collection.immutable.Nil
+import scala.annotation.tailrec
+import java.io.IOException
 
 object Interpreter {
   // This is stack-safe because of Monix's trampolined execution
@@ -223,9 +229,60 @@ object Interpreter {
       case project :: Nil =>
         state.build.getProjectFor(project) match {
           case Some(project) =>
-            compileAnd(cmd, state, List(project), cmd.excludeRoot, "`console`")(
-              state => Tasks.console(state, project, cmd.excludeRoot)
-            )
+            compileAnd(cmd, state, List(project), cmd.excludeRoot, "`console`") { state =>
+              cmd.repl match {
+                case ScalacRepl =>
+                if (cmd.ammoniteVersion.isDefined) {
+                  val errMsg = "Specifying an Ammonite version while using the Scalac console does not work"
+                  Task.now(state.withError(errMsg, ExitStatus.InvalidCommandLineOption))
+                }else {
+                  Tasks.console(state, project, cmd.excludeRoot)
+                }
+                case AmmoniteRepl =>
+                  val dag = state.build.getDagFor(project)
+                  val classpath = project.fullClasspath(dag, state.client)
+                  val jarsCmd =
+                    classpath.flatMap(elem => Seq("--extra-jars", elem.syntax))
+
+                  def findScalaVersion(dag: Dag[Project]): Option[String] = {
+                    dag match {
+                      case Aggregate(dags) => dags.flatMap(findScalaVersion).headOption
+                      case Leaf(value) => value.scalaInstance.map(_.version)
+                      case Parent(value, children) =>
+                        children.flatMap(findScalaVersion) match {
+                          case Nil => value.scalaInstance.map(_.version)
+                          case xs => Some(xs.head)
+                        }
+                    }
+                  }
+
+                  import bloop.engine.ExecutionContext.ioScheduler
+                  val scalaVersion = findScalaVersion(dag)
+                    .getOrElse(ScalaInstance.scalaInstanceFromBloop(state.logger))
+
+                  val ammVersion = cmd.ammoniteVersion.getOrElse("latest.release")
+                  val ammCmd = (List(
+                    "coursier",
+                    "launch",
+                    s"com.lihaoyi:ammonite_$scalaVersion:$ammVersion",
+                    "--main-class",
+                    "ammonite.Main"
+                  ) ++ jarsCmd).mkString(" ")
+                  cmd.outFile match {
+                    case None => Task.now(state.withInfo(ammCmd))
+                    case Some(outFile) =>
+                      try {
+                        Files.write(outFile, ammCmd.getBytes(StandardCharsets.UTF_8))
+                        val msg = s"Wrote Ammonite command to $outFile"
+                        Task.now(state.withInfo(msg))
+                      } catch {
+                        case _: IOException =>
+                          val msg = "Could not write Ammonite command"
+                          Task.now(state.withError(msg, ExitStatus.RunError))
+                      }
+                  }
+              }
+            }
           case None => Task.now(reportMissing(project :: Nil, state))
         }
       case projects =>

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -267,8 +267,7 @@ object Interpreter {
                     "--main-class",
                     "ammonite.Main",
                     "--scala-version",
-                    scalaVersion,
-                    "--force-scala-version"
+                    scalaVersion
                   )
 
                   val classpath = project.fullClasspath(dag, state.client)

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -280,7 +280,7 @@ object Interpreter {
                       try {
                         Files.write(outFile, ammoniteCmd.getBytes(StandardCharsets.UTF_8))
                         val msg = s"Wrote Ammonite command to $outFile"
-                        Task.now(state.withInfo(msg))
+                        Task.now(state.withDebug(msg)(DebugFilter.All))
                       } catch {
                         case _: IOException =>
                           val msg = s"Unexpected error when writing Ammonite command to $outFile"

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -255,7 +255,7 @@ object Interpreter {
 
                   import bloop.engine.ExecutionContext.ioScheduler
                   val dag = state.build.getDagFor(project)
-                  // If none version found, default on Bloop's scala version
+                  // If none version is found (e.g. all Java projects), use Bloop's scala version
                   val scalaVersion = findScalaVersion(dag)
                     .getOrElse(ScalaInstance.scalaInstanceFromBloop(state.logger))
 
@@ -265,7 +265,10 @@ object Interpreter {
                     "launch",
                     s"com.lihaoyi:ammonite_$scalaVersion:$ammVersion",
                     "--main-class",
-                    "ammonite.Main"
+                    "ammonite.Main",
+                    "--scala-version",
+                    scalaVersion,
+                    "--force-scala-version"
                   )
 
                   val classpath = project.fullClasspath(dag, state.client)

--- a/frontend/src/test/scala/bloop/ConsoleSpec.scala
+++ b/frontend/src/test/scala/bloop/ConsoleSpec.scala
@@ -11,7 +11,7 @@ import java.nio.file.Paths
 import bloop.io.AbsolutePath
 
 object ConsoleSpec extends BaseSuite {
-  test("default ammonite console works") {
+  test("default ammonite console works in multi-build project") {
     TestUtil.withinWorkspace { workspace =>
       object Sources {
         val `A.scala` =

--- a/frontend/src/test/scala/bloop/ConsoleSpec.scala
+++ b/frontend/src/test/scala/bloop/ConsoleSpec.scala
@@ -1,0 +1,55 @@
+package bloop
+
+import bloop.testing.BaseSuite
+import bloop.util.TestUtil
+import bloop.logging.RecordingLogger
+import bloop.util.TestProject
+import bloop.cli.ExitStatus
+import coursier.CoursierPaths
+import coursier.Cache
+import scala.util.Properties
+import java.nio.file.Paths
+
+object ConsoleSpec extends BaseSuite {
+  test("console works") {
+    TestUtil.withinWorkspace { workspace =>
+      object Sources {
+        val `A.scala` =
+          """/A.scala
+            |class A
+          """.stripMargin
+        val `B.scala` =
+          """/B.scala
+            |class B extends A
+          """.stripMargin
+      }
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(Sources.`A.scala`))
+      val `B` = TestProject(workspace, "b", List(Sources.`B.scala`), List(`A`))
+      val projects = List(`A`, `B`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.console(`B`)
+      assert(compiledState.status == ExitStatus.Ok)
+      assertValidCompilationState(compiledState, projects)
+
+      val cache = Paths.get(Properties.userHome, ".cache", "coursier", "v1")
+      val expectedCommand = s"coursier launch com.lihaoyi:ammonite_2.12.8:latest.release --main-class ammonite.Main --extra-jars ${workspace.syntax}/resources --extra-jars ${workspace.syntax}/target/b/classes --extra-jars ${workspace.syntax}/target/a/classes --extra-jars $cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.8/scala-library-2.12.8.jar --extra-jars $cache/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.8/scala-compiler-2.12.8.jar --extra-jars $cache/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.6/scala-xml_2.12-1.0.6.jar --extra-jars $cache/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.8/scala-reflect-2.12.8.jar"
+      assertNoDiff(
+        logger.captureTimeInsensitiveInfos
+          .filterNot(
+            msg =>
+              msg == "" || msg.startsWith("Non-compiled module") || msg
+                .startsWith(" Compilation completed in")
+          )
+          .mkString(System.lineSeparator()),
+          s"""|Compiling a (1 Scala source)
+          |Compiled a ???
+          |Compiling b (1 Scala source)
+          |Compiled b ???
+          |$expectedCommand
+          |""".stripMargin
+      )
+    }
+  }
+}

--- a/frontend/src/test/scala/bloop/ConsoleSpec.scala
+++ b/frontend/src/test/scala/bloop/ConsoleSpec.scala
@@ -43,7 +43,7 @@ object ConsoleSpec extends BaseSuite {
       val coursierClasspathArgs =
         classpathB.flatMap(elem => Seq("--extra-jars", elem.syntax))
       val expectedCommand =
-        s"coursier launch com.lihaoyi:ammonite_2.12.7:latest.release --main-class ammonite.Main ${coursierClasspathArgs
+        s"coursier launch com.lihaoyi:ammonite_2.12.7:latest.release --main-class ammonite.Main --scala-version 2.12.7 --force-scala-version ${coursierClasspathArgs
           .mkString(" ")}"
 
       assertNoDiff(

--- a/frontend/src/test/scala/bloop/ConsoleSpec.scala
+++ b/frontend/src/test/scala/bloop/ConsoleSpec.scala
@@ -5,8 +5,7 @@ import bloop.util.TestUtil
 import bloop.logging.RecordingLogger
 import bloop.util.TestProject
 import bloop.cli.ExitStatus
-import coursier.CoursierPaths
-import coursier.Cache
+import coursier.paths.CoursierPaths
 import scala.util.Properties
 import java.nio.file.Paths
 import bloop.io.AbsolutePath

--- a/frontend/src/test/scala/bloop/ConsoleSpec.scala
+++ b/frontend/src/test/scala/bloop/ConsoleSpec.scala
@@ -42,7 +42,7 @@ object ConsoleSpec extends BaseSuite {
       val coursierClasspathArgs =
         classpathB.flatMap(elem => Seq("--extra-jars", elem.syntax))
       val expectedCommand =
-        s"coursier launch com.lihaoyi:ammonite_2.12.7:latest.release --main-class ammonite.Main --scala-version 2.12.7 --force-scala-version ${coursierClasspathArgs
+        s"coursier launch com.lihaoyi:ammonite_2.12.7:latest.release --main-class ammonite.Main --scala-version 2.12.7 ${coursierClasspathArgs
           .mkString(" ")}"
 
       assertNoDiff(

--- a/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
+++ b/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
@@ -144,6 +144,11 @@ trait BloopHelpers {
       new TestState(TestUtil.blockingExecute(compileTask, state))
     }
 
+    def console(projects: TestProject*): TestState = {
+      val compileTask = Run(Commands.Console(projects.map(_.config.name).toList))
+      new TestState(TestUtil.blockingExecute(compileTask, state))
+    }
+
     def compileHandle(
         project: TestProject,
         delay: Option[FiniteDuration] = None,

--- a/launcher/src/test/scala/bloop/launcher/LauncherBaseSuite.scala
+++ b/launcher/src/test/scala/bloop/launcher/LauncherBaseSuite.scala
@@ -16,7 +16,7 @@ import java.io.ByteArrayOutputStream
 import scala.concurrent.Promise
 import scala.collection.JavaConverters._
 
-import coursier.CoursierPaths
+import coursier.paths.CoursierPaths
 
 /**
  * Defines a base suite to test the launcher. The test suite hijacks system

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
 
   val nailgunVersion = "ee3c4343"
   // Used to download the python client instead of resolving
-  val nailgunCommit = "8d42b9b6"
+  val nailgunCommit = "836f0b05"
 
   val zincVersion = "1.2.1+110-85b9a03c"
   val bspVersion = "2.0.0-M1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
 
   val nailgunVersion = "ee3c4343"
   // Used to download the python client instead of resolving
-  val nailgunCommit = "b076917b"
+  val nailgunCommit = "3ad39fb4"
 
   val zincVersion = "1.2.1+110-85b9a03c"
   val bspVersion = "2.0.0-M1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val zincVersion = "1.2.1+110-85b9a03c"
   val bspVersion = "2.0.0-M1"
   val scalazVersion = "7.2.20"
-  val coursierVersion = "1.1.0-M8"
+  val coursierVersion = "1.1.0-M14-4"
   val lmVersion = "1.0.0"
   val configDirsVersion = "10"
   val caseAppVersion = "1.2.0-faster-compile-time"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
 
   val nailgunVersion = "ee3c4343"
   // Used to download the python client instead of resolving
-  val nailgunCommit = "3ad39fb4"
+  val nailgunCommit = "774bc6e3"
 
   val zincVersion = "1.2.1+110-85b9a03c"
   val bspVersion = "2.0.0-M1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
 
   val nailgunVersion = "ee3c4343"
   // Used to download the python client instead of resolving
-  val nailgunCommit = "836f0b05"
+  val nailgunCommit = "b076917b"
 
   val zincVersion = "1.2.1+110-85b9a03c"
   val bspVersion = "2.0.0-M1"


### PR DESCRIPTION
Closes #877 

We launch Ammonite REPL by reading the classpath of the requested
project, and then write a Coursier command that can be executed.
This is picked up by Nailgun, see scalacenter/nailgun#11.

I believe that the version of Coursier used by Bloop does not support the `latest.release` functionality. What should be done about this? Also, there's a potential issue in the tests, I'll leave comment on that.