### PR TITLE
Don't warn about main classes in non-compiled projects

### DIFF
--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -206,22 +206,20 @@ object Tasks {
   def findMainClasses(state: State, project: Project): List[String] = {
     import state.logger
 
-    val analysis = {
-      state.results.lastSuccessfulResultOrEmpty(project).previous.analysis().toOption match {
-        case Some(analysis: Analysis) => analysis
-        case _ =>
-          logger.warn(
-            s"Cannot find main classes in '${project.name}'. No successful compilation detected."
-          )
-          Analysis.empty
-      }
-    }
+    state.results.lastSuccessfulResultOrEmpty(project).previous.analysis().toOption match {
+      case Some(analysis: Analysis) =>
+        val mainClasses = analysis.infos.allInfos.values.flatMap(_.getMainClasses).toList
+        logger.debug(s"Found ${mainClasses.size} main classes: ${mainClasses.mkString(", ")}.")(
+          DebugFilter.All
+        )
+        mainClasses
+      case _ =>
+        logger.debug(
+          s"Cannot find main classes in '${project.name}'. No successful compilation detected."
+        )(DebugFilter.All)
 
-    val mainClasses = analysis.infos.allInfos.values.flatMap(_.getMainClasses).toList
-    logger.debug(s"Found ${mainClasses.size} main classes${mainClasses.mkString(": ", ", ", ".")}")(
-      DebugFilter.All
-    )
-    mainClasses
+        Nil
+    }
   }
 
   def reasonOfInvalidPath(output: Path): Option[String] = {

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -303,7 +303,9 @@ object TestTask {
         val frameworks = found.frameworks
         val lastCompileResult = state.results.lastSuccessfulResultOrEmpty(project)
         val analysis = lastCompileResult.previous.analysis().toOption.getOrElse {
-          logger.warn(s"TestsFQCN was triggered, but no compilation detected for ${project.name}")
+          logger.debug(s"TestsFQCN was triggered, but no compilation detected for ${project.name}")(
+            DebugFilter.All
+          )
           Analysis.empty
         }
         val tests = discoverTests(analysis, frameworks)


### PR DESCRIPTION
Currently, metals is asking for scala main classes and test suites (to provide code lenses) quite often and if the project was not yet compiled, we get a warn for each of the modules in the project like in the image below. 

![bloop-no-compilation](https://user-images.githubusercontent.com/3709537/65507401-2791b300-dece-11e9-8721-a030b652cce7.png)

This PR changes those warns to debug-level messages so they are still discoverable but no longer overwhelm the output.