### PR TITLE
Reduce noise in bloop-launcher console output.

### DIFF
--- a/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
@@ -461,7 +461,7 @@ class BloopgunCli(
 
     def sysproc(cmd: List[String]): StatusCommand = {
       logger.info(Feedback.startingBloopServer(config))
-      logger.info(s"-> Command: $cmd")
+      logger.debug(s"-> Command: $cmd")
 
       // Don't use `shell.runCommand` b/c it uses an executor that gets shut down upon `System.exit`
       val process = new ProcessBuilder()


### PR DESCRIPTION
Previously, the Bloop launcher always printed out a large line in the
output:
```
-> Command: List(a.jar, b.jar, ....)
```
This line is now logged at debug level so that it doesn't appear by
default.