### PR TITLE
Use platform.config settings to compile Java code

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -48,7 +48,7 @@ case class CompileInputs(
     baseDirectory: AbsolutePath,
     scalacOptions: Array[String],
     javacOptions: Array[String],
-    javacHome: Option[AbsolutePath],
+    javacBin: Option[AbsolutePath],
     compileOrder: CompileOrder,
     classpathOptions: ClasspathOptions,
     previousResult: PreviousResult,
@@ -333,7 +333,7 @@ object Compiler {
     val start = System.nanoTime()
     val scalaInstance = compileInputs.scalaInstance
     val classpathOptions = compileInputs.classpathOptions
-    val compilers = compileInputs.compilerCache.get(scalaInstance, compileInputs.javacHome)
+    val compilers = compileInputs.compilerCache.get(scalaInstance, compileInputs.javacBin)
     val inputs = tracer.trace("creating zinc inputs")(_ => getInputs(compilers))
 
     // We don't need nanosecond granularity, we're happy with milliseconds

--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -48,6 +48,7 @@ case class CompileInputs(
     baseDirectory: AbsolutePath,
     scalacOptions: Array[String],
     javacOptions: Array[String],
+    javacHome: Option[AbsolutePath],
     compileOrder: CompileOrder,
     classpathOptions: ClasspathOptions,
     previousResult: PreviousResult,
@@ -332,7 +333,7 @@ object Compiler {
     val start = System.nanoTime()
     val scalaInstance = compileInputs.scalaInstance
     val classpathOptions = compileInputs.classpathOptions
-    val compilers = compileInputs.compilerCache.get(scalaInstance)
+    val compilers = compileInputs.compilerCache.get(scalaInstance, compileInputs.javacHome)
     val inputs = tracer.trace("creating zinc inputs")(_ => getInputs(compilers))
 
     // We don't need nanosecond granularity, we're happy with milliseconds

--- a/backend/src/main/scala/bloop/CompilerCache.scala
+++ b/backend/src/main/scala/bloop/CompilerCache.scala
@@ -44,11 +44,11 @@ final class CompilerCache(
     retrieveDir: AbsolutePath,
     logger: Logger,
     userResolvers: List[Resolver],
-    useSiteCache: Option[ConcurrentHashMap[ScalaInstance, Compilers]],
+    userScalaCache: Option[ConcurrentHashMap[ScalaInstance, Compilers]],
     scheduler: ExecutionContext
 ) {
 
-  private val cache = useSiteCache.getOrElse(new ConcurrentHashMap[ScalaInstance, Compilers]())
+  private val cache = userScalaCache.getOrElse(new ConcurrentHashMap[ScalaInstance, Compilers]())
   def get(scalaInstance: ScalaInstance): Compilers =
     cache.computeIfAbsent(scalaInstance, newCompilers)
 

--- a/backend/src/main/scala/sbt/internal/inc/javac/BloopForkedJavaUtils.scala
+++ b/backend/src/main/scala/sbt/internal/inc/javac/BloopForkedJavaUtils.scala
@@ -6,11 +6,35 @@ import xsbti.Reporter
 
 object BloopForkedJavaUtils {
   def launch(
-      javaHome: Option[File],
-      program: String,
+      javac: Option[File],
+      binaryName: String,
       sources: Seq[File],
       options: Seq[String],
       log: Logger,
       reporter: Reporter
-  ): Boolean = ForkedJava.launch(javaHome, "javac", sources, options, log, reporter)
+  ): Boolean = {
+    def normalizeSlash(s: String) = s.replace(File.separatorChar, '/')
+
+    val (jArgs, nonJArgs) = options.partition(_.startsWith("-J"))
+    val allArguments = nonJArgs ++ sources.map(_.getAbsolutePath)
+
+    val exe = javac match {
+      case None => binaryName
+      case Some(javacBinary) => javacBinary.getAbsolutePath()
+    }
+
+    ForkedJava.withArgumentFile(allArguments) { argsFile =>
+      val forkArgs = jArgs :+ s"@${normalizeSlash(argsFile.getAbsolutePath)}"
+      val cwd = new File(new File(".").getAbsolutePath).getCanonicalFile
+      val javacLogger = new JavacLogger(log, reporter, cwd)
+      var exitCode = -1
+      try {
+        exitCode = scala.sys.process.Process(exe +: forkArgs, cwd) ! javacLogger
+      } finally {
+        javacLogger.flush(binaryName, exitCode)
+      }
+      // We return true or false, depending on success.
+      exitCode == 0
+    }
+  }
 }

--- a/backend/src/test/scala/bloop/CompilerCacheSpec.scala
+++ b/backend/src/test/scala/bloop/CompilerCacheSpec.scala
@@ -72,7 +72,7 @@ class CompilerCacheSpec {
         val wr3 = new WriteReportingJavaFileObject(fo3, classFileManager)
 
         val ec = ExecutionContext.global
-        val compilerCache = new CompilerCache(null, tempDir, logger, List.empty, None, ec)
+        val compilerCache = new CompilerCache(null, tempDir, logger, List.empty, None, None, ec)
         val bloopCompiler = new compilerCache.BloopJavaCompiler(compiler)
         val invalidatingFileManager =
           new bloopCompiler.BloopInvalidatingFileManager(javacFileManager, classFileManager)

--- a/frontend/src/it/scala/bloop/CommunityBuild.scala
+++ b/frontend/src/it/scala/bloop/CommunityBuild.scala
@@ -86,7 +86,7 @@ abstract class CommunityBuild(val buildpressHomeDir: AbsolutePath) {
     val jars = Paths.getCacheDirectory("scala-jars")
     val provider =
       BloopComponentCompiler.getComponentProvider(Paths.getCacheDirectory("components"))
-    new CompilerCache(provider, jars, NoopLogger, Nil, None, scheduler)
+    new CompilerCache(provider, jars, NoopLogger, Nil, None, None, scheduler)
   }
 
   def loadStateForBuild(configDirectory: AbsolutePath, logger: Logger): State = {

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -7,13 +7,12 @@ import java.util.concurrent.ConcurrentHashMap
 
 import bloop.bsp.BspServer
 import bloop.io.AbsolutePath
-import bloop.util.CrossPlatform
+import bloop.util.{CrossPlatform, JavaRuntime}
 import bloop.cli.{CliOptions, CliParsers, Commands, CommonOptions, ExitStatus, Validate}
 import bloop.engine._
 import bloop.engine.tasks.Tasks
 import bloop.logging.{BloopLogger, DebugFilter, Logger}
 import bloop.data.ClientInfo.CliClientInfo
-import bloop.exec.JavaEnv
 
 import caseapp.core.{DefaultBaseCommand, Messages}
 import com.martiansoftware.nailgun.NGContext
@@ -247,7 +246,7 @@ object Cli {
   }
 
   // Attempt to load JDI when we initialize the CLI class
-  private val _ = JavaEnv.loadJavaDebugInterface
+  private val _ = JavaRuntime.loadJavaDebugInterface
   private def run(
       action: Action,
       pool: ClientPool,

--- a/frontend/src/main/scala/bloop/dap/DebuggeeRunner.scala
+++ b/frontend/src/main/scala/bloop/dap/DebuggeeRunner.scala
@@ -4,7 +4,7 @@ import bloop.cli.ExitStatus
 import bloop.data.{Platform, Project}
 import bloop.engine.State
 import bloop.engine.tasks.{RunMode, Tasks}
-import bloop.exec.JavaEnv
+import bloop.data.JdkConfig
 import bloop.testing.{LoggingEventHandler, TestInternals}
 import ch.epfl.scala.bsp.ScalaMainClass
 import monix.eval.Task
@@ -16,7 +16,7 @@ trait DebuggeeRunner {
 private final class MainClassDebugAdapter(
     project: Project,
     mainClass: ScalaMainClass,
-    env: JavaEnv,
+    env: JdkConfig,
     state: State
 ) extends DebuggeeRunner {
   def run(debugLogger: DebugSessionLogger): Task[ExitStatus] = {
@@ -73,7 +73,7 @@ object DebuggeeRunner {
       case Seq(project) =>
         project.platform match {
           case jvm: Platform.Jvm =>
-            Right(new MainClassDebugAdapter(project, mainClass, jvm.env, state))
+            Right(new MainClassDebugAdapter(project, mainClass, jvm.config, state))
           case platform =>
             Left(s"Unsupported platform: ${platform.getClass.getSimpleName}")
         }

--- a/frontend/src/main/scala/bloop/data/JdkConfig.scala
+++ b/frontend/src/main/scala/bloop/data/JdkConfig.scala
@@ -1,0 +1,29 @@
+package bloop.data
+
+import bloop.config.Config
+import bloop.util.JavaRuntime
+import bloop.io.AbsolutePath
+
+import scala.util.{Failure, Try}
+
+/**
+ * The configuration of a JDK for a concrete project. It can be used for either
+ * compiling a project (`javac` config) or running an application or tests (jdk config).
+ *
+ * @param javaHome The location, we expect to find `java` in `$javaHome/bin/java`.
+ * @param javaOptions JDK-specific options to pass at start-up.
+ */
+final case class JdkConfig(javaHome: AbsolutePath, javaOptions: Array[String])
+
+object JdkConfig {
+  val default: JdkConfig = JdkConfig(JavaRuntime.home, Array.empty)
+
+  def fromConfig(jvm: Config.JvmConfig): JdkConfig = {
+    val jvmHome = jvm.home.map(AbsolutePath.apply).getOrElse(default.javaHome)
+    JdkConfig(jvmHome, jvm.options.toArray)
+  }
+
+  def toConfig(config: JdkConfig): Config.JvmConfig = {
+    Config.JvmConfig(Some(config.javaHome.underlying), config.javaOptions.toList)
+  }
+}

--- a/frontend/src/main/scala/bloop/data/JdkConfig.scala
+++ b/frontend/src/main/scala/bloop/data/JdkConfig.scala
@@ -10,10 +10,12 @@ import scala.util.{Failure, Try}
  * The configuration of a JDK for a concrete project. It can be used for either
  * compiling a project (`javac` config) or running an application or tests (jdk config).
  *
- * @param javaHome The location, we expect to find `java` in `$javaHome/bin/java`.
+ * @param javaHome Can be the location obtained from `java.home` or `JAVA_HOME`.
  * @param javaOptions JDK-specific options to pass at start-up.
  */
-final case class JdkConfig(javaHome: AbsolutePath, javaOptions: Array[String])
+final case class JdkConfig(javaHome: AbsolutePath, javaOptions: Array[String]) {
+  def javacBin: Option[AbsolutePath] = JavaRuntime.javacBinaryFromJavaHome(javaHome)
+}
 
 object JdkConfig {
   val default: JdkConfig = JdkConfig(JavaRuntime.home, Array.empty)

--- a/frontend/src/main/scala/bloop/data/Platform.scala
+++ b/frontend/src/main/scala/bloop/data/Platform.scala
@@ -1,7 +1,7 @@
 package bloop.data
+
 import bloop.config.Config
 import bloop.engine.tasks.toolchains.{JvmToolchain, ScalaJsToolchain, ScalaNativeToolchain}
-import bloop.exec.JavaEnv
 
 sealed trait Platform {
   def userMainClass: Option[String]
@@ -9,7 +9,7 @@ sealed trait Platform {
 
 object Platform {
   final case class Jvm(
-      env: JavaEnv,
+      config: JdkConfig,
       toolchain: JvmToolchain,
       userMainClass: Option[String]
   ) extends Platform

--- a/frontend/src/main/scala/bloop/engine/Feedback.scala
+++ b/frontend/src/main/scala/bloop/engine/Feedback.scala
@@ -4,7 +4,7 @@ import java.nio.file.Path
 import bloop.data.Project
 import bloop.engine.Dag.RecursiveTrace
 import bloop.io.AbsolutePath
-import bloop.exec.JavaEnv
+import bloop.util.JavaRuntime
 
 object Feedback {
   private final val eol = System.lineSeparator
@@ -104,13 +104,13 @@ object Feedback {
     s"Stopped configuration of SemanticDB in Scala $version projects: $cause"
 
   def detectedJdkWithoutJDI(error: Throwable): String = {
-    s"""Debugging is not supported because Java Debug Interface couldn't be resolved in detected JDK ${JavaEnv.DefaultJavaHome}: '${error.getMessage}'. To enable it, check manually that you're running on a JDK and JDI is supported.
+    s"""Debugging is not supported because Java Debug Interface couldn't be resolved in detected JDK ${JavaRuntime.home}: '${error.getMessage}'. To enable it, check manually that you're running on a JDK and JDI is supported.
        |
        |Run bloop about for more information about the current JDK runtime.""".stripMargin
   }
 
   def detectedUnsupportedJreForDebugging(error: Throwable): String = {
-    s"""Debugging is not supported because bloop server is running on a JRE ${JavaEnv.DefaultJavaHome} with no support for Java Debug Interface: '${error.getMessage}'. To enable debugging, install a JDK and restart the bloop server.
+    s"""Debugging is not supported because bloop server is running on a JRE ${JavaRuntime.home} with no support for Java Debug Interface: '${error.getMessage}'. To enable debugging, install a JDK and restart the bloop server.
        |
        |Run bloop about for more information about the current JDK runtime.""".stripMargin
   }

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -11,7 +11,8 @@ import bloop.testing.{LoggingEventHandler, TestInternals}
 import bloop.engine.tasks.{CompileTask, LinkTask, Tasks, TestTask, RunMode}
 import bloop.cli.Commands.CompilingCommand
 import bloop.cli.Validate
-import bloop.data.{ClientInfo, Platform, Project}
+import bloop.util.JavaRuntime
+import bloop.data.{ClientInfo, Platform, Project, JdkConfig}
 import bloop.engine.Feedback.XMessageString
 import bloop.engine.tasks.toolchains.{ScalaJsToolchain, ScalaNativeToolchain}
 import bloop.reporter.{LogReporter, ReporterInputs}
@@ -25,8 +26,6 @@ import bloop.ScalaInstance
 import scala.collection.immutable.Nil
 import scala.annotation.tailrec
 import java.io.IOException
-
-import bloop.exec.JavaEnv
 
 object Interpreter {
   // This is stack-safe because of Monix's trampolined execution
@@ -99,21 +98,21 @@ object Interpreter {
     val scalaVersion = bloop.internal.build.BuildInfo.scalaVersion
     val zincVersion = bloop.internal.build.BuildInfo.zincVersion
     val developers = bloop.internal.build.BuildInfo.developers.mkString(", ")
-    val javaVersion = JavaEnv.version
-    val javaHome = JavaEnv.DefaultJavaHome
+    val javaVersion = JavaRuntime.version
+    val javaHome = JavaRuntime.home
     val jdiStatus = {
-      if (JavaEnv.loadJavaDebugInterface.isSuccess)
+      if (JavaRuntime.loadJavaDebugInterface.isSuccess)
         "Supports debugging user code, Java Debug Interface (JDI) is available."
       else
         "Doesn't support debugging user code, runtime doesn't implement Java Debug Interface (JDI)."
     }
 
-    val runtimeInfo = s"Detected Java ${JavaEnv.detectRuntime} runtime $jdiStatus"
+    val runtimeInfo = s"Detected Java ${JavaRuntime.current} runtime $jdiStatus"
 
     logger.info(s"$bloopName v$bloopVersion")
     logger.info("")
     logger.info(s"Using Scala v$scalaVersion and Zinc v$zincVersion")
-    logger.info(s"Running on Java ${JavaEnv.detectRuntime} v$javaVersion ($javaHome)")
+    logger.info(s"Running on Java ${JavaRuntime.current} v$javaVersion ($javaHome)")
     logger.info(s"  -> $jdiStatus")
     logger.info(s"Maintained by the Scala Center ($developers)")
 

--- a/frontend/src/main/scala/bloop/engine/State.scala
+++ b/frontend/src/main/scala/bloop/engine/State.scala
@@ -49,7 +49,7 @@ object State {
       val componentsDir = Paths.getCacheDirectory("components")
       val provider = BloopComponentCompiler.getComponentProvider(componentsDir)
       val jars = Paths.getCacheDirectory("scala-jars")
-      singleCompilerCache = new CompilerCache(provider, jars, logger, Nil, None, scheduler)
+      singleCompilerCache = new CompilerCache(provider, jars, logger, Nil, None, None, scheduler)
       singleCompilerCache
     }
   }

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -153,7 +153,7 @@ object CompileTask {
               project.out,
               newScalacOptions.toArray,
               project.javacOptions.toArray,
-              project.jdkConfig.map(_.javaHome),
+              project.jdkConfig.flatMap(_.javacBin),
               project.compileOrder,
               project.classpathOptions,
               lastSuccessful.previous,

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -153,6 +153,7 @@ object CompileTask {
               project.out,
               newScalacOptions.toArray,
               project.javacOptions.toArray,
+              project.jdkConfig.map(_.javaHome),
               project.compileOrder,
               project.classpathOptions,
               lastSuccessful.previous,

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -5,9 +5,9 @@ import java.nio.file.{Files, Path}
 import bloop.cli.ExitStatus
 import bloop.engine.caches.ResultsCache
 import bloop.logging.DebugFilter
-import bloop.data.Project
+import bloop.data.{Project, JdkConfig}
 import bloop.engine.{Dag, State}
-import bloop.exec.{Forker, JavaEnv, JvmProcessForker}
+import bloop.exec.{Forker, JvmProcessForker}
 import bloop.io.AbsolutePath
 import bloop.util.JavaCompat.EnrichOptional
 import bloop.testing.{LoggingEventHandler, TestSuiteEvent, TestSuiteEventHandler}
@@ -156,7 +156,7 @@ object Tasks {
   def runJVM(
       state: State,
       project: Project,
-      javaEnv: JavaEnv,
+      config: JdkConfig,
       cwd: AbsolutePath,
       fqn: String,
       args: Array[String],
@@ -165,7 +165,7 @@ object Tasks {
   ): Task[State] = {
     val dag = state.build.getDagFor(project)
     val classpath = project.fullClasspath(dag, state.client)
-    val forker = JvmProcessForker(javaEnv, classpath, mode)
+    val forker = JvmProcessForker(config, classpath, mode)
     val runTask =
       forker.runMain(cwd, fqn, args, skipJargs, state.logger, state.commonOptions)
     runTask.map { exitCode =>

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -60,10 +60,10 @@ object Tasks {
         logger.debug(s"Setting up the console classpath with ${entries.mkString(", ")}")(
           DebugFilter.All
         )
-        val javaHome = project.jdkConfig.map(_.javaHome)
+        val javacBin = project.jdkConfig.flatMap(_.javacBin)
         val loader = ClasspathUtilities.makeLoader(entries, instance)
         val compiler =
-          state.compilerCache.get(instance, javaHome).scalac.asInstanceOf[AnalyzingCompiler]
+          state.compilerCache.get(instance, javacBin).scalac.asInstanceOf[AnalyzingCompiler]
         val opts = ClasspathOptionsUtil.repl
         val options = project.scalacOptions :+ "-Xnojline"
         // We should by all means add better error handling here!

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -60,8 +60,10 @@ object Tasks {
         logger.debug(s"Setting up the console classpath with ${entries.mkString(", ")}")(
           DebugFilter.All
         )
+        val javaHome = project.jdkConfig.map(_.javaHome)
         val loader = ClasspathUtilities.makeLoader(entries, instance)
-        val compiler = state.compilerCache.get(instance).scalac.asInstanceOf[AnalyzingCompiler]
+        val compiler =
+          state.compilerCache.get(instance, javaHome).scalac.asInstanceOf[AnalyzingCompiler]
         val opts = ClasspathOptionsUtil.repl
         val options = project.scalacOptions :+ "-Xnojline"
         // We should by all means add better error handling here!

--- a/frontend/src/test/scala/bloop/ForkerSpec.scala
+++ b/frontend/src/test/scala/bloop/ForkerSpec.scala
@@ -6,8 +6,9 @@ import java.nio.file.{Files, Path}
 import java.util.concurrent.TimeUnit
 
 import bloop.cli.ExitStatus
+import bloop.data.JdkConfig
 import bloop.dap.DebugSessionLogger
-import bloop.exec.{Forker, JvmProcessForker, JavaEnv}
+import bloop.exec.{Forker, JvmProcessForker}
 import bloop.io.AbsolutePath
 import bloop.logging.RecordingLogger
 import bloop.util.TestUtil
@@ -45,7 +46,7 @@ class ForkerSpec {
   ): Unit =
     TestUtil.checkAfterCleanCompilation(runnableProject, dependencies) { state =>
       val project = TestUtil.getProject(TestUtil.RootProject, state)
-      val env = JavaEnv.default
+      val env = JdkConfig.default
       val classpath = project.fullClasspath(state.build.getDagFor(project), state.client)
       val config = JvmProcessForker(env, classpath)
       val logger = new RecordingLogger

--- a/frontend/src/test/scala/bloop/RunSpec.scala
+++ b/frontend/src/test/scala/bloop/RunSpec.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeUnit
 
 import bloop.bsp.BspServer
 import bloop.cli.Commands
-import bloop.exec.JavaEnv
+import bloop.data.JdkConfig
 import bloop.logging.RecordingLogger
 import bloop.util.TestUtil
 import bloop.util.TestUtil.{checkAfterCleanCompilation, getProject, loadTestProject, runAndCheck}
@@ -60,12 +60,12 @@ class RunSpec {
   def doesntDetectNonRunnableClasses() = {
     val projectName = "test-project"
     val projectsStructure = Map(projectName -> Map("A.scala" -> ArtificialSources.NotRunnable))
-    val javaEnv = JavaEnv.default
+    val jdkConfig = JdkConfig.default
     checkAfterCleanCompilation(
       projectsStructure,
       noDependencies,
       rootProjects = List(projectName),
-      javaEnv = javaEnv,
+      jdkConfig = jdkConfig,
       quiet = true
     ) { state =>
       val project = getProject(projectName, state)
@@ -78,12 +78,12 @@ class RunSpec {
   def canDetectOneMainClass() = {
     val projectName = "test-project"
     val projectsStructure = Map(projectName -> Map("A.scala" -> ArtificialSources.RunnableClass0))
-    val javaEnv = JavaEnv.default
+    val jdkConfig = JdkConfig.default
     checkAfterCleanCompilation(
       projectsStructure,
       noDependencies,
       rootProjects = List(projectName),
-      javaEnv = javaEnv,
+      jdkConfig = jdkConfig,
       quiet = true
     ) { state =>
       val project = getProject(projectName, state)
@@ -102,12 +102,12 @@ class RunSpec {
         "B.scala" -> ArtificialSources.RunnableClass1
       )
     )
-    val javaEnv = JavaEnv.default
+    val jdkConfig = JdkConfig.default
     checkAfterCleanCompilation(
       projectsStructure,
       noDependencies,
       rootProjects = List(projectName),
-      javaEnv = javaEnv,
+      jdkConfig = jdkConfig,
       quiet = true
     ) { state =>
       val project = getProject(projectName, state)

--- a/frontend/src/test/scala/bloop/nailgun/NailgunSpec.scala
+++ b/frontend/src/test/scala/bloop/nailgun/NailgunSpec.scala
@@ -5,7 +5,7 @@ import bloop.testing.BaseSuite
 import bloop.logging.RecordingLogger
 import bloop.internal.build.BuildInfo
 import bloop.util.TestUtil
-import bloop.exec.JavaEnv
+import bloop.util.JavaRuntime
 
 import java.nio.file.{Paths, Files}
 import java.util.concurrent.TimeUnit
@@ -17,7 +17,7 @@ object NailgunSpec extends BaseSuite with NailgunTestUtils {
   val configDir = simpleBuild.state.build.origin.underlying
 
   val jvmLine =
-    s"Running on Java ${JavaEnv.detectRuntime} v${JavaEnv.version} (${JavaEnv.DefaultJavaHome})"
+    s"Running on Java ${JavaRuntime.current} v${JavaRuntime.version} (${JavaRuntime.home})"
 
   def withServerInProject[T](op: (RecordingLogger, Client) => T): T =
     withServer(configDir, false, new RecordingLogger(ansiCodesSupported = false))(op)

--- a/frontend/src/test/scala/bloop/util/TestProject.scala
+++ b/frontend/src/test/scala/bloop/util/TestProject.scala
@@ -6,7 +6,7 @@ import java.nio.file.{Files, Path}
 import bloop.ScalaInstance
 import bloop.bsp.ProjectUris
 import bloop.config.Config
-import bloop.exec.JavaEnv
+import bloop.data.JdkConfig
 import bloop.io.{AbsolutePath, Paths, RelativePath}
 import bloop.logging.NoopLogger
 import bloop.util.TestUtil.ProjectArchetype
@@ -111,8 +111,7 @@ object TestProject {
     val allJars = instance.allJars.map(AbsolutePath.apply)
     val depsTargets = directDependencies.flatMap(d => classpathDeps(d))
     val classpath = (depsTargets ++ allJars ++ jars).map(_.underlying)
-    val javaConfig = jvmConfig.getOrElse(JavaEnv.toConfig(JavaEnv.default))
-    val javaEnv = JavaEnv.fromConfig(javaConfig)
+    val javaConfig = jvmConfig.getOrElse(JdkConfig.toConfig(JdkConfig.default))
     val setup = Config.CompileSetup.empty.copy(order = order)
     val scalaConfig = Config.Scala(
       finalScalaOrg,

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -67,7 +67,8 @@ object TestUtil {
     else {
       val scheduler = ExecutionContext.ioScheduler
       val jars = bloop.io.Paths.getCacheDirectory("scala-jars")
-      singleCompilerCache = new CompilerCache(componentProvider, jars, logger, Nil, None, scheduler)
+      singleCompilerCache =
+        new CompilerCache(componentProvider, jars, logger, Nil, None, None, scheduler)
       singleCompilerCache
     }
   }


### PR DESCRIPTION
So that we can reuse the same JVM used to run/test Java code to compile it
as well. In case a config for a project is Scala.js or Scala Native, Bloop
will pick the default Java home.

To make this possible, we first needed to refactor `JavaEnv` into
more specific abstractions, i.e. `JdkConfig` and `JavaRuntime`.

Fixes https://github.com/scalacenter/bloop/issues/968.