### PR TITLE
Add source dependencies to maven plugin

### DIFF
--- a/integrations/maven-bloop/src/main/java/bloop/integrations/maven/BloopMojo.java
+++ b/integrations/maven-bloop/src/main/java/bloop/integrations/maven/BloopMojo.java
@@ -37,6 +37,9 @@ public class BloopMojo extends ExtendedScalaContinuousCompileMojo {
     @Parameter(property = "bloop.executionFork", defaultValue = "false")
     private boolean bloopExecutionFork;
 
+    @Parameter(property = "downloadSources", defaultValue = "false")
+    private boolean downloadSources;
+
     @Parameter(property = "bloop.classpathOptions.bootLibrary", defaultValue = "true")
     private boolean classpathOptionsBootLibrary;
 
@@ -80,6 +83,10 @@ public class BloopMojo extends ExtendedScalaContinuousCompileMojo {
 
     public File getBloopConfigDir() {
         return bloopConfigDir;
+    }
+
+    public boolean shouldDownloadSources(){
+        return downloadSources;
     }
 
     public Config.CompileSetup getCompileSetup() {

--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -1,9 +1,8 @@
 package bloop.integrations.maven
 
 import java.io.File
-import java.nio.file.{Files, Path}
+import java.nio.file.{Files, Path, Paths}
 import java.util
-
 import bloop.config.Config
 import org.apache.maven.execution.MavenSession
 import org.apache.maven.model.Resource
@@ -12,8 +11,13 @@ import org.apache.maven.plugin.{MavenPluginManager, Mojo, MojoExecution}
 import org.apache.maven.project.MavenProject
 import org.codehaus.plexus.util.xml.Xpp3Dom
 import scala_maven.AppLauncher
-
+import scala.collection.JavaConverters._
 import scala.collection.mutable
+import org.apache.maven.artifact.Artifact
+import org.apache.maven.shared.invoker.DefaultInvocationRequest
+import java.{util => ju}
+import org.apache.maven.shared.invoker.DefaultInvoker
+import org.apache.maven.shared.invoker.InvocationResult
 
 object MojoImplementation {
   private val ScalaMavenGroupArtifact = "net.alchim31.maven:scala-maven-plugin"
@@ -87,6 +91,23 @@ object MojoImplementation {
       val analysisOut = None
       val sourceDirs = sourceDirs0.map(abs).toList
       val classesDir = abs(classesDir0)
+
+      val resolution = if (mojo.shouldDownloadSources()) {
+        // Run source dependencies download
+        val request = new DefaultInvocationRequest()
+        request.setPomFile(project.getBasedir)
+        request.setGoals(ju.Collections.singletonList("dependency:sources"))
+        val invoker = new DefaultInvoker()
+        val result: InvocationResult = invoker.execute(request)
+
+        val modules =
+          project.getArtifacts().asScala.collect {
+            case art if art.getType() == "jar" => artifactToConfigModule(art, project, session)
+          }
+        Some(Config.Resolution(modules.toList))
+      } else {
+        None
+      }
       val classpath = {
         val projectDependencies = dependencies.flatMap { d =>
           val build = d.getBuild()
@@ -107,7 +128,6 @@ object MojoImplementation {
         val javaHome = Some(abs(mojo.getJavaHome().getParentFile.getParentFile))
         val mainClass = if (launcher.getMainClass().isEmpty) None else Some(launcher.getMainClass())
         val platform = Some(Config.Platform.Jvm(Config.JvmConfig(javaHome, launcher.getJvmArgs().toList), mainClass))
-        val resolution = None
         // Resources in Maven require
         val resources = Some(resources0.asScala.toList.flatMap(a => Option(a.getTargetPath).toList).map(classesDir.resolve))
         val project = Config.Project(name, baseDirectory, sourceDirs, dependencyNames, classpath, out, classesDir, resources, `scala`, java, sbt, test, platform, resolution)
@@ -148,5 +168,40 @@ object MojoImplementation {
       val relativePath = catching(classOf[IllegalArgumentException]) opt (basePath relativize filePath)
       relativePath map (_.toString)
     } else None
+  }
+
+  private def artifactToConfigModule(
+      artifact: Artifact,
+      project: MavenProject,
+      session: MavenSession
+  ): Config.Module = {
+    val base = session.getLocalRepository().getBasedir()
+    val artifactPath = session.getLocalRepository().pathOf(artifact)
+    val sources = artifactPath.replace(".jar", "-sources.jar")
+    val sourcesPath = Paths.get(base).resolve(sources)
+    val sourcesList = if (sourcesPath.toFile().exists()) {
+      List(
+        Config.Artifact(
+          name = artifact.getArtifactId(),
+          classifier = Option("sources"),
+          checksum = None,
+          path = sourcesPath
+        )
+      )
+    } else {
+      Nil
+    }
+    Config.Module(
+      organization = artifact.getGroupId(),
+      name = artifact.getArtifactId(),
+      version = artifact.getVersion(),
+      configurations = None,
+      Config.Artifact(
+        name = artifact.getArtifactId(),
+        classifier = Option(artifact.getClassifier()),
+        checksum = None,
+        path = artifact.getFile().toPath()
+      ) :: sourcesList
+    )
   }
 }


### PR DESCRIPTION
This adds download of source dependencies for project and then appends them to the bloop config.

I have tried the official Maven Api, but that is way too complex to use. Here I use an existing plugin that downloads all source dependencies to local repo and then I resolve all source deps by hand from normal paths.