### PR TITLE
Increase the timeout during the launcher to 30s

### DIFF
--- a/launcher/src/main/scala/bloop/launcher/bsp/BspBridge.scala
+++ b/launcher/src/main/scala/bloop/launcher/bsp/BspBridge.scala
@@ -110,9 +110,9 @@ final class BspBridge(
 
   private final val BspStartLog = "The server is listening for incoming connections at"
   def waitForOpenBsp(conn: RunningBspConnection, attempts: Int = 0): Option[BspConnection] = {
-    println("Waiting 50ms until the bsp connection is up...", out)
-    Thread.sleep(50)
-    if (attempts == 200) {
+    if (attempts % 100 == 0) println("Waiting for the bsp connection to come up...", out)
+    Thread.sleep(10)
+    if (attempts == 3000) {
       printError("Giving up on waiting for a connection, printing embedded bloop logs:", out)
       printQuoted(conn.logs.toList.mkString(System.lineSeparator()), out)
       None


### PR DESCRIPTION
I have seen numerous timeouts in continuous integration when Fury is
starting up Bloop, while Bloop is actually launched successfully some
time shortly afterwards.

This makes a couple of changes to the startup process to try to mitigate
this:

- Increases the timeout from 10s to 30s
- Increases the frequency of checking if Bloop is up (this saves a
little time in what is the slowest part of Fury startup)
- Reduces the frequency of logging the "waiting" messages to once per
second