### PR TITLE
Remove default scala for java-only projects

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -779,8 +779,7 @@ final class BloopBspServices(
                 canTest = true,
                 canRun = true
               )
-              val javaInstance = ScalaInstance.scalaInstanceForJavaProjects(logger)(ioScheduler)
-              val isJavaOnly = p.scalaInstance == javaInstance
+              val isJavaOnly = p.scalaInstance.isEmpty
               val languageIds =
                 if (isJavaOnly) BloopBspServices.JavaOnly
                 else BloopBspServices.DefaultLanguages

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -139,7 +139,6 @@ object Project {
           )
         }
       }
-      .orElse(ScalaInstance.scalaInstanceForJavaProjects(logger)(ec))
 
     val setup = project.`scala`.flatMap(_.setup).getOrElse(Config.CompileSetup.empty)
     val platform = project.platform match {

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
@@ -111,8 +111,11 @@ final case class SuccessfulCompileBundle(
       ResultBundle(Compiler.Result.Empty, last, None)
     }
 
+    val ec = bloop.engine.ExecutionContext.ioScheduler
     val uniqueSources = javaSources ++ scalaSources
-    project.scalaInstance match {
+    val scalaInstance = project.scalaInstance.orElse(ScalaInstance.scalaInstanceForJavaProjects(logger)(ec))
+
+    scalaInstance match {
       case Some(instance) =>
         (scalaSources, javaSources) match {
           case (Nil, Nil) => Left(empty)

--- a/frontend/src/test/scala/bloop/LoadProjectSpec.scala
+++ b/frontend/src/test/scala/bloop/LoadProjectSpec.scala
@@ -1,27 +1,21 @@
 package bloop
 
-import java.util.concurrent.TimeUnit
-
 import bloop.config.Config
 import bloop.data.Project
-import bloop.engine.{BuildLoader, Dag}
 import bloop.io.AbsolutePath
 import bloop.logging.RecordingLogger
 import bloop.util.TestUtil
 import org.junit.Test
 
-import scala.concurrent.duration.FiniteDuration
-
 class LoadProjectSpec {
   @Test def LoadJavaProject(): Unit = {
-    // Make sure that when no scala setup is configured the project load succeeds (and the default instance is used)
+    // Make sure that when no scala setup is configured the project load succeeds (and no scala instance is defined)
     val logger = new RecordingLogger()
     val config0 = Config.File.dummyForTests
     val project = config0.project
     val configWithNoScala = config0.copy(config0.version, project.copy(scala = None))
     val origin = TestUtil.syntheticOriginFor(AbsolutePath.completelyUnsafe(""))
     val inferredInstance = Project.fromConfig(configWithNoScala, origin, logger).scalaInstance
-    assert(inferredInstance.isDefined)
-    assert(inferredInstance.get.version.nonEmpty)
+    assert(inferredInstance.isEmpty)
   }
 }


### PR DESCRIPTION
We should not export default Scala SDK for projects that don't use Scala
because these projects may be dependencies of other projects that
do use a different version of Scala. In this case external tools
may put both Scala SDKs on the classpath (the default one from the
Java-only project and the one coming from the dependent Scala project)
and if the default incorrect SDK "takes over", problems can happen.

See https://youtrack.jetbrains.com/issue/SCL-15892
Fixes #1008