### PR TITLE
Allow `bloopExportJarClassifiers` to be configured via environment.

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -133,7 +133,11 @@ object BloopDefaults {
   private lazy val cwd: String = System.getProperty("user.dir")
   lazy val globalSettings: Seq[Def.Setting[_]] = List(
     BloopKeys.bloopGlobalUniqueId := bloopGlobalUniqueIdTask.value,
-    BloopKeys.bloopExportJarClassifiers := None,
+    BloopKeys.bloopExportJarClassifiers := {
+      Option(System.getProperty("bloop.export-jar-classifiers"))
+        .orElse(Option(System.getenv("BLOOP_EXPORT_JAR_CLASSIFIERS")))
+        .map(_.split(",").toSet)
+    },
     BloopKeys.bloopInstall := bloopInstall.value,
     BloopKeys.bloopAggregateSourceDependencies := true,
     // Override classifiers so that we don't resolve always docs


### PR DESCRIPTION
Previously, the default value of `bloopExportJarClassifiers` was
hardcoded to `None`. This meant that users needed to change build.sbt to
override this value to include downloading of sources.

Now, users can globally configure this value to be
`Some(Set("sources"))` via environment variables
```
export BLOOP_EXPORT_JAR_CLASSIFIERS=sources,javadoc
```

Alternatively, they can achieve the same with a system property
```
sbt -Dbloop.export-jar-classifiers=sources,javadoc
```

This simplifies the "manual build import" step for Metals users, since
users can run `bloopInstall` from the sbt shell without modifying the
build or invoking verbose commands like
```
set bloopExportJarClassifiers in Global = Some(Set("sources"))
```