### PR TITLE
Query latest version from `public` Sonatype repository

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,3 +1,4 @@
 -XX:ReservedCodeCacheSize=512m
 -Dbloop.generate.sbt=false
 -Dsbt.execute.extrachecks=true
+-Dsbt-bloop.offload-compilation=true

--- a/frontend/src/test/resources/compiler-plugin-whitelist/build.sbt
+++ b/frontend/src/test/resources/compiler-plugin-whitelist/build.sbt
@@ -7,7 +7,9 @@ scalaVersion in ThisBuild := "2.12.8"
 lazy val `bloop-test-plugin` = project
   .settings(
     libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-    publishArtifact in Compile := false
+    publishArtifact in Compile := false,
+    bloopGenerate in Compile := None,
+    bloopGenerate in Test := None
   )
 
 val silencerVersion = "1.3.1"

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -141,10 +141,13 @@ object BloopDefaults {
       (if (bloopClassifiers.isEmpty) old else bloopClassifiers.get).toList
     },
     BloopKeys.bloopIsMetaBuild := {
+      /*
       val buildStructure = Keys.loadedBuild.value
       val baseDirectory = new File(buildStructure.root)
       val isMetaBuild = Keys.sbtPlugin.in(LocalRootProject).value
       isMetaBuild && baseDirectory.getAbsolutePath != cwd
+       */
+      false
     },
     Keys.onLoad := {
       val oldOnLoad = Keys.onLoad.value

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/build.sbt
@@ -17,6 +17,7 @@ val baz = project.dependsOn(bar % "compile->test")
 val woo = project.dependsOn(foo % "test->compile")
 val yay = project.dependsOn(foo)
 val zee = project.configs(IntegrationTest).dependsOn(foo % "it->test")
+val ziz = project.dependsOn(foo % Provided)
 
 val allBloopConfigFiles = settingKey[List[File]]("All config files to test")
 allBloopConfigFiles in ThisBuild := {
@@ -34,6 +35,8 @@ allBloopConfigFiles in ThisBuild := {
   val zeeConfig = bloopDir./("zee.json")
   val zeeTestConfig = bloopDir./("zee-test.json")
   val zeeItConfig = bloopDir./("zee-it.json")
+  val zizConfig = bloopDir./("ziz.json")
+  val zizTestConfig = bloopDir./("ziz-test.json")
   List(
     fooConfig,
     fooTestConfig,
@@ -47,7 +50,9 @@ allBloopConfigFiles in ThisBuild := {
     yayTestConfig,
     zeeConfig,
     zeeTestConfig,
-    zeeItConfig
+    zeeItConfig,
+    zizConfig,
+    zizTestConfig
   )
 }
 
@@ -81,6 +86,10 @@ checkBloopFile in ThisBuild := {
   // Test that zee-it contains a dependency to foo-test
   val zeeItConfigContents = readConfigFor("zee-it", allConfigs)
   assert(zeeItConfigContents.project.dependencies.sorted == List("foo-test", "zee"))
+
+  // A project depending on another via a provided dependency should export it as a dep
+  val zizConfigContents = readConfigFor("ziz", allConfigs)
+  assert(zeeItConfigContents.project.dependencies == List("foo"))
 }
 
 val checkSourceAndDocs = taskKey[Unit]("Check source and doc jars are resolved and persisted")

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,21 +1,12 @@
 val mvnVersion = "3.6.1"
 val mvnPluginToolsVersion = "3.6.0"
 
+// Create a proxy project instead of depending on plugin directly to work around https://github.com/sbt/sbt/issues/892
 val `bloop-shaded-plugin` = project
   .settings(
     sbtPlugin := true,
     exportJars := true,
-    scalaVersion := "2.12.9",
-    bloopGenerate in Compile := None,
-    bloopGenerate in Test := None,
-    compileInputs in Compile in compile := {
-      val inputs = (compileInputs in Compile in compile).value
-      val classDir = (classDirectory in Compile).value
-      val shadingJar = baseDirectory.value.getParentFile / "project" / "target" / "sbt-bloop-build-shaded" / "target" / "scala-2.12" / "sbt-1.0" / "sbt-bloop-build-shaded-raw-1.0.0-SNAPSHOT-shading.jar"
-      IO.unzip(shadingJar, classDir)
-      IO.delete(classDir / "META-INF" / "MANIFEST.MF")
-      inputs
-    }
+    libraryDependencies += "ch.epfl.scala" %% "sbt-bloop-build-shaded-naked" % "1.0.0-SNAPSHOT"
   )
 
 updateOptions := updateOptions.value.withLatestSnapshots(false)
@@ -24,7 +15,6 @@ val `bloop-build` = project
   .dependsOn(`bloop-shaded-plugin`)
   .settings(
     exportJars := true,
-    scalaVersion := "2.12.9",
     addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.1.0"),
     addSbtPlugin("ohnosequences" % "sbt-github-release" % "0.6.0"),
     addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4"),

--- a/project/project/BloopShadedPlugin.scala
+++ b/project/project/BloopShadedPlugin.scala
@@ -1,0 +1,14 @@
+package bloop.integrations.sbt
+
+import sbt.{AutoPlugin, Def}
+
+object BloopShadedPlugin extends AutoPlugin {
+  import sbt.plugins.JvmPlugin
+  override def requires = JvmPlugin
+  override def trigger = allRequirements
+  final val autoImport = BloopKeys
+
+  override def globalSettings: Seq[Def.Setting[_]] = BloopDefaults.globalSettings
+  override def buildSettings: Seq[Def.Setting[_]] = BloopDefaults.buildSettings
+  override def projectSettings: Seq[Def.Setting[_]] = BloopDefaults.projectSettings
+}

--- a/project/project/BloopgunInfo.scala
+++ b/project/project/BloopgunInfo.scala
@@ -1,5 +1,5 @@
 package bloopgun.internal.build
 
 case object BloopgunInfo {
-  val version: String = "1.3.4+58-26d56d16+20191103-1040"
+  val version: String = "1.3.4+138-21d49d80"
 }

--- a/sbt-shading/src/main/scala/build/ShadingPlugin.scala
+++ b/sbt-shading/src/main/scala/build/ShadingPlugin.scala
@@ -20,6 +20,7 @@ object BloopShadingPlugin extends AutoPlugin {
 
   val shadingNamespace = SettingKey[String]("shading-namespace")
   val shadeNamespaces = SettingKey[Set[String]]("shade-namespaces")
+  val shadeIgnoredNamespaces = SettingKey[Set[String]]("shade-ignored-namespaces")
   val toShadeJars = TaskKey[Seq[File]]("to-shade-jars")
   val toShadeClasses = TaskKey[Seq[String]]("to-shade-classes")
 
@@ -37,6 +38,7 @@ object BloopShadingPlugin extends AutoPlugin {
      * Allows to speed the shading phase, if everything under some namespaces is to be shaded.
      */
     val shadeNamespaces = BloopShadingPlugin.shadeNamespaces
+    val shadeIgnoredNamespaces = BloopShadingPlugin.shadeIgnoredNamespaces
     val toShadeJars = BloopShadingPlugin.toShadeJars
     val toShadeClasses = BloopShadingPlugin.toShadeClasses
 
@@ -51,6 +53,7 @@ object BloopShadingPlugin extends AutoPlugin {
           unshadedJars,
           namespace,
           shadeNamespaces.value,
+          shadeIgnoredNamespaces.value,
           toShadeClasses.value,
           toShadeJars.value
         )


### PR DESCRIPTION
It looks like Sonatype has moved the artifacts present in `staging` to
another repository called `public`. This commit updates a workaround I
did a few days ago to make our publish CI step work when the Sonatype
breaking change affected us. Now we should query the latest released
version correctly.

Fixes https://github.com/scalacenter/bloop/issues/1054