### PR TITLE
Add missing dependency on scala-library in shaded bloopgun

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -363,7 +363,8 @@ lazy val bloopgunShaded = project
     fork in run := true,
     fork in Test := true,
     bloopGenerate in Compile := None,
-    bloopGenerate in Test := None
+    bloopGenerate in Test := None,
+    libraryDependencies += Dependencies.scalaXml
   )
 
 lazy val launcher: Project = project

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Dependencies {
 
   val scalazVersion = "7.2.20"
   val coursierVersion = "2.0.0-RC3-4"
+  val scalaXmlVersion = "1.2.0"
   val lmVersion = "1.0.0"
   val configDirsVersion = "10"
   val caseAppVersion = "1.2.0-faster-compile-time"
@@ -69,6 +70,7 @@ object Dependencies {
   val coursier = "io.get-coursier" %% "coursier" % coursierVersion
   val coursierCache = "io.get-coursier" %% "coursier-cache" % coursierVersion
   val coursierScalaz = "io.get-coursier" %% "coursier-scalaz-interop" % coursierVersion
+  val scalaXml = "org.scala-lang.modules" %% "scala-xml" % scalaXmlVersion
   val shapeless = "ch.epfl.scala" %% "shapeless" % shapelessVersion
   val caseApp = "ch.epfl.scala" %% "case-app" % caseAppVersion
   val sourcecode = "com.lihaoyi" %% "sourcecode" % sourcecodeVersion


### PR DESCRIPTION
Fixes #1109. The shaded bloopgun already depends on scala-library so it
should be safe to also include scala-xml on the classpath.