### PR TITLE
Use MANIFEST jar to run commands that exceed OS limits

### DIFF
--- a/frontend/src/main/scala/bloop/exec/JvmProcessForker.scala
+++ b/frontend/src/main/scala/bloop/exec/JvmProcessForker.scala
@@ -189,16 +189,18 @@ final class JvmForker(config: JdkConfig, classpath: Array[AbsolutePath]) extends
 
   private def addTrailingSlashToDirectories(path: AbsolutePath): String = {
     val syntax = path.syntax
-    val separatorAdded = if (syntax.endsWith(".jar")) {
-      syntax
-    } else {
-      syntax + File.separator
+    val separatorAdded = {
+      if (syntax.endsWith(".jar")) {
+        syntax
+      } else {
+        syntax + File.separator
+      }
     }
+
     if (Properties.isWin) {
-      // On Windows, the drive letter is prepended to absolute paths
-      // Even though the official Java docs say to do this,
-      // it seems this fails for MANIFEST files, so we remove the drive letter
-      separatorAdded.substring(separatorAdded.indexOf(":") + 1)
+      // Remove drive letter as MANIFEST files don't support them on Windows
+      if (separatorAdded.indexOf(":") != 1) separatorAdded
+      else separatorAdded.substring(separatorAdded.indexOf(":") + 1)
     } else {
       separatorAdded
     }

--- a/frontend/src/test/scala/bloop/ForkerSpec.scala
+++ b/frontend/src/test/scala/bloop/ForkerSpec.scala
@@ -9,7 +9,7 @@ import bloop.logging.RecordingLogger
 import bloop.util.TestUtil
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
-import java.nio.file.Files
+import java.nio.file.{Files, Paths}
 import java.util.concurrent.TimeUnit
 import org.junit.Assert.{assertEquals, assertNotEquals}
 import org.junit.Test
@@ -24,16 +24,17 @@ class ForkerSpec {
   val mainClassName = "Main"
 
   object ArtificialSources {
-    val `A.scala` = s"""package $packageName
-                       |object $mainClassName {
-                       |  def main(args: Array[String]): Unit = {
-                       |    if (args.contains("crash")) throw new Exception
-                       |    println(s"Arguments: $${args.mkString(", ")}")
-                       |    val cwd = new java.io.File(sys.props("user.dir")).getCanonicalPath
-                       |    println(s"CWD: $$cwd")
-                       |    System.err.println("testing stderr")
-                       |  }
-                       |}""".stripMargin
+    val `A.scala` =
+      s"""package $packageName
+         |object $mainClassName {
+         |  def main(args: Array[String]): Unit = {
+         |    if (args.contains("crash")) throw new Exception
+         |    println(s"Arguments: $${args.mkString(", ")}")
+         |    val cwd = new java.io.File(sys.props("user.dir")).getCanonicalPath
+         |    println(s"CWD: $$cwd")
+         |    System.err.println("testing stderr")
+         |  }
+         |}""".stripMargin
   }
 
   val dependencies = Map.empty[String, Set[String]]
@@ -51,7 +52,7 @@ class ForkerSpec {
       val env = JdkConfig.default
       val classpath = project.fullClasspath(state.build.getDagFor(project), state.client)
       val config = JvmProcessForker(env, classpath)
-      val logger = new RecordingLogger()
+      val logger = new RecordingLogger
       val opts = state.commonOptions.copy(env = TestUtil.runAndTestProperties)
       val mainClass = s"$packageName.$mainClassName"
       val wait = Duration.apply(25, TimeUnit.SECONDS)
@@ -129,15 +130,41 @@ class ForkerSpec {
 
   @Test
   def canHandleLongClasspaths(): Unit = TestUtil.withinWorkspace { tmp =>
-    val longCp = Array.fill(JvmProcessForker.classpathCharLimit / 10) {
-      AbsolutePath(Files.createTempFile("forkerspec-temp", ".jar"))
-    }
+    TestUtil.withinWorkspace { tmpJarDir =>
+      val longCp = (1 to 3000).map { i =>
+        val tmpFile = tmpJarDir.resolve(s"forkerspec-temp-$i.jar").underlying
+        AbsolutePath(Files.createFile(tmpFile))
+      }.toArray
 
-    run(tmp, Array("foo", "bar", "baz"), longCp) {
-      case (exitCode, messages) =>
-        assertEquals(0, exitCode.toLong)
-        assert(messages.contains(("info", "Arguments: foo, bar, baz")))
-        assert(messages.contains(("error", "testing stderr")))
+      val charLimitMsg =
+        s"""|Supplied command to fork exceeds character limit of 30000
+            |Creating a temporary MANIFEST jar for classpath entries
+            |""".stripMargin
+
+      val cleanupPrefix = "Cleaning up temporary MANIFEST jar: "
+
+      def isCleanupMessage(message: (String, String)): Boolean = message match {
+        case ("debug", msg) if msg.startsWith(cleanupPrefix) =>
+          true
+        case _ =>
+          false
+      }
+
+      run(tmp, Array("foo", "bar", "baz"), longCp) {
+        case (exitCode, messages) =>
+          assertEquals(0, exitCode.toLong)
+          assert(messages.contains(("debug", charLimitMsg)))
+
+          val cleanupMessage = messages.filter(isCleanupMessage)
+          assertEquals(cleanupMessage.size, 1)
+
+          val tempManifestJar = Paths.get(cleanupMessage.head._2.stripPrefix(cleanupPrefix))
+          assert(tempManifestJar.isAbsolute)
+          assert(Files.notExists(tempManifestJar))
+
+          assert(messages.contains(("info", "Arguments: foo, bar, baz")))
+          assert(messages.contains(("error", "testing stderr")))
+      }
     }
   }
 


### PR DESCRIPTION
Previously, `JvmForker` passed the full classpath into the `java` invocation via `-cp`, without considering the implications for very long classpaths which break the command line length limits.

Now, it will create a temporary manifest jar to pass on classpath information in a command line-friendly way to the `java` invocation. This will allow us to run commands which exceed OS limits due to the length of the classpath. This will *not* address commands whose argument list to the main class causes it to fail despite shortening the classpath string.

Fixes https://github.com/scalacenter/bloop/issues/1094
Fixes https://github.com/scalacenter/bloop/issues/1084