### PR TITLE
Report better errors if project loading fails

### DIFF
--- a/backend/src/main/scala/bloop/ScalaInstance.scala
+++ b/backend/src/main/scala/bloop/ScalaInstance.scala
@@ -20,10 +20,22 @@ final class ScalaInstance private (
     override val version: String,
     override val allJars: Array[File]
 ) extends xsbti.compile.ScalaInstance {
-  override val compilerJar: File =
-    allJars.find(f => isJar(f.getName) && hasScalaCompilerName(f.getName)).orNull
-  override val libraryJar: File =
-    allJars.find(f => isJar(f.getName) && hasScalaLibraryName(f.getName)).orNull
+  override val compilerJar: File = {
+    allJars
+      .find(f => isJar(f.getName) && hasScalaCompilerName(f.getName))
+      .getOrElse(
+        sys.error(s"Missing compiler jar in Scala jars ${allJars.mkString(", ")}")
+      )
+  }
+
+  override val libraryJar: File = {
+    allJars
+      .find(f => isJar(f.getName) && hasScalaLibraryName(f.getName))
+      .getOrElse(
+        sys.error(s"Missing compiler jar in Scala jars ${allJars.mkString(", ")}")
+      )
+  }
+
   override val otherJars: Array[File] = allJars.filter { file =>
     val filename = file.getName
     isJar(filename) && !hasScalaCompilerName(filename) && !hasScalaLibraryName(filename)

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -138,7 +138,7 @@ object Project {
   final implicit val ps: scalaz.Show[Project] =
     new scalaz.Show[Project] { override def shows(f: Project): String = f.name }
 
-  private final class ProjectReadException(msg: String, cause: Throwable)
+  final class ProjectReadException(msg: String, cause: Throwable)
       extends RuntimeException(msg, cause)
 
   def fromBytesAndOrigin(bytes: Array[Byte], origin: Origin, logger: Logger): Project = {

--- a/frontend/src/test/scala/bloop/testing/BaseSuite.scala
+++ b/frontend/src/test/scala/bloop/testing/BaseSuite.scala
@@ -483,49 +483,6 @@ abstract class BaseSuite extends TestSuite with BloopHelpers {
     }
   }
 
-  import java.nio.file.Files
-  import java.nio.charset.StandardCharsets
-  def readFile(path: AbsolutePath): String = {
-    new String(Files.readAllBytes(path.underlying), StandardCharsets.UTF_8)
-  }
-
-  def writeFile(path: AbsolutePath, contents: String): AbsolutePath = {
-    import scala.util.Try
-    import java.nio.file.StandardOpenOption
-    val body = Try(TestUtil.parseFile(contents)).map(_.contents).getOrElse(contents)
-
-    // Running this piece in Windows can produce spurious `AccessDeniedException`s
-    if (!bloop.util.CrossPlatform.isWindows) {
-      // Delete the file, there are weird issues when creating new files and
-      // SYNCING for existing files in macOS, so it's just better to remove this
-      if (Files.exists(path.underlying)) {
-        Files.delete(path.underlying)
-      }
-
-      AbsolutePath(
-        Files.write(
-          path.underlying,
-          body.getBytes(StandardCharsets.UTF_8),
-          StandardOpenOption.CREATE_NEW,
-          StandardOpenOption.SYNC,
-          StandardOpenOption.WRITE
-        )
-      )
-    } else {
-      AbsolutePath(
-        Files.write(
-          path.underlying,
-          body.getBytes(StandardCharsets.UTF_8),
-          StandardOpenOption.CREATE,
-          StandardOpenOption.TRUNCATE_EXISTING,
-          StandardOpenOption.SYNC,
-          StandardOpenOption.WRITE
-        )
-      )
-    }
-
-  }
-
   import monix.execution.CancelableFuture
   import java.util.concurrent.TimeUnit
   import scala.concurrent.duration.FiniteDuration

--- a/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
+++ b/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
@@ -24,7 +24,6 @@ import monix.execution.Scheduler
 import bloop.config.ConfigCodecs
 
 trait BloopHelpers {
-  self: BaseSuite =>
   def loadState(
       workspace: AbsolutePath,
       projects: List[TestProject],
@@ -308,4 +307,48 @@ trait BloopHelpers {
     }
 
   }
+
+  import java.nio.file.Files
+  import java.nio.charset.StandardCharsets
+  def readFile(path: AbsolutePath): String = {
+    new String(Files.readAllBytes(path.underlying), StandardCharsets.UTF_8)
+  }
+
+  def writeFile(path: AbsolutePath, contents: String): AbsolutePath = {
+    import scala.util.Try
+    import java.nio.file.StandardOpenOption
+    val body = Try(TestUtil.parseFile(contents)).map(_.contents).getOrElse(contents)
+
+    // Running this piece in Windows can produce spurious `AccessDeniedException`s
+    if (!bloop.util.CrossPlatform.isWindows) {
+      // Delete the file, there are weird issues when creating new files and
+      // SYNCING for existing files in macOS, so it's just better to remove this
+      if (Files.exists(path.underlying)) {
+        Files.delete(path.underlying)
+      }
+
+      AbsolutePath(
+        Files.write(
+          path.underlying,
+          body.getBytes(StandardCharsets.UTF_8),
+          StandardOpenOption.CREATE_NEW,
+          StandardOpenOption.SYNC,
+          StandardOpenOption.WRITE
+        )
+      )
+    } else {
+      AbsolutePath(
+        Files.write(
+          path.underlying,
+          body.getBytes(StandardCharsets.UTF_8),
+          StandardOpenOption.CREATE,
+          StandardOpenOption.TRUNCATE_EXISTING,
+          StandardOpenOption.SYNC,
+          StandardOpenOption.WRITE
+        )
+      )
+    }
+
+  }
+
 }


### PR DESCRIPTION
1. No more `null`s inherited from the old Zinc `ScalaInstance`
2. Better error reporting if loading a project causes an error

Fixes https://github.com/scalacenter/bloop/issues/1142