### PR TITLE
Use Platform JVM when compiling

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -35,6 +35,7 @@ import bloop.CompileMode.Sequential
 import monix.execution.ExecutionModel
 
 case class CompileInputs(
+    javaInstance: JavaInstance,
     scalaInstance: ScalaInstance,
     compilerCache: CompilerCache,
     sources: Array[AbsolutePath],
@@ -411,9 +412,10 @@ object Compiler {
     }
 
     val start = System.nanoTime()
+    val javaInstance = compileInputs.javaInstance
     val scalaInstance = compileInputs.scalaInstance
     val classpathOptions = compileInputs.classpathOptions
-    val compilers = compileInputs.compilerCache.get(scalaInstance)
+    val compilers = compileInputs.compilerCache.get(javaInstance, scalaInstance)
     val inputs = tracer.trace("creating zinc inputs")(_ => getInputs(compilers))
 
     // We don't need nanosecond granularity, we're happy with milliseconds

--- a/backend/src/main/scala/bloop/JavaInstance.scala
+++ b/backend/src/main/scala/bloop/JavaInstance.scala
@@ -1,0 +1,10 @@
+package bloop
+
+import bloop.io.AbsolutePath
+
+case class JavaInstance(javaHome: AbsolutePath, options: Seq[String] = Seq.empty)
+
+object JavaInstance {
+  val Default = JavaInstance(AbsolutePath(
+    sys.props.get("bloop.compilation.java-home") getOrElse sys.props("java.home")))
+}

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -3,20 +3,17 @@ package bloop.data
 import bloop.exec.JavaEnv
 import bloop.io.AbsolutePath
 import bloop.logging.{DebugFilter, Logger}
-import bloop.ScalaInstance
+import bloop.{JavaInstance, ScalaInstance}
 import bloop.bsp.ProjectUris
 import bloop.config.{Config, ConfigEncoderDecoders}
 import bloop.engine.Dag
 import bloop.engine.tasks.toolchains.{JvmToolchain, ScalaJsToolchain, ScalaNativeToolchain}
 import bloop.io.ByteHasher
-
 import java.nio.charset.StandardCharsets
 
 import scala.util.Try
 import scala.collection.mutable
-
 import ch.epfl.scala.{bsp => Bsp}
-
 import xsbti.compile.{ClasspathOptions, CompileOrder}
 
 final case class Project(


### PR DESCRIPTION
Fixes #968

This is not the final fix.
What works:
- Compiling a project with JDK8 / JDK11 subprojects

What doesn't work:
- Compilation of the JDK8 part (99% of my project) got 2x slower. 
- Compiler JVM options are still not set yet

@jvican can you take a look and give me a hint what causes the slowdown? 
Did I somehow accidentally break preserving compilers between the runs?

Thanks