### PR TITLE
Enable option for BSP stable classes directories

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspDefinitions.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspDefinitions.scala
@@ -1,0 +1,16 @@
+package bloop.bsp
+
+import io.circe._
+import io.circe.derivation._
+import ch.epfl.scala.bsp.Uri
+
+object BloopBspDefinitions {
+  final case class BloopExtraBuildParams(
+      clientClassesRootDir: Option[Uri]
+  )
+
+  object BloopExtraBuildParams {
+    val encoder: RootEncoder[BloopExtraBuildParams] = deriveEncoder
+    val decoder: Decoder[BloopExtraBuildParams] = deriveDecoder
+  }
+}

--- a/frontend/src/main/scala/bloop/bsp/BspServer.scala
+++ b/frontend/src/main/scala/bloop/bsp/BspServer.scala
@@ -309,7 +309,10 @@ object BspServer {
         import bloop.io.Paths
         try {
           val externalClientClassesDir = latestState.client.getUniqueClassesDirFor(project)
-          if (externalClientClassesDir == project.genericClassesDir) Task.now(())
+          val skipDirectoryManagement =
+            externalClientClassesDir == project.genericClassesDir ||
+              latestState.client.hasManagedClassesDirectories
+          if (skipDirectoryManagement) Task.now(())
           else Task.fork(Task.eval(Paths.delete(externalClientClassesDir))).materialize
         } catch {
           case _: NoSuchFileException => Task.now(())

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -101,13 +101,11 @@ final case class Project(
   }
 
   /**
-   * Defines a path under which Bloop will create all bsp client-owned classes
-   * directories. These directories host compilation products and their
-   * contents are self-managed. The only management bloop does is to create
-   * them upon a connection start and delete them upon a client disconnection.
+   * Defines a project-specific path under which Bloop will create all bsp
+   * client-owned classes directories. These directories host compile products
+   * and their existence and contents are managed by Bloop itself.
    */
-  def bspClientClassesDirectories: AbsolutePath = {
-    import java.nio.file.Files
+  def bspClientClassesRootDirectory: AbsolutePath = {
     genericClassesDir.getParent.resolve("bloop-bsp-clients-classes")
   }
 }

--- a/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
@@ -14,6 +14,7 @@ import monix.eval.Task
 import bloop.engine.ExecutionContext
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
+import ch.epfl.scala.bsp.ScalacOptionsItem
 
 object TcpBspCompileSpec extends BspCompileSpec(BspProtocol.Tcp)
 object LocalBspCompileSpec extends BspCompileSpec(BspProtocol.Local)
@@ -162,7 +163,7 @@ class BspCompileSpec(
 
       // Add extra client classes directory
       val projectA = compiledState.getProjectFor(`A`)
-      val bspClientsRootDir = projectA.bspClientClassesDirectories
+      val bspClientsRootDir = projectA.bspClientClassesRootDirectory
       val orphanClientClassesDirName = projectA.genericClassesDir.underlying.getFileName().toString
       val orphanClientClassesDir =
         bspClientsRootDir.resolve(s"$orphanClientClassesDirName-test-123aAfd12i23")
@@ -189,6 +190,49 @@ class BspCompileSpec(
           FiniteDuration(2, TimeUnit.SECONDS),
           Task(sys.error(s"Expected deletion of $orphanClientClassesDir"))
         )
+      }
+    }
+  }
+
+  test("use client root classes directory and make sure project directories are stable") {
+    TestUtil.withinWorkspace { workspace =>
+      val sources = List(
+        """/main/scala/Foo.scala
+          |class Foo
+          """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", sources)
+      val projects = List(`A`)
+
+      val userClientClassesRootDir = workspace.resolve("root-client-dirs")
+      var firstScalacOptions: List[ScalacOptionsItem] = Nil
+      var secondScalacOptions: List[ScalacOptionsItem] = Nil
+      // Start first client and query for scalac options which creates client classes dirs
+      loadBspState(workspace, projects, logger, Some(userClientClassesRootDir)) { bspState =>
+        val (_, options) = bspState.scalaOptions(`A`)
+        firstScalacOptions = options.items
+        firstScalacOptions.foreach(d => assertIsDirectory(AbsolutePath(d.classDirectory.toPath)))
+      }
+
+      // Start second client and query for scalac options which should use same dirs as before
+      loadBspState(workspace, projects, logger, Some(userClientClassesRootDir)) { bspState =>
+        val (_, options) = bspState.scalaOptions(`A`)
+        secondScalacOptions = options.items
+        secondScalacOptions.foreach(d => assertIsDirectory(AbsolutePath(d.classDirectory.toPath)))
+      }
+
+      firstScalacOptions.zip(secondScalacOptions).foreach {
+        case (firstItem, secondItem) =>
+          assertNoDiff(
+            firstItem.classDirectory.value,
+            secondItem.classDirectory.value
+          )
+      }
+
+      firstScalacOptions.foreach { option =>
+        assertIsDirectory(AbsolutePath(option.classDirectory.toPath))
       }
     }
   }

--- a/frontend/src/test/scala/bloop/testing/BaseSuite.scala
+++ b/frontend/src/test/scala/bloop/testing/BaseSuite.scala
@@ -93,6 +93,12 @@ class BaseSuite extends TestSuite with BloopHelpers {
     }
   }
 
+  def assertIsDirectory(path: AbsolutePath): Unit = {
+    if (!path.isDirectory) {
+      fail(s"directory doesn't exist: $path", stackBump = 1)
+    }
+  }
+
   def assertIsNotDirectory(path: AbsolutePath): Unit = {
     if (path.isDirectory) {
       fail(s"directory exists: $path", stackBump = 1)


### PR DESCRIPTION
The following commit adds support for a parameter that clients can pass
to bloop so that bloop creates stable client classes directories
(client-specific directories) for a given client. The status quo is to
create client-specific directories that are only valid during a given
session and then they are removed but IntelliJ's model unfortunately
assumes stable classes directories. If we create a client classes
directory per session, IntelliJ needs to update the whole build model
and reindex everything, which is apparentely a very costly action that
can take up more than 5 minutes in certain projects.

For the sake of having a good intellij compatibility story, we add this
option. This option implies that the client (e.g. IntelliJ) is 100%
responsible for managing the contents created inside a root directory
provided by the initialize build params option. Bloop will create
project-specific classes directories where it will write the compilation
products produced by every BSP compile request triggered by IntelliJ.
IntelliJ has, in turn, the responsibility of ensuring that a root
directory is only used by one client.

It's worth noting that IntelliJ can only access the contents of the
client classes directories when bloop is not running any action. If
bloop is running any action (compile, test, run), IntelliJ cannot access
the contents of the classes diretories because it has no guarantee that
they will not change when the bloop action is done. Only when bloop runs
no action, that guarantee is met by the build server.

If you're a BSP build client implementor and you've just found this
option, beware that you need to **ensure** that there's only one build
client with a given BSP root directory where client classes directories
are stored. If you cannot ensure this, please do not use this feature.

Fixes https://github.com/scalacenter/bloop/issues/932