### PR TITLE
Don't evaluate `toString` when handling variables request

### DIFF
--- a/frontend/src/main/scala/bloop/dap/DebugServer.scala
+++ b/frontend/src/main/scala/bloop/dap/DebugServer.scala
@@ -4,6 +4,7 @@ import java.net.{ServerSocket, URI}
 
 import bloop.io.ServerHandle
 import bloop.logging.Logger
+import com.microsoft.java.debug.core.DebugSettings
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.execution.atomic.AtomicBoolean
@@ -17,6 +18,20 @@ final class StartedDebugServer(
 )
 
 object DebugServer {
+
+  /**
+   * Disable evaluation of variable's `toString` methods
+   * since code evaluation is not supported.
+   *
+   * Debug adapter, when asked for variables, tries to present them in a readable way,
+   * hence it evaluates the `toString` method for each object providing it.
+   * The adapter is not checking if evaluation is supported, so the whole request
+   * fails if there is at least one variable with custom `toString` in scope.
+   *
+   * See usages of [[com.microsoft.java.debug.core.adapter.variables.VariableDetailUtils.formatDetailsValue()]]
+   */
+  DebugSettings.getCurrent.showToString = false
+
   def start(
       runner: DebuggeeRunner,
       logger: Logger,

--- a/frontend/src/test/scala/bloop/dap/DebugAdapterConnection.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugAdapterConnection.scala
@@ -3,7 +3,6 @@ package bloop.dap
 import java.net.{InetSocketAddress, Socket, URI}
 
 import bloop.dap.DebugTestEndpoints._
-import bloop.dap.DebugTestProtocol.Response
 import com.microsoft.java.debug.core.protocol.Events
 import com.microsoft.java.debug.core.protocol.Requests._
 import com.microsoft.java.debug.core.protocol.Types.Capabilities
@@ -14,9 +13,11 @@ import java.io.Closeable
 import bloop.engine.ExecutionContext
 import java.util.concurrent.TimeUnit
 import monix.execution.Cancelable
-import com.microsoft.java.debug.core.Breakpoint
 import com.microsoft.java.debug.core.protocol.Responses.SetBreakpointsResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.ContinueResponseBody
+import com.microsoft.java.debug.core.protocol.Responses.ScopesResponseBody
+import com.microsoft.java.debug.core.protocol.Responses.StackTraceResponseBody
+import com.microsoft.java.debug.core.protocol.Responses.VariablesResponseBody
 
 /**
  * Manages a connection with a debug adapter.
@@ -59,6 +60,24 @@ private[dap] final class DebugAdapterConnection(
       arguments: SetBreakpointArguments
   ): Task[SetBreakpointsResponseBody] = {
     adapter.request(SetBreakpoints, arguments)
+  }
+
+  def stackTrace(threadId: Long): Task[StackTraceResponseBody] = {
+    val arguments = new StackTraceArguments()
+    arguments.threadId = threadId
+    adapter.request(StackTrace, arguments)
+  }
+
+  def scopes(frameId: Int): Task[ScopesResponseBody] = {
+    val arguments = new ScopesArguments
+    arguments.frameId = frameId
+    adapter.request(Scopes, arguments)
+  }
+
+  def variables(variablesReference: Int): Task[VariablesResponseBody] = {
+    val arguments = new VariablesArguments
+    arguments.variablesReference = variablesReference
+    adapter.request(Variables, arguments)
   }
 
   def stopped: Task[Events.StoppedEvent] = {

--- a/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
@@ -14,7 +14,6 @@ import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Promise, TimeoutException}
 import bloop.engine.ExecutionContext
 
-import com.microsoft.java.debug.core.protocol.Types.Capabilities
 import com.microsoft.java.debug.core.protocol.Requests.SetBreakpointArguments
 import com.microsoft.java.debug.core.protocol.Types
 import com.microsoft.java.debug.core.protocol.Types.SourceBreakpoint
@@ -220,7 +219,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
         startDebugServer(runner) { server =>
           val test = for {
             client <- server.startConnection
-            capabilities <- client.initialize()
+            _ <- client.initialize()
             _ <- client.launch()
             _ <- client.initialized
             scalaBreakpointsResult <- client.setBreakpoints(scalaBreakpoints)
@@ -257,6 +256,86 @@ object DebugServerSpec extends DebugBspBaseSuite {
                  |Breakpoint in hello java class constructor
                  |Breakpoint in hello java greet method
                  |Finished all breakpoints
+                 |""".stripMargin
+            )
+          }
+
+          TestUtil.await(FiniteDuration(60, SECONDS), ExecutionContext.ioScheduler)(test)
+        }
+      }
+    }
+  }
+
+  test("requesting stack traces and variables after breakpoints works") {
+    TestUtil.withinWorkspace { workspace =>
+      val source = """|/Main.scala
+                      |object Main {
+                      |  def main(args: Array[String]): Unit = {
+                      |    val foo = new Foo
+                      |    println(foo)
+                      |  }
+                      |}
+                      |
+                      |class Foo {
+                      |  override def toString = "foo"
+                      |}
+                      |""".stripMargin
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val project = TestProject(workspace, "r", List(source))
+
+      loadBspState(workspace, List(project), logger) { state =>
+        val runner = mainRunner(project, state)
+
+        val buildProject = state.toTestState.getProjectFor(project)
+        def srcFor(srcName: String) =
+          buildProject.sources.map(_.resolve(srcName)).find(_.exists).get
+        val `Main.scala` = srcFor("Main.scala")
+
+        val breakpoints = {
+          val arguments = new SetBreakpointArguments()
+          val breakpoint1 = new SourceBreakpoint()
+          breakpoint1.line = 4
+          arguments.source = new Types.Source(`Main.scala`.syntax, 0)
+          arguments.sourceModified = false
+          arguments.breakpoints = Array(breakpoint1)
+          arguments
+        }
+
+        startDebugServer(runner) { server =>
+          val test = for {
+            client <- server.startConnection
+            _ <- client.initialize()
+            _ <- client.launch()
+            _ <- client.initialized
+            breakpoints <- client.setBreakpoints(breakpoints)
+            _ = assert(breakpoints.breakpoints.forall(_.verified))
+            _ <- client.configurationDone()
+            stopped <- client.stopped
+            stackTrace <- client.stackTrace(stopped.threadId)
+            topFrame <- stackTrace.stackFrames.headOption
+              .map(Task.now)
+              .getOrElse(Task.raiseError(new NoSuchElementException("no frames on the stack")))
+            scopes <- client.scopes(topFrame.id)
+            localScope <- scopes.scopes
+              .find(_.name == "Local")
+              .map(Task.now)
+              .getOrElse(Task.raiseError(new NoSuchElementException("no local scope")))
+            localVars <- client.variables(localScope.variablesReference)
+            _ <- client.continue(stopped.threadId)
+            _ <- client.exited
+            _ <- client.terminated
+            _ <- Task.fromFuture(client.closedPromise.future)
+          } yield {
+            assert(client.socket.isClosed)
+            val localVariables = localVars.variables
+              .map(v => s"${v.name}: ${v.`type`} = ${v.value.takeWhile(c => c != '@')}")
+
+            assertNoDiff(
+              localVariables.mkString("\n"),
+              """|args: String[] = String[0]
+                 |foo: Foo = Foo
+                 |this: Main$ = Main$
                  |""".stripMargin
             )
           }

--- a/frontend/src/test/scala/bloop/dap/DebugTestEndpoints.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugTestEndpoints.scala
@@ -5,6 +5,9 @@ import com.microsoft.java.debug.core.protocol.Requests._
 import com.microsoft.java.debug.core.protocol.{Events, Types}
 import com.microsoft.java.debug.core.protocol.Responses.SetBreakpointsResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.ContinueResponseBody
+import com.microsoft.java.debug.core.protocol.Responses.ScopesResponseBody
+import com.microsoft.java.debug.core.protocol.Responses.StackTraceResponseBody
+import com.microsoft.java.debug.core.protocol.Responses.VariablesResponseBody
 
 private[dap] object DebugTestEndpoints {
   val Initialize = new Request[InitializeArguments, Types.Capabilities]("initialize")
@@ -12,6 +15,9 @@ private[dap] object DebugTestEndpoints {
   val Disconnect = new Request[DisconnectArguments, Unit]("disconnect")
   val SetBreakpoints =
     new Request[SetBreakpointArguments, SetBreakpointsResponseBody]("setBreakpoints")
+  val StackTrace = new Request[StackTraceArguments, StackTraceResponseBody]("stackTrace")
+  val Scopes = new Request[ScopesArguments, ScopesResponseBody]("scopes")
+  val Variables = new Request[VariablesArguments, VariablesResponseBody]("variables")
   val Continue = new Request[ContinueArguments, ContinueResponseBody]("continue")
   val ConfigurationDone = new Request[Unit, Unit]("configurationDone")
 


### PR DESCRIPTION
Previously, java-debug library would try to evaluate `toString` method for variables overriding it when servicing the `variables` request. Since code evaluation is not supported, it led to the failure of the whole request.

This changes the library setting to skip evaluation of `toString` methods.