### PR TITLE
Add newer version of maven-invoker explicitely to fix windows issues

### DIFF
--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -455,6 +455,7 @@ object BuildImplementation {
         Dependencies.mavenCore,
         Dependencies.mavenPluginApi,
         Dependencies.mavenPluginAnnotations,
+        Dependencies.mavenInvoker,
         // We add an explicit dependency to the maven-plugin artifact in the dependent plugin
         Dependencies.mavenScalaPlugin
           .withExplicitArtifacts(Vector(Artifact("scala-maven-plugin", "maven-plugin", "jar")))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,6 +75,7 @@ object Dependencies {
   import sbt.Provided
   val mavenCore = "org.apache.maven" % "maven-core" % mavenApiVersion % Provided
   val mavenPluginApi = "org.apache.maven" % "maven-plugin-api" % mavenApiVersion
+  val mavenInvoker = "org.apache.maven.shared" % "maven-invoker" % "3.0.1"
   val mavenPluginAnnotations = "org.apache.maven.plugin-tools" % "maven-plugin-annotations" % mavenAnnotationsVersion % Provided
   val mavenScalaPlugin = "net.alchim31.maven" % "scala-maven-plugin" % mavenScalaPluginVersion
 


### PR DESCRIPTION
The transitive invoker dependency is an old version that doesn't work with newer maven due to change of maven execution script from bat to cmd extension.