### PR TITLE
Disable shared sbt-bloop classes dirs when not offloading

### DIFF
--- a/integrations/sbt-bloop/src/main/scala-sbt-0.13/bloop/integrations/sbt/Offloader.scala
+++ b/integrations/sbt-bloop/src/main/scala-sbt-0.13/bloop/integrations/sbt/Offloader.scala
@@ -6,6 +6,7 @@ import sbt.{Def, Task, TaskKey, Compile, Test, Keys, File, Classpaths}
 object Offloader {
   val bloopAnalysisOut: Def.Initialize[Task[Option[File]]] = Def.task(None)
 
+  val isOffloadingEnabled: Def.Initialize[Boolean] = Def.setting(false)
   val compile: Def.Initialize[Task[CompileAnalysis]] = Def.task(CompileAnalysis.Empty)
   val compileIncremental: Def.Initialize[Task[CompileAnalysis]] = Def.task(CompileAnalysis.Empty)
   val bloopCompile: Def.Initialize[Task[CompileAnalysis]] = Def.task(CompileAnalysis.Empty)

--- a/integrations/sbt-bloop/src/main/scala-sbt-1.0/bloop/integrations/sbt/Offloader.scala
+++ b/integrations/sbt-bloop/src/main/scala-sbt-1.0/bloop/integrations/sbt/Offloader.scala
@@ -738,6 +738,9 @@ object Offloader {
     BloopCompileKeys.bloopCompilerReporterInternal.set(bloopCompilerReporterTask, sbtBloopPosition)
   )
 
+  val isOffloadingEnabled: Def.Initialize[Boolean] =
+    Def.setting(BloopCompileKeys.bloopCompileStateAtBootTimeInternal.value.get() != null)
+
   lazy val bloopCompileProjectSettings: Seq[Def.Setting[_]] = List(
     BloopCompileKeys.bloopDisableCompilation.set(bloopDisableCompilationTask, sbtBloopPosition),
     BloopCompileKeys.bloopCleanInternal.set(bloopClean, sbtBloopPosition),

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -326,9 +326,11 @@ object BloopDefaults {
   def generateBloopProductDirectories: Def.Initialize[File] = Def.setting {
     val configuration = Keys.configuration.value
     val bloopTarget = BloopKeys.bloopTargetDir.value
+    val isOffloadingEnabled = Offloader.isOffloadingEnabled.value
     Keys.classDirectory.?.value match {
-      case Some(value) => value
-      case None =>
+      // TODO: Use shared classes dir between bloop and sbt by default in next release
+      case Some(value) if isOffloadingEnabled => value
+      case _ =>
         val bloopClassesDir = bloopTarget / (Defaults.prefix(configuration.name) + "classes")
         if (!bloopClassesDir.exists()) sbt.IO.createDirectory(bloopClassesDir)
         bloopClassesDir


### PR DESCRIPTION
If offloading is not enabled, we use the default from previous versions.