### PR TITLE
notify BSP client the debuggee can be attached to

### DIFF
--- a/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
+++ b/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
@@ -11,8 +11,8 @@ import xsbti.Severity
 
 import scala.meta.jsonrpc.JsonRpcClient
 import ch.epfl.scala.bsp
-import ch.epfl.scala.bsp.BuildTargetIdentifier
-import ch.epfl.scala.bsp.endpoints.Build
+import ch.epfl.scala.bsp.{BuildTargetIdentifier, DebuggeeAddress}
+import ch.epfl.scala.bsp.endpoints.{Build, BuildTarget}
 import monix.execution.atomic.AtomicInt
 
 /**
@@ -210,6 +210,11 @@ final class BspServerLogger private (
       )
     )
     ()
+  }
+
+  def publishDebuggeeAttachable(port: Int): Unit = {
+    val notification = bsp.DebuggeeAddress(originId, s"tcp://localhost:$port")
+    BuildTarget.debuggeeListening.notify(notification)
   }
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val nailgunCommit = "d7ed5db"
 
   val zincVersion = "1.3.0-M4+25-0283d5c6"
-  val bspVersion = "2.0.0-M4"
+  val bspVersion = "2.0.0-M4+11-aea9deab"
   val scalazVersion = "7.2.20"
   val coursierVersion = "1.1.0-M14-4"
   val lmVersion = "1.0.0"


### PR DESCRIPTION
This sends a [new BSP notification](https://github.com/scalacenter/bsp/pull/98) to the client with the debuggee address. It is intended as a simpler approach to implementing Debug Adapter protocol inside bloop and as such it would supersede https://github.com/scalacenter/bloop/pull/944.

The reason for chosing this approach is its simplicity. The overall goal from the very beginning was to make `metals` capable of running and debugging main classes and tests. Having Debug Adapter inside bloop forces us to solve some complex problems like picking up source changes when restarting a debug session. 

This one notification is everything metals requires at the moment to implement the Debug Adapter on its own. It means that future Build Server would become much simpler as they would no longer need to provide a Debug Adapter on their own.