### PR TITLE
Delete both new and read-only paths for invalidated symbols

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -226,7 +226,6 @@ object Compiler {
       new mutable.ListBuffer[(AbsolutePath, BraveTracer) => Task[Unit]]()
     def getClassFileManager(): ClassFileManager = {
       new ClassFileManager {
-        private[this] val invalidatedClassFilesInLastRun = new mutable.HashSet[File]
         def delete(classes: Array[File]): Unit = {
           // Add to the blacklist so that we never copy them
           allInvalidatedClassFilesForProject.++=(classes)
@@ -284,6 +283,9 @@ object Compiler {
             allGeneratedRelativeClassFilePaths.put(relativeClassFilePath, generatedClassFile)
             val rebasedClassFile =
               new File(newClassFile.replace(newClassesDirPath, readOnlyClassesDirPath))
+            // Delete generated class file + rebased class file because
+            // invalidations can happen in both paths, no-op if missing
+            allInvalidatedClassFilesForProject.-=(generatedClassFile)
             allInvalidatedClassFilesForProject.-=(rebasedClassFile)
             supportedCompileProducts.foreach { supportedProductSuffix =>
               val productName = rebasedClassFile


### PR DESCRIPTION
When a symbol is generated, we removed the rebased read-only path from
the invalidated class files map assuming that an invalidated symbol
used always the read-only classes directory path. However, that's not
always the case -- the paths of an invalidated symbol can also use the
new classes directory and not handling that was an oversight. This
commit just fixes that so that we attempt to both remove the read-only
classes dir path and the write-only classes dir path.

Fixes #972.