### PR TITLE
Set Bloopgun to use deamons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Continuous Integration
 on:
   push:
+  pull_request:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -19,7 +20,7 @@ jobs:
           java-version: ${{ matrix.jdk }}
       - uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          node-version: "10.x"
       - name: Set up environment
         run: |
           curl -Lo coursier https://git.io/coursier-cli && chmod +x coursier && ./coursier --help
@@ -71,4 +72,3 @@ jobs:
               "sbtBloop10/scripted" \
               "benchmarks/jmh:run .*HotBloopBenchmark.* -wi 0 -i 1 -f1 -t1 -p project=with-tests -p projectName=with-tests"
         shell: bash
-

--- a/launcher/src/main/scala/bloop/launcher/bsp/BspBridge.scala
+++ b/launcher/src/main/scala/bloop/launcher/bsp/BspBridge.scala
@@ -189,7 +189,7 @@ final class BspBridge(
     }
 
     println("Starting thread that pumps stdin and redirects it to the bsp server...", out)
-    val pumpStdinToSocketStdout = shell.startThread("bsp-client-to-server", false) {
+    val pumpStdinToSocketStdout = shell.startThread("bsp-client-to-server", true) {
       var hasReportedClientError: Boolean = false
       while (isConnectionOpen) {
         val socketOut = socket.getOutputStream
@@ -220,7 +220,7 @@ final class BspBridge(
       "Starting thread that pumps server stdout and redirects it to the client stdout...",
       out
     )
-    val pumpSocketStdinToStdout = shell.startThread("bsp-server-to-client", false) {
+    val pumpSocketStdinToStdout = shell.startThread("bsp-server-to-client", true) {
       var hasReportedServerError: Boolean = false
       while (isConnectionOpen) {
         val socketIn = socket.getInputStream


### PR DESCRIPTION
As a follow up from https://gist.github.com/jvican/a4a081718ac330de3aa734fdfd665085

It seems those threads were keeping the connection alive and not allowing Metals to close.

@jvican Not exactly sure why we didn't run those as deamons, since anything starting Bloop launcher will not be able to kill those threads.