### PR TITLE
Add munit framework to default frameworks

### DIFF
--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -9,6 +9,14 @@ object Config {
   case class TestFramework(names: List[String])
 
   object TestFramework {
+    val utest = Config.TestFramework(
+      List("utest.runner.Framework")
+    )
+
+    val munit = Config.TestFramework(
+      List("munit.Framework")
+    )
+
     val ScalaCheck = Config.TestFramework(
       List(
         "org.scalacheck.ScalaCheckFramework"
@@ -36,7 +44,7 @@ object Config {
       )
     )
 
-    val DefaultFrameworks = List(JUnit, ScalaTest, ScalaCheck, Specs2)
+    val DefaultFrameworks = List(JUnit, ScalaTest, ScalaCheck, Specs2, utest, munit)
   }
 
   case class TestArgument(args: List[String], framework: Option[TestFramework])


### PR DESCRIPTION
As a result of this change, Maven and Gradle will add munit and utest as
a framework by default. We do this because there's currently no support
in these build tools to see which test frameworks are enabled and only
export those.