### PR TITLE
Add missing scala-xml dependency in shaded launcher

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -398,7 +398,8 @@ lazy val launcherShaded = project
     bloopGenerate in Test := None,
     libraryDependencies ++= List(
       "net.java.dev.jna" % "jna" % "4.5.0",
-      "net.java.dev.jna" % "jna-platform" % "4.5.0"
+      "net.java.dev.jna" % "jna-platform" % "4.5.0",
+      Dependencies.scalaXml
     )
   )
 


### PR DESCRIPTION
Similar to #1109 #1110 this _should_ fix a `java.lang.NoClassDefFoundError: scala/xml/Node` error encountered when using the launcher in some situations. I haven't figured out when exactly this error occurs and this change is untested.