### PR TITLE
Add missing `metals.` for Metals properties

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,5 +1,4 @@
 -XX:ReservedCodeCacheSize=512m
--Dbloop.generate.sbt=false
--Dbloop-sbt-already-installed=true
+-Dmetals.bloop-sbt-already-installed=true
 -Dsbt.execute.extrachecks=true
 -Dsbt-bloop.offload-compilation=false


### PR DESCRIPTION
Follow up from https://github.com/scalacenter/bloop/pull/1177

Forgot about the prefix and now we can remove the old property.