### PR TITLE
Replace plus sign `+` with minus `-` in version number.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,10 @@ import build.BuildImplementation.BuildDefaults
 
 useGpg in Global := false
 
+version in ThisBuild ~= { old =>
+  old.replace('+', '-')
+}
+
 // Tell bloop to aggregate source deps (benchmark) config files in the same bloop config dir
 bloopAggregateSourceDependencies in Global := true
 


### PR DESCRIPTION
Previously, nightly build versions were formatted with a plus sign like
`1.3.4+87-GITSHA`.  The plus sign needs to be URL encoded for it to be
used in filenames, for example `1.3.4%2B298-2c6ff971`. Tools that
don't handle this situation properly get "class not found" errors and
are therefore unable to run nightly versions of Bloop.

After this commit, the version number uses a minus sign instead
`1.3.4-98-2c6ff971` so that client tools don't have properly deal with
URL-encoding the filename.

It's fair to say that client tools should fix their buggy handling of
the plus sign in filename. However, I have currently had to fix this
issue in at least three different tools and now I'm facing issues with
the fourth tool. I would prefer to change the version encoding in Bloop
so I don't have to spend more time on this issue.