### PR TITLE
Fix "Type not found" errors due to incorrect class file invalidation

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -256,7 +256,8 @@ object Compiler {
             f =>
               // A safety measure in case Zinc does not get a complete list of generated classes
               val filePath = f.getAbsolutePath
-              if (!filePath.startsWith(readOnlyClassesDirPath)) true
+              if (!filePath.startsWith(readOnlyClassesDirPath))
+                false
               else {
                 import compileInputs.generatedClassFilePathsInDependentProjects
                 val relativeFilePath = filePath.replace(readOnlyClassesDirPath, "")


### PR DESCRIPTION
A bug in Compiler sometimes caused newly generated classes
to be invalidated and removed from the classpath during incremental
compilation. In case their source was not present in the input source
set in the following iteration, this led to errors of the
following kind:

[error] [E1] a/src/<file.scala>:
     not found: type <type>

Fixes #972