### PR TITLE
Require collection field types in jsoniter codecs

### DIFF
--- a/buildpress-config/src/main/scala/buildpress/config/Config.scala
+++ b/buildpress-config/src/main/scala/buildpress/config/Config.scala
@@ -46,13 +46,17 @@ object Config {
   case class RepoCacheEntries(repos: List[RepoCacheEntry])
   object RepoCacheEntries {
     implicit val codecSettings: JsonValueCodec[RepoCacheEntries] =
-      JsonCodecMaker.make[RepoCacheEntries](CodecMakerConfig.withTransientEmpty(false))
+      JsonCodecMaker.make[RepoCacheEntries](
+        CodecMakerConfig.withTransientEmpty(false).withRequireCollectionFields(true)
+      )
   }
 
   case class HashedPath(path: Path, hash: Int)
   object HashedPath {
     implicit val codecSettings: JsonValueCodec[HashedPath] =
-      JsonCodecMaker.make[HashedPath](CodecMakerConfig.withTransientEmpty(false))
+      JsonCodecMaker.make[HashedPath](
+        CodecMakerConfig.withTransientEmpty(false).withRequireCollectionFields(true)
+      )
   }
 
   final case class BuildSettingsHashes(individual: List[HashedPath]) {
@@ -75,13 +79,17 @@ object Config {
   }
   object BuildSettingsHashes {
     implicit val codecSettings: JsonValueCodec[BuildSettingsHashes] =
-      JsonCodecMaker.make[BuildSettingsHashes](CodecMakerConfig.withTransientEmpty(false))
+      JsonCodecMaker.make[BuildSettingsHashes](
+        CodecMakerConfig.withTransientEmpty(false).withRequireCollectionFields(true)
+      )
   }
 
   case class RepoCacheEntry(id: String, uri: URI, localPath: Path, hashes: BuildSettingsHashes)
   object RepoCacheEntry {
     implicit val codecSettings: JsonValueCodec[RepoCacheEntry] =
-      JsonCodecMaker.make[RepoCacheEntry](CodecMakerConfig.withTransientEmpty(false))
+      JsonCodecMaker.make[RepoCacheEntry](
+        CodecMakerConfig.withTransientEmpty(false).withRequireCollectionFields(true)
+      )
   }
 
   case class RepoCacheFile(version: String, cache: RepoCacheEntries)
@@ -91,7 +99,9 @@ object Config {
     final val LatestVersion = "1.0.0"
 
     implicit val codecSettings: JsonValueCodec[RepoCacheFile] =
-      JsonCodecMaker.make[RepoCacheFile](CodecMakerConfig.withTransientEmpty(false))
+      JsonCodecMaker.make[RepoCacheFile](
+        CodecMakerConfig.withTransientEmpty(false).withRequireCollectionFields(true)
+      )
   }
 
   def write(all: RepoCacheFile, target: Path): Unit = {

--- a/config/src/main/scala-2.11-13/bloop/config/ConfigCodecs.scala
+++ b/config/src/main/scala-2.11-13/bloop/config/ConfigCodecs.scala
@@ -116,22 +116,32 @@ object ConfigCodecs {
   }
 
   implicit val codecJvmConfig: JsonValueCodec[Config.JvmConfig] =
-    JsonCodecMaker.make[Config.JvmConfig](CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.make[Config.JvmConfig](
+      CodecMakerConfig.withTransientEmpty(false).withRequireCollectionFields(true)
+    )
 
   implicit val codecJsConfig: JsonValueCodec[Config.JsConfig] =
-    JsonCodecMaker.make[Config.JsConfig](CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.make[Config.JsConfig](
+      CodecMakerConfig.withTransientEmpty(false).withRequireCollectionFields(true)
+    )
 
   implicit val codecNativeConfig: JsonValueCodec[Config.NativeConfig] =
-    JsonCodecMaker.make[Config.NativeConfig](CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.make[Config.NativeConfig](
+      CodecMakerConfig.withTransientEmpty(false).withRequireCollectionFields(true)
+    )
 
   private case class MainClass(mainClass: Option[String])
   private implicit val codecMainClass: JsonValueCodec[MainClass] = {
     new JsonValueCodec[MainClass] {
       val nullValue: MainClass = null.asInstanceOf[MainClass]
       val codecOption: JsonValueCodec[Option[String]] =
-        JsonCodecMaker.make[Option[String]](CodecMakerConfig.withTransientEmpty(false))
+        JsonCodecMaker.make[Option[String]](
+          CodecMakerConfig.withTransientEmpty(false).withRequireCollectionFields(true)
+        )
       val codecList: JsonValueCodec[List[String]] =
-        JsonCodecMaker.make[List[String]](CodecMakerConfig.withTransientEmpty(false))
+        JsonCodecMaker.make[List[String]](
+          CodecMakerConfig.withTransientEmpty(false).withRequireCollectionFields(true)
+        )
       def encodeValue(x: MainClass, out: JsonWriter): Unit = {
         //codecOption.encodeValue(x.mainClass, out)
         codecList.encodeValue(x.mainClass.toList, out)
@@ -167,6 +177,7 @@ object ConfigCodecs {
           CodecMakerConfig
             .withDiscriminatorFieldName(Some("name"))
             .withTransientEmpty(false)
+            .withRequireCollectionFields(true)
         )
       val nullValue: Config.Platform = null.asInstanceOf[Config.Platform]
       def encodeValue(x: Config.Platform, out: JsonWriter): Unit = {
@@ -189,10 +200,14 @@ object ConfigCodecs {
     }
 
   implicit val codecProject: JsonValueCodec[Config.Project] =
-    JsonCodecMaker.make[Config.Project](CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.make[Config.Project](
+      CodecMakerConfig.withTransientEmpty(false).withRequireCollectionFields(true)
+    )
 
   implicit val codecFile: JsonValueCodec[Config.File] =
-    JsonCodecMaker.make[Config.File](CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.make[Config.File](
+      CodecMakerConfig.withTransientEmpty(false).withRequireCollectionFields(true)
+    )
 
   def read(configDir: Path): Either[Throwable, Config.File] = {
     read(Files.readAllBytes(configDir))

--- a/frontend/src/main/scala/bloop/data/WorkspaceSettings.scala
+++ b/frontend/src/main/scala/bloop/data/WorkspaceSettings.scala
@@ -54,7 +54,9 @@ object WorkspaceSettings {
   private[bloop] val settingsFileName = RelativePath("bloop.settings.json")
 
   private implicit val codecSettings: JsonValueCodec[WorkspaceSettings] =
-    JsonCodecMaker.make[WorkspaceSettings](CodecMakerConfig.withTransientEmpty(false))
+    JsonCodecMaker.make[WorkspaceSettings](
+      CodecMakerConfig.withTransientEmpty(false).withRequireCollectionFields(true)
+    )
   import com.github.plokhotnyuk.jsoniter_scala.{core => jsoniter}
   def readFromFile(configPath: AbsolutePath, logger: Logger): Option[WorkspaceSettings] = {
     val settingsPath = configPath.resolve(settingsFileName)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,7 +37,7 @@ object Dependencies {
   val ipcsocketVersion = "1.0.1"
   val monixVersion = "2.3.3"
   val circeVersion = "0.9.3"
-  val jsoniterVersion = "2.0.0"
+  val jsoniterVersion = "2.0.4"
   val circeVersion213 = "0.12.2"
   val nuprocessVersion = "1.2.4"
   val shapelessVersion = "2.3.3-lower-priority-coproduct"


### PR DESCRIPTION
Previously, Scala collection types in generated jsoniter codecs could be
left empty and the deserialization would not fail. However, this runs
constrary to the semantics in our previous Circe codecs and the
semantics we want to enforce: all fields should be mandatory unless they
are explicitly wrapped on an `Option` type.

This PR enables a new option that @plokhotnyuk introduced in https://github.com/plokhotnyuk/jsoniter-scala/pull/411/files