### PR TITLE
Update minimum Gradle version to 4.3 and some fixes

### DIFF
--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/BloopParameters.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/BloopParameters.scala
@@ -39,26 +39,32 @@ case class BloopParametersExtension(project: Project) {
 
   // include the source artifacts
   // In Gradle 4.3 the default property for Boolean is false (not null) so default has to be set here
-  private val includeSources_ : Property[java.lang.Boolean] = project.getObjects.property(classOf[java.lang.Boolean])
+  private val includeSources_ : Property[java.lang.Boolean] =
+    project.getObjects.property(classOf[java.lang.Boolean])
   includeSources_.set(true)
   @Input @Optional def getIncludeSources: Property[java.lang.Boolean] = includeSources_
 
   // include the Javadoc artifacts
   // In Gradle 4.3 the default property for Boolean is false (not null) so default has to be set here
-  private val includeJavadoc_ : Property[java.lang.Boolean] = project.getObjects.property(classOf[java.lang.Boolean])
+  private val includeJavadoc_ : Property[java.lang.Boolean] =
+    project.getObjects.property(classOf[java.lang.Boolean])
   includeJavadoc_.set(false)
   @Input @Optional def getIncludeJavadoc: Property[java.lang.Boolean] = includeJavadoc_
 
-  def createParameters: BloopParameters = BloopParameters(
-    targetDir_.getOrElse(project.getRootProject.getProjectDir / ".bloop"),
-    compilerName_.getOrElse("scala-compiler"),
-    stdLibName_.getOrElse("scala-library"),
-    includeSources_.get,
-    includeJavadoc_.get)
+  def createParameters: BloopParameters =
+    BloopParameters(
+      targetDir_.getOrElse(project.getRootProject.getProjectDir / ".bloop"),
+      compilerName_.getOrElse("scala-compiler"),
+      stdLibName_.getOrElse("scala-library"),
+      includeSources_.get,
+      includeJavadoc_.get
+    )
 }
 
-case class BloopParameters(targetDir: File,
-                           compilerName: String,
-                           stdLibName: String,
-                           includeSources: Boolean,
-                           includeJavadoc: Boolean)
+case class BloopParameters(
+    targetDir: File,
+    compilerName: String,
+    stdLibName: String,
+    includeSources: Boolean,
+    includeJavadoc: Boolean
+)

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/BloopParameters.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/BloopParameters.scala
@@ -2,50 +2,63 @@ package bloop.integrations.gradle
 
 import java.io.File
 
+import org.gradle.api.provider.Property
 import org.gradle.api.Project
+import org.gradle.api.tasks.{Input, Optional}
 import syntax._
 
 /**
  * Project extension to configure Bloop.
  *
- * For each property we have a private variable and a set of interface functions to support
- * convenient access from Scala, Java and the Groovy DSL.
- *
  * From the build definitions it can be used like the following:
  *
  * {{{
  * bloop {
- *   targetDir "$projectDir/.bloop"
- *   compilerName "scala-compiler"
+ *   targetDir = file("$projectDir/.bloop")
+ *   compilerName = "scala-compiler"
+ *   stdLibName = "scala-library"
+ *   includeSources = true
+ *   includeJavaDoc = false
  * }
  * }}}
  */
-class BloopParameters(project: Project) {
-  // targetDir
-  private var targetDir_ : File = project.getRootProject.getProjectDir / ".bloop"
-  def getTargetDir: File = targetDir_
-  def targetDir: File = getTargetDir
-  def targetDir(value: File): Unit = setTargetDir(value)
-  def targetDir(path: String): Unit = setTargetDir(new File(path))
-  def setTargetDir(value: File): Unit = {
-    targetDir_ = value
-  }
+case class BloopParametersExtension(project: Project) {
+  // Variable names are derived by Gradle from the annotated getter method
 
-  // compiler name
-  private var compilerName_ : String = "scala-compiler"
-  def getCompilerName: String = compilerName_
-  def compilerName: String = getCompilerName
-  def compilerName(value: String): Unit = setCompilerName(value)
-  def setCompilerName(value: String): Unit = {
-    compilerName_ = value
-  }
+  // location of bloop files
+  private val targetDir_ : Property[File] = project.getObjects.property(classOf[File])
+  @Input @Optional def getTargetDir: Property[File] = targetDir_
 
-  // standard library name
-  private var stdLibName_ : String = "scala-library"
-  def getStdLibName: String = stdLibName_
-  def stdLibName: String = getStdLibName
-  def stdLibName(value: String): Unit = setStdLibName(value)
-  def setStdLibName(value: String): Unit = {
-    stdLibName_ = value
-  }
+  // name of Scala compiler
+  private val compilerName_ : Property[String] = project.getObjects.property(classOf[String])
+  @Input @Optional def getCompilerName: Property[String] = compilerName_
+
+  // name of Scala library
+  private val stdLibName_ : Property[String] = project.getObjects.property(classOf[String])
+  @Input @Optional def getStdLibName: Property[String] = stdLibName_
+
+  // include the source artifacts
+  // In Gradle 4.3 the default property for Boolean is false (not null) so default has to be set here
+  private val includeSources_ : Property[java.lang.Boolean] = project.getObjects.property(classOf[java.lang.Boolean])
+  includeSources_.set(true)
+  @Input @Optional def getIncludeSources: Property[java.lang.Boolean] = includeSources_
+
+  // include the Javadoc artifacts
+  // In Gradle 4.3 the default property for Boolean is false (not null) so default has to be set here
+  private val includeJavadoc_ : Property[java.lang.Boolean] = project.getObjects.property(classOf[java.lang.Boolean])
+  includeJavadoc_.set(false)
+  @Input @Optional def getIncludeJavadoc: Property[java.lang.Boolean] = includeJavadoc_
+
+  def createParameters: BloopParameters = BloopParameters(
+    targetDir_.getOrElse(project.getRootProject.getProjectDir / ".bloop"),
+    compilerName_.getOrElse("scala-compiler"),
+    stdLibName_.getOrElse("scala-library"),
+    includeSources_.get,
+    includeJavadoc_.get)
 }
+
+case class BloopParameters(targetDir: File,
+                           compilerName: String,
+                           stdLibName: String,
+                           includeSources: Boolean,
+                           includeJavadoc: Boolean)

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
@@ -1,6 +1,6 @@
 package bloop.integrations.gradle
 
-import bloop.integrations.gradle.tasks.{BloopInstallTask, ConfigureBloopInstallTask, TaskLogging}
+import bloop.integrations.gradle.tasks.{BloopInstallTask, ConfigureBloopInstallTask}
 import org.gradle.api.{Plugin, Project}
 import syntax._
 
@@ -17,7 +17,7 @@ import syntax._
 final class BloopPlugin extends Plugin[Project] {
   override def apply(project: Project): Unit = {
     project.getLogger.info(s"Applying bloop plugin to project ${project.getName}", Seq.empty: _*)
-    project.createExtension[BloopParameters]("bloop", project)
+    project.createExtension[BloopParametersExtension]("bloop", project)
 
     // Creates two tasks: one to configure the plugin and the other one to generate the config files
     val configureBloopInstall =

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -6,29 +6,20 @@ import java.nio.file.Paths
 import java.nio.file.Files
 
 import bloop.config.Config
-import bloop.config.Config.{
-  CompileOrder,
-  CompileSetup,
-  JavaThenScala,
-  JvmConfig,
-  Mixed,
-  Platform,
-  TestArgument,
-  TestOptions
-}
+import bloop.config.Config.{CompileSetup, JavaThenScala, JvmConfig, Mixed, Platform}
 import bloop.integrations.gradle.BloopParameters
 import bloop.integrations.gradle.model.BloopConverter.SourceSetDep
 import bloop.integrations.gradle.syntax._
 import org.gradle.api.{GradleException, Project}
 import org.gradle.api.artifacts._
-import org.gradle.api.artifacts.result.ResolvedArtifactResult
-import org.gradle.api.file.FileCollection
+import org.gradle.api.artifacts.result.{ComponentArtifactsResult, ResolvedArtifactResult}
+import org.gradle.api.component.Artifact
 import org.gradle.api.internal.artifacts.publish.ArchivePublishArtifact
 import org.gradle.api.internal.file.copy.DefaultCopySpec
 import org.gradle.api.internal.tasks.DefaultSourceSetOutput
 import org.gradle.api.internal.tasks.compile.{DefaultJavaCompileSpec, JavaCompilerArgumentsBuilder}
 import org.gradle.api.plugins.{ApplicationPluginConvention, JavaPluginConvention}
-import org.gradle.api.specs.{Spec, Specs}
+import org.gradle.api.specs.Specs
 import org.gradle.api.tasks.{AbstractCopyTask, SourceSet, SourceSetOutput}
 import org.gradle.api.tasks.compile.{CompileOptions, JavaCompile}
 import org.gradle.api.tasks.scala.{ScalaCompile, ScalaCompileOptions}
@@ -43,10 +34,9 @@ import scala.util.{Failure, Success, Try}
 
 /**
  * Define the conversion from Gradle's project model to Bloop's project model.
- *
- * @param parameters Parameters provided by Gradle's user configuration
+ * @param parameters Plugin input parameters
  */
-final class BloopConverter(parameters: BloopParameters) {
+class BloopConverter(parameters: BloopParameters) {
 
   /**
    * Converts a project's given source set to a Bloop project
@@ -61,7 +51,6 @@ final class BloopConverter(parameters: BloopParameters) {
    * @param strictProjectDependencies Additional dependencies that cannot be inferred from Gradle's object model
    * @param project The Gradle project model
    * @param sourceSet The source set to convert
-   * @param targetDir Target directory for bloop files
    * @return Bloop configuration
    */
   def toBloopConfig(
@@ -83,19 +72,11 @@ final class BloopConverter(parameters: BloopParameters) {
         !resources.exists(_.toFile.exists())) {
       Failure(new GradleException("Test project has no source so ignore it"))
     } else {
+      // get relevant class path configs
       val compileClassPathConfiguration =
         project.getConfiguration(sourceSet.getCompileClasspathConfigurationName)
-
-      // get runtime classpath.  Config name has changed over Gradle versions so check both
-      val runtimeClassPathConfiguration = {
-        val runtimeConfig = project.getConfiguration(sourceSet.getRuntimeConfigurationName)
-        val runtimeClassPathConfig =
-          project.getConfiguration(sourceSet.getRuntimeConfigurationName + "Classpath")
-        if (runtimeClassPathConfig != null)
-          runtimeClassPathConfig
-        else
-          runtimeConfig
-      }
+      val runtimeClassPathConfiguration =
+        project.getConfiguration(sourceSet.getRuntimeClasspathConfigurationName)
 
       // create a map of all Gradle Java projects and their sourcesets
       val allSourceSetsToProjects = project.getRootProject.getAllprojects.asScala
@@ -110,20 +91,18 @@ final class BloopConverter(parameters: BloopParameters) {
       val runtimeProjectDependencies =
         getProjectDependencies(allSourceSetsToProjects, runtimeClassPathConfiguration)
 
-      // Strict project dependencies should have more priority than regular project dependencies
+      // all project dependencies
       val allDependencies = (strictProjectDependencies.map(_.bloopModuleName) ++
         compileProjectDependencies ++ runtimeProjectDependencies).distinct
 
       // retrieve project dependencies recursively to include transitive project dependencies
       // Bloop requires this for the classpath
-      val allCompileProjectDependencies = getProjectDependenciesRecursively(
-        compileClassPathConfiguration
-      )
-      val allRuntimeProjectDependencies = getProjectDependenciesRecursively(
-        runtimeClassPathConfiguration
-      )
+      val allCompileProjectDependencies =
+        getProjectDependenciesRecursively(compileClassPathConfiguration)
+      val allRuntimeProjectDependencies =
+        getProjectDependenciesRecursively(runtimeClassPathConfiguration)
 
-      // retrieve all artifacts (includes transitive)
+      // retrieve all artifacts (includes transitive?)
       val compileArtifacts: List[ResolvedArtifact] =
         compileClassPathConfiguration.getResolvedConfiguration.getResolvedArtifacts.asScala.toList
       val runtimeArtifacts: List[ResolvedArtifact] =
@@ -144,7 +123,7 @@ final class BloopConverter(parameters: BloopParameters) {
         .filter(
           resolvedArtifact =>
             !isProjectDependency(allCompileProjectDependencies, resolvedArtifact) &&
-              !isProjectDependency(allCompileProjectDependencies, resolvedArtifact)
+              !isProjectDependency(allRuntimeProjectDependencies, resolvedArtifact)
         )
 
       // convert artifacts to class dirs for projects and file paths for non-projects
@@ -197,10 +176,12 @@ final class BloopConverter(parameters: BloopParameters) {
 
       val compileClasspathFilesAsPaths = compileClassPathFiles
         .filter(f => isProjectSourceSet(allSourceSetsToProjects, f))
-        .map(f => getClassesDir(targetDir, dependencyToProjectName(allSourceSetsToProjects, f)))
+        .map(f => getClassesDir(targetDir,
+          dependencyToProjectName(allSourceSetsToProjects, f)))
       val runtimeClasspathFilesAsPaths = runtimeClassPathFiles
         .filter(f => isProjectSourceSet(allSourceSetsToProjects, f))
-        .map(f => getClassesDir(targetDir, dependencyToProjectName(allSourceSetsToProjects, f)))
+        .map(f => getClassesDir(targetDir,
+          dependencyToProjectName(allSourceSetsToProjects, f)))
 
       // get non-project artifacts for resolution
       val compileNonProjectDependencies: List[ResolvedArtifact] = compileArtifacts
@@ -236,7 +217,7 @@ final class BloopConverter(parameters: BloopParameters) {
         bloopProject = Config.Project(
           name = getProjectName(project, sourceSet),
           directory = project.getProjectDir.toPath,
-          workspaceDir = Option(project.getRootProject().getProjectDir().toPath()),
+          workspaceDir = Option(project.getRootProject.getProjectDir.toPath),
           sources = sources,
           dependencies = allDependencies,
           classpath = classpath,
@@ -254,10 +235,13 @@ final class BloopConverter(parameters: BloopParameters) {
     }
   }
 
-  private def getJavaCompileOptions(project: Project, sourceSet: SourceSet): CompileOptions = {
+  private def getJavaCompileTask(project: Project, sourceSet: SourceSet): JavaCompile = {
     val javaCompileTaskName = sourceSet.getCompileTaskName("java")
-    val javaCompileTask = project.getTask[JavaCompile](javaCompileTaskName)
-    javaCompileTask.getOptions
+    project.getTask[JavaCompile](javaCompileTaskName)
+  }
+
+  private def getJavaCompileOptions(project: Project, sourceSet: SourceSet): CompileOptions = {
+    getJavaCompileTask(project, sourceSet).getOptions
   }
 
   def getPlatform(
@@ -319,20 +303,9 @@ final class BloopConverter(parameters: BloopParameters) {
     }
   }
 
-  // Gradle has removed the getConfiguration method and replaced it with getTargetConfiguration around version 4.0
   private def getTargetConfiguration(projectDependency: ProjectDependency): String = {
-    try {
-      val getTargetConfiguration = classOf[ProjectDependency].getMethod("getTargetConfiguration")
-      val targetConfigName = getTargetConfiguration.invoke(projectDependency)
-      if (targetConfigName == null) Dependency.DEFAULT_CONFIGURATION
-      else targetConfigName.asInstanceOf[String]
-    } catch {
-      case _: NoSuchMethodException =>
-        val getConfiguration = classOf[ProjectDependency].getMethod("getConfiguration")
-        val configName = getConfiguration.invoke(projectDependency)
-        if (configName == null) Dependency.DEFAULT_CONFIGURATION
-        else configName.asInstanceOf[String]
-    }
+    Option(projectDependency.getTargetConfiguration)
+      .getOrElse(Dependency.DEFAULT_CONFIGURATION)
   }
 
   // find the source of the data going into an archive
@@ -348,10 +321,7 @@ final class BloopConverter(parameters: BloopParameters) {
       if (mainSpec == null)
         None
       else {
-        val getSourcePaths = classOf[DefaultCopySpec].getMethod("getSourcePaths")
-        val sourcePaths = getSourcePaths.invoke(mainSpec)
-        sourcePaths
-          .asInstanceOf[java.util.Set[Object]]
+        mainSpec.asInstanceOf[DefaultCopySpec].getSourcePaths
           .asScala
           .flatMap({
             case sourceSetOutput: DefaultSourceSetOutput =>
@@ -371,16 +341,7 @@ final class BloopConverter(parameters: BloopParameters) {
 
   // Gradle has removed getClassesDir and replaced with getClassesDirs - version 4.0
   private def matchesOutputDir(sourceSetOutput: SourceSetOutput, outputDir: File): Boolean = {
-    try {
-      val getClassesDirs = classOf[SourceSetOutput].getMethod("getClassesDirs")
-      val classesDirs = getClassesDirs.invoke(sourceSetOutput)
-      if (classesDirs == null)
-        false
-      else
-        classesDirs.asInstanceOf[FileCollection].getFiles.asScala.contains(outputDir)
-    } catch {
-      case _: NoSuchMethodException => sourceSetOutput.getClassesDir == outputDir;
-    }
+    sourceSetOutput.getClassesDirs.getFiles.asScala.contains(outputDir)
   }
 
   private def isProjectSourceSet(
@@ -486,8 +447,7 @@ final class BloopConverter(parameters: BloopParameters) {
           s =>
             List(
               s.getCompileClasspathConfigurationName,
-              s.getRuntimeConfigurationName,
-              s.getRuntimeConfigurationName + "Classpath"
+              s.getRuntimeClasspathConfigurationName
             ).map(name => name -> s)
         )
         .toMap
@@ -574,46 +534,64 @@ final class BloopConverter(parameters: BloopParameters) {
     projectDependencies.exists(dep => isProjectDependency(dep, resolvedArtifact))
   }
 
+  private def createArtifact(resolvedArtifactResult: ResolvedArtifactResult,
+                             name: String,
+                             classifier: String): Config.Artifact = {
+    Config.Artifact(
+      name = name,
+      classifier = Option(classifier),
+      checksum = None,
+      path = resolvedArtifactResult.getFile.toPath
+    )
+  }
+
+  def getArtifacts(resolvedArtifacts: collection.Set[ComponentArtifactsResult],
+                   name: String,
+                   artifactClass: Class[_ <: Artifact],
+                   classifier: String): collection.Set[Config.Artifact] = {
+    resolvedArtifacts
+      .flatMap(_.getArtifacts(artifactClass).asScala
+        .collect {
+          case resolvedArtifact: ResolvedArtifactResult => createArtifact(resolvedArtifact, name, classifier)
+        }
+      )
+  }
+
   private def artifactToConfigModule(
       artifact: ResolvedArtifact,
       project: Project
   ): Config.Module = {
 
+    val javadocArtifact = if (parameters.includeJavadoc) Seq(classOf[JavadocArtifact]) else Seq.empty
+    val sourcesArtifact = if (parameters.includeSources) Seq(classOf[SourcesArtifact]) else Seq.empty
+
     val resolutionResult = project
-      .getDependencies()
+      .getDependencies
       .createArtifactResolutionQuery()
       .forComponents(artifact.getId.getComponentIdentifier)
-      .withArtifacts(classOf[JvmLibrary], classOf[SourcesArtifact], classOf[JavadocArtifact])
+      .withArtifacts(classOf[JvmLibrary], javadocArtifact ++ sourcesArtifact: _*)
       .execute()
 
-    val name = artifact.getModuleVersion().getId().getName()
-    val resolvedSourcesDependencies =
-      resolutionResult
-        .getResolvedComponents()
-        .asScala
-        .flatMap(_.getArtifacts(classOf[SourcesArtifact]).asScala)
-        .collect {
-          case artifact: ResolvedArtifactResult =>
-            Config.Artifact(
-              name = name,
-              classifier = Option("sources"),
-              checksum = None,
-              path = artifact.getFile.toPath
-            )
-        }
-        .toList
+    val name = artifact.getModuleVersion.getId.getName
+    val resolvedArtifacts = resolutionResult
+      .getResolvedComponents
+      .asScala
+    val resolvedOtherDependencies = getArtifacts(resolvedArtifacts,
+      name, classOf[SourcesArtifact], "sources") ++
+      getArtifacts(resolvedArtifacts,
+        name, classOf[JavadocArtifact], "javadoc")
 
     Config.Module(
-      organization = artifact.getModuleVersion().getId().getGroup(),
-      name = artifact.getName(),
-      version = artifact.getModuleVersion().getId().getVersion(),
+      organization = artifact.getModuleVersion.getId.getGroup,
+      name = artifact.getName,
+      version = artifact.getModuleVersion.getId.getVersion,
       configurations = None,
       Config.Artifact(
         name = name,
-        classifier = Option(artifact.getClassifier()),
+        classifier = Option(artifact.getClassifier),
         checksum = None,
-        path = artifact.getFile().toPath()
-      ) :: resolvedSourcesDependencies
+        path = artifact.getFile.toPath
+      ) :: resolvedOtherDependencies.toList
     )
   }
 
@@ -667,20 +645,23 @@ final class BloopConverter(parameters: BloopParameters) {
         val target = s"project ${project.getName}/${sourceSet.getName}"
         val artifactNames =
           if (artifacts.isEmpty) ""
-          else s" Found artifacts:\n${artifacts.map(_.getFile.toString).mkString("\n")}"
+          else s" Found artifacts:\n${artifacts.map(a => s"${a.getName} ${a.getFile}").mkString("\n")}"
         Failure(
           new GradleException(
-            s"Expected Scala standard library in classpath of $target that defines Scala sources.$artifactNames"
+            s"Expected ${parameters.stdLibName} library in classpath of $target that defines Scala sources.$artifactNames"
           )
         )
     }
   }
 
   private def getJavaConfig(project: Project, sourceSet: SourceSet): Option[Config.Java] = {
-    val opts = getJavaCompileOptions(project, sourceSet)
+    val compileTask = getJavaCompileTask(project, sourceSet)
+    val opts = compileTask.getOptions
 
     val specs = new DefaultJavaCompileSpec()
     specs.setCompileOptions(opts)
+    specs.setSourceCompatibility(compileTask.getSourceCompatibility)
+    specs.setTargetCompatibility(compileTask.getTargetCompatibility)
 
     val builder = new JavaCompilerArgumentsBuilder(specs)
       .includeMainOptions(true)

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/BloopInstallTask.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/BloopInstallTask.scala
@@ -59,7 +59,14 @@ class BloopInstallTask extends DefaultTask with PluginUtils with TaskLogging {
     // Generate the bloop configuration files for the rest of the source sets
     for (sourceSet <- otherSourceSets) {
       val projectName = converter.getProjectName(project, sourceSet)
-      generateBloopConfiguration(projectName, strictDependencies, sourceSet, targetDir, converter, false)
+      generateBloopConfiguration(
+        projectName,
+        strictDependencies,
+        sourceSet,
+        targetDir,
+        converter,
+        false
+      )
     }
   }
 

--- a/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
+++ b/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
@@ -160,10 +160,13 @@ abstract class ConfigGenerationSuite {
     assert(config.project.`scala`.isEmpty)
     // no source or JavaDoc artifacts should exist
     assert(config.project.resolution.nonEmpty)
-    assert(!config.project.resolution.exists(res =>
-      res.modules.exists(conf =>
-        conf.artifacts.exists(artifact =>
-          artifact.classifier.nonEmpty))))
+    assert(
+      !config.project.resolution.exists(
+        res =>
+          res.modules
+            .exists(conf => conf.artifacts.exists(artifact => artifact.classifier.nonEmpty))
+      )
+    )
   }
 
   @Test def worksWithTransientProjectDependencies(): Unit = {
@@ -476,7 +479,6 @@ abstract class ConfigGenerationSuite {
     assert(configB.project.dependencies.isEmpty)
     assertEquals(List("a"), configATest.project.dependencies.sorted)
     assertEquals(List("a-test", "b"), configBTest.project.dependencies.sorted)
-
 
     assert(!hasClasspathEntryName(configB, "/a/build/classes"))
     assert(!hasClasspathEntryName(configB, "/a-test/build/classes"))
@@ -1349,7 +1351,11 @@ abstract class ConfigGenerationSuite {
     State.forTests(build, TestUtil.getCompilerCache(logger), logger)
   }
 
-  private def compileBloopProject(projectName: String, bloopDir: File, verbose: Boolean = false): State = {
+  private def compileBloopProject(
+      projectName: String,
+      bloopDir: File,
+      verbose: Boolean = false
+  ): State = {
     val state0 = loadBloopState(bloopDir)
     val state = if (verbose) state0.copy(logger = state0.logger.asVerbose) else state0
     val action = Run(Commands.Compile(List(projectName)))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,7 @@ object Dependencies {
   val mavenApiVersion = "3.6.1"
   val mavenAnnotationsVersion = "3.5"
   val mavenScalaPluginVersion = "3.2.2"
-  val gradleVersion = "3.5"
+  val gradleVersion = "4.3.1"
   val groovyVersion = "2.5.0"
   val ipcsocketVersion = "1.0.1"
   val monixVersion = "2.3.3"

--- a/project/GradleIntegration.scala
+++ b/project/GradleIntegration.scala
@@ -31,11 +31,13 @@ object GradleIntegration {
           logger.info("Extracting the api path from gradle...")
           val cmdBase =
             if (isWindows) "cmd.exe" :: "/C" :: s"${gradlePath}.bat" :: Nil else gradlePath :: Nil
-          val gradleCmd = cmdBase ++ Seq("--stacktrace", "--no-daemon", "printClassPath")
+          val gradleCmd = cmdBase ++ Seq("--stacktrace", "--no-daemon", "--console=plain", "--quiet", "printClassPath")
           val result: String = Process(gradleCmd, dummyProjectDir).!!
-
-          copyGeneratedArtifact(logger, libDir, targetApi, result, "gradle-api", version)
-          copyGeneratedArtifact(logger, libDir, targetTestKit, result, "gradle-test-kit", version)
+          // Gradle returns classpath plus linefeeds and logging so parse
+          val paths = result.split(java.io.File.pathSeparator)
+            .flatMap(_.split("\\r?\\n"))
+          copyGeneratedArtifact(logger, libDir, targetApi, paths, "gradle-api", version)
+          copyGeneratedArtifact(logger, libDir, targetTestKit, paths, "gradle-test-kit", version)
         }
       }
     } else {
@@ -48,12 +50,11 @@ object GradleIntegration {
       logger: Logger,
       libDir: File,
       targetFile: File,
-      classpath: String,
+      paths: Array[String],
       name: String,
       version: String
   ): Unit = {
-    val splitCharacter = if (isWindows) ';' else ':'
-    classpath.split(splitCharacter).find(_.endsWith(s"$name-$version.jar")) match {
+    paths.find(_.endsWith(s"$name-$version.jar")) match {
       case Some(gradleApi) =>
         // Copy the api to the lib jar so that it's accessible for the compiler
         val gradleApiJar = new File(gradleApi)
@@ -61,7 +62,7 @@ object GradleIntegration {
         IO.copyFile(gradleApiJar, targetFile)
       case None =>
         throw new MessageOnlyException(
-          s"Fatal: could not find $name artifact in the generated class path $classpath")
+          s"Fatal: could not find $name artifact in the generated class path [${paths.mkString(",")}]")
     }
   }
 
@@ -73,7 +74,7 @@ object GradleIntegration {
       |  testCompile gradleTestKit()
       |}
       |
-      |task("printClassPath") << {
+      |task("printClassPath") {
       |  println project.sourceSets.test.runtimeClasspath.asPath
       |}
     """.stripMargin

--- a/project/GradleIntegration.scala
+++ b/project/GradleIntegration.scala
@@ -31,10 +31,17 @@ object GradleIntegration {
           logger.info("Extracting the api path from gradle...")
           val cmdBase =
             if (isWindows) "cmd.exe" :: "/C" :: s"${gradlePath}.bat" :: Nil else gradlePath :: Nil
-          val gradleCmd = cmdBase ++ Seq("--stacktrace", "--no-daemon", "--console=plain", "--quiet", "printClassPath")
+          val gradleCmd = cmdBase ++ Seq(
+            "--stacktrace",
+            "--no-daemon",
+            "--console=plain",
+            "--quiet",
+            "printClassPath"
+          )
           val result: String = Process(gradleCmd, dummyProjectDir).!!
           // Gradle returns classpath plus linefeeds and logging so parse
-          val paths = result.split(java.io.File.pathSeparator)
+          val paths = result
+            .split(java.io.File.pathSeparator)
             .flatMap(_.split("\\r?\\n"))
           copyGeneratedArtifact(logger, libDir, targetApi, paths, "gradle-api", version)
           copyGeneratedArtifact(logger, libDir, targetTestKit, paths, "gradle-test-kit", version)
@@ -62,7 +69,8 @@ object GradleIntegration {
         IO.copyFile(gradleApiJar, targetFile)
       case None =>
         throw new MessageOnlyException(
-          s"Fatal: could not find $name artifact in the generated class path [${paths.mkString(",")}]")
+          s"Fatal: could not find $name artifact in the generated class path [${paths.mkString(",")}]"
+        )
     }
   }
 


### PR DESCRIPTION
Update minimum Gradle version supported to 4.3; remove reflection (no longer have to support < 4.3);
fix Gradle test API download and classpath extraction; and support v6.0. Fixes #1133

Incorporate @pkolaczk #1099 fix for #1092 (hope that's not bad etiquette) as input property handling had to be refactored for v4.3.

Fix JavaDoc artifact resolution - used to always download and discard (default is to not download).

Fix SourceCompatibility and TargetCompatibility for Java - didn't pick up settings.

