### PR TITLE
Add CLI lock timeout lock and be more flexible while locking

### DIFF
--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -330,7 +330,7 @@ object Cli {
 
     action match {
       case Exit(_) => taskToRun.map(_.status)
-      // Don't synchrknize on lock commands that can run concurrently on the same build for the same client
+      // Don't synchronize on lock commands that can run concurrently on the same build for the same client
       case Run(_: Commands.About, next) => taskToRun.map(_.status)
       case Run(_: Commands.Projects, next) => taskToRun.map(_.status)
       case Run(_: Commands.Autocomplete, next) => taskToRun.map(_.status)

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -20,6 +20,7 @@ import _root_.monix.eval.Task
 
 import scala.concurrent.Promise
 import scala.util.control.NonFatal
+import caseapp.core.CommandsMessages
 
 class Cli
 object Cli {
@@ -314,7 +315,10 @@ object Cli {
   ): Task[ExitStatus] = {
     action match {
       case Exit(_) => taskToRun.map(_.status)
-      // Don't synchronize BSP commands, BSP sessions can run concurrently on the same build
+      // Don't synchronize on lock commands that can run concurrently on the same build for the same client
+      case Run(_: Commands.About, next) => taskToRun.map(_.status)
+      case Run(_: Commands.Projects, next) => taskToRun.map(_.status)
+      case Run(_: Commands.Autocomplete, next) => taskToRun.map(_.status)
       case Run(_: Commands.Bsp, next) => taskToRun.map(_.status)
       case Run(_: Commands.ValidatedBsp, next) => taskToRun.map(_.status)
       case _ =>


### PR DESCRIPTION
Two changes:

### Timeout after default 60s trying to acquire CLI lock

We wait on the CLI lock to be free forever. Use instead a default of 60s 
waiting time and if the other client doesn't exit before that, then we give
up and exit with a error status code.

This is a friendly setting for CI instances that have a shared bloop server
and that commnicate with it via CLI clients. If the server is taken, giving
up and not forcing an infinite wait is good.

Users can tweak the default timeout in seconds via
`-Dbloop.cli-lock.seconds-to-timeout`

### Don't synchronize on CLI lock for non-compiling commands

CLI clients need synchronization so that they don't modify compilation 
inputs or outputs concurrently. However, the lock we use to synchronize the
clients is not required for non-compiling commands such as `bloop about` or
`bloop autocomplete`, which can work concurrently. Allow those.
