### PR TITLE
Adjust only 1-based diagnostic positions

### DIFF
--- a/shared/src/main/scala/bloop/logging/CompilationEvent.scala
+++ b/shared/src/main/scala/bloop/logging/CompilationEvent.scala
@@ -81,7 +81,8 @@ object CompilationEvent {
   case class Diagnostic(
       projectUri: bsp.Uri,
       problem: xsbti.Problem,
-      clear: Boolean
+      clear: Boolean,
+      hasOneBasedPosition: Boolean
   ) extends CompilationEvent
 
   /**


### PR DESCRIPTION
This fixes an issue with dotty diagnostics being treated as having 1-indexed lines, while dotty uses 0-based indexing.

Before:
![before](https://user-images.githubusercontent.com/3709537/66736807-90839f80-ee6a-11e9-8339-60a8e41c6ca0.png)

After:
![after](https://user-images.githubusercontent.com/3709537/66736813-94172680-ee6a-11e9-8783-d8ee3134e663.png)
