### PR TITLE
Add dotty support back

### DIFF
--- a/backend/src/main/scala/bloop/ScalaInstance.scala
+++ b/backend/src/main/scala/bloop/ScalaInstance.scala
@@ -12,6 +12,7 @@ import bloop.internal.build.BloopScalaInfo
 import bloop.logging.{DebugFilter, Logger}
 
 import scala.util.control.NonFatal
+import sbt.internal.inc.BloopComponentCompiler
 
 final class ScalaInstance private (
     val organization: String,
@@ -29,8 +30,7 @@ final class ScalaInstance private (
   }
 
   /** Is this `ScalaInstance` using Dotty? */
-  def isDotty: Boolean =
-    organization == "ch.epfl.lamp" && sbt.internal.inc.ScalaInstance.isDotty(version)
+  def isDotty: Boolean = organization == "ch.epfl.lamp" && version.startsWith("0.")
 
   override lazy val loaderLibraryOnly: ClassLoader =
     new URLClassLoader(Array(libraryJar.toURI.toURL), ScalaInstance.bootClassLoader)

--- a/frontend/src/test/scala/bloop/FileWatchingSpec.scala
+++ b/frontend/src/test/scala/bloop/FileWatchingSpec.scala
@@ -240,7 +240,7 @@ object FileWatchingSpec extends BaseSuite {
         state
       }
 
-      TestUtil.await(FiniteDuration(10, TimeUnit.SECONDS)) {
+      TestUtil.await(FiniteDuration(20, TimeUnit.SECONDS), ExecutionContext.ioScheduler) {
         for {
           _ <- waitUntilIteration(1)
           initialWatchedState <- Task(testValidLatestState)
@@ -248,7 +248,7 @@ object FileWatchingSpec extends BaseSuite {
           _ <- Task(writeFile(`A`.srcFor("A.scala"), Sources.`A2.scala`))
           // Write another change with a delay to simulate remote development in VS Code
           _ <- Task(writeFile(`A`.srcFor("A.scala"), Sources.`A3.scala`))
-            .delayExecution(FiniteDuration(250, TimeUnit.MILLISECONDS))
+            .delayExecution(FiniteDuration(100, TimeUnit.MILLISECONDS))
           _ <- waitUntilIteration(2)
           firstWatchedState <- Task(testValidLatestState)
           _ <- Task(writeFile(`A`.srcFor("A.scala"), Sources.`A2.scala`))

--- a/frontend/src/test/scala/bloop/util/TestProject.scala
+++ b/frontend/src/test/scala/bloop/util/TestProject.scala
@@ -69,6 +69,8 @@ object TestProject {
       directDependencies: List[TestProject] = Nil,
       enableTests: Boolean = false,
       scalacOptions: List[String] = Nil,
+      scalaOrg: Option[String] = None,
+      scalaCompiler: Option[String] = None,
       scalaVersion: Option[String] = None,
       resources: List[String] = Nil,
       jvmConfig: Option[Config.JvmConfig] = None,
@@ -87,8 +89,11 @@ object TestProject {
 
     import bloop.engine.ExecutionContext.ioScheduler
     val version = scalaVersion.getOrElse(Properties.versionNumberString)
+
+    val finalScalaOrg = scalaOrg.getOrElse("org.scala-lang")
+    val finalScalaCompiler = scalaCompiler.getOrElse("scala-compiler")
     val instance = scalaVersion
-      .map(v => ScalaInstance.apply("org.scala-lang", "scala-compiler", v, jars.toList, NoopLogger))
+      .map(v => ScalaInstance.apply(finalScalaOrg, finalScalaCompiler, v, jars.toList, NoopLogger))
       .getOrElse(TestUtil.scalaInstance)
 
     val allJars = instance.allJars.map(AbsolutePath.apply)
@@ -98,8 +103,8 @@ object TestProject {
     val javaEnv = JavaEnv.fromConfig(javaConfig)
     val setup = Config.CompileSetup.empty.copy(order = order)
     val scalaConfig = Config.Scala(
-      "org.scala-lang",
-      "scala-compiler",
+      finalScalaOrg,
+      finalScalaCompiler,
       version,
       scalacOptions,
       allJars.map(_.underlying).toList,


### PR DESCRIPTION
https://github.com/scalacenter/bloop/pull/460 initially added support
for Dotty but we removed it recently while experimenting with some
breaking changes in the Zinc compiler interface. Those changes were
afterwards refactored to be non-breaking with the Dotty compiler bridge,
which means Dotty continues to work with Bloop.

However, we must make a change in the Dotty compiler interface to
support invalidation of class files by hooking up into their compiler
symbol loaders. I'll follow up with that change in the Dotty repository.