### PR TITLE
Fix not found type errors during incremental compilation

### DIFF
--- a/backend/src/main/scala/bloop/CompileProducts.scala
+++ b/backend/src/main/scala/bloop/CompileProducts.scala
@@ -35,5 +35,5 @@ case class CompileProducts(
     resultForDependentCompilationsInSameRun: PreviousResult,
     resultForFutureCompilationRuns: PreviousResult,
     invalidatedCompileProducts: Set[File],
-    generatedRelativeClassFilePaths: Set[String]
+    generatedRelativeClassFilePaths: Map[String, File]
 )

--- a/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
@@ -135,7 +135,7 @@ object ResultsCache {
                       val dummy = ObservedLogger.dummy(logger, ExecutionContext.ioScheduler)
                       val reporter = new LogReporter(p, dummy, cwd, ReporterConfig.defaultFormat)
                       val products =
-                        CompileProducts(classesDir, classesDir, r, r, Set.empty, Set.empty)
+                        CompileProducts(classesDir, classesDir, r, r, Set.empty, Map.empty)
                       ResultBundle(
                         Result.Success(inputs, reporter, products, 0L, dummyTasks, false),
                         Some(LastSuccessfulResult(inputs, products, Task.now(()))),

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileDependenciesData.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileDependenciesData.scala
@@ -14,7 +14,7 @@ case class CompileDependenciesData(
     dependencyClasspath: Array[AbsolutePath],
     dependentResults: Map[File, PreviousResult],
     allInvalidatedClassFiles: Set[File],
-    allGeneratedClassFilePaths: Set[String]
+    allGeneratedClassFilePaths: Map[String, File]
 ) {
   def buildFullCompileClasspathFor(
       project: Project,
@@ -37,7 +37,7 @@ object CompileDependenciesData {
     val dependentClassesDir = new mutable.HashMap[AbsolutePath, Array[AbsolutePath]]()
     val dependentResources = new mutable.HashMap[AbsolutePath, Array[AbsolutePath]]()
     val dependentInvalidatedClassFiles = new mutable.HashSet[File]()
-    val dependentGeneratedClassFilePaths = new mutable.HashSet[String]()
+    val dependentGeneratedClassFilePaths = new mutable.HashMap[String, File]()
     dependentProducts.foreach {
       case (project, products) =>
         val genericClassesDir = project.genericClassesDir
@@ -50,7 +50,7 @@ object CompileDependenciesData {
 
         dependentClassesDir.put(genericClassesDir, classesDirs.map(AbsolutePath(_)))
         dependentInvalidatedClassFiles.++=(products.invalidatedCompileProducts)
-        dependentGeneratedClassFilePaths.++=(products.generatedRelativeClassFilePaths)
+        dependentGeneratedClassFilePaths.++=(products.generatedRelativeClassFilePaths.iterator)
         dependentResources.put(genericClassesDir, project.pickValidResources)
         resultsMap.put(genericClassesDir.toFile, products.resultForDependentCompilationsInSameRun)
     }
@@ -75,7 +75,7 @@ object CompileDependenciesData {
       rewrittenClasspath,
       resultsMap.toMap,
       dependentInvalidatedClassFiles.toSet,
-      dependentGeneratedClassFilePaths.toSet
+      dependentGeneratedClassFilePaths.toMap
     )
   }
 }


### PR DESCRIPTION
Implements a similar fix as
https://github.com/scalacenter/bloop/pull/881 but this time making sure
we remove generated class files in dependent projects from the
transitive invalidations.