### PR TITLE
Don't ever recompile already compiled classes

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -256,7 +256,8 @@ object Compiler {
             f =>
               // A safety measure in case Zinc does not get a complete list of generated classes
               val filePath = f.getAbsolutePath
-              if (!filePath.startsWith(readOnlyClassesDirPath)) true
+              if (!filePath.startsWith(readOnlyClassesDirPath))
+                false
               else {
                 import compileInputs.generatedClassFilePathsInDependentProjects
                 val relativeFilePath = filePath.replace(readOnlyClassesDirPath, "")

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopIncremental.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopIncremental.scala
@@ -104,7 +104,7 @@ object BloopIncremental {
         } yield callback.get
       }
 
-      incremental.entrypoint(initialInvClasses, initialInvSources, setOfSources, binaryChanges, lookup, previous, doCompile, manager, 1)
+      incremental.entrypoint(initialInvClasses, initialInvSources, setOfSources, Set.empty, binaryChanges, lookup, previous, doCompile, manager, 1)
     }
 
     analysisTask.materialize.map {


### PR DESCRIPTION
Fixes a highly critical problem that caused inconsistent
behavior of incremental compiler and could led to abysmal compile times 
as well as analysis corruption and not recompiling classes that 
should be compiled.

Invalidating a class that was already recompiled once and then letting
javac recompile it again caused javac to not actually recompile
the class and not emit the analysis for that class. And because the
class was already invalidated, its previous analysis was pruned,
hence lost completely. A class without analysis was then considered
removed and triggered many API changes, which invalidated classes
that shouldn't really be invalidated.

Impact of the bug:
- Recompiling far too many Java classes, sometimes
  orders of magnitude more
- Recompiling the same classes again and again
- Running too many rounds of incremental compilation,
  eventually triggering a slow "brute-force" transitive step
- **Saving incorrect analysis with many classes missing**
- **Not recompiling dependent classes on the next recompilation, due
  to broken, incomplete analysis loaded from the previous run**

Fixes #986, #987

@jvican I know that you asked me to stop submitting PRs, but this one is highly critical
and I believe the community will like it. Without this PR, Java compilation was just broken for any 
larger, non-trivial changeset. 