### PR TITLE
Avoid classpath separator in classes output directory.

### DIFF
--- a/frontend/src/main/scala/bloop/data/ClientInfo.scala
+++ b/frontend/src/main/scala/bloop/data/ClientInfo.scala
@@ -3,6 +3,7 @@ package bloop.data
 import bloop.io.AbsolutePath
 import bloop.util.UUIDUtil
 
+import java.io.File
 import java.nio.file.Files
 import java.util.concurrent.ConcurrentHashMap
 import java.io.PrintStream
@@ -170,7 +171,8 @@ object ClientInfo {
               val newClientDir = parent match {
                 case Left(unmanagedGlobalRootDir) =>
                   // Use format that avoids clashes between projects when storing in global root
-                  val projectDirName = s"${this.name}-${project.name}-$classesDirName"
+                  val projectName = project.name.replace(File.pathSeparatorChar, '_')
+                  val projectDirName = s"${this.name}-${projectName}-$classesDirName"
                   unmanagedGlobalRootDir.resolve(projectDirName)
                 case Right(managedProjectRootDir) =>
                   // We add unique id because we need it to correctly delete orphan dirs

--- a/frontend/src/main/scala/bloop/data/ClientInfo.scala
+++ b/frontend/src/main/scala/bloop/data/ClientInfo.scala
@@ -1,9 +1,9 @@
 package bloop.data
 
 import bloop.io.AbsolutePath
+import bloop.io.Filenames
 import bloop.util.UUIDUtil
 
-import java.io.File
 import java.nio.file.Files
 import java.util.concurrent.ConcurrentHashMap
 import java.io.PrintStream
@@ -171,9 +171,8 @@ object ClientInfo {
               val newClientDir = parent match {
                 case Left(unmanagedGlobalRootDir) =>
                   // Use format that avoids clashes between projects when storing in global root
-                  val projectName = project.name.replace(File.pathSeparatorChar, '_')
-                  val projectDirName = s"${this.name}-${projectName}-$classesDirName"
-                  unmanagedGlobalRootDir.resolve(projectDirName)
+                  val projectDirName = s"${this.name}-${project.name}-$classesDirName"
+                  unmanagedGlobalRootDir.resolve(Filenames.escapeSpecialCharacters(projectDirName))
                 case Right(managedProjectRootDir) =>
                   // We add unique id because we need it to correctly delete orphan dirs
                   val projectDirName = s"$classesDirName-$uniqueId"

--- a/frontend/src/main/scala/bloop/io/Filenames.scala
+++ b/frontend/src/main/scala/bloop/io/Filenames.scala
@@ -1,0 +1,7 @@
+package bloop.io
+
+object Filenames {
+  lazy val specialCharacters = "[^\\p{Alnum}-]".r
+  def escapeSpecialCharacters(filename: String): String =
+    specialCharacters.replaceAllIn(filename, "_")
+}


### PR DESCRIPTION
Fixes #1101. Previously, when project names included classpath
separators like `:` then it was not possible to run/test via IntelliJ.
Now, we replace path separators in the classes output directory with
underscore `_`.