### PR TITLE
Silence error from _arguments:comparguments:325

### DIFF
--- a/etc/zsh/_bloop
+++ b/etc/zsh/_bloop
@@ -81,7 +81,7 @@ _project_or_flags() {
     fi
 }
 
-_arguments \
+_arguments >/dev/null 2>&1  \
     ":command:_commands" \
     ":project_or_flags:_project_or_flags" \
     "*::flags:_tests_or_flags"


### PR DESCRIPTION
When loading zsh completion script on Mac OSX the following error occurs:
```bash
_arguments:comparguments:325: can only be called from completion function
```
This change simply omits it. Are there any other proposals?