### PR TITLE
Drop dependency between release and test jobs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
 
   release:
     name: Publish on ${{ matrix.os }}
-    needs: test
     runs-on: ${{ matrix.os }}
     if: github.event_name == 'push'
     strategy:


### PR DESCRIPTION
Previously, the release job only ran if tests passed. This caused the
release to not run on flaky test failures. Now, the release job runs
regardless if the tests pass or not.

A nice effect of this change is that releases finish faster. We use the
same setup in Metals and have not experienced issues with releasing
unwanted commits. If something lands into master we want to release it
regardless of test results.