### PR TITLE
Add BSP endpoint to query jvm test environment

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -683,9 +683,9 @@ final class BloopBspServices(
             fullClasspath = project.fullClasspath(dag, state.client).map(_.toString)
             environmentVariables = state.commonOptions.env.toMap
             workingDirectory = state.commonOptions.workingDirectory
-            javaOptions = project.platform match {
-              case Platform.Jvm(config, _, _) => config.javaOptions.toList
-              case _ => List()
+            javaOptions <- project.platform match {
+              case Platform.Jvm(config, _, _) => Some(config.javaOptions.toList)
+              case _ => None
             }
           } yield {
             bsp.JvmEnvironmentItem(

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -685,18 +685,18 @@ final class BloopBspServices(
             environmentVariables = state.commonOptions.env.toMap
             workingDirectory = state.commonOptions.workingDirectory
             javaOptions = project.platform match {
-              case Platform.Jvm(config, _,_) => config.javaOptions.toList
+              case Platform.Jvm(config, _, _) => config.javaOptions.toList
               case _ => List()
             }
           } yield {
-                  bsp.JvmEnvironmentItem(
-                    id,
-                    fullClasspath.toList,
-                    javaOptions,
-                    workingDirectory,
-                    environmentVariables)
-            }
-
+            bsp.JvmEnvironmentItem(
+              id,
+              fullClasspath.toList,
+              javaOptions,
+              workingDirectory,
+              environmentVariables
+            )
+          }
 
           val resp = new bsp.JvmTestEnvironmentResult(environmentEntries)
           Task.now((state, Right(resp)))

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -42,7 +42,7 @@ import monix.execution.atomic.AtomicInt
 import monix.execution.atomic.AtomicBoolean
 
 import scala.collection.concurrent.TrieMap
-import scala.collection.{immutable, mutable}
+import scala.collection.mutable
 import scala.collection.JavaConverters._
 import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -54,7 +54,6 @@ import monix.reactive.subjects.BehaviorSubject
 import bloop.engine.tasks.compilation.CompileClientStore
 import bloop.data.ClientInfo.BspClientInfo
 import bloop.logging.BloopLogger
-import cats.Traverse
 
 final class BloopBspServices(
     callSiteState: State,

--- a/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
@@ -379,12 +379,17 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
       }
     }
 
-    def jvmTestEnvironment(project: TestProject, originId: Option[String]): (ManagedBspTestState, bsp.JvmTestEnvironmentResult) = {
+    def jvmTestEnvironment(
+        project: TestProject,
+        originId: Option[String]
+    ): (ManagedBspTestState, bsp.JvmTestEnvironmentResult) = {
       val scalacOptionsTask = runAfterTargets(project) { target =>
-        endpoints.BuildTarget.jvmTestEnvironment.request(bsp.JvmTestEnvironmentParams(List(target), originId)).map {
-          case Left(error) => fail(s"Received error ${error}")
-          case Right(options) => options
-        }
+        endpoints.BuildTarget.jvmTestEnvironment
+          .request(bsp.JvmTestEnvironmentParams(List(target), originId))
+          .map {
+            case Left(error) => fail(s"Received error ${error}")
+            case Right(options) => options
+          }
       }
 
       TestUtil.await(FiniteDuration(5, "s")) {

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -122,6 +122,10 @@ class BspProtocolSpec(
         val environmentItem = result.items.head
         assert(result.items.size == 1)
         assert(environmentItem.environmentVariables.contains("BLOOP_OWNER"))
+        assertNoDiff(
+          "BLOOP_OWNER",
+          environmentItem.environmentVariables.keys.mkString("\n")
+        )
         assert(Paths.get(environmentItem.workingDirectory).getFileName.toString == "frontend")
         assert(
           environmentItem.classpath

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -1,5 +1,7 @@
 package bloop.bsp
 
+import java.io.File
+
 import bloop.engine.State
 import bloop.config.Config
 import bloop.io.AbsolutePath
@@ -121,7 +123,7 @@ class BspProtocolSpec(
         assert(result.items.size == 1)
         assert(environmentItem.environmentVariables.contains("BLOOP_OWNER"))
         assert(Paths.get(environmentItem.workingDirectory).getFileName.toString == "frontend")
-        assert(environmentItem.classpath.exists(_.contains(s"target/${`A`.config.name}")))
+        assert(environmentItem.classpath.exists(_.contains(s"target" + File.separator + s"${`A`.config.name}")))
         assert(environmentItem.jvmOptions == jvmOptions)
       }
     }

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -123,7 +123,10 @@ class BspProtocolSpec(
         assert(result.items.size == 1)
         assert(environmentItem.environmentVariables.contains("BLOOP_OWNER"))
         assert(Paths.get(environmentItem.workingDirectory).getFileName.toString == "frontend")
-        assert(environmentItem.classpath.exists(_.contains(s"target" + File.separator + s"${`A`.config.name}")))
+        assert(
+          environmentItem.classpath
+            .exists(_.contains(s"target" + File.separator + s"${`A`.config.name}"))
+        )
         assert(environmentItem.jvmOptions == jvmOptions)
       }
     }

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -121,7 +121,7 @@ class BspProtocolSpec(
         val environmentItem = result.items.head
         assert(result.items.size == 1)
         assert(environmentItem.environmentVariables.contains("BLOOP_OWNER"))
-        assert(environmentItem.workingDirectory == "/home/tpasternak/Documents/bloop/frontend")
+        assert(environmentItem.workingDirectory.endsWith("/frontend"))
         assert(environmentItem.classpath.exists(_.contains(s"target/${`A`.config.name}")))
         assert(environmentItem.jvmOptions == jvmOptions)
       }

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -7,8 +7,7 @@ import bloop.cli.{BspProtocol, ExitStatus}
 import bloop.util.{TestProject, TestUtil}
 import bloop.logging.RecordingLogger
 import bloop.internal.build.BuildInfo
-
-import java.nio.file.{Files, Path}
+import java.nio.file.{Files, Path, Paths}
 import java.util.stream.Collectors
 
 import scala.collection.JavaConverters._
@@ -121,7 +120,7 @@ class BspProtocolSpec(
         val environmentItem = result.items.head
         assert(result.items.size == 1)
         assert(environmentItem.environmentVariables.contains("BLOOP_OWNER"))
-        assert(environmentItem.workingDirectory.endsWith("/frontend"))
+        assert(Paths.get(environmentItem.workingDirectory).getFileName.toString == "frontend")
         assert(environmentItem.classpath.exists(_.contains(s"target/${`A`.config.name}")))
         assert(environmentItem.jvmOptions == jvmOptions)
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val nailgunCommit = "a2520c1e"
 
   val zincVersion = "1.3.0-M4+32-b1accb96"
-  val bspVersion = "2.0.0-M4+10-61e61e87"
+  val bspVersion = "2.0.0-M4+37-2b6db522"
   val javaDebugVersion = "0.21.0+1-7f1080f1"
 
   val scalazVersion = "7.2.20"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val nailgunCommit = "a2520c1e"
 
   val zincVersion = "1.3.0-M4+32-b1accb96"
-  val bspVersion = "2.0.0-M4+49-c9bce16c"
+  val bspVersion = "2.0.0-M5"
   val javaDebugVersion = "0.21.0+1-7f1080f1"
 
   val scalazVersion = "7.2.20"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val nailgunCommit = "a2520c1e"
 
   val zincVersion = "1.3.0-M4+32-b1accb96"
-  val bspVersion = "2.0.0-M4+37-2b6db522"
+  val bspVersion = "2.0.0-M4+49-c9bce16c"
   val javaDebugVersion = "0.21.0+1-7f1080f1"
 
   val scalazVersion = "7.2.20"


### PR DESCRIPTION
Implement BSP endpoint: `buildTarget/jvmTestEnvironment` according
to the new BSP specification.

EXCERPT FROM BSP SPECIFICATION:

The JVM test environment request is sent from the client to the server in order to
gather information required to launch a Java process. This is useful when the
client wants to control the Java process execution, for example to enable custom
Java agents or launch a custom main class during unit testing or debugging

The data provided by this endpoint may change beteween compilations, so it should
not be cached in any form. The client should ask for it right before test exection,
after all the targets are compiled.

- method: `buildTarget/jvmTestEnvironment`
- params: `JvmEnvironmentParams`

```ts
export interface JvmEnvironmentParams(
    targets: BuildTargetIdentifier[],
    originId?: String
)
```

Response:

- result: `JvmEnvironmentResult`, defined as follows
- error: JSON-RPC code and message set in case an exception happens during the
  request.

```ts
export interface JvmEnvironmentEntry{
    target: BuildTargetIdentifier;
    classpath: String[];
    jvmOptions: String[];
}

export interface JvmEnvironmentResult{
    entries: JvmEnvironmentEntry[];
    workingDirectory: String;
    environmentVariables: Map<String, String>;
}
```