### PR TITLE
Close sockets after the BSP connection has been terminated

### DIFF
--- a/launcher/src/main/scala/bloop/launcher/Launcher.scala
+++ b/launcher/src/main/scala/bloop/launcher/Launcher.scala
@@ -106,7 +106,11 @@ class LauncherMain(
       case Right(Left(_)) => SuccessfulRun
 
       case Right(Right(Some(socket))) =>
-        bridge.wireBspConnectionStreams(socket)
+        try{
+          bridge.wireBspConnectionStreams(socket)
+        } finally {
+          socket.close()
+        }
         SuccessfulRun
 
       case Right(Right(None)) =>


### PR DESCRIPTION
When the BSP connection is not used anymore, the socket remains open indefinitely. If the application that spawned the connection doesn't terminate immediately after `LauncherMain.runLauncher` returns, this causes a resource leak.