### PR TITLE
Import Gradle test jvm options and system properties to test platform

### DIFF
--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -45,12 +45,9 @@ object Config {
 
   case class Test(frameworks: List[TestFramework], options: TestOptions)
   object Test {
-    def defaultConfiguration(systemProperties: Iterable[(String, Any)] = Map.empty): Test = {
-      val formattedProperties = for ((k, v) <- systemProperties.toList) yield s"-D$k=$v"
-      val junit = Config.TestArgument(List("-v", "-a") ++ formattedProperties, Some(Config.TestFramework.JUnit))
-      val scalaTest = Config.TestArgument(formattedProperties, Some(Config.TestFramework.ScalaTest))
-      val specs2 = Config.TestArgument(formattedProperties, Some(Config.TestFramework.Specs2))
-      Config.Test(Config.TestFramework.DefaultFrameworks, Config.TestOptions(Nil, List(junit, scalaTest, specs2)))
+    def defaultConfiguration: Test = {
+      val junit = List(Config.TestArgument(List("-v", "-a"), Some(Config.TestFramework.JUnit)))
+      Config.Test(Config.TestFramework.DefaultFrameworks, Config.TestOptions(Nil, junit))
     }
   }
 

--- a/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
+++ b/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
@@ -972,6 +972,9 @@ abstract class ConfigGenerationSuite {
          |apply plugin: 'bloop'
          |
          |test.systemProperty("property", "value")
+         |test.jvmArgs = ["-XX:+UseG1GC", "-verbose:gc"]
+         |test.minHeapSize = "1g"
+         |test.maxHeapSize = "2g"
          |
       """.stripMargin
     )
@@ -992,8 +995,11 @@ abstract class ConfigGenerationSuite {
     val projectFile = new File(bloopDir, s"${projectName}-test.json")
     val projectConfig = readValidBloopConfig(projectFile)
     assert(projectConfig.project.test.isDefined)
-    val test = projectConfig.project.test.get
-    assert(test.options.arguments.exists(_.args.contains("-Dproperty=value")))
+    val platform = projectConfig.project.platform
+    assert(platform.isDefined)
+    assert(platform.get.isInstanceOf[Platform.Jvm])
+    val config = platform.get.asInstanceOf[Platform.Jvm].config
+    assert(config.options.toSet == Set("-XX:+UseG1GC", "-verbose:gc", "-Xms1g", "-Xmx2g", "-Dproperty=value"))
   }
 
 

--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -123,7 +123,7 @@ object MojoImplementation {
       // FORMAT: OFF
       val config = {
         val sbt = None
-        val test = Some(Config.Test.defaultConfiguration())
+        val test = Some(Config.Test.defaultConfiguration)
         val java = Some(Config.Java(mojo.getJavacArgs().asScala.toList))
         val `scala` = Some(Config.Scala(mojo.getScalaOrganization(), mojo.getScalaArtifactID(), mojo.getScalaVersion(), scalacArgs, allScalaJars, analysisOut, Some(compileSetup)))
         val javaHome = Some(abs(mojo.getJavaHome().getParentFile.getParentFile))


### PR DESCRIPTION
settings.

This reverts #975 and replaces it with a better and more universal approach.

Gradle `test.systemProperties` actually sets the system properties on the forked test JVM. This patch brings the same behavior to Bloop. Additionally `test.jvmArgs` and memory settings are also exported to JVM args of the test platform.

