### PR TITLE
Add new "sourcesGlobs" field to Bloop JSON configuration.

### DIFF
--- a/config/src/main/scala-2.10/bloop/config/ConfigCodecs.scala
+++ b/config/src/main/scala-2.10/bloop/config/ConfigCodecs.scala
@@ -189,6 +189,9 @@ object ConfigCodecs {
   implicit val sbtEncoder: ObjectEncoder[Sbt] = deriveEncoder
   implicit val sbtDecoder: Decoder[Sbt] = deriveDecoder
 
+  implicit val sourcesGlobsEncoder: ObjectEncoder[SourcesGlobs] = deriveEncoder
+  implicit val sourcesGlobsDecoder: Decoder[SourcesGlobs] = deriveDecoder
+
   implicit val projectEncoder: ObjectEncoder[Project] = deriveEncoder
   implicit val projectDecoder: Decoder[Project] = deriveDecoder
 

--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -221,11 +221,19 @@ object Config {
       modules: List[Module]
   )
 
+  case class SourcesGlobs(
+      directory: Path,
+      walkDepth: Option[Int],
+      includes: List[String],
+      excludes: List[String]
+  )
+
   case class Project(
       name: String,
       directory: Path,
       workspaceDir: Option[Path],
       sources: List[Path],
+      sourcesGlobs: Option[List[SourcesGlobs]],
       dependencies: List[String],
       classpath: List[Path],
       out: Path,
@@ -241,7 +249,7 @@ object Config {
 
   object Project {
     // FORMAT: OFF
-    private[bloop] val empty: Project = Project("", emptyPath, None, List(), List(), List(), emptyPath, emptyPath, None, None, None, None, None, None, None)
+    private[bloop] val empty: Project = Project("", emptyPath, None, List(), None, List(), List(),  emptyPath, emptyPath, None, None, None, None, None, None, None)
     // FORMAT: ON
 
     def analysisFileName(projectName: String) = s"$projectName-analysis.bin"
@@ -282,6 +290,7 @@ object Config {
         workingDirectory,
         Some(workingDirectory),
         List(sourceFile),
+        None,
         List("dummy-2"),
         List(scalaLibraryJar),
         outDir,

--- a/frontend/src/it/scala/bloop/CommunityBuild.scala
+++ b/frontend/src/it/scala/bloop/CommunityBuild.scala
@@ -135,6 +135,7 @@ abstract class CommunityBuild(val buildpressHomeDir: AbsolutePath) {
         scalacOptions = Nil,
         javacOptions = Nil,
         sources = Nil,
+        sourcesGlobs = Nil,
         testFrameworks = Nil,
         testOptions = Config.TestOptions.empty,
         out = dummyClassesDir,

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -934,7 +934,7 @@ final class BloopBspServices(
       val response = bsp.SourcesResult(
         projects.iterator.map {
           case (target, project) =>
-            val sources = project.sources.map {
+            val sources = project.allSourceFilesAndDirectories().map {
               s =>
                 import bsp.SourceItemKind._
                 val uri = s.underlying.toUri()

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -28,6 +28,7 @@ import ch.epfl.scala.{bsp => Bsp}
 import xsbti.compile.{ClasspathOptions, CompileOrder}
 import bloop.config.ConfigCodecs
 import scala.util.control.NonFatal
+import monix.eval.Task
 
 final case class Project(
     name: String,
@@ -86,7 +87,7 @@ final case class Project(
   }
 
   /** Returns concatenated list of "sources" and expanded "sourcesGlobs". */
-  def allSourceFilesAndDirectories(): List[AbsolutePath] = {
+  def allSourceFilesAndDirectories: Task[List[AbsolutePath]] = Task {
     val buf = mutable.ListBuffer.empty[AbsolutePath]
     buf ++= sources
     sourcesGlobs.foreach { glob =>

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -246,7 +246,7 @@ object Project {
       scala.map(_.options).getOrElse(Nil),
       project.java.map(_.options).getOrElse(Nil),
       project.sources.map(AbsolutePath.apply),
-      SourcesGlobs.fromConfig(project),
+      SourcesGlobs.fromConfig(project, logger),
       project.test.map(_.frameworks).getOrElse(Nil),
       project.test.map(_.options).getOrElse(Config.TestOptions.empty),
       AbsolutePath(project.out),

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -11,6 +11,14 @@ import bloop.engine.tasks.toolchains.{JvmToolchain, ScalaJsToolchain, ScalaNativ
 import bloop.io.ByteHasher
 
 import java.nio.charset.StandardCharsets
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.PathMatcher
+import java.nio.file.Path
+import java.nio.file.FileVisitor
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.FileVisitOption
+import java.nio.file.SimpleFileVisitor
 
 import scala.util.Try
 import scala.collection.mutable
@@ -34,6 +42,7 @@ final case class Project(
     scalacOptions: List[String],
     javacOptions: List[String],
     sources: List[AbsolutePath],
+    sourcesGlobs: List[SourcesGlobs],
     testFrameworks: List[Config.TestFramework],
     testOptions: Config.TestOptions,
     out: AbsolutePath,
@@ -74,6 +83,30 @@ final case class Project(
         None
     }
     customWorkingDirectory.getOrElse(baseDirectory)
+  }
+
+  /** Returns concatenated list of "sources" and expanded "sourcesGlobs". */
+  def allSourceFilesAndDirectories(): List[AbsolutePath] = {
+    val buf = mutable.ListBuffer.empty[AbsolutePath]
+    buf ++= sources
+    sourcesGlobs.foreach { glob =>
+      if (Files.isDirectory(glob.directory)) {
+        Files.walkFileTree(
+          glob.directory,
+          java.util.EnumSet.of(FileVisitOption.FOLLOW_LINKS),
+          glob.walkDepth,
+          new SimpleFileVisitor[Path] {
+            override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+              if (glob.matches(file)) {
+                buf += AbsolutePath(file)
+              }
+              FileVisitResult.CONTINUE
+            }
+          }
+        )
+      }
+    }
+    buf.result()
   }
 
   val uniqueId = s"${origin.path.syntax}#${name}"
@@ -213,6 +246,7 @@ object Project {
       scala.map(_.options).getOrElse(Nil),
       project.java.map(_.options).getOrElse(Nil),
       project.sources.map(AbsolutePath.apply),
+      SourcesGlobs.fromConfig(project),
       project.test.map(_.frameworks).getOrElse(Nil),
       project.test.map(_.options).getOrElse(Config.TestOptions.empty),
       AbsolutePath(project.out),

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -90,9 +90,9 @@ final case class Project(
     val buf = mutable.ListBuffer.empty[AbsolutePath]
     buf ++= sources
     sourcesGlobs.foreach { glob =>
-      if (Files.isDirectory(glob.directory)) {
+      if (Files.isDirectory(glob.directory.underlying)) {
         Files.walkFileTree(
-          glob.directory,
+          glob.directory.underlying,
           java.util.EnumSet.of(FileVisitOption.FOLLOW_LINKS),
           glob.walkDepth,
           new SimpleFileVisitor[Path] {

--- a/frontend/src/main/scala/bloop/data/SourcesGlobs.scala
+++ b/frontend/src/main/scala/bloop/data/SourcesGlobs.scala
@@ -5,18 +5,20 @@ import java.nio.file.PathMatcher
 import java.nio.file.Path
 import bloop.config.Config
 import scala.util.Properties
+import bloop.io.AbsolutePath
 
 case class SourcesGlobs(
-    directory: Path,
+    directory: AbsolutePath,
     walkDepth: Int,
     includes: List[PathMatcher],
     excludes: List[PathMatcher]
 ) {
   def matches(path: Path): Boolean = {
+    val relativePath = AbsolutePath(path).toRelative(directory)
     def matchesList(lst: List[PathMatcher]): Boolean = lst match {
       case Nil => false
       case head :: tail =>
-        if (head.matches(path)) true
+        if (head.matches(relativePath.underlying)) true
         else matchesList(tail)
     }
     matchesList(includes) && !matchesList(excludes)
@@ -30,7 +32,7 @@ object SourcesGlobs {
       case Some(globs) =>
         globs.flatMap { glob =>
           SourcesGlobs.fromStrings(
-            glob.directory,
+            AbsolutePath(glob.directory),
             glob.walkDepth,
             glob.includes,
             glob.excludes
@@ -40,28 +42,20 @@ object SourcesGlobs {
   }
 
   def fromStrings(
-      directory: Path,
+      directory: AbsolutePath,
       walkDepth: Option[Int],
       includes: List[String],
       excludes: List[String]
   ): List[SourcesGlobs] = {
     if (includes.isEmpty) Nil
     else {
-      val uriPath = directory.toUri().getPath()
-      val basePath =
-        if (Properties.isWin) uriPath.stripPrefix("/")
-        else uriPath
-      val prefix = s"glob:${basePath}"
       val fs = FileSystems.getDefault()
-      def newPathMatcher(glob: String): PathMatcher = {
-        fs.getPathMatcher(prefix + glob)
-      }
       List(
         SourcesGlobs(
           directory,
           walkDepth.getOrElse(Int.MaxValue),
-          includes = includes.map(newPathMatcher),
-          excludes = excludes.map(newPathMatcher)
+          includes = includes.map(fs.getPathMatcher),
+          excludes = excludes.map(fs.getPathMatcher)
         )
       )
     }

--- a/frontend/src/main/scala/bloop/data/SourcesGlobs.scala
+++ b/frontend/src/main/scala/bloop/data/SourcesGlobs.scala
@@ -1,0 +1,69 @@
+package bloop.data
+
+import java.nio.file.FileSystems
+import java.nio.file.PathMatcher
+import java.nio.file.Path
+import bloop.config.Config
+import scala.util.Properties
+
+case class SourcesGlobs(
+    directory: Path,
+    walkDepth: Int,
+    includes: List[PathMatcher],
+    excludes: List[PathMatcher]
+) {
+  def matches(path: Path): Boolean = {
+    def matchesList(lst: List[PathMatcher]): Boolean = lst match {
+      case Nil => false
+      case head :: tail =>
+        if (head.matches(path)) true
+        else matchesList(tail)
+    }
+    matchesList(includes) && !matchesList(excludes)
+  }
+}
+
+object SourcesGlobs {
+  def fromConfig(project: Config.Project): List[SourcesGlobs] = {
+    project.sourcesGlobs match {
+      case None => Nil
+      case Some(globs) =>
+        globs.flatMap { glob =>
+          SourcesGlobs.fromStrings(
+            glob.directory,
+            glob.walkDepth,
+            glob.includes,
+            glob.excludes
+          )
+        }
+    }
+  }
+
+  def fromStrings(
+      directory: Path,
+      walkDepth: Option[Int],
+      includes: List[String],
+      excludes: List[String]
+  ): List[SourcesGlobs] = {
+    if (includes.isEmpty) Nil
+    else {
+      val uriPath = directory.toUri().getPath()
+      val basePath =
+        if (Properties.isWin) uriPath.stripPrefix("/")
+        else uriPath
+      val prefix = s"glob:${basePath}"
+      val fs = FileSystems.getDefault()
+      def newPathMatcher(glob: String): PathMatcher = {
+        fs.getPathMatcher(prefix + glob)
+      }
+      List(
+        SourcesGlobs(
+          directory,
+          walkDepth.getOrElse(Int.MaxValue),
+          includes = includes.map(newPathMatcher),
+          excludes = excludes.map(newPathMatcher)
+        )
+      )
+    }
+  }
+}

--- a/frontend/src/main/scala/bloop/data/SourcesGlobs.scala
+++ b/frontend/src/main/scala/bloop/data/SourcesGlobs.scala
@@ -70,7 +70,7 @@ object SourcesGlobs {
       } catch {
         case NonFatal(e) =>
           logger.error(
-            s"ignoring invalid 'sourcesGlobs' object containing directory '$directory' in project '$projectName'"
+            s"Ignoring invalid 'sourcesGlobs' object containing directory '$directory' in project '$projectName'"
           )
           logger.trace(e)
           Nil

--- a/frontend/src/main/scala/bloop/data/SourcesGlobs.scala
+++ b/frontend/src/main/scala/bloop/data/SourcesGlobs.scala
@@ -3,9 +3,13 @@ package bloop.data
 import java.nio.file.FileSystems
 import java.nio.file.PathMatcher
 import java.nio.file.Path
-import bloop.config.Config
+
 import scala.util.Properties
+import scala.util.control.NonFatal
+
+import bloop.config.Config
 import bloop.io.AbsolutePath
+import bloop.logging.Logger
 
 case class SourcesGlobs(
     directory: AbsolutePath,
@@ -26,38 +30,51 @@ case class SourcesGlobs(
 }
 
 object SourcesGlobs {
-  def fromConfig(project: Config.Project): List[SourcesGlobs] = {
+  def fromConfig(project: Config.Project, logger: Logger): List[SourcesGlobs] = {
     project.sourcesGlobs match {
       case None => Nil
       case Some(globs) =>
         globs.flatMap { glob =>
           SourcesGlobs.fromStrings(
+            project.name,
             AbsolutePath(glob.directory),
             glob.walkDepth,
             glob.includes,
-            glob.excludes
+            glob.excludes,
+            logger
           )
         }
     }
   }
 
   def fromStrings(
+      projectName: String,
       directory: AbsolutePath,
       walkDepth: Option[Int],
       includes: List[String],
-      excludes: List[String]
+      excludes: List[String],
+      logger: Logger
   ): List[SourcesGlobs] = {
     if (includes.isEmpty) Nil
     else {
-      val fs = FileSystems.getDefault()
-      List(
-        SourcesGlobs(
-          directory,
-          walkDepth.getOrElse(Int.MaxValue),
-          includes = includes.map(fs.getPathMatcher),
-          excludes = excludes.map(fs.getPathMatcher)
+      try {
+        val fs = FileSystems.getDefault()
+        List(
+          SourcesGlobs(
+            directory,
+            walkDepth.getOrElse(Int.MaxValue),
+            includes = includes.map(fs.getPathMatcher),
+            excludes = excludes.map(fs.getPathMatcher)
+          )
         )
-      )
+      } catch {
+        case NonFatal(e) =>
+          logger.error(
+            s"ignoring invalid 'sourcesGlobs' object containing directory '$directory' in project '$projectName'"
+          )
+          logger.trace(e)
+          Nil
+      }
     }
   }
 }

--- a/frontend/src/main/scala/bloop/io/SourceHasher.scala
+++ b/frontend/src/main/scala/bloop/io/SourceHasher.scala
@@ -105,7 +105,7 @@ object SourceHasher {
         val discovery = fileVisitor(glob.matches)
         if (isCancelled.get) ()
         else {
-          Files.walkFileTree(glob.directory, opts, glob.walkDepth, discovery)
+          Files.walkFileTree(glob.directory.underlying, opts, glob.walkDepth, discovery)
         }
       }
     }.doOnFinish {

--- a/frontend/src/test/scala/bloop/DagSpec.scala
+++ b/frontend/src/test/scala/bloop/DagSpec.scala
@@ -2,6 +2,7 @@ package bloop
 
 import bloop.config.Config
 import bloop.data.Project
+import bloop.data.SourcesGlobs
 import bloop.engine.Dag.{DagResult, RecursiveTrace}
 import bloop.engine.{Aggregate, Dag, Leaf, Parent}
 import bloop.logging.RecordingLogger
@@ -23,7 +24,7 @@ class DagSpec {
   def dummyOrigin = TestUtil.syntheticOriginFor(dummyPath)
   def dummyProject(name: String, dependencies: List[String]): Project =
     Project(name, dummyPath, None, dependencies, Some(dummyInstance), Nil, Nil, compileOptions,
-      dummyPath, Nil, Nil, Nil, Nil, Config.TestOptions.empty, dummyPath, dummyPath,
+      dummyPath, Nil, Nil, Nil, Nil, Nil, Config.TestOptions.empty, dummyPath, dummyPath,
       Project.defaultPlatform(logger), None, None, dummyOrigin)
   // format: ON
 

--- a/frontend/src/test/scala/bloop/SourcesGlobsCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/SourcesGlobsCompileSpec.scala
@@ -1,0 +1,68 @@
+package bloop
+
+import bloop.logging.RecordingLogger
+import scala.concurrent.Promise
+import bloop.util.TestUtil
+import java.nio.file.Files
+import scala.concurrent.Await
+import scala.concurrent.duration.FiniteDuration
+import bloop.util.TestProject
+import java.util.concurrent.TimeUnit
+import bloop.cli.ExitStatus
+import bloop.config.Config
+import bloop.data.SourcesGlobs
+
+object SourcesGlobsCompileSpec extends bloop.testing.BaseSuite {
+
+  test("compile respects sources globs field") {
+    TestUtil.withinWorkspace { workspace =>
+      val sources = List(
+        """/main/scala/Foo.scala
+          |package foo
+          |class Foo
+          """.stripMargin,
+        """/main/scala/FooTest.scala
+          |package foo
+          |class Foo // would be compile error if this was not excluded via globs.
+          """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val baseProject = TestProject(workspace, "a", sources)
+      val globDirectory =
+        baseProject.config.directory.resolve("src").resolve("main").resolve("scala")
+      val `A` = baseProject.copy(
+        config = baseProject.config.copy(
+          sources = Nil,
+          sourcesGlobs = Some(
+            List(
+              Config.SourcesGlobs(
+                globDirectory,
+                walkDepth = None,
+                includes = List("*.scala"),
+                excludes = List("*Test.scala")
+              )
+            )
+          )
+        )
+      )
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.compile(`A`)
+      assertExitStatus(compiledState, ExitStatus.Ok)
+      assertNoDiff(
+        logger.compilingInfos.mkString("\n"),
+        "Compiling a (1 Scala source)"
+      )
+
+      // Create new file and assert that we now compile two files instead of one file.
+      logger.clear()
+      Files.write(globDirectory.resolve("Foo2.scala"), Array.emptyByteArray)
+      val compiledState2 = state.clean(`A`).compile(`A`)
+      assertNoDiff(
+        logger.compilingInfos.mkString("\n"),
+        "Compiling a (2 Scala sources)"
+      )
+    }
+  }
+}

--- a/frontend/src/test/scala/bloop/SourcesGlobsCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/SourcesGlobsCompileSpec.scala
@@ -39,8 +39,8 @@ object SourcesGlobsCompileSpec extends bloop.testing.BaseSuite {
               Config.SourcesGlobs(
                 globDirectory,
                 walkDepth = None,
-                includes = List("*.scala"),
-                excludes = List("*Test.scala")
+                includes = List("glob:*.scala"),
+                excludes = List("glob:*Test.scala")
               )
             )
           )

--- a/frontend/src/test/scala/bloop/SourcesGlobsCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/SourcesGlobsCompileSpec.scala
@@ -49,7 +49,7 @@ object SourcesGlobsCompileSpec extends bloop.testing.BaseSuite {
       val projects = List(`A`)
       val state = loadState(workspace, projects, logger)
       val compiledState = state.compile(`A`)
-      assertExitStatus(compiledState, ExitStatus.Ok)
+      assertValidCompilationState(compiledState, projects)
       assertNoDiff(
         logger.compilingInfos.mkString("\n"),
         "Compiling a (1 Scala source)"
@@ -59,6 +59,7 @@ object SourcesGlobsCompileSpec extends bloop.testing.BaseSuite {
       logger.clear()
       Files.write(globDirectory.resolve("Foo2.scala"), Array.emptyByteArray)
       val compiledState2 = state.clean(`A`).compile(`A`)
+      assertValidCompilationState(compiledState2, projects)
       assertNoDiff(
         logger.compilingInfos.mkString("\n"),
         "Compiling a (2 Scala sources)"

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -18,6 +18,7 @@ import bloop.bsp.BloopBspDefinitions.BloopExtraBuildParams
 import io.circe.Json
 import ch.epfl.scala.bsp.Uri
 import bloop.testing.DiffAssertions.TestFailedException
+import bloop.data.SourcesGlobs
 
 object TcpBspProtocolSpec extends BspProtocolSpec(BspProtocol.Tcp)
 object LocalBspProtocolSpec extends BspProtocolSpec(BspProtocol.Local)
@@ -340,6 +341,76 @@ class BspProtocolSpec(
         checkSources(testJsProject)
         checkSources(rootMain)
         checkSources(rootTest)
+      }
+    }
+  }
+
+  test("sources globs are expanded in sources request") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      object Sources {
+        val `Hello.scala` =
+          """/Hello.scala
+            |object A
+          """.stripMargin
+        val `HelloTest.scala` =
+          """/HelloTest.scala
+            |object HelloTest
+          """.stripMargin
+
+        // This file is ignored because `walkDepth == 1`, meaning that the globs
+        // only expand to file that are depth 1 from the base directory.
+        val `toodeep/Hello.scala` =
+          """/toodeep/HelloTest.scala
+            |package toodeep
+            |object Hello
+          """.stripMargin
+      }
+
+      val globDirectory =
+        workspace.underlying.resolve("a").resolve("src")
+      val baseProject = TestProject(
+        workspace,
+        "a",
+        sources = List(
+          Sources.`Hello.scala`,
+          Sources.`HelloTest.scala`,
+          Sources.`toodeep/Hello.scala`
+        ),
+        sourcesGlobs = List(
+          Config.SourcesGlobs(
+            globDirectory,
+            walkDepth = Some(1),
+            includes = List("*.scala"),
+            excludes = List("*Test.scala")
+          )
+        )
+      )
+      val `A` = baseProject.copy(config = baseProject.config.copy(sources = Nil))
+
+      val projects = List(`A`)
+      loadBspState(workspace, projects, logger) { state =>
+        val project = state.underlying.build.loadedProjects.head
+        def assertSourcesMatches(expected: String): Unit = {
+          val obtained = for {
+            item <- state.requestSources(`A`).items
+            source <- item.sources
+          } yield globDirectory.relativize(source.uri.toPath).iterator().asScala.mkString("/")
+          assertNoDiff(
+            obtained.mkString("\n"),
+            expected
+          )
+        }
+        assertSourcesMatches("Hello.scala")
+        val hello2 = globDirectory.resolve("Hello2.scala")
+        Files.write(hello2, Array.emptyByteArray)
+        assertSourcesMatches(
+          """Hello.scala
+            |Hello2.scala
+            |""".stripMargin
+        )
+        Files.delete(hello2)
+        assertSourcesMatches("Hello.scala")
       }
     }
   }

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -381,8 +381,8 @@ class BspProtocolSpec(
           Config.SourcesGlobs(
             globDirectory,
             walkDepth = Some(1),
-            includes = List("*.scala"),
-            excludes = List("*Test.scala")
+            includes = List("glob:*.scala"),
+            excludes = List("glob:*Test.scala")
           )
         )
       )

--- a/frontend/src/test/scala/bloop/io/SourcesGlobsSpec.scala
+++ b/frontend/src/test/scala/bloop/io/SourcesGlobsSpec.scala
@@ -35,9 +35,9 @@ object SourcesGlobsSpec extends bloop.testing.BaseSuite {
         val baseProject = state.build.loadedProjects.head.project
         val globDirectory = baseProject.baseDirectory.resolve("src")
         val sourcesGlobs = SourcesGlobs.fromStrings(
-          globDirectory.underlying,
+          globDirectory,
           None,
-          if (includeGlobs.isEmpty) List("**")
+          if (includeGlobs.isEmpty) List("glob:**")
           else includeGlobs,
           excludeGlobs
         )
@@ -72,7 +72,7 @@ object SourcesGlobsSpec extends bloop.testing.BaseSuite {
   checkGlobs(
     "include",
     List("Foo.scala", "FooTest.scala"),
-    List("*Test.scala"),
+    List("glob:*Test.scala"),
     List(),
     """|FooTest.scala
        |""".stripMargin
@@ -82,7 +82,7 @@ object SourcesGlobsSpec extends bloop.testing.BaseSuite {
     "exclude",
     List("Foo.scala", "FooTest.scala"),
     List(),
-    List("*Test.scala"),
+    List("glob:*Test.scala"),
     """|Foo.scala
        |""".stripMargin
   )
@@ -90,7 +90,7 @@ object SourcesGlobsSpec extends bloop.testing.BaseSuite {
   checkGlobs(
     "recursive-include",
     List("main/scala/Foo.scala", "main/scala/FooTest.scala"),
-    List("**/Foo.scala"),
+    List("glob:**/Foo.scala"),
     List(),
     """|main/scala/Foo.scala
        |""".stripMargin
@@ -99,7 +99,7 @@ object SourcesGlobsSpec extends bloop.testing.BaseSuite {
   checkGlobs(
     "double-asterisk-slash",
     List("Foo.scala", "inner/Bar.scala"),
-    List("**/*.scala"),
+    List("glob:**/*.scala"),
     List(),
     // NOTE(olafur): globs in Bloop follow `java.nio.file.PathMatcher`
     // semantics, which may be incompatible with how other builds tools
@@ -113,7 +113,7 @@ object SourcesGlobsSpec extends bloop.testing.BaseSuite {
   checkGlobs(
     "double-asterisk-no-slash",
     List("Foo.scala", "inner/Bar.scala"),
-    List("**.scala"),
+    List("glob:**.scala"),
     List(),
     """|Foo.scala
        |inner/Bar.scala
@@ -124,7 +124,7 @@ object SourcesGlobsSpec extends bloop.testing.BaseSuite {
     "recursive-exclude",
     List("main/scala/Foo.scala", "main/scala/FooTest.scala"),
     List(),
-    List("**/Foo.scala"),
+    List("glob:**/Foo.scala"),
     """|main/scala/FooTest.scala
        |""".stripMargin
   )
@@ -133,7 +133,7 @@ object SourcesGlobsSpec extends bloop.testing.BaseSuite {
     "recursive-exclude",
     List("main/scala/Foo.scala", "main/scala/FooTest.scala"),
     List(),
-    List("**/Foo.scala"),
+    List("glob:**/Foo.scala"),
     """|main/scala/FooTest.scala
        |""".stripMargin
   )

--- a/frontend/src/test/scala/bloop/io/SourcesGlobsSpec.scala
+++ b/frontend/src/test/scala/bloop/io/SourcesGlobsSpec.scala
@@ -59,10 +59,8 @@ object SourcesGlobsSpec extends bloop.testing.BaseSuite {
           .map(
             _.source
               .toRelative(globDirectory)
-              .underlying
-              .iterator()
-              .asScala
-              .mkString("/")
+              .toUri(isDirectory = false)
+              .toString()
               .stripPrefix("globs/src/")
           )
           .sorted
@@ -156,7 +154,7 @@ object SourcesGlobsSpec extends bloop.testing.BaseSuite {
       .replaceAllLiterally(AbsolutePath.workingDirectory.toString(), "PATH")
     assertNoDiff(
       obtained,
-      "ignoring invalid 'sourcesGlobs' object containing directory 'PATH' in project 'error'"
+      "Ignoring invalid 'sourcesGlobs' object containing directory 'PATH' in project 'error'"
     )
   }
 

--- a/frontend/src/test/scala/bloop/io/SourcesGlobsSpec.scala
+++ b/frontend/src/test/scala/bloop/io/SourcesGlobsSpec.scala
@@ -1,0 +1,141 @@
+package bloop.io
+
+import bloop.logging.RecordingLogger
+import scala.concurrent.Promise
+import bloop.util.TestUtil
+import java.nio.file.Files
+import scala.concurrent.Await
+import scala.concurrent.duration.FiniteDuration
+import bloop.util.TestProject
+import java.util.concurrent.TimeUnit
+import bloop.cli.ExitStatus
+import bloop.config.Config
+import bloop.data.SourcesGlobs
+
+object SourcesGlobsSpec extends bloop.testing.BaseSuite {
+
+  def checkGlobs(
+      name: String,
+      filenames: List[String],
+      includeGlobs: List[String],
+      excludeGlobs: List[String],
+      expectedFilenames: String
+  )(implicit filename: sourcecode.File, line: sourcecode.Line): Unit =
+    test(name) {
+      TestUtil.withinWorkspace { workspace =>
+        import bloop.engine.ExecutionContext.ioScheduler
+        val testProject = TestProject(
+          workspace,
+          "globs",
+          filenames.map(name => s"/$name${System.lineSeparator()}// command")
+        )
+        val logger = new RecordingLogger(ansiCodesSupported = false)
+        val configDir = TestProject.populateWorkspace(workspace, List(testProject))
+        val state = TestUtil.loadTestProject(configDir.underlying, logger)
+        val baseProject = state.build.loadedProjects.head.project
+        val globDirectory = baseProject.baseDirectory.resolve("src")
+        val sourcesGlobs = SourcesGlobs.fromStrings(
+          globDirectory.underlying,
+          None,
+          if (includeGlobs.isEmpty) List("**")
+          else includeGlobs,
+          excludeGlobs
+        )
+        val project = baseProject.copy(
+          sources = Nil,
+          sourcesGlobs = sourcesGlobs
+        )
+        val hashedSources = SourceHasher.findAndHashSourcesInProject(
+          project,
+          1,
+          Promise[Unit](),
+          ioScheduler
+        )
+        val Right(result) = TestUtil.await(10, TimeUnit.SECONDS)(hashedSources)
+        import scala.collection.JavaConverters._
+        val obtainedFilenames = result
+          .map(
+            _.source
+              .toRelative(globDirectory)
+              .underlying
+              .iterator()
+              .asScala
+              .mkString("/")
+              .stripPrefix("globs/src/")
+          )
+          .sorted
+          .mkString("\n")
+        assertNoDiff(obtainedFilenames, expectedFilenames)
+      }
+    }
+
+  checkGlobs(
+    "include",
+    List("Foo.scala", "FooTest.scala"),
+    List("*Test.scala"),
+    List(),
+    """|FooTest.scala
+       |""".stripMargin
+  )
+
+  checkGlobs(
+    "exclude",
+    List("Foo.scala", "FooTest.scala"),
+    List(),
+    List("*Test.scala"),
+    """|Foo.scala
+       |""".stripMargin
+  )
+
+  checkGlobs(
+    "recursive-include",
+    List("main/scala/Foo.scala", "main/scala/FooTest.scala"),
+    List("**/Foo.scala"),
+    List(),
+    """|main/scala/Foo.scala
+       |""".stripMargin
+  )
+
+  checkGlobs(
+    "double-asterisk-slash",
+    List("Foo.scala", "inner/Bar.scala"),
+    List("**/*.scala"),
+    List(),
+    // NOTE(olafur): globs in Bloop follow `java.nio.file.PathMatcher`
+    // semantics, which may be incompatible with how other builds tools
+    // interpret file globs. For example, "Foo.scala" matches the glob "**/*" in
+    // Pants while it doesn't with Bloop. Client tools are responsible for
+    // pre-processing globs so that they match `PathMatcher` semantics.
+    """|inner/Bar.scala
+       |""".stripMargin
+  )
+
+  checkGlobs(
+    "double-asterisk-no-slash",
+    List("Foo.scala", "inner/Bar.scala"),
+    List("**.scala"),
+    List(),
+    """|Foo.scala
+       |inner/Bar.scala
+       |""".stripMargin
+  )
+
+  checkGlobs(
+    "recursive-exclude",
+    List("main/scala/Foo.scala", "main/scala/FooTest.scala"),
+    List(),
+    List("**/Foo.scala"),
+    """|main/scala/FooTest.scala
+       |""".stripMargin
+  )
+
+  checkGlobs(
+    "recursive-exclude",
+    List("main/scala/Foo.scala", "main/scala/FooTest.scala"),
+    List(),
+    List("**/Foo.scala"),
+    """|main/scala/FooTest.scala
+       |""".stripMargin
+  )
+
+}

--- a/frontend/src/test/scala/bloop/util/TestProject.scala
+++ b/frontend/src/test/scala/bloop/util/TestProject.scala
@@ -90,7 +90,8 @@ abstract class BaseTestProject {
       resources: List[String] = Nil,
       jvmConfig: Option[Config.JvmConfig] = None,
       order: Config.CompileOrder = Config.Mixed,
-      jars: Array[AbsolutePath] = Array()
+      jars: Array[AbsolutePath] = Array(),
+      sourcesGlobs: List[Config.SourcesGlobs] = Nil
   ): TestProject = {
     val projectBaseDir = Files.createDirectories(baseDir.underlying.resolve(name))
     val origin = TestUtil.syntheticOriginFor(baseDir)
@@ -140,6 +141,8 @@ abstract class BaseTestProject {
       projectBaseDir,
       Option(baseDir.underlying),
       List(sourceDir.underlying),
+      if (sourcesGlobs.isEmpty) None
+      else Some(sourcesGlobs),
       directDependencies.map(_.config.name),
       classpath,
       outDir.underlying,

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -387,6 +387,7 @@ object TestUtil {
       scalacOptions = Nil,
       javacOptions = Nil,
       sources = sourceDirectories,
+      sourcesGlobs = Nil,
       testFrameworks = testFrameworks,
       testOptions = Config.TestOptions.empty,
       out = out,
@@ -497,7 +498,7 @@ object TestUtil {
     val classesDir = Files.createDirectory(outDir.resolve("classes"))
 
     // format: OFF
-    val configFileG = bloop.config.Config.File(Config.File.LatestVersion, Config.Project("g", baseDir, Option(baseDir), Nil, List("g"), Nil, outDir, classesDir, None, None, None, None, None, None, None))
+    val configFileG = bloop.config.Config.File(Config.File.LatestVersion, Config.Project("g", baseDir, Option(baseDir), Nil, None, List("g"), Nil, outDir, classesDir, None, None, None, None, None, None, None))
     bloop.config.write(configFileG, jsonTargetG)
     // format: ON
 

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -217,6 +217,7 @@ class BloopConverter(parameters: BloopParameters) {
           directory = project.getProjectDir.toPath,
           workspaceDir = Option(project.getRootProject.getProjectDir.toPath),
           sources = sources,
+          sourcesGlobs = None,
           dependencies = allDependencies,
           classpath = classpath,
           out = outDir,

--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -131,7 +131,7 @@ object MojoImplementation {
         val platform = Some(Config.Platform.Jvm(Config.JvmConfig(javaHome, launcher.getJvmArgs().toList), mainClass))
         // Resources in Maven require
         val resources = Some(resources0.asScala.toList.flatMap(a => Option(a.getTargetPath).toList).map(classesDir.resolve))
-        val project = Config.Project(name, baseDirectory, Some(root.toPath), sourceDirs, dependencyNames, classpath, out, classesDir, resources, `scala`, java, sbt, test, platform, resolution)
+        val project = Config.Project(name, baseDirectory, Some(root.toPath), sourceDirs, None, dependencyNames, classpath, out, classesDir, resources, `scala`, java, sbt, test, platform, resolution)
         Config.File(Config.File.LatestVersion, project)
       }
       // FORMAT: ON

--- a/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
+++ b/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
@@ -101,6 +101,7 @@ object Bloop extends ExternalModule {
         directory = module.millSourcePath.toNIO,
         workspaceDir = Option(pwd.wrapped),
         sources = module.allSources().map(_.path.toNIO).toList,
+        sourcesGlobs = None,
         dependencies = module.moduleDeps.map(name).toList,
         classpath = classpath().map(_.toNIO).toList,
         out = out(module).toNIO,

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -1009,7 +1009,7 @@ object BloopDefaults {
             val resources = Some(bloopResourcesTask.value)
 
             val sbt = None // Written by `postGenerate` instead
-            val project = Config.Project(projectName, baseDirectory, Option(buildBaseDirectory.toPath), sources, dependenciesAndAggregates,
+            val project = Config.Project(projectName, baseDirectory, Option(buildBaseDirectory.toPath), sources, None, dependenciesAndAggregates,
               classpath, out, classesDir, resources, Some(`scala`), Some(java), sbt, Some(testOptions), Some(platform), resolution)
             Config.File(Config.File.LatestVersion, project)
           }

--- a/shared/src/main/scala/bloop/io/RelativePath.scala
+++ b/shared/src/main/scala/bloop/io/RelativePath.scala
@@ -1,6 +1,7 @@
 package bloop.io
 
 import java.io.File
+import java.net.URI
 import java.nio.file.{Path, Paths => NioPaths}
 
 final class RelativePath private (val underlying: Path) extends AnyVal {
@@ -9,6 +10,17 @@ final class RelativePath private (val underlying: Path) extends AnyVal {
   override def toString: String = underlying.toString
 
   def toFile: File = underlying.toFile()
+  def toUri(isDirectory: Boolean): URI = {
+    val suffix = if (isDirectory) "/" else ""
+    // Can't use toNIO.toUri because it produces an absolute URI.
+    import scala.collection.JavaConverters._
+    val names = underlying.iterator().asScala
+    val uris = names.map { name =>
+      // URI encode each part of the path individually.
+      new URI(null, null, name.toString, null)
+    }
+    URI.create(uris.mkString("", "/", suffix))
+  }
   def toAbsolute(root: AbsolutePath): AbsolutePath = root.resolve(this)
   def relativize(other: RelativePath): RelativePath =
     RelativePath(underlying.relativize(other.underlying))


### PR DESCRIPTION
Fixes #1164.

Previously, Bloop targets could only have either source files or
source directories. This caused problems when integrating with builds
tools like Pants that allow targets to have declare the list of source
files via include/exclude globs.

Now, Bloop targets can specify the list of source files via file globs
using the new "sourcesGlobs" field in the Bloop JSON configuration
section. For example,
```json
{
  "sources": ["/path/to/Foo.scala"],
  "sourcesGlobs": [
      {
        "directory": "/glob/directory",
        "walkDepth": 3, // optional
        "includes": ["*.scala"],
        "excludes": ["*Test.scala"]
      }
  ]
}
```

The example above would expand to all Scala source files that are in
depth 3 from the directory "globDirectory" and don't have a filename
that ends with "*Test.scala".

BSP does not support file globs so the `buildTargets/sources` request
expands file globs at request time.