### PR TITLE
Add the '--no-home-predef' flag to Ammonite

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -297,7 +297,10 @@ object Interpreter {
                   val classpath = project.fullClasspath(dag, state.client)
                   val coursierClasspathArgs =
                     classpath.flatMap(elem => Seq("--extra-jars", elem.syntax))
-                  val ammoniteCmd = (coursierCmd ++ coursierClasspathArgs).mkString(" ")
+
+                  val ammArgs = Seq("-- --no-home-predef")
+
+                  val ammoniteCmd = (coursierCmd ++ coursierClasspathArgs ++ ammArgs).mkString(" ")
                   cmd.outFile match {
                     case None => Task.now(state.withInfo(ammoniteCmd))
                     case Some(outFile) =>

--- a/frontend/src/test/scala/bloop/ConsoleSpec.scala
+++ b/frontend/src/test/scala/bloop/ConsoleSpec.scala
@@ -43,7 +43,7 @@ object ConsoleSpec extends BaseSuite {
         classpathB.flatMap(elem => Seq("--extra-jars", elem.syntax))
       val expectedCommand =
         s"coursier launch com.lihaoyi:ammonite_2.12.8:latest.release --main-class ammonite.Main --scala-version 2.12.8 ${coursierClasspathArgs
-          .mkString(" ")}"
+          .mkString(" ")} -- --no-home-predef"
 
       assertNoDiff(
         logger.captureTimeInsensitiveInfos


### PR DESCRIPTION
# Summary

Ammonite allows the creation of a predef file located in `~/.ammonite/predef.sc`. This file is often times customizing the Ammonite experience heavily and as such contains library dependencies.

I would therefore argue that when using `bloop console some-project` the predef file should not be part of the Ammonite start up as this can (and did in my case) interfere with the projects setup and even lead to Ammonite crashing (e.g. when a dependency in the predef is only available for versions of Scala that are different from the projects).

Additionally it simply seems more correct to me to not include any predefined code when using `bloop console some-project`.

This pull request passes the `--no-home-predef` flag to Ammonite at startup.

# Further Notes

- The startup flags for Ammonite can be found by issuing `amm --help`
- The code changes have been tested locally with `sbt frontend/testOnly *ConsoleSpec`
- It may make sense to allow the caller of `bloop console some-project` to pass all available Ammonite flags (as a future improvement)