### PR TITLE
Upgrade nuprocess version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,7 @@ object Dependencies {
   val circeVersion = "0.9.3"
   val jsoniterVersion = "2.0.4"
   val circeVersion213 = "0.12.2"
-  val nuprocessVersion = "1.2.6"
+  val nuprocessVersion = "2.0.0"
   val shapelessVersion = "2.3.3-lower-priority-coproduct"
   val scalaNative03Version = "0.3.9"
   val scalaNative04Version = "0.4.0-M2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,7 @@ object Dependencies {
   val circeVersion = "0.9.3"
   val jsoniterVersion = "2.0.4"
   val circeVersion213 = "0.12.2"
-  val nuprocessVersion = "1.2.4"
+  val nuprocessVersion = "1.2.6"
   val shapelessVersion = "2.3.3-lower-priority-coproduct"
   val scalaNative03Version = "0.3.9"
   val scalaNative04Version = "0.4.0-M2"


### PR DESCRIPTION
We need the fix in https://github.com/brettwooldridge/NuProcess/pull/107
to run bloop in systems that use Zulu. Otherwise, logic breaks with:

```
[E] Error looking up function 'Java_java_lang_ProcessImpl_init': /usr/lib/jvm/zulu-8-amd64/jre/lib/amd64/libjava.so: undefined symbol: Java_java_lang_ProcessImpl_init
```