### PR TITLE
Fix missing dependencies to files referenced directly

### DIFF
--- a/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
+++ b/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
@@ -808,6 +808,8 @@ abstract class ConfigGenerationSuite {
     writeBuildScript(
       buildFileB,
       s"""
+         |import org.gradle.internal.jvm.Jvm
+         |
          |plugins {
          |  id 'bloop'
          |}
@@ -822,6 +824,7 @@ abstract class ConfigGenerationSuite {
          |dependencies {
          |  compile 'org.typelevel:cats-core_2.12:1.2.0'
          |  compile(project(path: ':a',  configuration: 'foo'))
+         |  testRuntime files(Jvm.current().toolsJar)
          |}
       """.stripMargin
     )
@@ -869,6 +872,7 @@ abstract class ConfigGenerationSuite {
     assert(hasClasspathEntryName(configBTest, "scala-library"))
     assert(hasClasspathEntryName(configB, "cats-core"))
     assert(hasClasspathEntryName(configBTest, "cats-core"))
+    assert(hasClasspathEntryName(configBTest, "tools.jar"))
 
     assert(compileBloopProject("b", bloopDir).status.isOk)
   }


### PR DESCRIPTION
In gradle it is possible to define a dependency to an external file
like this:

  dependencies {
    runtime files(Jvm.current().toolsJar)
  }

Unfortunately such dependencies do not come as ResolvedArtifacts
from the Gradle API, and therefore they were missed in the generated
bloop configuration. This commit fixes importing them.

Fixes #978