### PR TITLE
Add failing test where source files are pulled in multiple times

### DIFF
--- a/frontend/src/main/scala/bloop/io/SourceHasher.scala
+++ b/frontend/src/main/scala/bloop/io/SourceHasher.scala
@@ -83,7 +83,7 @@ object SourceHasher {
       .toListL
 
     Task.mapBoth(discoverFileTree, copyFilesInParallel) {
-      case (_, sources) => sources
+      case (_, sources) => sources.distinct
     }
   }
 }

--- a/frontend/src/test/scala/bloop/CompileSpec.scala
+++ b/frontend/src/test/scala/bloop/CompileSpec.scala
@@ -1299,6 +1299,7 @@ object CompileSpec extends bloop.testing.BaseSuite {
         }
         base.copy(config = base.config.copy(sources = srcs))
       }
+
       val projects = List(`A`)
       val state = loadState(workspace, projects, logger)
       val compiledState = state.compile(`A`)


### PR DESCRIPTION
This manifests when a bloop.config.Config has a specific file as well as
a parent directory of the file listed as sources

This test ensures that the tested bloop config has both `src` and `src/main/scala/Foo.scala` listed as sources.

The code creating the `TestProject` is admittedly a little weird, but it appears that the normal path to creating `TestProjects` is populating their sources with a single directory: https://github.com/scalacenter/bloop/blob/ad4c22f59c3f65853b03b9e0f3390fdfca9c2063/frontend/src/test/scala/bloop/util/TestProject.scala#L123