### PR TITLE
Improve BSP services performance

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -642,7 +642,7 @@ final class BloopBspServices(
           val build = state.build
           val projects = build.loadedProjects.map(_.project)
           val targets = bsp.WorkspaceBuildTargetsResult(
-            projects.map { p =>
+            projects.par.map { p =>
               val id = toBuildTargetId(p)
               val tag = {
                 if (p.name.endsWith("-test") && build.getProjectFor(s"${p.name}-test").isEmpty)
@@ -672,7 +672,7 @@ final class BloopBspServices(
                 dataKind = Some(bsp.BuildTargetDataKind.Scala),
                 data = extra
               )
-            }
+            }.toList
           )
 
           Task.now((state, Right(targets)))
@@ -690,7 +690,7 @@ final class BloopBspServices(
     ): BspResult[bsp.SourcesResult] = {
 
       val response = bsp.SourcesResult(
-        projects.iterator.map {
+        projects.par.map {
           case (target, project) =>
             val sources = project.sources.map {
               s =>
@@ -734,7 +734,7 @@ final class BloopBspServices(
     ): BspResult[bsp.ResourcesResult] = {
 
       val response = bsp.ResourcesResult(
-        projects.iterator.map {
+        projects.par.map {
           case (target, project) =>
             val resources = project.resources.flatMap { s =>
               if (s.exists) {
@@ -770,7 +770,7 @@ final class BloopBspServices(
         state: State
     ): BspResult[bsp.DependencySourcesResult] = {
       val response = bsp.DependencySourcesResult(
-        projects.iterator.map {
+        projects.par.map {
           case (target, project) =>
             val sourceJars = project.resolution.toList.flatMap { res =>
               res.modules.flatMap { m =>
@@ -806,7 +806,7 @@ final class BloopBspServices(
         state: State
     ): BspResult[bsp.ScalacOptionsResult] = {
       val response = bsp.ScalacOptionsResult(
-        projects.iterator.map {
+        projects.par.map {
           case (target, project) =>
             val dag = state.build.getDagFor(project)
             val fullClasspath = project.fullClasspath(dag, state.client)

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -642,7 +642,7 @@ final class BloopBspServices(
           val build = state.build
           val projects = build.loadedProjects.map(_.project)
           val targets = bsp.WorkspaceBuildTargetsResult(
-            projects.par.map { p =>
+            projects.map { p =>
               val id = toBuildTargetId(p)
               val tag = {
                 if (p.name.endsWith("-test") && build.getProjectFor(s"${p.name}-test").isEmpty)
@@ -672,7 +672,7 @@ final class BloopBspServices(
                 dataKind = Some(bsp.BuildTargetDataKind.Scala),
                 data = extra
               )
-            }.toList
+            }
           )
 
           Task.now((state, Right(targets)))
@@ -690,7 +690,7 @@ final class BloopBspServices(
     ): BspResult[bsp.SourcesResult] = {
 
       val response = bsp.SourcesResult(
-        projects.par.map {
+        projects.iterator.map {
           case (target, project) =>
             val sources = project.sources.map {
               s =>
@@ -734,7 +734,7 @@ final class BloopBspServices(
     ): BspResult[bsp.ResourcesResult] = {
 
       val response = bsp.ResourcesResult(
-        projects.par.map {
+        projects.iterator.map {
           case (target, project) =>
             val resources = project.resources.flatMap { s =>
               if (s.exists) {
@@ -770,7 +770,7 @@ final class BloopBspServices(
         state: State
     ): BspResult[bsp.DependencySourcesResult] = {
       val response = bsp.DependencySourcesResult(
-        projects.par.map {
+        projects.iterator.map {
           case (target, project) =>
             val sourceJars = project.resolution.toList.flatMap { res =>
               res.modules.flatMap { m =>
@@ -806,7 +806,7 @@ final class BloopBspServices(
         state: State
     ): BspResult[bsp.ScalacOptionsResult] = {
       val response = bsp.ScalacOptionsResult(
-        projects.par.map {
+        projects.iterator.map {
           case (target, project) =>
             val dag = state.build.getDagFor(project)
             val fullClasspath = project.fullClasspath(dag, state.client)


### PR DESCRIPTION
1. BSP services that generate output from many projects now map pojects in parallel - reduces service call latency.
2. Writing to an `OutputStream` by single bytes was not the most efficient way of sending out data - replaced by channel. Could go probably further and avoid copying buffers at all if we didn't use `OutputStream`s, but a bigger refactoring would be needed and I don't have the time now ;)

Impact of this change:

Before this change importing our multi-module project took ~13-15 seconds with Intellij IDEA, and Bloop was using 100% of one CPU core for ~ 10 s.

After this change it takes ~ 2.5 s (most of that probably on the IDEA side), and the CPU spike on the Bloop side is hardly noticeable.




