### PR TITLE
Add debug information to the maven bloop plugin

### DIFF
--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -139,6 +139,7 @@ object MojoImplementation {
       val configTarget = new File(mojo.getBloopConfigDir, s"$name.json")
       val finalTarget = relativize(root, configTarget).getOrElse(configTarget.getAbsolutePath)
       log.info(s"Generated $finalTarget")
+      log.debug(s"Configuration to be serialized:\n$config")
       bloop.config.write(config, configTarget.toPath)
     }
 


### PR DESCRIPTION
Tried working on https://github.com/scalacenter/bloop/issues/928 but we don't have enough information and it's not the first case it fails there. When there is an issue with NPEs while writing config we have no way of detecting where it happens.