### PR TITLE
Query latest version from `public` Sonatype repository

### DIFF
--- a/docs-gen/src/main/scala/bloop/docs/Sonatype.scala
+++ b/docs-gen/src/main/scala/bloop/docs/Sonatype.scala
@@ -17,8 +17,8 @@ case class Release(version: String, lastModified: Date) {
 }
 
 object Sonatype {
-  lazy val releaseBloop = current //Sonatype.fetchLatest("bloop-frontend_2.12", "staging")
-  lazy val releaseLauncher = current //Sonatype.fetchLatest("bloop-launcher_2.12", "staging")
+  lazy val releaseBloop = Sonatype.fetchLatest("bloop-frontend_2.12", "public")
+  lazy val releaseLauncher = Sonatype.fetchLatest("bloop-launcher_2.12", "public")
 
   // Copy-pasted from https://github.com/scalameta/metals/blob/994e5e6746ad327ce727d688ad9831e0fbb69b3f/metals-docs/src/main/scala/docs/Snapshot.scala
   lazy val current: Release = Release(BuildInfo.version, new Date())


### PR DESCRIPTION
It looks like Sonatype has moved the artifacts present in `staging` to
another repository called `public`. This commit updates a workaround I
did a few days ago to make our publish CI step work when the Sonatype
breaking change affected us. Now we should query the latest released
version correctly.

Fixes https://github.com/scalacenter/bloop/issues/1054