### PR TITLE
Detect JDI initial notification on Windows

### DIFF
--- a/bridges/scalajs-1.0/src/main/scala/bloop/scalajs/jsenv/NodeJsHandler.scala
+++ b/bridges/scalajs-1.0/src/main/scala/bloop/scalajs/jsenv/NodeJsHandler.scala
@@ -73,7 +73,7 @@ final class NodeJsHandler(logger: Logger, exit: Promise[Unit], files: List[Virtu
       if (!remaining.isEmpty)
         logger.info(remaining)
     } else {
-      Forker.linesFrom(buffer, outBuilder).foreach(logger.info(_))
+      Forker.onEachLine(buffer, outBuilder)(logger.info(_))
     }
   }
 
@@ -84,7 +84,7 @@ final class NodeJsHandler(logger: Logger, exit: Promise[Unit], files: List[Virtu
       if (!remaining.isEmpty)
         logger.info(remaining)
     } else {
-      Forker.linesFrom(buffer, outBuilder).foreach(logger.info(_))
+      Forker.onEachLine(buffer, outBuilder)(logger.info(_))
     }
   }
 

--- a/frontend/src/main/scala/bloop/dap/DebugSessionLogger.scala
+++ b/frontend/src/main/scala/bloop/dap/DebugSessionLogger.scala
@@ -52,11 +52,11 @@ final class DebugSessionLogger(
   override def info(msg: String): Unit = {
     underlying.info(msg)
 
-    import DebugSessionLogger.ListeningMessagePrefix
+    import DebugSessionLogger.JDINotificationPrefix
     // Expect the first log to be JDI notification since debuggee runs with `quiet=n` JDI option
-    if (msg.startsWith(ListeningMessagePrefix)) {
+    if (msg.startsWith(JDINotificationPrefix)) {
       if (initialized.compareAndSet(false, true)) {
-        val port = Integer.parseInt(msg.drop(ListeningMessagePrefix.length))
+        val port = Integer.parseInt(msg.drop(JDINotificationPrefix.length))
         val address = new InetSocketAddress("localhost", port)
         listener(address)
       }
@@ -72,5 +72,5 @@ final class DebugSessionLogger(
 }
 
 object DebugSessionLogger {
-  val ListeningMessagePrefix = "Listening for transport dt_socket at address: "
+  val JDINotificationPrefix = "Listening for transport dt_socket at address: "
 }

--- a/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
@@ -33,6 +33,7 @@ import scala.meta.jsonrpc.{BaseProtocolMessage, LanguageClient, LanguageServer, 
 import scala.collection.mutable
 import bloop.logging.Logger
 import bloop.cli.ExitStatus
+import bloop.util.CrossPlatform
 import monix.reactive.subjects.BehaviorSubject
 
 abstract class BspBaseSuite extends BaseSuite with BspClientTest {
@@ -301,7 +302,11 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
         result <- f(client)
       } yield result
 
-      TestUtil.await(30, TimeUnit.SECONDS)(session)
+      val timeout =
+        if (CrossPlatform.isWindows) FiniteDuration(60, TimeUnit.SECONDS)
+        else FiniteDuration(30, TimeUnit.SECONDS)
+
+      TestUtil.await(timeout)(session)
     }
 
     def scalaOptions(project: TestProject): (ManagedBspTestState, bsp.ScalacOptionsResult) = {

--- a/frontend/src/test/scala/bloop/dap/DebugAdapterConnection.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugAdapterConnection.scala
@@ -40,16 +40,16 @@ private[dap] final class DebugAdapterConnection(
     }
   )
 
-  def initialize(): Task[Response[Capabilities]] = {
+  def initialize(): Task[Capabilities] = {
     val arguments = new InitializeArguments()
     adapter.request(Initialize, arguments)
   }
 
-  def configurationDone(): Task[Response[Unit]] = {
+  def configurationDone(): Task[Unit] = {
     adapter.request(ConfigurationDone, ())
   }
 
-  def launch(): Task[Response[Unit]] = {
+  def launch(): Task[Unit] = {
     val arguments = new LaunchArguments
     arguments.noDebug = true
     adapter.request(Launch, arguments)
@@ -63,7 +63,7 @@ private[dap] final class DebugAdapterConnection(
     }
   }
 
-  def disconnect(restart: Boolean): Task[Response[Unit]] = {
+  def disconnect(restart: Boolean): Task[Unit] = {
     val arguments = new DisconnectArguments
     arguments.restart = restart
     for {

--- a/frontend/src/test/scala/bloop/dap/DebugAdapterProxy.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugAdapterProxy.scala
@@ -28,7 +28,7 @@ private[dap] final class DebugAdapterProxy(
   private val requests = mutable.Map.empty[Int, Promise[Messages.Response]]
   val events = new DebugEvents()
 
-  def request[A, B](endpoint: DebugTestProtocol.Request[A, B], parameters: A): Task[Response[B]] = {
+  def request[A, B](endpoint: DebugTestProtocol.Request[A, B], parameters: A): Task[B] = {
     val message = endpoint.serialize(parameters)
     val response = send(message)
     response.flatMap(endpoint.deserialize)

--- a/frontend/src/test/scala/bloop/dap/DebugBspBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugBspBaseSuite.scala
@@ -1,24 +1,22 @@
 package bloop.dap
 
 import bloop.TestSchedulers
+import bloop.bsp.BloopBspDefinitions.BloopExtraBuildParams
 import bloop.bsp.BspBaseSuite
 import bloop.cli.{BspProtocol, Commands}
 import bloop.engine.State
 import bloop.io.AbsolutePath
 import bloop.logging.BspClientLogger
-import bloop.bsp.BloopBspDefinitions.BloopExtraBuildParams
-
-import monix.execution.Scheduler
-
 import ch.epfl.scala.bsp
-
+import monix.execution.Scheduler
 import scala.collection.mutable
 import scala.concurrent.Promise
 
 abstract class DebugBspBaseSuite extends BspBaseSuite {
   protected val debugDefaultScheduler: Scheduler =
     TestSchedulers.async("debug-bsp-default", threads = 5)
-  override def protocol: BspProtocol = BspProtocol.Local
+
+  override def protocol: BspProtocol = if (isWindows) BspProtocol.Tcp else BspProtocol.Local
 
   override def openBspConnection[T](
       state: State,

--- a/frontend/src/test/scala/bloop/dap/DebugProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugProtocolSpec.scala
@@ -2,16 +2,12 @@ package bloop.dap
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-
-import bloop.cli.BspProtocol
 import bloop.logging.RecordingLogger
 import bloop.util.{TestProject, TestUtil}
 import ch.epfl.scala.bsp
 import ch.epfl.scala.bsp.DebugSessionParamsDataKind._
 
 object DebugProtocolSpec extends DebugBspBaseSuite {
-  override val protocol: BspProtocol = BspProtocol.Local
-
   test("starts a debug session") {
     TestUtil.withinWorkspace { workspace =>
       val main =

--- a/frontend/src/test/scala/bloop/dap/DebugProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugProtocolSpec.scala
@@ -154,7 +154,6 @@ object DebugProtocolSpec extends DebugBspBaseSuite {
             _ <- client.initialize()
             _ <- client.launch()
             _ <- client.configurationDone()
-            _ <- client.exited
             _ <- client.terminated
             output <- client.allOutput
           } yield output

--- a/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
@@ -3,7 +3,7 @@ package bloop.dap
 import java.net.{ConnectException, SocketException, SocketTimeoutException}
 import java.util.NoSuchElementException
 import java.util.concurrent.TimeUnit.{MILLISECONDS, SECONDS}
-import bloop.cli._
+import bloop.cli.ExitStatus
 import bloop.logging.RecordingLogger
 import bloop.util.{TestProject, TestUtil}
 import ch.epfl.scala.bsp.ScalaMainClass

--- a/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
@@ -1,24 +1,19 @@
 package bloop.dap
+
 import java.net.{ConnectException, SocketException, SocketTimeoutException}
 import java.util.NoSuchElementException
 import java.util.concurrent.TimeUnit.{MILLISECONDS, SECONDS}
-
-import bloop.bsp.BspBaseSuite
-import bloop.cli.BspProtocol
 import bloop.logging.RecordingLogger
 import bloop.util.{TestProject, TestUtil}
 import ch.epfl.scala.bsp.ScalaMainClass
 import monix.eval.Task
 import monix.execution.Cancelable
-
-import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Promise, TimeoutException}
 import bloop.engine.ExecutionContext
 
-object DebugServerSpec extends BspBaseSuite {
-  override val protocol: BspProtocol.Local.type = BspProtocol.Local
+object DebugServerSpec extends DebugBspBaseSuite {
   private val ServerNotListening = new IllegalStateException("Server is not accepting connections")
 
   test("cancelling server closes server connection") {
@@ -75,7 +70,7 @@ object DebugServerSpec extends BspBaseSuite {
             _ <- Task.fromFuture(client.closedPromise.future)
           } yield ()
 
-          TestUtil.await(FiniteDuration(10, SECONDS), ExecutionContext.ioScheduler)(test)
+          TestUtil.await(FiniteDuration(30, SECONDS), ExecutionContext.ioScheduler)(test)
         }
       }
     }
@@ -113,7 +108,7 @@ object DebugServerSpec extends BspBaseSuite {
             assertNoDiff(output, "Hello, World!")
           }
 
-          TestUtil.await(FiniteDuration(10, SECONDS), ExecutionContext.ioScheduler)(test)
+          TestUtil.await(FiniteDuration(60, SECONDS), ExecutionContext.ioScheduler)(test)
         }
       }
     }
@@ -138,7 +133,7 @@ object DebugServerSpec extends BspBaseSuite {
             _ <- client.terminated
           } yield ()
 
-          TestUtil.await(FiniteDuration(5, SECONDS), ExecutionContext.ioScheduler)(test)
+          TestUtil.await(FiniteDuration(60, SECONDS), ExecutionContext.ioScheduler)(test)
         }
       }
     }

--- a/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
@@ -66,7 +66,6 @@ object DebugServerSpec extends DebugBspBaseSuite {
             _ <- client.configurationDone()
             _ <- Task(server.cancel())
             _ <- client.terminated
-            _ <- client.exited
             _ <- Task.fromFuture(client.closedPromise.future)
           } yield ()
 

--- a/frontend/src/test/scala/bloop/dap/DebugTestClient.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugTestClient.scala
@@ -19,13 +19,13 @@ final class DebugTestClient(connect: () => DebugAdapterConnection) {
    */
   private var activeSession = connect()
 
-  def initialize(): Task[Response[Capabilities]] =
+  def initialize(): Task[Capabilities] =
     activeSession.initialize()
 
-  def configurationDone(): Task[Response[Unit]] =
+  def configurationDone(): Task[Unit] =
     activeSession.configurationDone()
 
-  def launch(): Task[Response[Unit]] =
+  def launch(): Task[Unit] =
     activeSession.launch()
 
   def exited: Task[Events.ExitedEvent] =
@@ -47,7 +47,7 @@ final class DebugTestClient(connect: () => DebugAdapterConnection) {
     activeSession.allOutput
   }
 
-  def disconnect(): Task[Response[Unit]] = {
+  def disconnect(): Task[Unit] = {
     activeSession.disconnect(restart = false)
   }
 


### PR DESCRIPTION
This makes the `Forker` split the process output on both unix- and windows- style newlines, regardless of the underlying OS.

Motivation here is that we cannot make the assumption on the basis of the underlying OS, because there is no guarantee that the application is intended to run on the same OS it is being developed on.

It changes the current behavior only in cases where the application produces an output with mixed newline style.