### PR TITLE
[debug] Switch to sbt-coursier 1.1.0-M14-2

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -16,7 +16,7 @@ val `bloop-build` = project
     addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.1.1"),
     addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.1"),
     addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2"),
-    addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13-2"),
+    addSbtCoursier,
     addSbtPlugin("org.scalameta" % "sbt-mdoc" % "1.2.10"),
     addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools" % "1.1.1"),
     addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.4.0"),

--- a/project/project/build.sbt
+++ b/project/project/build.sbt
@@ -104,3 +104,5 @@ val root = project
       sbt.internal.inc.Analysis.empty
     }
   )
+
+addSbtCoursier

--- a/project/project/project/build.sbt
+++ b/project/project/project/build.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13-2")
+addSbtCoursier
 libraryDependencies += ("ch.epfl.scala" % "jarjar" % "1.7.2-patched")
   .exclude("org.apache.maven", "maven-plugin-api")
   .exclude("org.apache.ant", "ant")

--- a/project/project/project/project/plugins.sbt
+++ b/project/project/project/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13-2")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M14-2")


### PR DESCRIPTION
Just a check, as a follow up to https://github.com/scalacenter/bloop/pull/1039. This is the coursier and sbt-coursier versions right before `1.1.0-M14-5` (coursier) / `1.1.0-M14-3` (sbt-coursier). So if the changes in those versions are really the problem, I would expect the PR here to pass.