### PR TITLE
Don't use blp-server from local installation in bloopgun and launcher.

### DIFF
--- a/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
@@ -363,8 +363,7 @@ class BloopgunCli(
       logger: SnailgunLogger
   ): Option[mode.Out] = {
     ServerStatus
-      .findServerToRun(bloopVersion, config.serverLocation, shell, logger)
-      .orElse(ServerStatus.resolveServer(bloopVersion, logger))
+      .resolveServer(bloopVersion, logger)
       .map(mode.fire(_, config, logger))
   }
 

--- a/launcher/src/test/scala/bloop/launcher/LauncherSpec.scala
+++ b/launcher/src/test/scala/bloop/launcher/LauncherSpec.scala
@@ -100,14 +100,14 @@ class LauncherSpec(bloopVersion: String)
           // After installing, let's run the launcher in an environment where bloop is available
           val result1 = runBspLauncherWithEnvironment(Array(bloopVersion), shellWithPython)
           val expectedLogs1 = List(
-            BloopgunFeedback.DetectedBloopInstallation,
+            BloopgunFeedback.resolvingDependency(bloopDependency),
             BloopgunFeedback.startingBloopServer(defaultConfig),
             LauncherFeedback.openingBspConnection(Nil)
           )
 
           val prohibitedLogs1 = List(
             LauncherFeedback.installingBloop(bloopVersion),
-            BloopgunFeedback.resolvingDependency(bloopDependency)
+            BloopgunFeedback.DetectedBloopInstallation
           )
 
           result1.throwIfFailed


### PR DESCRIPTION
Previously, the Bloop launcher and bloopgun would use a `blp-server`
binary from the local computer to launch Bloop.  This behavior was
especially surprising when using the Bloop launcher since the explicitly
provided version would be ignored.  In the example log below, the Bloop
version v1.3.4 was picked from my local Homebrew installation over the
explicitly provided version number 1.3.4+226-153862a1.
```
$ cs launch ch.epfl.scala:bloop-launcher_2.12:1.3.4+226-153862a1 -- 1.3.4+226-153862a1 --skip-bsp-connection
Starting the bsp launcher for bloop...
Attempting a connection to the server...
No server running at 127.0.0.1:8212, let's fire one...
A bloop installation has been detected either in the PATH or $HOME/.bloop
Starting bloop server at 127.0.0.1:8212...
-> Command: List(sh, /usr/local/Cellar/bloop/1.3.4/bin/blp-server, 8212, -J-XX:MaxInlineLevel=20, -J-XX:+UseParallelGC)
Attempting a connection to the server...
bloop v1.3.4
```

Now, with this change

* the launcher always launches Bloop with the provided version number
* bloopgun always launches Bloop with the same version as bloopgun itself