### PR TITLE
URL-encode file paths for manifest jars.

### DIFF
--- a/frontend/src/main/scala/bloop/exec/JvmProcessForker.scala
+++ b/frontend/src/main/scala/bloop/exec/JvmProcessForker.scala
@@ -8,6 +8,8 @@ import bloop.logging.{DebugFilter, Logger}
 import bloop.util.CrossPlatform
 import java.io.File
 import java.net.URLClassLoader
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.jar.{Attributes, JarOutputStream, Manifest}
 import monix.eval.Task
@@ -188,7 +190,9 @@ final class JvmForker(config: JdkConfig, classpath: Array[AbsolutePath]) extends
   }
 
   private def addTrailingSlashToDirectories(path: AbsolutePath): String = {
-    val syntax = path.syntax
+    // NOTE(olafur): manifest jars must use URL-encoded paths.
+    // https://docs.oracle.com/javase/7/docs/technotes/guides/jar/jar.html
+    val syntax = path.toBspUri.toURL.getPath
     val separatorAdded = {
       if (syntax.endsWith(".jar")) {
         syntax


### PR DESCRIPTION
Previously, we used `Path.toString` for generating `Class-Path` entries
of a manifest jar. This encoding works correctly for normal paths but it
fails when the file path has special characters like `+`. To properly
handle such characters in the filepath, we need to URL-encode the file
path. This is necessary in order to use artifacts like
`bloop-backend_2.12-1.4.0-RC1+11-2b1413fb.jar`.

cc/ @wiwa 