### PR TITLE
Display Java version and home in bloop about

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -103,9 +103,9 @@ object Interpreter {
 
     logger.info(s"$bloopName v$bloopVersion")
     logger.info("")
-    logger.info(s"Running on Scala v$scalaVersion and Zinc v$zincVersion")
+    logger.info(s"Using Scala v$scalaVersion and Zinc v$zincVersion")
     (javaVersion, javaHome) match {
-      case (Some(v), Some(h)) => logger.info(s"Running on JVM version $v at home $h")
+      case (Some(v), Some(h)) => logger.info(s"Running on Java v$v ($h)")
       case _ =>
     }
     logger.info(s"Maintained by the Scala Center ($developers)")

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -98,10 +98,16 @@ object Interpreter {
     val scalaVersion = bloop.internal.build.BuildInfo.scalaVersion
     val zincVersion = bloop.internal.build.BuildInfo.zincVersion
     val developers = bloop.internal.build.BuildInfo.developers.mkString(", ")
+    val javaVersion = Option(System.getProperty("java.version"))
+    val javaHome = Option(System.getProperty("java.home"))
 
     logger.info(s"$bloopName v$bloopVersion")
     logger.info("")
     logger.info(s"Running on Scala v$scalaVersion and Zinc v$zincVersion")
+    (javaVersion, javaHome) match {
+      case (Some(v), Some(h)) => logger.info(s"Running on JVM version $v at home $h")
+      case _ =>
+    }
     logger.info(s"Maintained by the Scala Center ($developers)")
 
     state.mergeStatus(ExitStatus.Ok)

--- a/frontend/src/test/scala/bloop/nailgun/NailgunSpec.scala
+++ b/frontend/src/test/scala/bloop/nailgun/NailgunSpec.scala
@@ -18,7 +18,7 @@ object NailgunSpec extends BaseSuite with NailgunTestUtils {
   val javaVersion = Option(System.getProperty("java.version"))
   val javaHome = Option(System.getProperty("java.home"))
   val jvmLine = (javaVersion, javaHome) match {
-    case (Some(v), Some(h)) => s"Running on JVM version $v at home $h"
+    case (Some(v), Some(h)) => s"Running on Java v$v ($h)"
     case _ => ""
   }
 
@@ -92,7 +92,7 @@ object NailgunSpec extends BaseSuite with NailgunTestUtils {
       assertNoDiff(
         logger.infos.filterNot(_ == "").mkString(System.lineSeparator()),
         s"""|bloop v${BuildInfo.version}
-            |Running on Scala v${BuildInfo.scalaVersion} and Zinc v${BuildInfo.zincVersion}
+            |Using Scala v${BuildInfo.scalaVersion} and Zinc v${BuildInfo.zincVersion}
             |$jvmLine
             |Maintained by the Scala Center (Martin Duhem, Jorge Vicente Cantero)
             |""".stripMargin
@@ -149,7 +149,7 @@ object NailgunSpec extends BaseSuite with NailgunTestUtils {
       assertNoDiff(
         logger.infos.filterNot(_ == "").mkString(System.lineSeparator()),
         s"""|bloop v${BuildInfo.version}
-            |Running on Scala v${BuildInfo.scalaVersion} and Zinc v${BuildInfo.zincVersion}
+            |Using Scala v${BuildInfo.scalaVersion} and Zinc v${BuildInfo.zincVersion}
             |$jvmLine
             |Maintained by the Scala Center (Martin Duhem, Jorge Vicente Cantero)
             |""".stripMargin

--- a/frontend/src/test/scala/bloop/nailgun/NailgunSpec.scala
+++ b/frontend/src/test/scala/bloop/nailgun/NailgunSpec.scala
@@ -15,6 +15,13 @@ object NailgunSpec extends BaseSuite with NailgunTestUtils {
   val simpleBuild = loadBuildFromResources("simple-build", workspace, new RecordingLogger)
   val configDir = simpleBuild.state.build.origin.underlying
 
+  val javaVersion = Option(System.getProperty("java.version"))
+  val javaHome = Option(System.getProperty("java.home"))
+  val jvmLine = (javaVersion, javaHome) match {
+    case (Some(v), Some(h)) => s"Running on JVM version $v at home $h"
+    case _ => ""
+  }
+
   def withServerInProject[T](op: (RecordingLogger, Client) => T): T =
     withServer(configDir, false, new RecordingLogger(ansiCodesSupported = false))(op)
 
@@ -86,6 +93,7 @@ object NailgunSpec extends BaseSuite with NailgunTestUtils {
         logger.infos.filterNot(_ == "").mkString(System.lineSeparator()),
         s"""|bloop v${BuildInfo.version}
             |Running on Scala v${BuildInfo.scalaVersion} and Zinc v${BuildInfo.zincVersion}
+            |$jvmLine
             |Maintained by the Scala Center (Martin Duhem, Jorge Vicente Cantero)
             |""".stripMargin
       )
@@ -142,6 +150,7 @@ object NailgunSpec extends BaseSuite with NailgunTestUtils {
         logger.infos.filterNot(_ == "").mkString(System.lineSeparator()),
         s"""|bloop v${BuildInfo.version}
             |Running on Scala v${BuildInfo.scalaVersion} and Zinc v${BuildInfo.zincVersion}
+            |$jvmLine
             |Maintained by the Scala Center (Martin Duhem, Jorge Vicente Cantero)
             |""".stripMargin
       )


### PR DESCRIPTION
As suggested in gitter, this PR changes `bloop about` to show the JVM version and java home bloop is running on:

<img width="825" alt="image" src="https://user-images.githubusercontent.com/3615303/58523792-c104be80-8193-11e9-959f-d3c4201fd64b.png">
