### PR TITLE
Fix case where waiting client is cancelled

### DIFF
--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -49,7 +49,7 @@ object Bloop extends CaseApp[CliOptions] {
       // Ignore the exit status here, all we want is the task to finish execution or fail.
       val p = Promise[Unit]().success(())
       Cli.waitUntilEndOfWorld(a, options, state.pool, config, state.logger, p) {
-        t.map(s => { State.stateCache.updateBuild(s.copy(status = ExitStatus.Ok)); s })
+        t.map(s => { State.stateCache.updateBuild(s.copy(status = ExitStatus.Ok)); s.status })
       }
 
       // Recover the state if the previous task has been successful.


### PR DESCRIPTION
Make sure we don't try to acquire the lock again if the client waiting
for it already disconnected. If that's the case, skip and return a zero
exit status code.