### PR TITLE
Add support for packagePrefix

### DIFF
--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -234,6 +234,7 @@ object Config {
       workspaceDir: Option[Path],
       sources: List[Path],
       sourcesGlobs: Option[List[SourcesGlobs]],
+      sourceRoots: Option[List[String]],
       dependencies: List[String],
       classpath: List[Path],
       out: Path,
@@ -249,7 +250,7 @@ object Config {
 
   object Project {
     // FORMAT: OFF
-    private[bloop] val empty: Project = Project("", emptyPath, None, List(), None, List(), List(),  emptyPath, emptyPath, None, None, None, None, None, None, None)
+    private[bloop] val empty: Project = Project("", emptyPath, None, List(), None, None, List(), List(),  emptyPath, emptyPath, None, None, None, None, None, None, None)
     // FORMAT: ON
 
     def analysisFileName(projectName: String) = s"$projectName-analysis.bin"
@@ -290,6 +291,7 @@ object Config {
         workingDirectory,
         Some(workingDirectory),
         List(sourceFile),
+        None,
         None,
         List("dummy-2"),
         List(scalaLibraryJar),

--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -234,7 +234,7 @@ object Config {
       workspaceDir: Option[Path],
       sources: List[Path],
       sourcesGlobs: Option[List[SourcesGlobs]],
-      sourceRoots: Option[List[String]],
+      sourceRoots: Option[List[Path]],
       dependencies: List[String],
       classpath: List[Path],
       out: Path,

--- a/frontend/src/it/scala/bloop/CommunityBuild.scala
+++ b/frontend/src/it/scala/bloop/CommunityBuild.scala
@@ -136,6 +136,7 @@ abstract class CommunityBuild(val buildpressHomeDir: AbsolutePath) {
         javacOptions = Nil,
         sources = Nil,
         sourcesGlobs = Nil,
+        sourceRoots = None,
         testFrameworks = Nil,
         testOptions = Config.TestOptions.empty,
         out = dummyClassesDir,

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -948,7 +948,8 @@ final class BloopBspServices(
               // TODO(jvican): Don't default on false for generated, add this info to JSON fields
               bsp.SourceItem(bsp.Uri(bspUri), kind, false)
             }
-            bsp.SourcesItem(target, items)
+            val roots = project.sourceRoots.map(_.map(bsp.Uri(_)))
+            bsp.SourcesItem(target, items, roots)
           }
       }.toList
 

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -948,7 +948,7 @@ final class BloopBspServices(
               // TODO(jvican): Don't default on false for generated, add this info to JSON fields
               bsp.SourceItem(bsp.Uri(bspUri), kind, false)
             }
-            val roots = project.sourceRoots.map(_.map(bsp.Uri(_)))
+            val roots = project.sourceRoots.map(_.map(p => bsp.Uri(p.toBspUri)))
             bsp.SourcesItem(target, items, roots)
           }
       }.toList

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -44,7 +44,7 @@ final case class Project(
     javacOptions: List[String],
     sources: List[AbsolutePath],
     sourcesGlobs: List[SourcesGlobs],
-    sourceRoots: Option[List[String]],
+    sourceRoots: Option[List[AbsolutePath]],
     testFrameworks: List[Config.TestFramework],
     testOptions: Config.TestOptions,
     out: AbsolutePath,
@@ -235,6 +235,8 @@ object Project {
       .getOrElse(out.resolve(Config.Project.analysisFileName(project.name)))
     val resources = project.resources.toList.flatten.map(AbsolutePath.apply)
 
+    val sourceRoots = project.sourceRoots.map(_.map(AbsolutePath.apply))
+
     Project(
       project.name,
       AbsolutePath(project.directory),
@@ -249,7 +251,7 @@ object Project {
       project.java.map(_.options).getOrElse(Nil),
       project.sources.map(AbsolutePath.apply),
       SourcesGlobs.fromConfig(project, logger),
-      project.sourceRoots,
+      sourceRoots,
       project.test.map(_.frameworks).getOrElse(Nil),
       project.test.map(_.options).getOrElse(Config.TestOptions.empty),
       AbsolutePath(project.out),

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -1,5 +1,7 @@
 package bloop.data
 
+import java.net.URI
+
 import bloop.io.AbsolutePath
 import bloop.logging.{DebugFilter, Logger}
 import bloop.ScalaInstance
@@ -9,7 +11,6 @@ import bloop.engine.Dag
 import bloop.engine.caches.SemanticDBCache
 import bloop.engine.tasks.toolchains.{JvmToolchain, ScalaJsToolchain, ScalaNativeToolchain}
 import bloop.io.ByteHasher
-
 import java.nio.charset.StandardCharsets
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.PathMatcher
@@ -22,11 +23,10 @@ import java.nio.file.SimpleFileVisitor
 
 import scala.util.Try
 import scala.collection.mutable
-
 import ch.epfl.scala.{bsp => Bsp}
-
 import xsbti.compile.{ClasspathOptions, CompileOrder}
 import bloop.config.ConfigCodecs
+
 import scala.util.control.NonFatal
 import monix.eval.Task
 
@@ -44,6 +44,7 @@ final case class Project(
     javacOptions: List[String],
     sources: List[AbsolutePath],
     sourcesGlobs: List[SourcesGlobs],
+    sourceRoots: Option[List[String]],
     testFrameworks: List[Config.TestFramework],
     testOptions: Config.TestOptions,
     out: AbsolutePath,
@@ -248,6 +249,7 @@ object Project {
       project.java.map(_.options).getOrElse(Nil),
       project.sources.map(AbsolutePath.apply),
       SourcesGlobs.fromConfig(project, logger),
+      project.sourceRoots,
       project.test.map(_.frameworks).getOrElse(Nil),
       project.test.map(_.options).getOrElse(Config.TestOptions.empty),
       AbsolutePath(project.out),

--- a/frontend/src/test/scala/bloop/DagSpec.scala
+++ b/frontend/src/test/scala/bloop/DagSpec.scala
@@ -24,7 +24,7 @@ class DagSpec {
   def dummyOrigin = TestUtil.syntheticOriginFor(dummyPath)
   def dummyProject(name: String, dependencies: List[String]): Project =
     Project(name, dummyPath, None, dependencies, Some(dummyInstance), Nil, Nil, compileOptions,
-      dummyPath, Nil, Nil, Nil, Nil, Nil, Config.TestOptions.empty, dummyPath, dummyPath,
+      dummyPath, Nil, Nil, Nil, Nil, None, Nil, Config.TestOptions.empty, dummyPath, dummyPath,
       Project.defaultPlatform(logger), None, None, dummyOrigin)
   // format: ON
 

--- a/frontend/src/test/scala/bloop/util/TestProject.scala
+++ b/frontend/src/test/scala/bloop/util/TestProject.scala
@@ -143,6 +143,7 @@ abstract class BaseTestProject {
       List(sourceDir.underlying),
       if (sourcesGlobs.isEmpty) None
       else Some(sourcesGlobs),
+      None,
       directDependencies.map(_.config.name),
       classpath,
       outDir.underlying,

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -388,6 +388,7 @@ object TestUtil {
       javacOptions = Nil,
       sources = sourceDirectories,
       sourcesGlobs = Nil,
+      sourceRoots = None,
       testFrameworks = testFrameworks,
       testOptions = Config.TestOptions.empty,
       out = out,
@@ -498,7 +499,7 @@ object TestUtil {
     val classesDir = Files.createDirectory(outDir.resolve("classes"))
 
     // format: OFF
-    val configFileG = bloop.config.Config.File(Config.File.LatestVersion, Config.Project("g", baseDir, Option(baseDir), Nil, None, List("g"), Nil, outDir, classesDir, None, None, None, None, None, None, None))
+    val configFileG = bloop.config.Config.File(Config.File.LatestVersion, Config.Project("g", baseDir, Option(baseDir), Nil, None, None, List("g"), Nil, outDir, classesDir, None, None, None, None, None, None, None))
     bloop.config.write(configFileG, jsonTargetG)
     // format: ON
 

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -218,6 +218,7 @@ class BloopConverter(parameters: BloopParameters) {
           workspaceDir = Option(project.getRootProject.getProjectDir.toPath),
           sources = sources,
           sourcesGlobs = None,
+          sourceRoots = None,
           dependencies = allDependencies,
           classpath = classpath,
           out = outDir,

--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -131,7 +131,7 @@ object MojoImplementation {
         val platform = Some(Config.Platform.Jvm(Config.JvmConfig(javaHome, launcher.getJvmArgs().toList), mainClass))
         // Resources in Maven require
         val resources = Some(resources0.asScala.toList.flatMap(a => Option(a.getTargetPath).toList).map(classesDir.resolve))
-        val project = Config.Project(name, baseDirectory, Some(root.toPath), sourceDirs, None, dependencyNames, classpath, out, classesDir, resources, `scala`, java, sbt, test, platform, resolution)
+        val project = Config.Project(name, baseDirectory, Some(root.toPath), sourceDirs, None, None, dependencyNames, classpath, out, classesDir, resources, `scala`, java, sbt, test, platform, resolution)
         Config.File(Config.File.LatestVersion, project)
       }
       // FORMAT: ON

--- a/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
+++ b/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
@@ -102,6 +102,7 @@ object Bloop extends ExternalModule {
         workspaceDir = Option(pwd.wrapped),
         sources = module.allSources().map(_.path.toNIO).toList,
         sourcesGlobs = None,
+        sourceRoots = None,
         dependencies = module.moduleDeps.map(name).toList,
         classpath = classpath().map(_.toNIO).toList,
         out = out(module).toNIO,

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -1016,7 +1016,7 @@ object BloopDefaults {
             val resources = Some(bloopResourcesTask.value)
 
             val sbt = None // Written by `postGenerate` instead
-            val project = Config.Project(projectName, baseDirectory, Option(buildBaseDirectory.toPath), sources, None, dependenciesAndAggregates,
+            val project = Config.Project(projectName, baseDirectory, Option(buildBaseDirectory.toPath), sources, None, None, dependenciesAndAggregates,
               classpath, out, classesDir, resources, Some(`scala`), Some(java), sbt, Some(testOptions), Some(platform), resolution)
             Config.File(Config.File.LatestVersion, project)
           }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val nailgunCommit = "a2520c1e"
 
   val zincVersion = "1.3.0-M4+32-b1accb96"
-  val bspVersion = "2.0.0-M6"
+  val bspVersion = "2.0.0-M7"
   val javaDebugVersion = "0.21.0+1-7f1080f1"
 
   val scalazVersion = "7.2.20"


### PR DESCRIPTION
See https://github.com/build-server-protocol/build-server-protocol/pull/109 for details

I added packagePrefix at project/build target level. Not sure if it should be more granular, and if so, where exactly it should be located as we have sources that is a list of files or dirs but also sourceGlobs. Sources seems to usually contain specific files, attaching packagePrefix to each of these would be quite strange.