### PR TITLE
Create parents of invalidated symbolic links

### DIFF
--- a/backend/src/main/scala/bloop/BloopClassFileManager.scala
+++ b/backend/src/main/scala/bloop/BloopClassFileManager.scala
@@ -249,6 +249,8 @@ final class BloopClassFileManager(
 object BloopClassFileManager {
   def link(link: Path, target: Path): Try[Unit] = {
     Try {
+      // Make sure parent directory for link exists
+      Files.createDirectories(link.getParent)
       // Try symbolic link before hard link
       try Files.createSymbolicLink(link, target)
       catch {

--- a/frontend/src/test/scala/bloop/BaseCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/BaseCompileSpec.scala
@@ -452,6 +452,7 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
       object Sources {
         val `Foo.scala` =
           """/Foo.scala
+            |package common
             |import Enrichments._
             |class Foo
           """.stripMargin
@@ -459,22 +460,26 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
         // A dummy file to avoid surpassing the 50% changed sources and trigger a full compile
         val `Dummy.scala` =
           """/Dummy.scala
+            |package common
             |class Dummy
           """.stripMargin
 
         // A second dummy file
         val `Dummy2.scala` =
           """/Dummy2.scala
+            |package common
             |class Dummy2
           """.stripMargin
 
         val `Enrichments.scala` =
           """/Enrichments.scala
+            |package common
             |object Enrichments {}
           """.stripMargin
 
         val `Enrichments2.scala` =
           """/Enrichments.scala
+            |package common
             |object Enrichments {
             |  implicit class XtensionString(str: String) {
             |    def isGreeting: Boolean = str == "Hello world"
@@ -484,6 +489,7 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
 
         val `Bar.scala` =
           """/Bar.scala
+            |package common
             |import Enrichments._
             |class Bar {
             |  val foo: Foo = new Foo
@@ -494,6 +500,7 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
 
         val `Baz.scala` =
           """/Baz.scala
+            |package common
             |import Enrichments._
             |class Baz extends Bar
           """.stripMargin


### PR DESCRIPTION
When a file is invalidated from one project to another one, we create a
symbolic link to make sure the invalidation is picked up by downstream
projects. If the link can't be created because the package where it's
being created doesn't exist, Bloop makes sure it creates it.

Fixes the following issue:

```
Failed to create link for invalidated file /private/var/folders/mw/jwr3v0rs4g179tn27dr5b36w0000gn/T/bloop-test-workspace6216784217427414920/target/a/bloop-internal-classes/bloop-cli-hs8t9mOxSEGMFXJXlPH2Sg==/common/Bar.class: /private/var/folders/mw/jwr3v0rs4g179tn27dr5b36w0000gn/T/bloop-test-workspace6216784217427414920/target/b/bloop-internal-classes/bloop-cli-nrOUxfNzRx-hAFm8ovcrqQ==/common/Bar.class -> /private/var/folders/mw/jwr3v0rs4g179tn27dr5b36w0000gn/T/bloop-test-workspace6216784217427414920/target/a/bloop-internal-classes/bloop-cli-hs8t9mOxSEGMFXJXlPH2Sg==/common/Bar.class
```