### PR TITLE
Propagate origin id from BSP requests to loggers

### DIFF
--- a/backend/src/main/scala/bloop/logging/BloopLogger.scala
+++ b/backend/src/main/scala/bloop/logging/BloopLogger.scala
@@ -19,7 +19,8 @@ final class BloopLogger(
     err: PrintStream,
     private val debugCount: Int,
     colorOutput: Boolean,
-    val debugFilter: DebugFilter
+    val debugFilter: DebugFilter,
+    originId: Option[String]
 ) extends Logger {
   override def ansiCodesSupported() = true
   override def debug(msg: String)(implicit ctx: DebugFilter): Unit =
@@ -31,13 +32,16 @@ final class BloopLogger(
 
   override def asDiscrete: Logger = {
     if (debugCount <= 0) this
-    else new BloopLogger(name, out, err, debugCount - 1, colorOutput, debugFilter)
+    else new BloopLogger(name, out, err, debugCount - 1, colorOutput, debugFilter, originId)
   }
 
   override def isVerbose: Boolean = debugCount > 0
   override def asVerbose: Logger = {
-    new BloopLogger(name, out, err, debugCount + 1, colorOutput, debugFilter)
+    new BloopLogger(name, out, err, debugCount + 1, colorOutput, debugFilter, originId)
   }
+
+  override def withOriginId(originId: Option[String]): Logger =
+    new BloopLogger(name, out, err, debugCount, colorOutput, debugFilter, originId)
 
   @scala.annotation.tailrec
   private def trace(prefix: String, exception: Throwable): Unit = {
@@ -103,7 +107,9 @@ object BloopLogger {
       isVerbose: Boolean,
       colorOutput: Boolean,
       filter: DebugFilter
-  ): BloopLogger = new BloopLogger(name, out, err, if (isVerbose) 1 else 0, colorOutput, filter)
+  ): BloopLogger = {
+    new BloopLogger(name, out, err, if (isVerbose) 1 else 0, colorOutput, filter, None)
+  }
 
   /**
    * Instantiates a new `BloopLogger` using the specified streams.

--- a/backend/src/main/scala/bloop/logging/ObservedLogger.scala
+++ b/backend/src/main/scala/bloop/logging/ObservedLogger.scala
@@ -17,6 +17,8 @@ final class ObservedLogger[+UseSiteLogger <: Logger] private (
   override def asDiscrete: Logger = new ObservedLogger(underlying.asDiscrete, observer)
   override def asVerbose: Logger = new ObservedLogger(underlying.asVerbose, observer)
   override def ansiCodesSupported: Boolean = underlying.ansiCodesSupported
+  override def withOriginId(originId: Option[String]): Logger =
+    new ObservedLogger(underlying.withOriginId(originId), observer)
 
   override def debugFilter: DebugFilter = underlying.debugFilter
   override def debug(msg: String)(implicit ctx: DebugFilter): Unit =

--- a/backend/src/test/scala/bloop/logging/RecordingLogger.scala
+++ b/backend/src/test/scala/bloop/logging/RecordingLogger.scala
@@ -131,6 +131,7 @@ class RecordingLogger(
   override def isVerbose: Boolean = true
   override def asVerbose: Logger = this
   override def asDiscrete: Logger = this
+  override def withOriginId(originId: Option[String]): Logger = this
 
   def dump(out: PrintStream = System.out): Unit = {
     out.println {

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -16,7 +16,7 @@ import bloop.engine.tasks.toolchains.{ScalaJsToolchain, ScalaNativeToolchain}
 import bloop.engine._
 import bloop.internal.build.BuildInfo
 import bloop.io.{AbsolutePath, RelativePath}
-import bloop.logging.{BspServerLogger, DebugFilter}
+import bloop.logging.{BspServerLogger, DebugFilter, Logger}
 import bloop.reporter.{BspProjectReporter, ProblemPerPhase, ReporterConfig, ReporterInputs}
 import bloop.testing.{BspLoggingEventHandler, TestInternals}
 
@@ -64,7 +64,7 @@ final class BloopBspServices(
   private type BspResult[T] = Task[(State, BspResponse[T])]
 
   /** The return type of a bsp computation wrapped by `ifInitialized` */
-  private type BspComputation[T] = State => BspResult[T]
+  private type BspComputation[T] = (State, BspServerLogger) => BspResult[T]
 
   /**
    * Schedule the async response handlers to run on the default computation
@@ -78,13 +78,6 @@ final class BloopBspServices(
   // Disable ansi codes for now so that the BSP clients don't get unescaped color codes
   private val taskIdCounter: AtomicInt = AtomicInt(0)
   private val baseBspLogger = BspServerLogger(callSiteState, client, taskIdCounter, false)
-
-  def bspLoggerForRequest(originId: Option[String]): BspServerLogger = {
-    originId match {
-      case None => baseBspLogger
-      case Some(originId) => baseBspLogger.withOriginId(originId)
-    }
-  }
 
   final val services = JsonRpcServices
     .empty(baseBspLogger)
@@ -137,7 +130,10 @@ final class BloopBspServices(
          * had and therefore we can fail to reset diagnostics. */
         val newState = {
           val previous = previouslyFailedCompilations.toMap
-          state0.copy(results = state0.results.replacePreviousResults(previous))
+          state0.copy(
+            results = state0.results.replacePreviousResults(previous),
+            client = clientInfo
+          )
         }
 
         currentState = newState
@@ -277,8 +273,9 @@ final class BloopBspServices(
   }
 
   def ifInitialized[T](
-      bspLogger: BspServerLogger
+      originId: Option[String]
   )(compute: BspComputation[T]): BspEndpointResponse[T] = {
+    val bspLogger = baseBspLogger.withOriginId(originId)
     // Give a time window for `isInitialized` to complete, otherwise assume it didn't happen
     isInitializedTask
       .flatMap(response => clientInfoTask.map(clientInfo => response.map(_ => clientInfo)))
@@ -289,9 +286,8 @@ final class BloopBspServices(
       .flatMap {
         case Left(e) => Task.now(Left(e))
         case Right(clientInfo) =>
-          reloadState(currentState.build.origin, clientInfo, None, bspLogger).flatMap { state0 =>
-            val state = state0.copy(client = clientInfo)
-            compute(state).flatMap {
+          reloadState(currentState.build.origin, clientInfo, None, bspLogger).flatMap { state =>
+            compute(state, bspLogger).flatMap {
               case (state, e) => saveState(state, bspLogger).map(_ => e)
             }
           }
@@ -338,7 +334,8 @@ final class BloopBspServices(
       userProjects: Seq[ProjectMapping],
       state: State,
       compileArgs: List[String],
-      bspLogger: BspServerLogger
+      originId: Option[String],
+      logger: BspServerLogger
   ): BspResult[bsp.CompileResult] = {
     val cancelCompilation = Promise[Unit]()
     def reportError(p: Project, problems: List[ProblemPerPhase], elapsedMs: Long): String = {
@@ -351,6 +348,7 @@ final class BloopBspServices(
     def compile(projects: List[Project]): Task[State] = {
       val cwd = state.build.origin.getParent
       val config = ReporterConfig.defaultFormat.copy(reverseOrder = false)
+
       val createReporter = (inputs: ReporterInputs[BspServerLogger]) => {
         val btid = bsp.BuildTargetIdentifier(inputs.project.bspUri)
         val reportAllPreviousProblems = {
@@ -370,15 +368,7 @@ final class BloopBspServices(
       }
 
       val dag = Aggregate(projects.map(p => state.build.getDagFor(p)))
-      CompileTask.compile(
-        state,
-        dag,
-        createReporter,
-        pipeline,
-        false,
-        cancelCompilation,
-        bspLogger
-      )
+      CompileTask.compile(state, dag, createReporter, pipeline, false, cancelCompilation, logger)
     }
 
     val projects: List[Project] = {
@@ -412,11 +402,11 @@ final class BloopBspServices(
 
       val response: Either[ProtocolError, bsp.CompileResult] = {
         if (cancelCompilation.isCompleted)
-          Right(bsp.CompileResult(None, bsp.StatusCode.Cancelled, None, None))
+          Right(bsp.CompileResult(originId, bsp.StatusCode.Cancelled, None, None))
         else {
           errorMsgs match {
-            case Nil => Right(bsp.CompileResult(None, bsp.StatusCode.Ok, None, None))
-            case xs => Right(bsp.CompileResult(None, bsp.StatusCode.Error, None, None))
+            case Nil => Right(bsp.CompileResult(originId, bsp.StatusCode.Ok, None, None))
+            case xs => Right(bsp.CompileResult(originId, bsp.StatusCode.Error, None, None))
           }
         }
       }
@@ -426,16 +416,15 @@ final class BloopBspServices(
   }
 
   def compile(params: bsp.CompileParams): BspEndpointResponse[bsp.CompileResult] = {
-    val bspLogger = bspLoggerForRequest(params.originId)
-    ifInitialized(bspLogger) { (state: State) =>
+    ifInitialized(params.originId) { (state: State, logger: BspServerLogger) =>
       mapToProjects(params.targets, state) match {
         case Left(error) =>
           // Log the mapping error to the user via a log event + an error status code
-          bspLogger.error(error)
+          logger.error(error)
           Task.now((state, Right(bsp.CompileResult(None, bsp.StatusCode.Error, None, None))))
         case Right(mappings) =>
           val compileArgs = params.arguments.getOrElse(Nil)
-          compileProjects(mappings, state, compileArgs, bspLogger)
+          compileProjects(mappings, state, compileArgs, params.originId, logger)
       }
     }
   }
@@ -443,11 +432,10 @@ final class BloopBspServices(
   def scalaTestClasses(
       params: bsp.ScalaTestClassesParams
   ): BspEndpointResponse[bsp.ScalaTestClassesResult] = {
-    val bspLogger = bspLoggerForRequest(params.originId)
-    ifInitialized(bspLogger) { state: State =>
+    ifInitialized(params.originId) { (state: State, logger: BspServerLogger) =>
       mapToProjects(params.targets, state) match {
         case Left(error) =>
-          bspLogger.error(error)
+          logger.error(error)
           Task.now((state, Right(bsp.ScalaTestClassesResult(Nil))))
 
         case Right(projects) =>
@@ -476,16 +464,16 @@ final class BloopBspServices(
       Tasks.test(state, List(project), Nil, testFilter, handler, false)
     }
 
-    val bspLogger = bspLoggerForRequest(params.originId)
-    ifInitialized(bspLogger) { (state: State) =>
+    val originId = params.originId
+    ifInitialized(originId) { (state: State, logger: BspServerLogger) =>
       mapToProjects(params.targets, state) match {
         case Left(error) =>
           // Log the mapping error to the user via a log event + an error status code
-          bspLogger.error(error)
-          Task.now((state, Right(bsp.TestResult(None, bsp.StatusCode.Error, None, None))))
+          logger.error(error)
+          Task.now((state, Right(bsp.TestResult(originId, bsp.StatusCode.Error, None, None))))
         case Right(mappings) =>
           val args = params.arguments.getOrElse(Nil)
-          compileProjects(mappings, state, args, bspLogger).flatMap {
+          compileProjects(mappings, state, args, originId, logger).flatMap {
             case (newState, compileResult) =>
               compileResult match {
                 case Right(result) =>
@@ -495,7 +483,7 @@ final class BloopBspServices(
 
                   sequentialTestExecution.materialize.map(_.toEither).map {
                     case Right(newState) =>
-                      (newState, Right(bsp.TestResult(None, bsp.StatusCode.Ok, None, None)))
+                      (newState, Right(bsp.TestResult(originId, bsp.StatusCode.Ok, None, None)))
                     case Left(e) =>
                       //(newState, Right(bsp.TestResult(None, bsp.StatusCode.Error, None)))
                       val errorMessage =
@@ -518,11 +506,10 @@ final class BloopBspServices(
         className <- Tasks.findMainClasses(state, project)
       } yield bsp.ScalaMainClass(className, Nil, Nil)
 
-    val bspLogger = bspLoggerForRequest(params.originId)
-    ifInitialized(bspLogger) { state: State =>
+    ifInitialized(params.originId) { (state: State, logger: BspServerLogger) =>
       mapToProjects(params.targets, state) match {
         case Left(error) =>
-          bspLogger.error(error)
+          logger.error(error)
           Task.now((state, Right(bsp.ScalaMainClassesResult(Nil))))
 
         case Right(projects) =>
@@ -573,16 +560,16 @@ final class BloopBspServices(
       }
     }
 
-    val bspLogger = bspLoggerForRequest(params.originId)
-    ifInitialized(bspLogger) { (state: State) =>
+    val originId = params.originId
+    ifInitialized(originId) { (state: State, logger: BspServerLogger) =>
       mapToProject(params.target, state) match {
         case Left(error) =>
           // Log the mapping error to the user via a log event + an error status code
-          bspLogger.error(error)
-          Task.now((state, Right(bsp.RunResult(None, bsp.StatusCode.Error))))
+          logger.error(error)
+          Task.now((state, Right(bsp.RunResult(originId, bsp.StatusCode.Error))))
         case Right((tid, project)) =>
           val args = params.arguments.getOrElse(Nil)
-          compileProjects(List((tid, project)), state, args, bspLogger).flatMap {
+          compileProjects(List((tid, project)), state, args, originId, logger).flatMap {
             case (newState, compileResult) =>
               compileResult match {
                 case Right(result) =>
@@ -603,7 +590,7 @@ final class BloopBspServices(
                           else if (exitStatus.isOk) bsp.StatusCode.Ok
                           else bsp.StatusCode.Error
                         }
-                        (state, Right(bsp.RunResult(None, status)))
+                        (state, Right(bsp.RunResult(originId, status)))
                     }
 
                 case Left(error) => Task.now((state, Left(error)))
@@ -640,8 +627,7 @@ final class BloopBspServices(
   def buildTargets(
       request: bsp.WorkspaceBuildTargetsRequest
   ): BspEndpointResponse[bsp.WorkspaceBuildTargetsResult] = {
-    val bspLogger = bspLoggerForRequest(None)
-    ifInitialized(bspLogger) { (state: State) =>
+    ifInitialized(None) { (state: State, logger: BspServerLogger) =>
       def reportBuildError(msg: String): Unit = {
         endpoints.Build.showMessage.notify(
           ShowMessageParams(MessageType.Error, None, None, msg)
@@ -670,7 +656,7 @@ final class BloopBspServices(
                 canTest = true,
                 canRun = true
               )
-              val javaInstance = ScalaInstance.scalaInstanceForJavaProjects(bspLogger)(ioScheduler)
+              val javaInstance = ScalaInstance.scalaInstanceForJavaProjects(logger)(ioScheduler)
               val isJavaOnly = p.scalaInstance == javaInstance
               val languageIds =
                 if (isJavaOnly) BloopBspServices.JavaOnly
@@ -728,12 +714,11 @@ final class BloopBspServices(
       Task.now((state, Right(response)))
     }
 
-    val bspLogger = bspLoggerForRequest(None)
-    ifInitialized(bspLogger) { (state: State) =>
+    ifInitialized(None) { (state: State, logger: BspServerLogger) =>
       mapToProjects(request.targets, state) match {
         case Left(error) =>
           // Log the mapping error to the user via a log event + an error status code
-          bspLogger.error(error)
+          logger.error(error)
           Task.now((state, Right(bsp.SourcesResult(Nil))))
         case Right(mappings) => sources(mappings, state)
       }
@@ -766,12 +751,11 @@ final class BloopBspServices(
       Task.now((state, Right(response)))
     }
 
-    val bspLogger = bspLoggerForRequest(None)
-    ifInitialized(bspLogger) { (state: State) =>
+    ifInitialized(None) { (state: State, logger: BspServerLogger) =>
       mapToProjects(request.targets, state) match {
         case Left(error) =>
           // Log the mapping error to the user via a log event + an error status code
-          bspLogger.error(error)
+          logger.error(error)
           Task.now((state, Right(bsp.ResourcesResult(Nil))))
         case Right(mappings) => resources(mappings, state)
       }
@@ -803,12 +787,11 @@ final class BloopBspServices(
       Task.now((state, Right(response)))
     }
 
-    val bspLogger = bspLoggerForRequest(None)
-    ifInitialized(bspLogger) { (state: State) =>
+    ifInitialized(None) { (state: State, logger: BspServerLogger) =>
       mapToProjects(request.targets, state) match {
         case Left(error) =>
           // Log the mapping error to the user via a log event + an error status code
-          bspLogger.error(error)
+          logger.error(error)
           Task.now((state, Right(bsp.DependencySourcesResult(Nil))))
         case Right(mappings) => sources(mappings, state)
       }
@@ -841,12 +824,11 @@ final class BloopBspServices(
       Task.now((state, Right(response)))
     }
 
-    val bspLogger = bspLoggerForRequest(None)
-    ifInitialized(bspLogger) { (state: State) =>
+    ifInitialized(None) { (state: State, logger: BspServerLogger) =>
       mapToProjects(request.targets, state) match {
         case Left(error) =>
           // Log the mapping error to the user via a log event + an error status code
-          bspLogger.error(error)
+          logger.error(error)
           // TODO(jvican): Add status code to scalac options result
           Task.now((state, Right(bsp.ScalacOptionsResult(Nil))))
         case Right(mappings) => scalacOptions(mappings, state)

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -17,7 +17,7 @@ import bloop.engine.tasks.compilation.{FinalCompileResult, _}
 import bloop.io.{AbsolutePath, ParallelOps}
 import bloop.io.ParallelOps.CopyMode
 import bloop.tracing.BraveTracer
-import bloop.logging.{BspServerLogger, DebugFilter, Logger, ObservedLogger, LoggerAction}
+import bloop.logging.{DebugFilter, Logger, ObservedLogger, LoggerAction}
 import bloop.reporter.{
   Reporter,
   ReporterAction,

--- a/frontend/src/main/scala/bloop/logging/BspClientLogger.scala
+++ b/frontend/src/main/scala/bloop/logging/BspClientLogger.scala
@@ -9,6 +9,8 @@ final class BspClientLogger[L <: Logger](val underlying: L) extends Logger with 
   override def isVerbose: Boolean = underlying.isVerbose
   override def asDiscrete: Logger = new BspClientLogger(underlying.asDiscrete)
   override def asVerbose: Logger = new BspClientLogger(underlying.asVerbose)
+  override def withOriginId(originId: Option[String]): Logger =
+    new BspClientLogger(underlying.withOriginId(originId))
 
   override def printDebug(msg: String): Unit = underlying.printDebug(msg)
   override def debug(msg: String)(implicit ctx: DebugFilter): Unit =

--- a/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
+++ b/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
@@ -27,16 +27,20 @@ final class BspServerLogger private (
     underlying: Logger,
     implicit val client: JsonRpcClient,
     taskIdCounter: AtomicInt,
-    ansiSupported: Boolean
+    ansiSupported: Boolean,
+    val originId: Option[String]
 ) extends Logger
     with ScribeAdapter {
   override def debugFilter: DebugFilter = underlying.debugFilter
 
   override def isVerbose: Boolean = underlying.isVerbose
   override def asDiscrete: Logger =
-    new BspServerLogger(name, underlying.asDiscrete, client, taskIdCounter, ansiSupported)
+    new BspServerLogger(name, underlying.asDiscrete, client, taskIdCounter, ansiSupported, originId)
   override def asVerbose: Logger =
-    new BspServerLogger(name, underlying.asVerbose, client, taskIdCounter, ansiSupported)
+    new BspServerLogger(name, underlying.asVerbose, client, taskIdCounter, ansiSupported, originId)
+
+  def withOriginId(originId: String): BspServerLogger =
+    new BspServerLogger(name, underlying, client, taskIdCounter, ansiSupported, Some(originId))
 
   override def ansiCodesSupported: Boolean = ansiSupported || underlying.ansiCodesSupported()
 
@@ -47,7 +51,7 @@ final class BspServerLogger private (
   override def trace(t: Throwable): Unit = underlying.trace(t)
 
   override def error(msg: String): Unit = {
-    Build.logMessage.notify(bsp.LogMessageParams(bsp.MessageType.Error, None, None, msg))
+    Build.logMessage.notify(bsp.LogMessageParams(bsp.MessageType.Error, None, originId, msg))
     ()
   }
 
@@ -57,18 +61,18 @@ final class BspServerLogger private (
     // Metals and other clients should be showing `showMessage` to users
     import ch.epfl.scala.bsp.MessageType
     import ch.epfl.scala.bsp.ShowMessageParams
-    val showParams = ShowMessageParams(MessageType.Warning, None, None, msg)
+    val showParams = ShowMessageParams(MessageType.Warning, None, originId, msg)
     bsp.endpoints.Build.showMessage.notify(showParams)
     ()
   }
 
   override def warn(msg: String): Unit = {
-    Build.logMessage.notify(bsp.LogMessageParams(bsp.MessageType.Warning, None, None, msg))
+    Build.logMessage.notify(bsp.LogMessageParams(bsp.MessageType.Warning, None, originId, msg))
     ()
   }
 
   override def info(msg: String): Unit = {
-    Build.logMessage.notify(bsp.LogMessageParams(bsp.MessageType.Info, None, None, msg))
+    Build.logMessage.notify(bsp.LogMessageParams(bsp.MessageType.Info, None, originId, msg))
     ()
   }
 
@@ -106,7 +110,7 @@ final class BspServerLogger private (
           bsp.PublishDiagnosticsParams(
             textDocument,
             buildTargetId,
-            None,
+            originId,
             List(diagnostic),
             event.clear
           )
@@ -220,6 +224,6 @@ object BspServerLogger {
       ansiCodesSupported: Boolean
   ): BspServerLogger = {
     val name: String = s"bsp-logger-${BspServerLogger.counter.incrementAndGet()}"
-    new BspServerLogger(name, state.logger, client, taskIdCounter, ansiCodesSupported)
+    new BspServerLogger(name, state.logger, client, taskIdCounter, ansiCodesSupported, None)
   }
 }

--- a/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
+++ b/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
@@ -38,9 +38,8 @@ final class BspServerLogger private (
     new BspServerLogger(name, underlying.asDiscrete, client, taskIdCounter, ansiSupported, originId)
   override def asVerbose: Logger =
     new BspServerLogger(name, underlying.asVerbose, client, taskIdCounter, ansiSupported, originId)
-
-  def withOriginId(originId: String): BspServerLogger =
-    new BspServerLogger(name, underlying, client, taskIdCounter, ansiSupported, Some(originId))
+  override def withOriginId(originId: Option[String]): BspServerLogger =
+    new BspServerLogger(name, underlying, client, taskIdCounter, ansiSupported, originId)
 
   override def ansiCodesSupported: Boolean = ansiSupported || underlying.ansiCodesSupported()
 
@@ -193,7 +192,7 @@ final class BspServerLogger private (
     val json = bsp.CompileReport.encodeCompileReport(
       bsp.CompileReport(
         bsp.BuildTargetIdentifier(event.projectUri),
-        None,
+        originId,
         errors,
         warnings,
         None

--- a/frontend/src/main/scala/bloop/logging/NoopLogger.scala
+++ b/frontend/src/main/scala/bloop/logging/NoopLogger.scala
@@ -14,4 +14,5 @@ object NoopLogger extends Logger {
   override def isVerbose: Boolean = false
   override def asDiscrete: Logger = this
   override def asVerbose: Logger = this
+  override def withOriginId(originId: Option[String]): Logger = this
 }

--- a/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
@@ -133,13 +133,13 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
       }
     }
 
-    def compileTask(project: TestProject): Task[ManagedBspTestState] = {
+    def compileTask(project: TestProject, originId: Option[String]): Task[ManagedBspTestState] = {
       runAfterTargets(project) { target =>
         // Handle internal state before sending compile request
         diagnostics.clear()
         currentCompileIteration.increment(1)
 
-        BuildTarget.compile.request(bsp.CompileParams(List(target), None, None)).flatMap {
+        BuildTarget.compile.request(bsp.CompileParams(List(target), originId, None)).flatMap {
           case Right(r) =>
             // `headL` returns latest saved state from bsp because source is behavior subject
             serverStates.headL.map { state =>
@@ -162,7 +162,7 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
         delay: Option[FiniteDuration] = None
     ): CancelableFuture[ManagedBspTestState] = {
       val interpretedTask = {
-        val task = compileTask(project)
+        val task = compileTask(project, None)
         delay match {
           case Some(duration) => task.delayExecution(duration)
           case None => task
@@ -172,10 +172,10 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
       interpretedTask.runAsync(ExecutionContext.scheduler)
     }
 
-    def compile(project: TestProject): ManagedBspTestState = {
+    def compile(project: TestProject, originId: Option[String] = None): ManagedBspTestState = {
       // Use a default timeout of 30 seconds for every operation
       TestUtil.await(FiniteDuration(30, "s")) {
-        compileTask(project)
+        compileTask(project, originId)
       }
     }
 

--- a/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
@@ -130,7 +130,8 @@ trait BspClientTest {
 
       implicit val lsClient = new LanguageClient(out, logger)
       val messages = BaseProtocolMessage.fromInputStream(in, logger)
-      val services = customServices(TestUtil.createTestServices(addDiagnosticsHandler, logger))
+      val services =
+        customServices(TestUtil.createTestServices(addDiagnosticsHandler, logger))
       val lsServer = new LanguageServer(messages, lsClient, services, ioScheduler, logger)
       val runningClientServer = lsServer.startTask.runAsync(ioScheduler)
 
@@ -280,7 +281,7 @@ trait BspClientTest {
         ()
       }
       .notification(endpoints.Build.publishDiagnostics) {
-        case p @ bsp.PublishDiagnosticsParams(tid, btid, _, diagnostics, reset) =>
+        case p @ bsp.PublishDiagnosticsParams(tid, btid, originId, diagnostics, reset) =>
           record(
             btid,
             (builder: StringBuilder) => {
@@ -310,6 +311,11 @@ trait BspClientTest {
                 .++=(s"#${compileIteration()}: $canonical\n")
                 .++=(s"  -> $report\n")
                 .++=(s"  -> reset = $reset\n")
+
+              originId match {
+                case None => builder
+                case Some(originId) => builder.++=(s"  -> origin = $originId\n")
+              }
             }
           )
           ()

--- a/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
@@ -269,6 +269,7 @@ trait BspClientTest {
                   (builder: StringBuilder) => {
                     builder.++=(s"#${compileIteration()}: task finish ${taskFinish.taskId.id}\n")
                     builder.++=(s"  -> errors ${report.errors}, warnings ${report.warnings}\n")
+                    report.originId.foreach(originId => builder.++=(s"  -> origin = $originId\n"))
                     taskFinish.message.foreach(msg => builder.++=(s"  -> Msg: ${msg}\n"))
                     taskFinish.dataKind.foreach(msg => builder.++=(s"  -> Data kind: ${msg}\n"))
                     builder

--- a/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
@@ -172,6 +172,7 @@ class BspCompileSpec(
              |  -> origin = test-origin
              |#1: task finish 1
              |  -> errors 0, warnings 1
+             |  -> origin = test-origin
              |  -> Msg: Compiled 'a'
              |  -> Data kind: compile-report
              |""".stripMargin

--- a/frontend/src/test/scala/bloop/logging/BufferedLogger.scala
+++ b/frontend/src/test/scala/bloop/logging/BufferedLogger.scala
@@ -21,6 +21,8 @@ final class BufferedLogger private (
   override def isVerbose: Boolean = underlying.isVerbose
   override def asVerbose: Logger = new BufferedLogger(underlying.asVerbose, buffer)
   override def asDiscrete: Logger = new BufferedLogger(underlying.asDiscrete, buffer)
+  override def withOriginId(originId: Option[String]): Logger =
+    new BufferedLogger(underlying.withOriginId(originId), buffer)
 
   // Custom functions for buffered logger
   def clear(): Unit = buffer.clear()

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -473,33 +473,44 @@ object TestUtil {
     configDir
   }
 
-  def createTestServices(addDiagnosticsHandler: Boolean, logger0: BspClientLogger[_]): Services = {
+  def createTestServices(
+      addDiagnosticsHandler: Boolean,
+      logger0: BspClientLogger[_]
+  ): Services = {
     implicit val ctx: DebugFilter = DebugFilter.Bsp
     import ch.epfl.scala.bsp
     import ch.epfl.scala.bsp.endpoints
     val logger: bloop.logging.Logger = logger0
+    def fmt(msg: String, originId: Option[String]): String = {
+      originId match {
+        case None => msg
+        case Some(origin) => msg + s"(origin id: $origin)"
+      }
+    }
+
     val rawServices = Services
       .empty(logger0)
       .notification(endpoints.Build.showMessage) {
-        case bsp.ShowMessageParams(bsp.MessageType.Log, _, _, msg) => logger.debug(msg)
-        case bsp.ShowMessageParams(bsp.MessageType.Info, _, _, msg) => logger.info(msg)
-        case bsp.ShowMessageParams(bsp.MessageType.Warning, _, _, msg) => logger.warn(msg)
-        case bsp.ShowMessageParams(bsp.MessageType.Error, _, _, msg) => logger.error(msg)
+        case bsp.ShowMessageParams(bsp.MessageType.Log, _, o, msg) => logger.debug(fmt(msg, o))
+        case bsp.ShowMessageParams(bsp.MessageType.Info, _, o, msg) => logger.info(fmt(msg, o))
+        case bsp.ShowMessageParams(bsp.MessageType.Warning, _, o, msg) => logger.warn(fmt(msg, o))
+        case bsp.ShowMessageParams(bsp.MessageType.Error, _, o, msg) => logger.error(fmt(msg, o))
       }
       .notification(endpoints.Build.logMessage) {
-        case bsp.LogMessageParams(bsp.MessageType.Log, _, _, msg) => logger.debug(msg)
-        case bsp.LogMessageParams(bsp.MessageType.Info, _, _, msg) => logger.info(msg)
-        case bsp.LogMessageParams(bsp.MessageType.Warning, _, _, msg) => logger.warn(msg)
-        case bsp.LogMessageParams(bsp.MessageType.Error, _, _, msg) => logger.error(msg)
+        case bsp.LogMessageParams(bsp.MessageType.Log, _, o, msg) => logger.debug(fmt(msg, o))
+        case bsp.LogMessageParams(bsp.MessageType.Info, _, o, msg) => logger.info(fmt(msg, o))
+        case bsp.LogMessageParams(bsp.MessageType.Warning, _, o, msg) => logger.warn(fmt(msg, o))
+        case bsp.LogMessageParams(bsp.MessageType.Error, _, o, msg) => logger.error(fmt(msg, o))
       }
 
     // Lsp4s fails if we try to repeat a handler for a given notification
     if (!addDiagnosticsHandler) rawServices
     else {
       rawServices.notification(endpoints.Build.publishDiagnostics) {
-        case bsp.PublishDiagnosticsParams(uri, _, _, diagnostics, _) =>
+        case bsp.PublishDiagnosticsParams(uri, _, originId, diagnostics, _) =>
           // We prepend diagnostics so that tests can check they came from this notification
-          def printDiagnostic(d: bsp.Diagnostic): String = s"[diagnostic] ${d.message} ${d.range}"
+          def printDiagnostic(d: bsp.Diagnostic): String =
+            fmt(s"[diagnostic] ${d.message} ${d.range}", originId)
           diagnostics.foreach { d =>
             d.severity match {
               case Some(bsp.DiagnosticSeverity.Error) => logger.error(printDiagnostic(d))

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -6,7 +6,16 @@ import java.nio.file.Paths
 import java.nio.file.Files
 
 import bloop.config.Config
-import bloop.config.Config.{CompileOrder, CompileSetup, JavaThenScala, JvmConfig, Mixed, Platform, TestArgument, TestOptions}
+import bloop.config.Config.{
+  CompileOrder,
+  CompileSetup,
+  JavaThenScala,
+  JvmConfig,
+  Mixed,
+  Platform,
+  TestArgument,
+  TestOptions
+}
 import bloop.integrations.gradle.BloopParameters
 import bloop.integrations.gradle.model.BloopConverter.SourceSetDep
 import bloop.integrations.gradle.syntax._
@@ -108,9 +117,11 @@ final class BloopConverter(parameters: BloopParameters) {
       // retrieve project dependencies recursively to include transitive project dependencies
       // Bloop requires this for the classpath
       val allCompileProjectDependencies = getProjectDependenciesRecursively(
-        compileClassPathConfiguration)
+        compileClassPathConfiguration
+      )
       val allRuntimeProjectDependencies = getProjectDependenciesRecursively(
-        runtimeClassPathConfiguration)
+        runtimeClassPathConfiguration
+      )
 
       // retrieve all artifacts (includes transitive)
       val compileArtifacts: List[ResolvedArtifact] =
@@ -130,9 +141,11 @@ final class BloopConverter(parameters: BloopParameters) {
           }
         })
         .toSet
-        .filter(resolvedArtifact =>
-          !isProjectDependency(allCompileProjectDependencies, resolvedArtifact) &&
-            !isProjectDependency(allCompileProjectDependencies, resolvedArtifact))
+        .filter(
+          resolvedArtifact =>
+            !isProjectDependency(allCompileProjectDependencies, resolvedArtifact) &&
+              !isProjectDependency(allCompileProjectDependencies, resolvedArtifact)
+        )
 
       // convert artifacts to class dirs for projects and file paths for non-projects
       val compileClasspathItems = compileArtifacts.map(
@@ -141,14 +154,18 @@ final class BloopConverter(parameters: BloopParameters) {
             allSourceSetsToProjects,
             targetDir,
             allCompileProjectDependencies,
-            resolvedArtifact))
+            resolvedArtifact
+          )
+      )
       val runtimeClasspathItems = runtimeArtifacts.map(
         resolvedArtifact =>
           convertToPath(
             allSourceSetsToProjects,
             targetDir,
             allRuntimeProjectDependencies,
-            resolvedArtifact))
+            resolvedArtifact
+          )
+      )
 
       // retrieve all file/dir dependencies (includes transitive?)
       val compileClassPathFiles: Set[File] =
@@ -187,11 +204,13 @@ final class BloopConverter(parameters: BloopParameters) {
 
       // get non-project artifacts for resolution
       val compileNonProjectDependencies: List[ResolvedArtifact] = compileArtifacts
-        .filter(resolvedArtifact =>
-          !isProjectDependency(allCompileProjectDependencies, resolvedArtifact))
+        .filter(
+          resolvedArtifact => !isProjectDependency(allCompileProjectDependencies, resolvedArtifact)
+        )
       val runtimeNonProjectDependencies: List[ResolvedArtifact] = runtimeArtifacts
-        .filter(resolvedArtifact =>
-          !isProjectDependency(allRuntimeProjectDependencies, resolvedArtifact))
+        .filter(
+          resolvedArtifact => !isProjectDependency(allRuntimeProjectDependencies, resolvedArtifact)
+        )
       val nonProjectDependencies =
         (compileNonProjectDependencies ++ runtimeNonProjectDependencies).distinct
 
@@ -241,14 +260,18 @@ final class BloopConverter(parameters: BloopParameters) {
     javaCompileTask.getOptions
   }
 
-  def getPlatform(project: Project, sourceSet: SourceSet, isTestSourceSet: Boolean): Option[Platform] = {
+  def getPlatform(
+      project: Project,
+      sourceSet: SourceSet,
+      isTestSourceSet: Boolean
+  ): Option[Platform] = {
     val forkOptions = getJavaCompileOptions(project, sourceSet).getForkOptions
     val projectJdkPath = Option(forkOptions.getJavaHome).map(_.toPath)
 
     lazy val compileJvmOptions =
       Option(forkOptions.getMemoryInitialSize).map(mem => s"-Xms$mem").toList ++
-      Option(forkOptions.getMemoryMaximumSize).map(mem => s"-Xmx$mem").toList ++
-      forkOptions.getJvmArgs.asScala.toList
+        Option(forkOptions.getMemoryMaximumSize).map(mem => s"-Xmx$mem").toList ++
+        forkOptions.getJvmArgs.asScala.toList
 
     lazy val testTask = project.getTask[Test]("test")
     lazy val testProperties =
@@ -257,9 +280,9 @@ final class BloopConverter(parameters: BloopParameters) {
 
     lazy val testJvmOptions =
       Option(testTask.getMinHeapSize).map(mem => s"-Xms$mem").toList ++
-      Option(testTask.getMaxHeapSize).map(mem => s"-Xmx$mem").toList ++
-      testTask.getJvmArgs.asScala.toList ++
-      testProperties
+        Option(testTask.getMaxHeapSize).map(mem => s"-Xmx$mem").toList ++
+        testTask.getJvmArgs.asScala.toList ++
+        testProperties
 
     val projectJvmOptions =
       if (isTestSourceSet) testJvmOptions
@@ -313,7 +336,8 @@ final class BloopConverter(parameters: BloopParameters) {
   // find the source of the data going into an archive
   private def getSourceSet(
       allSourceSetsToProjects: Map[SourceSet, Project],
-      abstractCopyTask: AbstractCopyTask): Option[SourceSet] = {
+      abstractCopyTask: AbstractCopyTask
+  ): Option[SourceSet] = {
     try {
       // protected method
       val getMainSpec = classOf[AbstractCopyTask].getDeclaredMethod("getMainSpec")
@@ -359,7 +383,8 @@ final class BloopConverter(parameters: BloopParameters) {
 
   private def isProjectSourceSet(
       allSourceSetsToProjects: Map[SourceSet, Project],
-      file: File): Boolean = {
+      file: File
+  ): Boolean = {
     // check if the dependency matches any projects output dir
     allSourceSetsToProjects.keys
       .exists(ss => matchesOutputDir(ss.getOutput, file) || file == ss.getOutput.getResourcesDir)
@@ -367,19 +392,25 @@ final class BloopConverter(parameters: BloopParameters) {
 
   private def isProjectSourceSet(
       allSourceSetsToProjects: Map[SourceSet, Project],
-      selfResolvingDependency: SelfResolvingDependency): Boolean = {
+      selfResolvingDependency: SelfResolvingDependency
+  ): Boolean = {
     // check if the dependency matches any projects output dir
     val sourceOutputDirs = selfResolvingDependency.resolve().asScala
     allSourceSetsToProjects.keys
-      .exists(ss =>
-        sourceOutputDirs
-          .exists(outputDir =>
-            matchesOutputDir(ss.getOutput, outputDir) || outputDir == ss.getOutput.getResourcesDir))
+      .exists(
+        ss =>
+          sourceOutputDirs
+            .exists(
+              outputDir =>
+                matchesOutputDir(ss.getOutput, outputDir) || outputDir == ss.getOutput.getResourcesDir
+            )
+      )
   }
 
   private def getProjectDependencies(
       allSourceSetsToProjects: Map[SourceSet, Project],
-      configuration: Configuration): List[String] = {
+      configuration: Configuration
+  ): List[String] = {
     // We cannot turn this into a set directly because we need the topological order for correctness
     configuration.getAllDependencies.asScala.collect {
       case projectDependency: ProjectDependency
@@ -392,7 +423,8 @@ final class BloopConverter(parameters: BloopParameters) {
   }
 
   private def getProjectDependenciesRecursively(
-      configuration: Configuration): List[ProjectDependency] = {
+      configuration: Configuration
+  ): List[ProjectDependency] = {
     // We cannot turn this into a set directly because we need the topological order for correctness
     configuration.getAllDependencies.asScala
       .collect {
@@ -428,7 +460,8 @@ final class BloopConverter(parameters: BloopParameters) {
 
   private def getSourceSet(
       allSourceSetsToProjects: Map[SourceSet, Project],
-      projectDependency: ProjectDependency): SourceSet = {
+      projectDependency: ProjectDependency
+  ): SourceSet = {
     // use configuration to find which is the correct source set
     val depProject = projectDependency.getDependencyProject
     val configurationName = getTargetConfiguration(projectDependency)
@@ -452,7 +485,9 @@ final class BloopConverter(parameters: BloopParameters) {
             List(
               s.getCompileClasspathConfigurationName,
               s.getRuntimeConfigurationName,
-              s.getRuntimeConfigurationName + "Classpath").map(name => name -> s))
+              s.getRuntimeConfigurationName + "Classpath"
+            ).map(name => name -> s)
+        )
         .toMap
 
       // take first source set that matches the configuration or default to main
@@ -465,32 +500,37 @@ final class BloopConverter(parameters: BloopParameters) {
 
   private def dependencyToProjectName(
       allSourceSetsToProjects: Map[SourceSet, Project],
-      selfResolvingDependency: SelfResolvingDependency): String = {
+      selfResolvingDependency: SelfResolvingDependency
+  ): String = {
     val sourceOutputDirs = selfResolvingDependency.resolve().asScala
     allSourceSetsToProjects
       .find(
         ss =>
           sourceOutputDirs.exists(ss2 => matchesOutputDir(ss._1.getOutput, ss2)) ||
-            sourceOutputDirs.contains(ss._1.getOutput.getResourcesDir))
+            sourceOutputDirs.contains(ss._1.getOutput.getResourcesDir)
+      )
       .map(ss => getProjectName(ss._2, ss._1))
       .get
   }
 
   private def dependencyToProjectName(
       allSourceSetsToProjects: Map[SourceSet, Project],
-      file: File): String = {
+      file: File
+  ): String = {
     allSourceSetsToProjects
       .find(
         ss =>
           matchesOutputDir(ss._1.getOutput, file) ||
-            file == ss._1.getOutput.getResourcesDir)
+            file == ss._1.getOutput.getResourcesDir
+      )
       .map(ss => getProjectName(ss._2, ss._1))
       .get
   }
 
   private def dependencyToProjectName(
       allSourceSetsToProjects: Map[SourceSet, Project],
-      projectDependency: ProjectDependency): String = {
+      projectDependency: ProjectDependency
+  ): String = {
     val depProject = projectDependency.getDependencyProject
     getProjectName(depProject, getSourceSet(allSourceSetsToProjects, projectDependency))
   }
@@ -498,7 +538,8 @@ final class BloopConverter(parameters: BloopParameters) {
   private def dependencyToClassPath(
       allSourceSetsToProjects: Map[SourceSet, Project],
       targetDir: File,
-      projectDependency: ProjectDependency): Path = {
+      projectDependency: ProjectDependency
+  ): Path = {
     val depProject = projectDependency.getDependencyProject
     getClassesDir(targetDir, depProject, getSourceSet(allSourceSetsToProjects, projectDependency))
   }
@@ -507,7 +548,8 @@ final class BloopConverter(parameters: BloopParameters) {
       allSourceSetsToProjects: Map[SourceSet, Project],
       targetDir: File,
       projectDependencies: List[ProjectDependency],
-      resolvedArtifact: ResolvedArtifact): Path = {
+      resolvedArtifact: ResolvedArtifact
+  ): Path = {
     projectDependencies
       .find(dep => isProjectDependency(dep, resolvedArtifact))
       .map(dep => dependencyToClassPath(allSourceSetsToProjects, targetDir, dep))
@@ -516,7 +558,8 @@ final class BloopConverter(parameters: BloopParameters) {
 
   private def isProjectDependency(
       dependency: ProjectDependency,
-      resolvedArtifact: ResolvedArtifact): Boolean = {
+      resolvedArtifact: ResolvedArtifact
+  ): Boolean = {
     dependency.getGroup == resolvedArtifact.getModuleVersion.getId.getGroup &&
     dependency.getName == resolvedArtifact.getModuleVersion.getId.getName &&
     dependency.getVersion == resolvedArtifact.getModuleVersion.getId.getVersion
@@ -524,13 +567,15 @@ final class BloopConverter(parameters: BloopParameters) {
 
   private def isProjectDependency(
       projectDependencies: List[ProjectDependency],
-      resolvedArtifact: ResolvedArtifact): Boolean = {
+      resolvedArtifact: ResolvedArtifact
+  ): Boolean = {
     projectDependencies.exists(dep => isProjectDependency(dep, resolvedArtifact))
   }
 
   private def artifactToConfigModule(
       artifact: ResolvedArtifact,
-      project: Project): Config.Module = {
+      project: Project
+  ): Config.Module = {
 
     val resolutionResult = project
       .getDependencies()
@@ -601,7 +646,8 @@ final class BloopConverter(parameters: BloopParameters) {
           // Use the compile setup and analysis out defaults, Gradle doesn't expose its customization
           Success(
             Some(
-              Config.Scala(scalaOrg, compilerName, scalaVersion, options, scalaJars, None, Some(setup))
+              Config
+                .Scala(scalaOrg, compilerName, scalaVersion, options, scalaJars, None, Some(setup))
             )
           )
         } else {
@@ -639,7 +685,7 @@ final class BloopConverter(parameters: BloopParameters) {
       .includeClasspath(false)
       .includeSourceFiles(false)
       .includeLauncherOptions(false)
-    
+
     var args = builder.build().asScala.toList.filter(_.nonEmpty)
 
     if (!args.contains("-source")) {
@@ -652,9 +698,9 @@ final class BloopConverter(parameters: BloopParameters) {
     }
 
     // if annotation processor is not configured to run we remove the source
-    if (args.contains("-proc:none") && args.contains("-s")){
+    if (args.contains("-proc:none") && args.contains("-s")) {
       args = args.takeWhile(_ != "-s") ++ args.dropWhile(_ != "-s").drop(2)
-    } else if (args.contains("-s")){
+    } else if (args.contains("-s")) {
       Files.createDirectories(Paths.get(args(args.indexOf("-s") + 1)))
     }
 

--- a/shared/src/main/scala/bloop/logging/Logger.scala
+++ b/shared/src/main/scala/bloop/logging/Logger.scala
@@ -16,6 +16,9 @@ abstract class Logger extends xsbti.Logger with BaseSbtLogger {
   /** Return a logger that doesn't log verbose and debug events. */
   def asDiscrete: Logger
 
+  /** Return a logger that doesn't log verbose and debug events. */
+  def withOriginId(originId: Option[String]): Logger
+
   /** Context for debug logging. */
   def debugFilter: DebugFilter
 


### PR DESCRIPTION
Makes sure that bloop bsp services handle the origin id field set in
certain BSP requests to let clients trace the origin of logMessage,
showMessage or diagnostics.

Fixes https://github.com/scalacenter/bloop/issues/679