### PR TITLE
Fix Windows drive letter handling in jar manifest

### DIFF
--- a/frontend/src/main/scala/bloop/exec/JvmProcessForker.scala
+++ b/frontend/src/main/scala/bloop/exec/JvmProcessForker.scala
@@ -198,9 +198,9 @@ final class JvmForker(config: JdkConfig, classpath: Array[AbsolutePath]) extends
     }
 
     if (Properties.isWin) {
-      // Remove drive letter as MANIFEST files don't support them on Windows
+      // Prepend drive letters in windows with slash
       if (separatorAdded.indexOf(":") != 1) separatorAdded
-      else separatorAdded.substring(separatorAdded.indexOf(":") + 1)
+      else File.separator + separatorAdded
     } else {
       separatorAdded
     }


### PR DESCRIPTION
Bloop has manifest classpath entries in Windows going from...
```c:/users/...```
to...
```/users/...```
which doesn't work when using multiple drive letters e.g.
```c:/users/... d:/dev/...```

Changed to produce this...
```/c:/users/... /d:/dev/...```

[reference](https://stackoverflow.com/questions/18659774/how-do-i-handle-files-with-spaces-in-the-classpath-in-manifest-mf)