### PR TITLE
Add options for Dotty to create semanticDB when Metals is present

### DIFF
--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -257,7 +257,7 @@ object Project {
     val workspaceDir = project.workspaceDirectory.getOrElse(configDir.getParent)
     val isDotty = project.scalaInstance.exists(_.isDotty)
 
-    def enableSemanticDB(options: List[String], pluginPath: AbsolutePath): List[String] = {
+    def enableSemanticdb(options: List[String], pluginPath: AbsolutePath): List[String] = {
       val baseSemanticdbOptions = List(
         "-P:semanticdb:failures:warning",
         "-P:semanticdb:synthetics:on",
@@ -273,7 +273,7 @@ object Project {
       (baseOptions ++ baseSemanticdbOptions ++ pluginOption).distinct
     }
 
-    def enableDottySemanticDB(options: List[String]) = {
+    def enableDottySemanticdb(options: List[String]) = {
       val ysemanticdb = if (!options.contains("-Ysemanticdb")) List("-Ysemanticdb") else Nil
       val sourceRoot =
         if (!options.contains("-sourceroot")) List("-sourceroot", workspaceDir.toString()) else Nil
@@ -291,12 +291,15 @@ object Project {
     val options = projectWithRangePositions.scalacOptions
 
     semanticDBPlugin match {
-      case None if isDotty =>
-        val optionsWithSemanticDB = enableDottySemanticDB(options)
-        projectWithRangePositions.copy(scalacOptions = optionsWithSemanticDB)
-      case None => projectWithRangePositions
+      case None =>
+        if (isDotty) {
+          val optionsWithSemanticDB = enableDottySemanticdb(options)
+          projectWithRangePositions.copy(scalacOptions = optionsWithSemanticDB)
+        } else {
+          projectWithRangePositions
+        }
       case Some(pluginPath) =>
-        val optionsWithSemanticDB = enableSemanticDB(options, pluginPath)
+        val optionsWithSemanticDB = enableSemanticdb(options, pluginPath)
         projectWithRangePositions.copy(scalacOptions = optionsWithSemanticDB)
     }
   }


### PR DESCRIPTION
This changes are needed so that user experience for Dotty will be exactly the same as it in Scala 2.

Previously, user would have to add the settings manually.

We only need 2 settings in this case: `-Ysemanticdb` and `-sourceroot`

@jvican Let me know if this makes sense.