### PR TITLE
Don't match on hidden source files

### DIFF
--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -293,10 +293,10 @@ object CompileTask {
             stateWithResults.copy(status = ExitStatus.Ok)
           } else {
             results.foreach {
-              case FinalNormalCompileResult.HasException(project, t) =>
-                rawLogger
-                  .error(s"Unexpected error when compiling ${project.name}: '${t.getMessage}'")
-                rawLogger.trace(t)
+              case FinalNormalCompileResult.HasException(project, err) =>
+                val errMsg = err.fold(identity, _.getMessage)
+                rawLogger.error(s"Unexpected error when compiling ${project.name}: '$errMsg'")
+                err.foreach(rawLogger.trace(_))
               case _ => () // Do nothing when the final compilation result is not an actual error
             }
 

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileResult.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileResult.scala
@@ -126,10 +126,12 @@ case class FinalNormalCompileResult private (
 
 object FinalNormalCompileResult {
   object HasException {
-    def unapply(res: FinalNormalCompileResult): Option[(Project, Throwable)] = {
+    def unapply(res: FinalNormalCompileResult): Option[(Project, Either[String, Throwable])] = {
       res.result.fromCompiler match {
-        case Compiler.Result.Failed(_, Some(t), _, _) =>
-          Some((res.project, t))
+        case Compiler.Result.Failed(_, Some(err), _, _) =>
+          Some((res.project, Right(err)))
+        case Compiler.Result.GlobalError(problem) =>
+          Some((res.project, Left(problem)))
         case _ => None
       }
     }

--- a/frontend/src/main/scala/bloop/io/SourceWatcher.scala
+++ b/frontend/src/main/scala/bloop/io/SourceWatcher.scala
@@ -64,10 +64,9 @@ final class SourceWatcher private (
       private[this] val scheduledResubmissions = new ConcurrentHashMap[Path, Cancelable]()
       override def onEvent(event: DirectoryChangeEvent): Unit = {
         val targetFile = event.path()
-        val targetPath = targetFile.toFile.getAbsolutePath()
         val attrs = Files.readAttributes(targetFile, classOf[BasicFileAttributes])
-        if (attrs.isRegularFile &&
-            (targetPath.endsWith(".scala") || targetPath.endsWith(".java"))) {
+
+        if (attrs.isRegularFile && SourceHasher.matchSourceFile(targetFile)) {
           if (attrs.size != 0L) {
             val resubmission = scheduledResubmissions.remove(targetFile)
             if (resubmission != null) resubmission.cancel()

--- a/frontend/src/test/scala/bloop/io/SourceHasherSpec.scala
+++ b/frontend/src/test/scala/bloop/io/SourceHasherSpec.scala
@@ -57,4 +57,36 @@ object SourceHasherSpec extends bloop.testing.BaseSuite {
       assert(!cancelPromise2.isCompleted)
     }
   }
+
+  test("test that hidden source files are not matched") {
+    // Hidden source files should not be matched. Editors such as emacs can
+    // write hidden files to serve as backups, e.g. interlock files
+    TestUtil.withinWorkspace { workspace =>
+      val hiddenScalaFile = workspace.resolve(".Hello.scala")
+      val hiddenJavaFile = workspace.resolve(".Hello.java")
+
+      val validScalaFile = workspace.resolve("Hello.scala")
+      val validJavaFile = workspace.resolve("Hello.java")
+
+      val nestedDir = workspace.resolve("nested")
+      val hiddenNestedJavaFile = nestedDir.resolve(".#Hello.java")
+      val validNestedJavaFile = nestedDir.resolve("Hello.java")
+
+      val nestedHiddenDir = workspace.resolve(".nested")
+      val hiddenInHiddenNestedDirJavaFile = nestedHiddenDir.resolve(".#Hello.java")
+      val validInHiddenNestedDirJavaFile = nestedHiddenDir.resolve("Hello.java")
+
+      assert(!SourceHasher.matchSourceFile(hiddenScalaFile.underlying))
+      assert(!SourceHasher.matchSourceFile(hiddenJavaFile.underlying))
+
+      assert(SourceHasher.matchSourceFile(validScalaFile.underlying))
+      assert(SourceHasher.matchSourceFile(validJavaFile.underlying))
+
+      assert(!SourceHasher.matchSourceFile(hiddenNestedJavaFile.underlying))
+      assert(SourceHasher.matchSourceFile(validNestedJavaFile.underlying))
+
+      assert(!SourceHasher.matchSourceFile(hiddenInHiddenNestedDirJavaFile.underlying))
+      assert(SourceHasher.matchSourceFile(validInHiddenNestedDirJavaFile.underlying))
+    }
+  }
 }


### PR DESCRIPTION
To avoid conflicts when leading with Emacs Interlock files, we
 whitelist hidden source files from the `SourceWatcher` so that fired
 modifications on these files are ignored and from the `SourceHasher` so
 that these files are never discovered and hashed during the
 `CompileInputs` bundling.

 Fixes https://github.com/scalacenter/bloop/issues/1088