### PR TITLE
Fixes unnecessary dependency in sbt extractor

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -484,7 +484,7 @@ object BloopDefaults {
         )
 
         mapping(configuration.name) match {
-          case Nil => List(projectNameFromString(ref.project, Compile, logger))
+          case Nil => Nil
           case configurationNames =>
             val configurations = configurationNames.iterator
               .flatMap(name => activeDependentConfigurations.find(_.name == name).toList)

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/build.sbt
@@ -83,6 +83,9 @@ checkBloopFile in ThisBuild := {
     "Source file is missing in foo."
   )
 
+  val barConfigContents = readConfigFor("bar", allConfigs)
+  assert(barConfigContents.project.dependencies.sorted == List())
+
   // Test that 'yay-test' does not add a dependency to 'foo-test' without the "test->test" configuration
   // Default if no configuration is dependency to `Compile` (double checked by '-> yay/test:compile')
   val yayTestConfigContents = readConfigFor("yay-test", allConfigs)
@@ -90,7 +93,6 @@ checkBloopFile in ThisBuild := {
 
   // Test that zee-it contains a dependency to foo-test
   val zeeItConfigContents = readConfigFor("zee-it", allConfigs)
-  println(zeeItConfigContents.project.dependencies.sorted)
   assert(zeeItConfigContents.project.dependencies.sorted == List("foo-test", "zee"))
 }
 


### PR DESCRIPTION
This commit removes a bit of logic that was inherited from the previous
extractor that was not configuration based and that was not spotted
before. This extra line was adding an unncessary compile dependency
between projects when the project instead had another dependency (e.g.
test, it) on that project.