### PR TITLE
Fix hydra integration and make tests succeed

### DIFF
--- a/backend/src/main/scala/bloop/reporter/Reporter.scala
+++ b/backend/src/main/scala/bloop/reporter/Reporter.scala
@@ -30,7 +30,7 @@ abstract class Reporter(
     val logger: Logger,
     override val cwd: AbsolutePath,
     override val config: ReporterConfig,
-    val _problems: mutable.Buffer[ProblemPerPhase] = mutable.ArrayBuffer.empty
+    val _problems: Reporter.Buffer[ProblemPerPhase]
 ) extends ZincReporter {
   private case class PositionId(sourcePath: String, offset: Int)
   private val _severities = TrieMap.empty[PositionId, Severity]
@@ -307,5 +307,68 @@ object Reporter {
         }
     }
     problemsPerFile.toMap
+  }
+
+  import java.util.concurrent.{ConcurrentLinkedQueue => JConcurrentLinkedQueue}
+  import scala.collection.JavaConverters._
+  import scala.reflect.ClassTag
+  object Buffer {
+    def apply[A](needsConcurrentBuffer: Boolean): Buffer[A] = {
+      if (needsConcurrentBuffer) new ConcurrentBuffer[A](new JConcurrentLinkedQueue())
+      else new DelegatingBuffer[A](mutable.ArrayBuffer.empty)
+    }
+  }
+
+  sealed trait Buffer[A] extends Any {
+    def +=(element: A): Unit
+    def clear(): Unit
+    def exists(predicate: A => Boolean): Boolean
+    def foreach(f: A => Unit): Unit
+    def map[B](f: A => B): Buffer[B]
+    def reverse: Buffer[A]
+    def toArray[B >: A: ClassTag]: Array[B]
+    def toList: List[A]
+  }
+
+  private class DelegatingBuffer[A](val underlying: mutable.Buffer[A])
+      extends AnyVal
+      with Buffer[A] {
+    override def +=(element: A): Unit = underlying += element
+    override def clear(): Unit = underlying.clear()
+    override def exists(predicate: A => Boolean): Boolean = underlying.exists(predicate)
+    override def foreach(f: A => Unit): Unit = underlying.foreach(f)
+    override def map[B](f: A => B): Buffer[B] = new DelegatingBuffer(underlying.map(f))
+    override def reverse: Buffer[A] = new DelegatingBuffer(underlying.reverse)
+    override def toList: List[A] = underlying.toList
+    override def toArray[B >: A: ClassTag]: Array[B] = underlying.toArray
+  }
+
+  private class ConcurrentBuffer[A](val underlying: JConcurrentLinkedQueue[A])
+      extends AnyVal
+      with Buffer[A] {
+    override def +=(element: A): Unit = { underlying.add(element); () }
+    override def clear(): Unit = underlying.clear()
+    override def exists(predicate: A => Boolean): Boolean = weakIterator.exists(predicate)
+    override def foreach(f: A => Unit): Unit = weakIterator.foreach(f)
+    override def map[B](f: A => B): Buffer[B] = {
+      val mapped = new JConcurrentLinkedQueue[B]()
+      weakIterator.foreach(element => mapped.add(f(element)))
+      new ConcurrentBuffer(mapped)
+    }
+    override def reverse: Buffer[A] = {
+      val reversed = mutable.Stack.empty[A]
+      weakIterator.foreach(reversed.push)
+      newBuffer(reversed: _*)
+    }
+    override def toList: List[A] = weakIterator.toList
+    override def toArray[B >: A: ClassTag]: Array[B] = weakIterator.toArray
+
+    private def newBuffer[B](elements: B*): ConcurrentBuffer[B] = {
+      val mapped = new JConcurrentLinkedQueue[B]()
+      elements.foreach(mapped.add)
+      new ConcurrentBuffer(mapped)
+    }
+
+    private def weakIterator: Iterator[A] = underlying.iterator().asScala
   }
 }

--- a/backend/src/main/scala/sbt/internal/inc/HydraSupport.scala
+++ b/backend/src/main/scala/sbt/internal/inc/HydraSupport.scala
@@ -8,7 +8,7 @@ import sbt.librarymanagement.Configurations
 object HydraSupport {
   import xsbti.compile.ScalaInstance
 
-  val bridgeVersion = sys.props.get("bloop.hydra.bridgeVersion").getOrElse("0.1.0")
+  val bridgeVersion = sys.props.get("bloop.hydra.bridgeVersion").getOrElse("0.2.0")
   val bridgeNamePrefix =
     sys.props.get("bloop.hydra.bridgeNamePrefix").getOrElse("bloop-hydra-bridge")
 

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/ConcurrentAnalysisCallback.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/ConcurrentAnalysisCallback.scala
@@ -34,11 +34,17 @@ import sbt.internal.inc.SourceInfos
 import bloop.CompileMode
 import xsbti.compile.Signature
 
-trait IBloopAnalysisCallback extends xsbti.AnalysisCallback {
-  def get: Analysis
-}
-
-final class BloopAnalysisCallback(
+/**
+ * This class provides a thread-safe implementation of `xsbti.AnalysisCallback` which is required to compile with the
+ * Triplequote Hydra compiler.
+ *
+ * In essence, the implementation is a merge of the `BloopAnalysisCallback` with the original sbt default `AnalysisCallback`
+ * implementation (https://github.com/sbt/zinc/blob/develop/internal/zinc-core/src/main/scala/sbt/internal/inc/Compile.scala),
+ * which is already thread-safe.
+ *
+ * IMPORTANT: All modifications made to BloopAnalysisCallback` must be replicated here.
+ */
+final class ConcurrentAnalysisCallback(
     compileMode: CompileMode,
     internalBinaryToSourceClassName: String => Option[String],
     internalSourceToClassNamesMap: File => Set[String],
@@ -62,36 +68,39 @@ final class BloopAnalysisCallback(
       classLike: ClassLike
   )
 
-  import collection.mutable
+  import java.util.concurrent.{ConcurrentLinkedQueue, ConcurrentHashMap}
+  import scala.collection.concurrent.TrieMap
 
-  private[this] val srcs = mutable.HashSet[File]()
-  private[this] val classApis = new mutable.HashMap[String, ApiInfo]
-  private[this] val objectApis = new mutable.HashMap[String, ApiInfo]
-  private[this] val classPublicNameHashes = new mutable.HashMap[String, Array[NameHash]]
-  private[this] val objectPublicNameHashes = new mutable.HashMap[String, Array[NameHash]]
-  private[this] val usedNames = new mutable.HashMap[String, mutable.HashSet[UsedName]]
-  private[this] val unreportedProblems = new mutable.HashMap[File, mutable.ListBuffer[Problem]]
-  private[this] val reportedProblems = new mutable.HashMap[File, mutable.ListBuffer[Problem]]
-  private[this] val mainClasses = new mutable.HashMap[File, mutable.ListBuffer[String]]
-  private[this] val binaryDeps = new mutable.HashMap[File, mutable.HashSet[File]]
+  private type ConcurrentSet[A] = ConcurrentHashMap.KeySetView[A, java.lang.Boolean]
+
+  private[this] val srcs = ConcurrentHashMap.newKeySet[File]()
+  private[this] val classApis = new TrieMap[String, ApiInfo]
+  private[this] val objectApis = new TrieMap[String, ApiInfo]
+  private[this] val classPublicNameHashes = new TrieMap[String, Array[NameHash]]
+  private[this] val objectPublicNameHashes = new TrieMap[String, Array[NameHash]]
+  private[this] val usedNames = new TrieMap[String, ConcurrentSet[UsedName]]
+  private[this] val unreportedProblems = new TrieMap[File, ConcurrentLinkedQueue[Problem]]
+  private[this] val reportedProblems = new TrieMap[File, ConcurrentLinkedQueue[Problem]]
+  private[this] val mainClasses = new TrieMap[File, ConcurrentLinkedQueue[String]]
+  private[this] val binaryDeps = new TrieMap[File, ConcurrentSet[File]]
 
   // source file to set of generated (class file, binary class name); only non local classes are stored here
-  private[this] val nonLocalClasses = new mutable.HashMap[File, mutable.HashSet[(File, String)]]
-  private[this] val localClasses = new mutable.HashMap[File, mutable.HashSet[File]]
+  private[this] val nonLocalClasses = new TrieMap[File, ConcurrentSet[(File, String)]]
+  private[this] val localClasses = new TrieMap[File, ConcurrentSet[File]]
   // mapping between src class name and binary (flat) class name for classes generated from src file
-  private[this] val classNames = new mutable.HashMap[File, mutable.HashSet[(String, String)]]
+  private[this] val classNames = new TrieMap[File, ConcurrentSet[(String, String)]]
   // generated class file to its source class name
-  private[this] val classToSource = new mutable.HashMap[File, String]
+  private[this] val classToSource = new TrieMap[File, String]
   // internal source dependencies
-  private[this] val intSrcDeps = new mutable.HashMap[String, mutable.HashSet[InternalDependency]]
+  private[this] val intSrcDeps = new TrieMap[String, ConcurrentSet[InternalDependency]]
   // external source dependencies
-  private[this] val extSrcDeps = new mutable.HashMap[String, mutable.HashSet[ExternalDependency]]
-  private[this] val binaryClassName = new mutable.HashMap[File, String]
+  private[this] val extSrcDeps = new TrieMap[String, ConcurrentSet[ExternalDependency]]
+  private[this] val binaryClassName = new TrieMap[File, String]
   // source files containing a macro def.
-  private[this] val macroClasses = mutable.HashSet[String]()
+  private[this] val macroClasses = ConcurrentHashMap.newKeySet[String]()
 
-  private def add[A, B](map: mutable.HashMap[A, mutable.HashSet[B]], a: A, b: B): Unit = {
-    map.getOrElseUpdate(a, new mutable.HashSet[B]()).+=(b)
+  private def add[A, B](map: TrieMap[A, ConcurrentSet[B]], a: A, b: B): Unit = {
+    map.getOrElseUpdate(a, ConcurrentHashMap.newKeySet[B]()).add(b)
     ()
   }
 
@@ -116,8 +125,8 @@ final class BloopAnalysisCallback(
     for (source <- InterfaceUtil.jo2o(pos.sourceFile)) {
       val map = if (reported) reportedProblems else unreportedProblems
       map
-        .getOrElseUpdate(source, new mutable.ListBuffer())
-        .+=(InterfaceUtil.problem(category, pos, msg, severity, None))
+        .getOrElseUpdate(source, new ConcurrentLinkedQueue)
+        .add(InterfaceUtil.problem(category, pos, msg, severity, None))
     }
   }
 
@@ -232,7 +241,7 @@ final class BloopAnalysisCallback(
   }
 
   def mainClass(sourceFile: File, className: String): Unit = {
-    mainClasses.getOrElseUpdate(sourceFile, new mutable.ListBuffer).+=(className)
+    mainClasses.getOrElseUpdate(sourceFile, new ConcurrentLinkedQueue).add(className)
     ()
   }
 
@@ -250,7 +259,8 @@ final class BloopAnalysisCallback(
     base.copy(compilations = base.compilations.add(compilation))
   def addUsedNames(base: Analysis): Analysis = (base /: usedNames) {
     case (a, (className, names)) =>
-      (a /: names) {
+      import scala.collection.JavaConverters._
+      names.asScala.foldLeft(a) {
         case (a, name) => a.copy(relations = a.relations.addUsedName(className, name))
       }
   }
@@ -298,33 +308,40 @@ final class BloopAnalysisCallback(
   }
 
   def addProductsAndDeps(base: Analysis): Analysis = {
-    (base /: srcs) {
+    import scala.collection.JavaConverters._
+    srcs.asScala.foldLeft(base) {
       case (a, src) =>
         val stamp = stampReader.source(src)
         val classesInSrc =
-          classNames.getOrElse(src, new mutable.HashSet[(String, String)]()).map(_._1)
+          classNames
+            .getOrElse(src, ConcurrentHashMap.newKeySet[(String, String)]())
+            .asScala
+            .map(_._1)
         val analyzedApis = classesInSrc.map(analyzeClass)
         val info = SourceInfos.makeInfo(
-          getOrNil(reportedProblems, src),
-          getOrNil(unreportedProblems, src),
-          getOrNil(mainClasses, src)
+          getOrNil(reportedProblems.mapValues { _.asScala.toSeq }, src),
+          getOrNil(unreportedProblems.mapValues { _.asScala.toSeq }, src),
+          getOrNil(mainClasses.mapValues { _.asScala.toSeq }, src)
         )
-        val binaries = binaryDeps.getOrElse(src, Nil: Iterable[File])
+        val binaries = binaryDeps.getOrElse(src, ConcurrentHashMap.newKeySet[File]).asScala
         val localProds = localClasses
-          .getOrElse(src, new mutable.HashSet[File]())
+          .getOrElse(src, ConcurrentHashMap.newKeySet[File]())
+          .asScala
           .map { classFile =>
             val classFileStamp = stampReader.product(classFile)
             Analysis.LocalProduct(classFile, classFileStamp)
           }
         val binaryToSrcClassName =
           (classNames
-            .getOrElse(src, new mutable.HashSet[(String, String)]())
+            .getOrElse(src, ConcurrentHashMap.newKeySet[(String, String)]())
+            .asScala
             .map {
               case (srcClassName, binaryClassName) => (binaryClassName, srcClassName)
             })
             .toMap
         val nonLocalProds = nonLocalClasses
-          .getOrElse(src, Nil: Iterable[(File, String)])
+          .getOrElse(src, ConcurrentHashMap.newKeySet[(File, String)]())
+          .asScala
           .map {
             case (classFile, binaryClassName) =>
               val srcClassName = binaryToSrcClassName(binaryClassName)
@@ -333,10 +350,12 @@ final class BloopAnalysisCallback(
           }
 
         val internalDeps = classesInSrc.flatMap(
-          cls => intSrcDeps.getOrElse(cls, new mutable.HashSet[InternalDependency]())
+          cls =>
+            intSrcDeps.getOrElse(cls, ConcurrentHashMap.newKeySet[InternalDependency]()).asScala
         )
         val externalDeps = classesInSrc.flatMap(
-          cls => extSrcDeps.getOrElse(cls, new mutable.HashSet[ExternalDependency]())
+          cls =>
+            extSrcDeps.getOrElse(cls, ConcurrentHashMap.newKeySet[ExternalDependency]()).asScala
         )
         val binDeps = binaries.map(d => (d, binaryClassName(d), stampReader binary d))
 

--- a/frontend/src/main/scala/bloop/reporter/BspProjectReporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/BspProjectReporter.scala
@@ -23,8 +23,25 @@ final class BspProjectReporter(
     cwd: AbsolutePath,
     config: ReporterConfig,
     reportAllPreviousProblems: Boolean,
-    override val _problems: mutable.Buffer[ProblemPerPhase] = mutable.ArrayBuffer.empty
+    override val _problems: Reporter.Buffer[ProblemPerPhase]
 ) extends Reporter(logger, cwd, config, _problems) {
+
+  def this(
+      project: Project,
+      logger: BspServerLogger,
+      cwd: AbsolutePath,
+      config: ReporterConfig,
+      reportAllPreviousProblems: Boolean
+  ) =
+    this(
+      project,
+      logger,
+      cwd,
+      config,
+      reportAllPreviousProblems,
+      createBuffer[ProblemPerPhase](project)
+    )
+
   private lazy val taskId = logger.nextTaskId
 
   /** A cycle count, initialized to 0 when it's a no-op. */

--- a/frontend/src/main/scala/bloop/reporter/BspProjectReporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/BspProjectReporter.scala
@@ -48,8 +48,8 @@ final class BspProjectReporter(
   /** A cycle count, initialized to 0 when it's a no-op. */
   private val cycleCount: AtomicInt = AtomicInt(0)
 
-  /** A thread-safe map with all the files under compilation. */
-  private val compilingFiles = TrieMap.empty[File, Boolean]
+  /** A thread-safe set with all the files under compilation. */
+  private val compilingFiles = ConcurrentSet[File]()
 
   /** A thread-safe map with all the files that have been cleared. */
   private val clearedFilesForClient = TrieMap.empty[File, Boolean]
@@ -179,7 +179,7 @@ final class BspProjectReporter(
     logger.publishCompilationStart(
       CompilationEvent.StartCompilation(project.name, project.bspUri, msg, taskId)
     )
-    sources.foreach(sourceFile => compilingFiles.+=(sourceFile -> true))
+    compilingFiles ++ sources
   }
 
   private def clearProblemsAtPhase(

--- a/frontend/src/main/scala/bloop/reporter/LogReporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/LogReporter.scala
@@ -20,8 +20,15 @@ final class LogReporter(
     override val logger: Logger,
     cwd: AbsolutePath,
     config: ReporterConfig,
-    override val _problems: mutable.Buffer[ProblemPerPhase] = mutable.ArrayBuffer.empty
+    override val _problems: Reporter.Buffer[ProblemPerPhase]
 ) extends Reporter(logger, cwd, config, _problems) {
+
+  def this(
+      project: Project,
+      logger: Logger,
+      cwd: AbsolutePath,
+      config: ReporterConfig
+  ) = this(project, logger, cwd, config, createBuffer[ProblemPerPhase](project))
 
   // Contains the files that are compiled in all incremental compiler cycles
   private val compilingFiles = mutable.HashSet[File]()

--- a/frontend/src/main/scala/bloop/reporter/LogReporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/LogReporter.scala
@@ -14,6 +14,8 @@ import sbt.util.InterfaceUtil
 import scala.collection.mutable
 import scala.collection.concurrent.TrieMap
 import bloop.logging.CompilationEvent
+import java.util.concurrent.ConcurrentHashMap
+import scala.collection.JavaConverters._
 
 final class LogReporter(
     val project: Project,
@@ -31,7 +33,7 @@ final class LogReporter(
   ) = this(project, logger, cwd, config, createBuffer[ProblemPerPhase](project))
 
   // Contains the files that are compiled in all incremental compiler cycles
-  private val compilingFiles = mutable.HashSet[File]()
+  private val compilingFiles = ConcurrentHashMap.newKeySet[File]()
 
   private final val format = config.format(this)
   override def printSummary(): Unit = {
@@ -67,7 +69,7 @@ final class LogReporter(
   override def reportStartIncrementalCycle(sources: Seq[File], outputDirs: Seq[File]): Unit = {
     // TODO(jvican): Fix https://github.com/scalacenter/bloop/issues/386 here
     require(sources.size > 0) // This is an invariant enforced in the call-site
-    compilingFiles ++= sources
+    compilingFiles.addAll(sources.asJava)
     logger.info(Reporter.compilationMsgFor(project.name, sources))
   }
 

--- a/frontend/src/main/scala/bloop/reporter/LogReporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/LogReporter.scala
@@ -14,8 +14,6 @@ import sbt.util.InterfaceUtil
 import scala.collection.mutable
 import scala.collection.concurrent.TrieMap
 import bloop.logging.CompilationEvent
-import java.util.concurrent.ConcurrentHashMap
-import scala.collection.JavaConverters._
 
 final class LogReporter(
     val project: Project,
@@ -33,7 +31,7 @@ final class LogReporter(
   ) = this(project, logger, cwd, config, createBuffer[ProblemPerPhase](project))
 
   // Contains the files that are compiled in all incremental compiler cycles
-  private val compilingFiles = ConcurrentHashMap.newKeySet[File]()
+  private val compilingFiles = ConcurrentSet[File]()
 
   private final val format = config.format(this)
   override def printSummary(): Unit = {
@@ -69,7 +67,7 @@ final class LogReporter(
   override def reportStartIncrementalCycle(sources: Seq[File], outputDirs: Seq[File]): Unit = {
     // TODO(jvican): Fix https://github.com/scalacenter/bloop/issues/386 here
     require(sources.size > 0) // This is an invariant enforced in the call-site
-    compilingFiles.addAll(sources.asJava)
+    compilingFiles ++ sources
     logger.info(Reporter.compilationMsgFor(project.name, sources))
   }
 

--- a/frontend/src/main/scala/bloop/reporter/package.scala
+++ b/frontend/src/main/scala/bloop/reporter/package.scala
@@ -4,9 +4,17 @@ import bloop.data.Project
 import bloop.reporter.Reporter
 
 import java.util.concurrent.ConcurrentHashMap
+import scala.collection.JavaConverters._
 
 package object reporter {
   type ConcurrentSet[A] = ConcurrentHashMap.KeySetView[A, java.lang.Boolean]
+  object ConcurrentSet {
+    def apply[A](): ConcurrentSet[A] = ConcurrentHashMap.newKeySet[A]()
+  }
+
+  implicit class ConcurrentSetLike[A](val underlying: ConcurrentSet[A]) extends AnyVal {
+    def ++(elements: Seq[A]): Unit = { underlying.addAll(elements.asJava); () }
+  }
 
   def createBuffer[A](project: Project): Reporter.Buffer[A] = {
     val needsConcurrentBuffer = project.scalaInstance.map(_.supportsHydra).getOrElse(false)

--- a/frontend/src/main/scala/bloop/reporter/package.scala
+++ b/frontend/src/main/scala/bloop/reporter/package.scala
@@ -1,0 +1,11 @@
+package bloop
+
+import bloop.data.Project
+import bloop.reporter.Reporter
+
+package object reporter {
+  def createBuffer[A](project: Project): Reporter.Buffer[A] = {
+    val needsConcurrentBuffer = project.scalaInstance.map(_.supportsHydra).getOrElse(false)
+    Reporter.Buffer(needsConcurrentBuffer)
+  }
+}

--- a/frontend/src/main/scala/bloop/reporter/package.scala
+++ b/frontend/src/main/scala/bloop/reporter/package.scala
@@ -3,7 +3,11 @@ package bloop
 import bloop.data.Project
 import bloop.reporter.Reporter
 
+import java.util.concurrent.ConcurrentHashMap
+
 package object reporter {
+  type ConcurrentSet[A] = ConcurrentHashMap.KeySetView[A, java.lang.Boolean]
+
   def createBuffer[A](project: Project): Reporter.Buffer[A] = {
     val needsConcurrentBuffer = project.scalaInstance.map(_.supportsHydra).getOrElse(false)
     Reporter.Buffer(needsConcurrentBuffer)

--- a/frontend/src/test/scala/bloop/BaseCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/BaseCompileSpec.scala
@@ -547,24 +547,24 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
     TestUtil.withinWorkspace { workspace =>
       object Sources {
         val `Foo.scala` =
-          """/main/scala/Foo.scala
+          """/Foo.scala
             |class Foo
           """.stripMargin
 
         val `Bar.scala` =
-          """/main/scala/Bar.scala
+          """/Bar.scala
             |class Bar {
             |  val foo: Foo = new Foo
             |}
           """.stripMargin
 
         val `Foo2.scala` =
-          """/main/scala/Foo.scala
+          """/Foo.scala
             |class Foo2
           """.stripMargin
 
         val `Bar2.scala` =
-          """/main/scala/Bar.scala
+          """/Bar.scala
             |class Bar {
             |  val foo: Foo2 = new Foo2
             |}
@@ -619,7 +619,7 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
       createFakeCompileProducts(lastClassesDirA, clientDirA, "Bar.class")
 
       // #2: Compiler after renaming `Foo` to `Foo2`, which should make `Bar` fail in second cycle
-      assertIsFile(writeFile(`A`.srcFor("main/scala/Foo.scala"), Sources.`Foo2.scala`))
+      assertIsFile(writeFile(`A`.srcFor("Foo.scala"), Sources.`Foo2.scala`))
       val secondCompiledState = compiledState.compile(`A`)
       assertExitStatus(secondCompiledState, ExitStatus.CompilationError)
       assertInvalidCompilationState(
@@ -630,7 +630,7 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
         hasSameContentsInClassesDir = true
       )
 
-      val targetBar = TestUtil.universalPath("a/src/main/scala/Bar.scala")
+      val targetBar = TestUtil.universalPath("a/src/Bar.scala")
       assertNoDiff(
         s"""
            |[E2] ${targetBar}:2:22
@@ -646,7 +646,7 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
         logger.renderErrors(exceptContaining = "Failed to compile")
       )
 
-      assertIsFile(writeFile(`A`.srcFor("main/scala/Bar.scala"), Sources.`Bar2.scala`))
+      assertIsFile(writeFile(`A`.srcFor("Bar.scala"), Sources.`Bar2.scala`))
       val thirdCompiledState = secondCompiledState.compile(`A`)
       assertExitStatus(thirdCompiledState, ExitStatus.Ok)
 
@@ -924,24 +924,24 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
     TestUtil.withinWorkspace { workspace =>
       object Sources {
         val `Dummy.scala` =
-          """/main/scala/Dummy.scala
+          """/Dummy.scala
             |class Dummy
           """.stripMargin
 
         val `Foo.scala` =
-          """/main/scala/Foo.scala
+          """/Foo.scala
             |class Foo {
             |  def foo: String = ""
             |}
           """.stripMargin
 
         val `Bar.scala` =
-          """/main/scala/Bar.scala
+          """/Bar.scala
             |class Bar extends Foo
           """.stripMargin
 
         val `Baz.scala` =
-          """/main/scala/Baz.scala
+          """/Baz.scala
             |class Baz {
             |  val bar: Bar = new Bar
             |  def hello = println(bar.foo)
@@ -959,7 +959,7 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
           """.stripMargin
 
         val `Foo2.scala` =
-          """/main/scala/Foo.scala
+          """/Foo.scala
             |class Foo {
             |  def foo: String = ""
             |  def foo2: String = ""
@@ -967,7 +967,7 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
           """.stripMargin
 
         val `Baz2.scala` =
-          """/main/scala/Baz.scala
+          """/Baz.scala
             |class Baz {
             |  val bar: Bar = new Bar
             |  def hello = println(bar.foo2)
@@ -997,11 +997,11 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
       assertValidCompilationState(compiledState, projects)
 
       Files.move(
-        `B`.srcFor("main/scala/Foo.scala").underlying,
-        `A`.srcFor("main/scala/Foo.scala", exists = false).underlying
+        `B`.srcFor("Foo.scala").underlying,
+        `A`.srcFor("Foo.scala", exists = false).underlying
       )
 
-      writeFile(`A`.srcFor("main/scala/Foo.scala"), Sources.`Foo2.scala`)
+      writeFile(`A`.srcFor("Foo.scala"), Sources.`Foo2.scala`)
 
       val compiledStateBackup = compiledState.backup
 
@@ -1013,7 +1013,7 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
       assertExistingCompileProduct(secondCompiledState, `A`, RelativePath("Foo.class"))
 
       // Add change depending on new method to make sure that `Foo.class` coming from dependency is picked
-      writeFile(`B`.srcFor("main/scala/Baz.scala"), Sources.`Baz2.scala`)
+      writeFile(`B`.srcFor("Baz.scala"), Sources.`Baz2.scala`)
 
       // Then compile `B` to make sure right info from `A` is passed to `B` for invalidation
       val thirdCompiledState = secondCompiledState.compile(`B`)

--- a/frontend/src/test/scala/bloop/HydraCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/HydraCompileSpec.scala
@@ -19,7 +19,7 @@ object HydraCompileSpec extends BaseCompileSpec {
   private val TriplequoteResolver = MavenRepository(
     "https://repo.triplequote.com/artifactory/libs-release/"
   )
-  private val HydraVersion = "2.1.13"
+  private val HydraVersion = "2.2.1"
 
   object HydraTestProject extends bloop.util.BaseTestProject {
     override protected def mkScalaInstance(

--- a/frontend/src/test/scala/bloop/HydraCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/HydraCompileSpec.scala
@@ -56,8 +56,7 @@ object HydraCompileSpec extends BaseCompileSpec {
   }
 
   override def test(name: String)(fun: => Any): Unit = {
-    //if (hydraLicenseExists) super.test(name)(fun)
-    //else ignore(name, "Hydra license is missing")(fun)
-    ignore(name, "Hydra license is missing")(fun)
+    if (hydraLicenseExists) super.test(name)(fun)
+    else ignore(name, "Hydra license is missing")(fun)
   }
 }


### PR DESCRIPTION
Mirrors https://github.com/scalacenter/bloop/pull/1184

This PR should fix the execution of tests with Hydra. It includes two important fixes:

1) Thread-safe analysis callback, which is required by Hydra since several compilation threads may be stepping on each others.
2) Updated the bloop-hydra-bridge version as it contains an important fix to
correctly handle invalidated classfiles.

For more details, please have a look at the commit messages.

Aspects that still need to be improved:

1) Shall we rename `IBloopAnalysisCallback` to something else?
2) A thread-safe Reporter is likely need for correct execution with Hydra. But switching the mutable data structures used in the different Reporter implementations into concurrent ones might be a first good approximation.