### PR TITLE
Add bloop-sbt-already-installed property for Metals 0.8.0+ versions

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,4 +1,5 @@
 -XX:ReservedCodeCacheSize=512m
 -Dbloop.generate.sbt=false
+-Dbloop-sbt-already-installed=true
 -Dsbt.execute.extrachecks=true
 -Dsbt-bloop.offload-compilation=false


### PR DESCRIPTION
We recently promoted the `bloop.generate.sbt` setting to user configuration and the name needed to also change to `bloop-sbt-already-installed`.

@jvican Adding it now so I don't forget to do it when releasing.