### PR TITLE
Add default `-Xss1m` compiler option

### DIFF
--- a/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
@@ -45,7 +45,7 @@ import java.io.BufferedReader
  *
  * The main library entrypoint for bloopgun, the Bloop binary CLI.
  *
- * It uses Nailgun to communicate to the Bloop server and has support for:
+ * It uses Nailgun to communicate to the Bloop server, the Bloop CLI:
  *
  *   1. Prints Bloop-specific feedback to the user to improve the CLI UX.
  *      * Print custom error if user types `bloop repl`.

--- a/bloopgun/src/main/scala/bloop/bloopgun/util/Environment.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/util/Environment.scala
@@ -78,6 +78,7 @@ object Environment {
 
   // TODO: Add more options to better tweak GC based on benchmarks
   val PerformanceSensitiveOptsForBloop = List(
+    "-Xss1m",
     "-XX:MaxInlineLevel=20", // Specific option for faster C2, ignored by GraalVM
     "-XX:+UseParallelGC" // Full parallel GC is the best choice for Scala compilation
   )

--- a/launcher/src/main/scala/bloop/launcher/Launcher.scala
+++ b/launcher/src/main/scala/bloop/launcher/Launcher.scala
@@ -71,12 +71,15 @@ class LauncherMain(
       else args0.splitAt(index)
     }
 
-    val (jvmOptions, cliOptions) = args.partition(_.startsWith("-J"))
+    val (userJvmOptions, cliOptions) = args.partition(_.startsWith("-J"))
     val (cliFlags, cliArgs) = cliOptions.toList.partition(_.startsWith("--"))
     val skipBspConnection = cliFlags.exists(_ == SkipBspConnection)
+
+    val defaultJvmOptions = bloop.bloopgun.util.Environment.PerformanceSensitiveOptsForBloop
+    val allJvmOptions = userJvmOptions.toList ++ defaultJvmOptions
     if (cliArgs.size == 1) {
       val bloopVersion = cliArgs.apply(0)
-      runLauncher(bloopVersion, skipBspConnection, jvmOptions.toList)
+      runLauncher(bloopVersion, skipBspConnection, allJvmOptions)
     } else {
       printError(Feedback.NoBloopVersion, out)
       FailedToParseArguments


### PR DESCRIPTION
The stack size required by many macros such as shapeless is large.
Sometimes, compilations would fail on the bloop side because the stack
size is exceeded. This commit uses a larger default of 1m for the stack
that should remove these issues in the future.