### PR TITLE
Add all necessary SemanticDB options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,3 @@ benchmark-bridge/corpus/
 lowered.hnir
 
 project/metals.sbt
-.bloop/*
-.metals/*

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -237,13 +237,10 @@ object Project {
       // engine so that semanticdb files are replicated in those directories
       val hasSemanticDB = hasSemanticDBEnabledInCompilerOptions(options)
       val pluginOption = if (hasSemanticDB) Nil else List(s"-Xplugin:$pluginPath")
-      val sourceRootOption =
-        if (hasSemanticdbSourceRoot(options)) {
-          Nil
-        } else {
-          List(s"-P:semanticdb:sourceroot:$workspaceDir")
-        }
-      (options ++ baseSemanticdbOptions ++ pluginOption ++ sourceRootOption).distinct
+      val baseOptions = s"-P:semanticdb:sourceroot:$workspaceDir" :: options.filterNot(
+        isSemanticdbSourceRoot
+      )
+      (baseOptions ++ baseSemanticdbOptions ++ pluginOption).distinct
     }
 
     def enableRangePositions(options: List[String]): List[String] = {
@@ -267,7 +264,7 @@ object Project {
     options.exists(opt => opt.contains("-Xplugin") && opt.contains("semanticdb-scalac"))
   }
 
-  def hasSemanticdbSourceRoot(options: List[String]): Boolean = {
-    options.exists(opt => opt.contains("semanticdb:sourceroot"))
+  def isSemanticdbSourceRoot(option: String): Boolean = {
+    option.contains("semanticdb:sourceroot")
   }
 }

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -227,27 +227,29 @@ object Project {
       logger: Logger
   ): Project = {
     def enableSemanticDB(options: List[String], pluginPath: AbsolutePath): List[String] = {
+      val workspaceDir = project.workspaceDirectory.getOrElse(configDir.getParent)
+      val baseSemanticdbOptions = List(
+        "-P:semanticdb:failures:warning",
+        "-P:semanticdb:synthetics:on",
+        "-Xplugin-require:semanticdb"
+      )
+      // TODO: Handle user-configured `targetroot`s inside Bloop's compilation
+      // engine so that semanticdb files are replicated in those directories
       val hasSemanticDB = hasSemanticDBEnabledInCompilerOptions(options)
-      if (hasSemanticDB) options
-      else {
-        val workspaceDir = project.workspaceDirectory.getOrElse(configDir.getParent)
-        // TODO: Handle user-configured `targetroot`s inside Bloop's compilation
-        // engine so that semanticdb files are replicated in those directories
-        val semanticdbScalacOptions = List(
-          "-P:semanticdb:failures:warning",
-          s"-P:semanticdb:sourceroot:$workspaceDir",
-          "-P:semanticdb:synthetics:on",
-          "-Xplugin-require:semanticdb",
-          s"-Xplugin:$pluginPath"
-        )
-
-        (options ++ semanticdbScalacOptions.toList).distinct
-      }
+      val pluginOption = if (hasSemanticDB) Nil else List(s"-Xplugin:$pluginPath")
+      val sourceRootOption =
+        if (hasSemanticdbSourceRoot(options)) {
+          Nil
+        } else {
+          List(s"-P:semanticdb:sourceroot:$workspaceDir")
+        }
+      (options ++ baseSemanticdbOptions ++ pluginOption ++ sourceRootOption).distinct
     }
 
     def enableRangePositions(options: List[String]): List[String] = {
       val hasYrangepos = options.exists(_.contains("-Yrangepos"))
-      if (hasYrangepos) options else options :+ "-Yrangepos"
+      val isDotty = project.scalaInstance.exists(_.isDotty)
+      if (hasYrangepos || isDotty) options else options :+ "-Yrangepos"
     }
 
     val projectWithRangePositions =
@@ -263,5 +265,9 @@ object Project {
 
   def hasSemanticDBEnabledInCompilerOptions(options: List[String]): Boolean = {
     options.exists(opt => opt.contains("-Xplugin") && opt.contains("semanticdb-scalac"))
+  }
+
+  def hasSemanticdbSourceRoot(options: List[String]): Boolean = {
+    options.exists(opt => opt.contains("semanticdb:sourceroot"))
   }
 }

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -151,11 +151,14 @@ class BspMetalsClientSpec(
     }
   }
 
-  test("initialize metals client in workspace with already enabled semanticdb and -Yrangepos") {
+  test(
+    "initialize metals client in workspace with already enabled semanticdb, -Yrangepos and invalid sourcepath"
+  ) {
     TestUtil.withinWorkspace { workspace =>
+      val correctSourceRootOption = s"-P:semanticdb:sourceroot:$workspace"
       val defaultScalacOptions = List(
+        s"-P:semanticdb:sourceroot:bad-root",
         "-P:semanticdb:failures:warning",
-        s"-P:semanticdb:sourceroot:$workspace",
         "-P:semanticdb:synthetics:on",
         "-Xplugin-require:semanticdb",
         s"-Xplugin:path-to-plugin/semanticdb-scalac_2.12.8-4.2.0.jar.jar",
@@ -191,7 +194,7 @@ class BspMetalsClientSpec(
         )
 
         val scalacOptions = state.scalaOptions(`A`)._2.items.head.options
-        assert(scalacOptions == defaultScalacOptions)
+        assert(scalacOptions == correctSourceRootOption :: defaultScalacOptions.drop(1))
       }
     }
   }

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -106,12 +106,13 @@ class BspMetalsClientSpec(
 
   test("initialize metals client in workspace with already enabled semanticdb") {
     TestUtil.withinWorkspace { workspace =>
+      val pluginPath = s"-Xplugin:path-to-plugin/semanticdb-scalac_2.12.8-4.2.0.jar.jar"
       val defaultScalacOptions = List(
         "-P:semanticdb:failures:warning",
         s"-P:semanticdb:sourceroot:$workspace",
         "-P:semanticdb:synthetics:on",
         "-Xplugin-require:semanticdb",
-        s"-Xplugin:path-to-plugin/semanticdb-scalac_2.12.8-4.2.0.jar.jar"
+        pluginPath
       )
 
       val `A` = TestProject(
@@ -119,7 +120,7 @@ class BspMetalsClientSpec(
         "A",
         Nil,
         scalaVersion = Some(testedScalaVersion),
-        scalacOptions = defaultScalacOptions
+        scalacOptions = List(pluginPath)
       )
       val projects = List(`A`)
       val configDir = TestProject.populateWorkspace(workspace, projects)
@@ -143,8 +144,8 @@ class BspMetalsClientSpec(
              |""".stripMargin
         )
 
-        val scalacOptions = state.scalaOptions(`A`)._2.items.head.options
-        val expected = defaultScalacOptions :+ "-Yrangepos"
+        val scalacOptions = state.scalaOptions(`A`)._2.items.head.options.toSet
+        val expected = (defaultScalacOptions :+ "-Yrangepos").toSet
         assert(scalacOptions == expected)
       }
     }


### PR DESCRIPTION
This is important if somebody already added a SemanticDB plugin, but not all the options required by metals.

Also added a check to not add `-Yrangepos` to Dotty.