### PR TITLE
Compile on java9+

### DIFF
--- a/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
+++ b/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
@@ -86,7 +86,7 @@ abstract class ConfigGenerationSuite {
         .withArguments("tasks", "--all")
         .build()
 
-    assert(result.getOutput.lines.contains("bloopInstall"))
+    assert(result.getOutput.linesIterator.contains("bloopInstall"))
   }
 
   @Test def worksWithScala211Project(): Unit = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
   val junitSystemRulesVersion = "1.19.0"
   val graphvizVersion = "0.2.2"
   val directoryWatcherVersion = "0.8.0+6-f651bd93"
-  val mavenApiVersion = "3.5.2"
+  val mavenApiVersion = "3.6.1"
   val mavenAnnotationsVersion = "3.5"
   val mavenScalaPluginVersion = "3.2.2"
   val gradleVersion = "3.0"

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,5 +1,5 @@
-val mvnVersion = "3.5.2"
-val mvnPluginToolsVersion = "3.5"
+val mvnVersion = "3.6.1"
+val mvnPluginToolsVersion = "3.6.0"
 val circeDerivation = "io.circe" %% "circe-derivation" % "0.9.0-M3"
 
 val `bloop-build` = project


### PR DESCRIPTION


MVN version updates fix:

```
[info] Done compiling.
[error] java.lang.IllegalArgumentException
[error] 	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:160)
[error] 	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:143)
[error] 	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:418)
[error] 	at org.apache.maven.tools.plugin.extractor.annotations.scanner.DefaultMojoAnnotationsScanner.analyzeClassStream(DefaultMojoAnnotationsScanner.java:214)
[error] 	at org.apache.maven.tools.plugin.extractor.annotations.scanner.DefaultMojoAnnotationsScanner.scanDirectory(DefaultMojoAnnotationsScanner.java:198)
[error] 	at org.apache.maven.tools.plugin.extractor.annotations.scanner.DefaultMojoAnnotationsScanner.scan(DefaultMojoAnnotationsScanner.java:108)
[error] 	at org.apache.maven.tools.plugin.extractor.annotations.scanner.DefaultMojoAnnotationsScanner.scan(DefaultMojoAnnotationsScanner.java:84)
[error] 	at ch.epfl.scala.sbt.maven.MavenPluginImplementation$MavenPluginDefaults$SbtJavaAnnotationsMojoDescriptorExtractor.getMojoDescriptors(MavenPluginIntegration.scala:289)
[error] 	at ch.epfl.scala.sbt.maven.MavenPluginImplementation$MavenPluginDefaults$.$anonfun$resourceGenerators$4(MavenPluginIntegration.scala:128)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:44)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:40)
[error] 	at sbt.std.Transform$$anon$4.work(System.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:269)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error] 	at sbt.Execute.work(Execute.scala:278)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:269)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[error] 	at java.base/java.lang.Thread.run(Thread.java:834)
[error] (mavenBloop / Compile / managedResources) java.lang.IllegalArgumentException
```