### PR TITLE
Fix memory leak in listing directories

### DIFF
--- a/backend/src/main/scala/bloop/io/ClasspathHasher.scala
+++ b/backend/src/main/scala/bloop/io/ClasspathHasher.scala
@@ -92,7 +92,7 @@ object ClasspathHasher {
             ()
           }
 
-          /* 
+          /*
            * As a protective measure, set up a task that will be run after 15s
            * of hashing and will complete the downstream promise to unlock
            * downstream clients on the assumption that the hashing of this
@@ -138,7 +138,9 @@ object ClasspathHasher {
           acquiredByOtherTasks.+=(
             Task.fromFuture(promise.future).flatMap { hash =>
               if (hash == BloopStamps.cancelledHash) {
-                logger.warn(s"Disabling sharing of hash for $entry, upstream hashing took more than ${timeoutSeconds}s!")
+                logger.warn(
+                  s"Disabling sharing of hash for $entry, upstream hashing took more than ${timeoutSeconds}s!"
+                )
                 // If the process that acquired it cancels the computation, try acquiring it again
                 Task.fork(Task.eval(acquireHashingEntry(entry, entryIdx)))
               } else {

--- a/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
@@ -151,7 +151,8 @@ object ResultsCache {
               val deleteOrphans = Task {
                 import scala.collection.JavaConverters._
                 val orphanInternalDirs = new mutable.ListBuffer[Path]()
-                Files.list(internalClassesDir.underlying).iterator.asScala.foreach { path =>
+                Paths.list(internalClassesDir).foreach { absPath =>
+                  val path = absPath.underlying
                   val fileName = path.getFileName().toString
                   /*
                    * An internal classes directory is orphan if it's mapped to

--- a/frontend/src/test/scala/bloop/CompileSpec.scala
+++ b/frontend/src/test/scala/bloop/CompileSpec.scala
@@ -270,7 +270,7 @@ object CompileSpec extends bloop.testing.BaseSuite {
       assertNonExistingInternalClassesDir(secondCompiledState)(compiledState, List(`A`))
       // There should only be 2 dirs: current classes dir and external (no empty classes dir)
       val targetA = workspace.resolve("target").resolve("a")
-      val classesDirInA = list(targetA).map(ap => ap.toRelative(targetA).syntax)
+      val classesDirInA = bloop.io.Paths.list(targetA).map(ap => ap.toRelative(targetA).syntax)
       assert(classesDirInA.size == 2)
     }
   }

--- a/frontend/src/test/scala/bloop/testing/BaseSuite.scala
+++ b/frontend/src/test/scala/bloop/testing/BaseSuite.scala
@@ -29,6 +29,7 @@ import utest.ufansi.Str
 import utest.ufansi.Color
 
 import monix.eval.Task
+import bloop.io.Paths
 
 class BaseSuite extends TestSuite with BloopHelpers {
   val pprint = _root_.pprint.PPrinter.BlackWhite
@@ -126,14 +127,6 @@ class BaseSuite extends TestSuite with BloopHelpers {
         }
       }
       .sortBy(_.path.toString)
-  }
-
-  def list(
-      dir: AbsolutePath
-  )(implicit filename: sourcecode.File, line: sourcecode.Line): List[AbsolutePath] = {
-    import java.nio.file.Files
-    import scala.collection.JavaConverters._
-    Files.list(dir.underlying).iterator.asScala.map(AbsolutePath(_)).toList
   }
 
   def assertDifferentExternalClassesDirs(

--- a/notes/v1.3.1.md
+++ b/notes/v1.3.1.md
@@ -49,10 +49,20 @@ Read the complete installation instructions in our [Installation page][installat
 `v1.3.0` added an Ammonite integration in Bloop. Every time `bloop
 console` is run, bloop compiles the project and then creates an Ammonite REPL
 session. This integration required the cooperation of the nailgun script that
-ended up misfunctioning due to a `git revert` error. The bug would print the Ammonite command to run but would not actually run it.
+ended up misfunctioning due to a `git revert` error. The bug would print the
+Ammonite command to run but would not actually run it.
 
 A workaround would be to run `sh -c $(bloop console $PROJECT)`, however
 `v1.3.1` fixes the CLI client so that this workaround is no longer needed.
+
+## Fixed directory resource leak
+
+`v1.3.0` had a piece of code listing directories via `Files.list()` that
+ended up not freeing up open file pointers. Over a long bsp session, these
+open file pointers would add up and eventually lead to fatal exceptions in
+systems such as macOS.
+
+`v1.3.1` fixes that by closing the resources opened by `Files.list()`.
 
 ## Contributors :busts_in_silhouette:
 


### PR DESCRIPTION
Two crashes due to excessive open file pointers in my macOS machine have
fired a red alarm that have led me to discover a memory leak in the way
we were listing directories. This memory leak was caused because
`Files.list` returns an stream that must be closed, but I have not seen
that before because I was converting that stream to a Scala iterator
via the automatic Java converters and at the end of that iteration
resources were not correctly cleaned up.

Now we make sure that we always close these resources.