### PR TITLE
Support running custom scala main class in BSP

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -614,8 +614,7 @@ final class BloopBspServices(
   def run(params: bsp.RunParams): BspEndpointResponse[bsp.RunResult] = {
     def parseMainClass(project: Project, state: State): Either[Exception, bsp.ScalaMainClass] = {
       params.dataKind match {
-        // TODO replace with RunParamsDataKind.ScalaMainClass once bsp updates
-        case Some("scala-main-class") =>
+        case Some(bsp.RunParamsDataKind.ScalaMainClass) =>
           params.data match {
             case None =>
               Left(new IllegalStateException(s"Missing data for $params"))

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -612,7 +612,7 @@ final class BloopBspServices(
   }
 
   def run(params: bsp.RunParams): BspEndpointResponse[bsp.RunResult] = {
-    def getMainClass(project: Project, state: State): Either[Exception, bsp.ScalaMainClass] = {
+    def parseMainClass(project: Project, state: State): Either[Exception, bsp.ScalaMainClass] = {
       params.dataKind match {
         // TODO replace with RunParamsDataKind.ScalaMainClass once bsp updates
         case Some("scala-main-class") =>
@@ -643,7 +643,7 @@ final class BloopBspServices(
       import bloop.engine.tasks.LinkTask.{linkMainWithJs, linkMainWithNative}
       val cwd = state.commonOptions.workingPath
 
-      getMainClass(project, state) match {
+      parseMainClass(project, state) match {
         case Left(error) =>
           Task.now(sys.error(s"Failed to run main class in $project due to: ${error.getMessage}"))
         case Right(mainClass) =>

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -612,6 +612,29 @@ final class BloopBspServices(
   }
 
   def run(params: bsp.RunParams): BspEndpointResponse[bsp.RunResult] = {
+    def getMainClass(project: Project, state: State): Either[Exception, bsp.ScalaMainClass] = {
+      params.dataKind match {
+        // TODO replace with RunParamsDataKind.ScalaMainClass once bsp updates
+        case Some("scala-main-class") =>
+          params.data match {
+            case None =>
+              Left(new IllegalStateException(s"Missing data for $params"))
+            case Some(json) =>
+              json.as[bsp.ScalaMainClass]
+          }
+        case Some(kind) =>
+          Left(new IllegalArgumentException(s"Unsupported data kind: $kind"))
+        case None =>
+          val cmd = Commands.Run(List(project.name))
+          Interpreter.getMainClass(state, project, cmd.main) match {
+            case Right(name) =>
+              Right(new bsp.ScalaMainClass(name, cmd.args, Nil))
+            case Left(_) =>
+              Left(new IllegalStateException(s"Main class for project $project not found"))
+          }
+      }
+    }
+
     def run(
         id: BuildTargetIdentifier,
         project: Project,
@@ -619,40 +642,44 @@ final class BloopBspServices(
     ): Task[State] = {
       import bloop.engine.tasks.LinkTask.{linkMainWithJs, linkMainWithNative}
       val cwd = state.commonOptions.workingPath
-      val cmd = Commands.Run(List(project.name))
-      Interpreter.getMainClass(state, project, cmd.main) match {
-        case Left(state) =>
-          Task.now(sys.error(s"Failed to run main class in ${project.name}"))
+
+      getMainClass(project, state) match {
+        case Left(error) =>
+          Task.now(sys.error(s"Failed to run main class in $project due to: ${error.getMessage}"))
         case Right(mainClass) =>
           project.platform match {
             case Platform.Jvm(javaEnv, _, _) =>
-              val mainArgs = cmd.args.toArray
+              val mainArgs = mainClass.arguments.toArray
+              val env = JavaEnv(javaEnv.javaHome, javaEnv.javaOptions ++ mainClass.jvmOptions)
               Tasks.runJVM(
                 state,
                 project,
-                javaEnv,
+                env,
                 cwd,
-                mainClass,
+                mainClass.`class`,
                 mainArgs,
                 skipJargs = false,
                 RunMode.Normal
               )
             case platform @ Platform.Native(config, _, _) =>
+              val cmd = Commands.Run(List(project.name))
               val target = ScalaNativeToolchain.linkTargetFrom(project, config)
-              linkMainWithNative(cmd, project, state, mainClass, target, platform).flatMap {
-                state =>
+              linkMainWithNative(cmd, project, state, mainClass.`class`, target, platform)
+                .flatMap { state =>
                   val args = (target.syntax +: cmd.args).toArray
                   if (!state.status.isOk) Task.now(state)
-                  else Tasks.runNativeOrJs(state, project, cwd, mainClass, args)
-              }
+                  else Tasks.runNativeOrJs(state, project, cwd, mainClass.`class`, args)
+                }
             case platform @ Platform.Js(config, _, _) =>
+              val cmd = Commands.Run(List(project.name))
               val target = ScalaJsToolchain.linkTargetFrom(project, config)
-              linkMainWithJs(cmd, project, state, mainClass, target, platform).flatMap { state =>
-                // We use node to run the program (is this a special case?)
-                val args = ("node" +: target.syntax +: cmd.args).toArray
-                if (!state.status.isOk) Task.now(state)
-                else Tasks.runNativeOrJs(state, project, cwd, mainClass, args)
-              }
+              linkMainWithJs(cmd, project, state, mainClass.`class`, target, platform)
+                .flatMap { state =>
+                  // We use node to run the program (is this a special case?)
+                  val args = ("node" +: target.syntax +: cmd.args).toArray
+                  if (!state.status.isOk) Task.now(state)
+                  else Tasks.runNativeOrJs(state, project, cwd, mainClass.`class`, args)
+                }
           }
       }
     }


### PR DESCRIPTION
Previously the `data` and `dataKind` fields in `RunParams` were ignored and the default class in the build target was run. 

Now, if those fields are specified, we use the information (class name, arguments and jvmOptions) to run the correct class. If `dataKind` is not specified, the old approach is used for backward compatibility