### PR TITLE
Control inclusion of javadoc and source artifacts in Gradle

### DIFF
--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/BloopParameters.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/BloopParameters.scala
@@ -48,4 +48,18 @@ class BloopParameters(project: Project) {
   def setStdLibName(value: String): Unit = {
     stdLibName_ = value
   }
+
+  private var includeJavadoc_ : Boolean = true
+  def includeJavadoc: Boolean = includeJavadoc_
+  def getIncludeJavadoc = includeJavadoc_
+  def setIncludeJavadoc(value: Boolean): Unit = {
+    includeJavadoc_ = value
+  }
+
+  private var includeSources_ : Boolean = true
+  def includeSources: Boolean = includeSources_
+  def getIncludeSources = includeSources_
+  def setIncludeSources(value: Boolean): Unit = {
+    includeSources_ = value
+  }
 }


### PR DESCRIPTION
This commit allows to
optionally disable downloading javadoc and source artifacts.

In build.gradle:
bloop {
  includeJavadoc = false
  includeSources = false
}

From command line:
gradle bloopInstall -PbloopIncludeJavadoc=false -PbloopIncludeSources=false