### PR TITLE
Increase the debuggee startup timeout

### DIFF
--- a/frontend/src/main/scala/bloop/dap/DebugSession.scala
+++ b/frontend/src/main/scala/bloop/dap/DebugSession.scala
@@ -109,7 +109,7 @@ final class DebugSession(
           .map(DebugSession.toAttachRequest(requestId, _))
           .foreachL(super.dispatchRequest)
           .timeoutTo(
-            FiniteDuration(5, TimeUnit.SECONDS),
+            FiniteDuration(15, TimeUnit.SECONDS),
             Task {
               val response = DebugSession.failed(request, "Could not start debuggee")
               this.sendResponse(response)

--- a/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
@@ -177,7 +177,7 @@ object DebugServerSpec extends BspBaseSuite {
         _ <- client.launch()
       } yield ()
 
-      TestUtil.await(10, SECONDS)(test)
+      TestUtil.await(20, SECONDS)(test)
     }
   }
 
@@ -305,7 +305,7 @@ object DebugServerSpec extends BspBaseSuite {
       .doOnFinish(_ => Task(testServer.close()))
       .doOnCancel(Task(testServer.close()))
 
-    TestUtil.await(15, SECONDS)(test)
+    TestUtil.await(20, SECONDS)(test)
     ()
   }
 


### PR DESCRIPTION
In some cases this timeout might be too low (e.g. when the task was not yet started). This seems like a probable cause for failing tests on [metals CI](https://github.com/scalameta/metals/pull/942). Increasing timeout here does not seem to be a major issue, since previous value already was quite arbitrary.