### PR TITLE
Resolve correct linker versions in non-JVM builds

### DIFF
--- a/backend/src/main/scala/bloop/ScalaInstance.scala
+++ b/backend/src/main/scala/bloop/ScalaInstance.scala
@@ -148,7 +148,10 @@ object ScalaInstance {
       logger: Logger
   )(implicit ec: ExecutionContext): ScalaInstance = {
     def resolveInstance: ScalaInstance = {
-      val allPaths = DependencyResolution.resolve(scalaOrg, scalaName, scalaVersion, logger)
+      val allPaths = DependencyResolution.resolve(
+        List(DependencyResolution.Artifact(scalaOrg, scalaName, scalaVersion)),
+        logger
+      )
       val allJars = allPaths.collect {
         case path if path.underlying.toString.endsWith(".jar") => path.underlying.toFile
       }

--- a/backend/src/main/scala/sbt/internal/inc/BloopComponentCompiler.scala
+++ b/backend/src/main/scala/sbt/internal/inc/BloopComponentCompiler.scala
@@ -127,7 +127,12 @@ object BloopComponentCompiler {
       def isPrefixedWith(artifact: File, prefix: String) = artifact.getName.startsWith(prefix)
       val allArtifacts = {
         BloopDependencyResolution
-          .resolve(ScalaOrganization, ScalaCompilerID, scalaVersion, logger)(scheduler)
+          .resolve(
+            List(
+              BloopDependencyResolution.Artifact(ScalaOrganization, ScalaCompilerID, scalaVersion)
+            ),
+            logger
+          )(scheduler)
           .map(_.toFile)
           .toVector
       }
@@ -241,9 +246,10 @@ private[inc] class BloopComponentCompiler(
         import coursier.core.Type
         val resolveSources = bridgeSources.explicitArtifacts.exists(_.`type` == Type.source.value)
         val allArtifacts = BloopDependencyResolution.resolveWithErrors(
-          bridgeSources.organization,
-          bridgeSources.name,
-          bridgeSources.revision,
+          List(
+            BloopDependencyResolution
+              .Artifact(bridgeSources.organization, bridgeSources.name, bridgeSources.revision)
+          ),
           logger,
           resolveSources = resolveSources
         )(scheduler) match {

--- a/frontend/src/main/scala/bloop/engine/caches/SemanticDBCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/SemanticDBCache.scala
@@ -38,7 +38,10 @@ object SemanticDBCache {
 
     def attemptResolution: Either[String, AbsolutePath] = {
       import bloop.engine.ExecutionContext.ioScheduler
-      DependencyResolution.resolveWithErrors(organization, module, version, logger)(ioScheduler) match {
+      DependencyResolution.resolveWithErrors(
+        List(DependencyResolution.Artifact(organization, module, version)),
+        logger
+      )(ioScheduler) match {
         case Left(error) => Left(error.getMessage())
         case Right(paths) =>
           paths.find(_.syntax.contains("semanticdb-scalac")) match {

--- a/frontend/src/main/scala/bloop/testing/TestInternals.scala
+++ b/frontend/src/main/scala/bloop/testing/TestInternals.scala
@@ -90,7 +90,10 @@ object TestInternals {
       case Some(paths) => paths
       case None =>
         import bloop.engine.ExecutionContext.ioScheduler
-        val paths = DependencyResolution.resolve(sbtOrg, testAgentId, testAgentVersion, logger)
+        val paths = DependencyResolution.resolve(
+          List(DependencyResolution.Artifact(sbtOrg, testAgentId, testAgentVersion)),
+          logger
+        )
         testAgentFiles = Some(paths)
         paths
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -111,19 +111,19 @@ object Dependencies {
   val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
   val nuprocess = "com.zaxxer" % "nuprocess" % nuprocessVersion
 
-  val scalaNativeTools03 = "org.scala-native" %% "tools" % scalaNative03Version
-  val scalaNativeTools04 = "org.scala-native" %% "tools" % scalaNative04Version
-  val scalaJsTools06 = "org.scala-js" %% "scalajs-tools" % scalaJs06Version
-  val scalaJsSbtTestAdapter06 = "org.scala-js" %% "scalajs-sbt-test-adapter" % scalaJs06Version
-  val scalaJsEnvs06 = "org.scala-js" %% "scalajs-js-envs" % scalaJs06Version
+  val scalaNativeTools03 = "org.scala-native" %% "tools" % scalaNative03Version % Provided
+  val scalaNativeTools04 = "org.scala-native" %% "tools" % scalaNative04Version % Provided
+  val scalaJsTools06 = "org.scala-js" %% "scalajs-tools" % scalaJs06Version % Provided
+  val scalaJsSbtTestAdapter06 = "org.scala-js" %% "scalajs-sbt-test-adapter" % scalaJs06Version % Provided
+  val scalaJsEnvs06 = "org.scala-js" %% "scalajs-js-envs" % scalaJs06Version % Provided
 
-  val scalaJsLinker10 = "org.scala-js" %% "scalajs-linker" % scalaJs10Version
-  val scalaJsIO10 = "org.scala-js" %% "scalajs-io" % scalaJs10Version
-  val scalaJsEnvs10 = "org.scala-js" %% "scalajs-js-envs" % scalaJs10Version
-  val scalaJsEnvNode10 = "org.scala-js" %% "scalajs-env-nodejs" % scalaJs10Version
-  val scalaJsEnvJsdomNode10 = "org.scala-js" %% "scalajs-env-jsdom-nodejs" % scalaJs10Version
-  val scalaJsSbtTestAdapter10 = "org.scala-js" %% "scalajs-sbt-test-adapter" % scalaJs10Version
-  val scalaJsLogging10 = "org.scala-js" %% "scalajs-logging" % scalaJs10Version
+  val scalaJsLinker10 = "org.scala-js" %% "scalajs-linker" % scalaJs10Version % Provided
+  val scalaJsIO10 = "org.scala-js" %% "scalajs-io" % scalaJs10Version % Provided
+  val scalaJsEnvs10 = "org.scala-js" %% "scalajs-js-envs" % scalaJs10Version % Provided
+  val scalaJsEnvNode10 = "org.scala-js" %% "scalajs-env-nodejs" % scalaJs10Version % Provided
+  val scalaJsEnvJsdomNode10 = "org.scala-js" %% "scalajs-env-jsdom-nodejs" % scalaJs10Version % Provided
+  val scalaJsSbtTestAdapter10 = "org.scala-js" %% "scalajs-sbt-test-adapter" % scalaJs10Version % Provided
+  val scalaJsLogging10 = "org.scala-js" %% "scalajs-logging" % scalaJs10Version % Provided
 
   val mill = "com.lihaoyi" %% "mill-scalalib" % millVersion % Provided
   val xxHashLibrary = "net.jpountz.lz4" % "lz4" % xxHashVersion


### PR DESCRIPTION
The linker versions are still hard-coded in `Dependencies.scala`, but have
been annotated with sbt's `Provided` scope. When the bridges are resolved
now, the platform-specific libraries have to be included explicitly which
allows us to specify the same version as in the user's build configuration.

Closes #1062.