### PR TITLE
Use Project#getPath instead of #getName

### DIFF
--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -414,10 +414,28 @@ class BloopConverter(parameters: BloopParameters) {
   }
 
   def getProjectName(project: Project, sourceSet: SourceSet): String = {
+    val projectsWithName = project.getRootProject
+      .getAllprojects()
+      .asScala
+      .filter(p => p.getName == project.getName)
+    val rawProjectName = if (projectsWithName.size == 1) project.getName else project.getPath
+    val sanitizedProjectName = rawProjectName.zipWithIndex
+      .map {
+        case (c, i) =>
+          if (i == 0 && c == ':') {
+            None
+          } else if (c == ':') {
+            Some('-')
+          } else {
+            Some(c)
+          }
+      }
+      .flatten
+      .mkString
     if (sourceSet.getName == SourceSet.MAIN_SOURCE_SET_NAME) {
-      project.getName
+      sanitizedProjectName
     } else {
-      s"${project.getName}-${sourceSet.getName}"
+      s"${sanitizedProjectName}-${sourceSet.getName}"
     }
   }
 


### PR DESCRIPTION
Please forgive if this solution is naive, it appeared to fix my calling project though!

From the gradle java api docs:
```
String getName()
Returns the name of this project. The project's name is not necessarily unique within a project hierarchy. You should use the getPath() method for a unique identifier for the project.
```

This _does_ generate possibly "weird" looking project names with the colons in them, ie `:one:two:three`. I don't _think_ this is a problem, but we could def transform this if that's desired to look nicer. /shrug