### PR TITLE
Infer working directory from JVM -Duser.dir system property.

### DIFF
--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -62,6 +62,19 @@ final case class Project(
     case Config.ScalaThenJava => CompileOrder.ScalaThenJava
   }
 
+  def workingDirectory: AbsolutePath = {
+    val customWorkingDirectory = platform match {
+      case jvm: Platform.Jvm =>
+        jvm.config.javaOptions.collectFirst {
+          case option if option.startsWith("-Duser.dir=") =>
+            AbsolutePath(option.stripPrefix("-Duser.dir="))
+        }
+      case _ =>
+        None
+    }
+    customWorkingDirectory.getOrElse(baseDirectory)
+  }
+
   val uniqueId = s"${origin.path.syntax}#${name}"
   override def toString: String = s"$name"
   override val hashCode: Int =

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -551,7 +551,7 @@ object Interpreter {
 
   private def run(cmd: Commands.Run, state: State): Task[State] = {
     def doRun(project: Project)(state: State): Task[State] = {
-      val cwd = project.baseDirectory
+      val cwd = project.workingDirectory
       compileAnd(cmd, state, List(project), false, cmd.cliOptions.noColor, "`run`") { state =>
         getMainClass(state, project, cmd.main) match {
           case Left(failedState) => Task.now(failedState)

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -113,7 +113,7 @@ object Tasks {
         }
       }
 
-      val cwd = project.baseDirectory
+      val cwd = project.workingDirectory
       TestTask.runTestSuites(
         state,
         project,

--- a/frontend/src/test/scala/bloop/LoadProjectSpec.scala
+++ b/frontend/src/test/scala/bloop/LoadProjectSpec.scala
@@ -2,6 +2,9 @@ package bloop
 
 import bloop.config.Config
 import bloop.data.Project
+import bloop.data.Platform
+import bloop.data.JdkConfig
+import bloop.io.Paths
 import bloop.io.AbsolutePath
 import bloop.logging.RecordingLogger
 import bloop.util.TestUtil
@@ -17,5 +20,26 @@ class LoadProjectSpec {
     val origin = TestUtil.syntheticOriginFor(AbsolutePath.completelyUnsafe(""))
     val inferredInstance = Project.fromConfig(configWithNoScala, origin, logger).scalaInstance
     assert(inferredInstance.isEmpty)
+  }
+
+  @Test def CustomWorkingDirectory(): Unit = {
+    val logger = new RecordingLogger()
+    val dummyForTest = Config.File.dummyForTests
+    val origin = TestUtil.syntheticOriginFor(AbsolutePath.completelyUnsafe(""))
+    val project = Project.fromConfig(dummyForTest, origin, logger)
+    assert(
+      project.baseDirectory == project.workingDirectory,
+      s"${project.baseDirectory} != ${project.workingDirectory}"
+    )
+    val platform = project.platform.asInstanceOf[Platform.Jvm]
+    val userdir = AbsolutePath("foobar")
+    val customProject = project.copy(
+      platform =
+        platform.copy(config = platform.config.copy(javaOptions = Array(s"-Duser.dir=$userdir")))
+    )
+    assert(
+      customProject.workingDirectory == userdir,
+      s"${customProject.workingDirectory} != ${userdir}"
+    )
   }
 }


### PR DESCRIPTION
Previously, the working directory for forked processes was always the
base directory of the project. This caused problems for the Pants
integration since the working directory in Pants is always the workspace
directory. We can't set the project's base directory to the workspace
directory since IntelliJ requires different projects to have unique base
directories.

This commit updates the logic for inferring the working the directory of
a process by checking if the `-Duser.dir=` system property is configured
in the JVM platform configuration. If the property is customized, then
Bloop uses that working directory instead of base directory.