### PR TITLE
Fix error checking blacklisted versions

### DIFF
--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginWhitelist.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginWhitelist.scala
@@ -77,7 +77,14 @@ object CompilerPluginWhitelist {
       parallelUnits: Int
   ): Task[List[String]] = {
     case class WorkItem(pluginFlag: String, idx: Int, result: Promise[Boolean])
-    val enableTask = scalaVersionBlacklist.find(v => scalaVersion.startsWith(v)) match {
+    val actualScalaVersion = scalaVersion.split('-').headOption
+    val blacklistedVersions = scalaVersionBlacklist.find { v =>
+      actualScalaVersion.exists { userVersion =>
+        if (v.endsWith(".")) userVersion.startsWith(v) else userVersion == v
+      }
+    }
+
+    val enableTask = blacklistedVersions match {
       case Some(blacklistedVersion) =>
         logger.debug(s"Disabled compiler plugin classloading, unsupported in ${blacklistedVersion}")
         Task.now(scalacOptions)


### PR DESCRIPTION
This pull request fixes a bug detecting when a version is blacklisted or
not. The issue was happening because 2.12.10 starts with 2.12.1, so it
was being considered blacklisted.

I would expected codebases on 2.12.10 and forward will run faster after
this change.