### PR TITLE
Respect global configuration in `$HOME/.bloop/bloop.json`

### DIFF
--- a/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
@@ -443,6 +443,10 @@ class BloopgunCli(
         if (globalOptions.nonEmpty) {
           logger.info(s"Picked up custom Java options $globalOptions")
         }
+        // NOTE: global options take precedence because `bloop.json` is the
+        // recommended way to customize the JVM options and users should be able
+        // use `bloop.json` without having to learn about caveats when it
+        // doesn't work.
         baseOptions ++ globalOptions
       }
 
@@ -509,7 +513,11 @@ class BloopgunCli(
         StatusCommand(code, output)
       } catch {
         case e: IOException =>
-          StatusCommand(1, e.getMessage())
+          logger.trace(e)
+          StatusCommand(
+            1,
+            s"Failed to start process '${cmd.mkString(" ")}'\nError: ${e.getMessage()}"
+          )
       }
     }
 

--- a/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
@@ -29,7 +29,6 @@ import scala.collection.mutable
 
 import scopt.OParser
 
-import scala.tools.nsc.Global
 import scala.sys.process.ProcessIO
 import java.lang.ProcessBuilder.Redirect
 import scala.util.Try
@@ -64,7 +63,7 @@ import java.io.IOException
  * because it can affect already connected clients to the server instance.
  */
 class BloopgunCli(
-    bloopVersion: String,
+    baseBloopVersion: String,
     in: InputStream,
     out: PrintStream,
     err: PrintStream,
@@ -72,12 +71,12 @@ class BloopgunCli(
     cwd: Path
 ) {
   def this(
-      bloopVersion: String,
+      baseBloopVersion: String,
       in: InputStream,
       out: PrintStream,
       err: PrintStream,
       shell: Shell
-  ) = this(bloopVersion, in, out, err, shell, Environment.cwd)
+  ) = this(baseBloopVersion, in, out, err, shell, Environment.cwd)
   def run(args: Array[String]): Int = {
     var setServer: Boolean = false
     var setPort: Boolean = false
@@ -200,7 +199,7 @@ class BloopgunCli(
 
     val (cliArgsToParse, extraArgsForServer) =
       if (args.contains("--")) args.span(_ == "--") else (args, Array.empty[String])
-    OParser.parse(cliParser, cliArgsToParse, BloopgunParams(bloopVersion), setup) match {
+    OParser.parse(cliParser, cliArgsToParse, BloopgunParams(baseBloopVersion), setup) match {
       case None => 1
       case Some(params0) =>
         val params = params0.copy(args = additionalCmdArgs ++ extraArgsForServer)
@@ -442,7 +441,7 @@ class BloopgunCli(
           }
         val globalOptions = globalSettings.javaOptions.getOrElse(Nil)
         if (globalOptions.nonEmpty) {
-          logger.info(s"Picked up global Java options $globalOptions")
+          logger.info(s"Picked up custom Java options $globalOptions")
         }
         baseOptions ++ globalOptions
       }

--- a/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
@@ -87,9 +87,14 @@ class BloopgunCli(
     val cliParser = {
       val builder = OParser.builder[BloopgunParams]
       val bloopVersionOpt = builder
-        .opt[String]("bloop-version")
-        .action((bloopVersion, params) => { params.copy(bloopVersion = bloopVersion) })
-        .text("Specify the Bloop version to use for launching a new Bloop server")
+        .opt[String]("fallback-bloop-version")
+        .action((fallbackBloopVersion, params) => {
+          params.copy(bloopVersion = fallbackBloopVersion)
+        })
+        .text(
+          "Specify the Bloop version to use for launching a new Bloop server when there is no running server. " +
+            "This option is ignored when there is a running server in the background."
+        )
       val nailgunServerOpt = builder
         .opt[String]("nailgun-server")
         .action((server, params) => { setServer = true; params.copy(nailgunServer = server) })
@@ -436,6 +441,9 @@ class BloopgunCli(
             jvmOpts ++ extraJvmOpts
           }
         val globalOptions = globalSettings.javaOptions.getOrElse(Nil)
+        if (globalOptions.nonEmpty) {
+          logger.info(s"Picked up global Java options $globalOptions")
+        }
         baseOptions ++ globalOptions
       }
 

--- a/bloopgun/src/main/scala/bloop/bloopgun/BloopgunParams.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/BloopgunParams.scala
@@ -1,6 +1,7 @@
 package bloop.bloopgun
 
 final case class BloopgunParams(
+    bloopVersion: String,
     nailgunServer: String = Defaults.Host,
     nailgunPort: Int = Defaults.Port,
     help: Boolean = false,

--- a/bloopgun/src/main/scala/bloop/bloopgun/util/Environment.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/util/Environment.scala
@@ -23,6 +23,15 @@ object Environment {
   def cwd: Path = Paths.get(System.getProperty("user.dir"))
   def homeDirectory: Path = Paths.get(System.getProperty("user.home"))
   def defaultBloopDirectory: Path = homeDirectory.resolve(".bloop")
+  def bloopGlobalSettingsPath: Path = defaultBloopDirectory.resolve("bloop.json")
+
+  def bloopGlobalSettings(logger: Logger): Either[String, GlobalSettings] = {
+    if (Files.isReadable(bloopGlobalSettingsPath)) {
+      GlobalSettings.readFromFile(bloopGlobalSettingsPath, logger)
+    } else {
+      Right(GlobalSettings.default)
+    }
+  }
 
   /**
    * Returns the path of the running program, imitating `sys.argv[0]` in Python.

--- a/bloopgun/src/main/scala/bloop/bloopgun/util/GlobalSettings.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/util/GlobalSettings.scala
@@ -1,0 +1,53 @@
+package bloop.bloopgun.util
+
+import com.github.plokhotnyuk.jsoniter_scala.{core => jsoniter}
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.core.WriterConfig
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+import com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig
+import java.nio.file.Path
+import java.nio.file.Paths
+import snailgun.logging.Logger
+import scala.util.Failure
+import scala.util.Success
+import java.nio.file.Files
+import scala.util.Try
+
+case class GlobalSettings(
+    javaHome: Option[String] = None,
+    javaOptions: Option[List[String]] = None
+) {
+  def javaBinary: String = {
+    javaHome match {
+      case Some(home) => Paths.get(home).resolve("bin").resolve("java").toString()
+      case None => "java"
+    }
+  }
+}
+
+object GlobalSettings {
+  private implicit val codecSettings: JsonValueCodec[GlobalSettings] =
+    JsonCodecMaker.make[GlobalSettings](
+      CodecMakerConfig.withTransientEmpty(false).withRequireCollectionFields(true)
+    )
+
+  def readFromFile(settingsPath: Path, logger: Logger): Either[String, GlobalSettings] = {
+    if (!Files.isReadable(settingsPath))
+      Left(s"Global settings file '$settingsPath' is not readable")
+    else {
+      logger.debug(s"Loading global settings from $settingsPath")
+      val bytes = Files.readAllBytes(settingsPath)
+      Try(jsoniter.readFromArray(bytes)) match {
+        case Success(settings) =>
+          Right(settings)
+        case Failure(e: JsonReaderException) =>
+          Left(e.getMessage())
+        case Failure(e) =>
+          throw e
+      }
+    }
+  }
+
+  def default: GlobalSettings = GlobalSettings()
+}

--- a/build.sbt
+++ b/build.sbt
@@ -272,6 +272,8 @@ lazy val bloopgun: Project = project
       Dependencies.slf4jNop,
       Dependencies.coursier,
       Dependencies.coursierCache,
+      Dependencies.jsoniterCore,
+      Dependencies.jsoniterMacros % Provided,
       // Necessary to compile to native (see https://github.com/coursier/coursier/blob/0bf1c4f364ceff76892751a51361a41dfc478b8d/build.sbt#L376)
       "org.bouncycastle" % "bcprov-jdk15on" % "1.64",
       "org.bouncycastle" % "bcpkix-jdk15on" % "1.64"

--- a/build.sbt
+++ b/build.sbt
@@ -348,6 +348,7 @@ def shadeSettingsForModule(moduleId: String, module: Reference) = List(
     "scopt",
     "macrocompat",
     "com.zaxxer.nuprocess",
+    "com.github.plokhotnyuk.jsoniter_scala",
     // Coursier direct and transitive deps
     "coursier",
     "shapeless",

--- a/docs/server.md
+++ b/docs/server.md
@@ -55,6 +55,41 @@ If you are integrating your tool with bloop and want to install and start the se
   <dd><p>Use the server jar or script in the given path</p></dd>
 </dl>
 
+## Global settings for the server
+
+Use the `$HOME/.bloop/bloop.json` file to configure the Bloop server. The
+Bloop server must be restarted to pick up new configuration changes.
+
+### Custom Java options
+
+Update the `javaOptions` field to configure custom Java options that should
+be used when starting a new Bloop server. For example, use this to increase
+the memory to Bloop.
+
+```jsonc
+// $HOME/.bloop/bloop.json
+{
+  "javaOptions": ["-Xmx16G"]
+}
+```
+
+### Custom Java home
+
+Update the `javaHome` field declare what Java version the Bloop server should
+run on. For example, use this to declare that Bloop should compile with JDK
+11 or JDK 8.
+
+```jsonc
+// $HOME/.bloop/bloop.json
+{
+  "javaHome": "/Library/Java/JavaVirtualMachines/jdk1.8.0_111.jdk"
+}
+```
+
+The `java` binary should exist in `$JAVA_HOME/bin/java`. The Bloop server
+will not start correctly if the `javaHome` field points directly to the
+`java` binary.
+
 ## Automatic management of the server
 
 It is generally a good practice to have a way to manage the lifecycle of the server. 

--- a/docs/server.md
+++ b/docs/server.md
@@ -22,9 +22,8 @@ For example, `bloop server`:
 
 1. Finds the location of a bootstrapped jar automatically in the bloop installation
    directory
-1. Runs the server with the jvm options in the `.jvmopts` file in the bloop installation
-   directory. The `.jvmopts` file can contain the flags separated by either a new line or
-   a whitespace.
+1. Runs the server with the JVM options configured in `$HOME/.bloop/bloop.json`, see
+   [custom Java options](#custom-java-options).
 1. Provides a way to evolve the way the server is run and managed in the future, which
    makes it especially compatibility-friendly.
    
@@ -45,8 +44,8 @@ If you are integrating your tool with bloop and want to install and start the se
 * `NAILGUN_PORT` must be a free TCP port. For now, only ports in the localhost is
   supported.
 * `JVM_OPTS` must be valid JVM arguments prefixed with `-J`, used to pass in
-  temporary jvm options to the server. For a permanent solution, add the options in
-  `.jvmopts` file.
+  temporary jvm options to the server. For a permanent solution, add the options
+  to [`$HOME/.bloop/bloop.json`](#custom-java-options).
   
 #### Flags
 
@@ -123,8 +122,8 @@ Command examples:
 1. `brew services stop bloop`: stops the bloop server.
 1. `brew services restart bloop`: restarts the bloop server.
 
-JVM options in the optional `/usr/local/Cellar/bloop/$version/bin/.jvmopts` are respected.
-If you change the `.jvmopts` file you have to restart the server for the changes to make effect.
+JVM options in the optional [`$HOME/.bloop/bloop.json`](#custom-java-options) file are respected.
+If you change the `bloop.json` file you have to restart the server for the changes to make effect.
 
 ### via `systemd`
 

--- a/launcher/src/main/scala/bloop/launcher/Launcher.scala
+++ b/launcher/src/main/scala/bloop/launcher/Launcher.scala
@@ -76,7 +76,7 @@ class LauncherMain(
     val skipBspConnection = cliFlags.exists(_ == SkipBspConnection)
 
     val defaultJvmOptions = bloop.bloopgun.util.Environment.PerformanceSensitiveOptsForBloop
-    val allJvmOptions = userJvmOptions.toList ++ defaultJvmOptions
+    val allJvmOptions = defaultJvmOptions ++ userJvmOptions
     if (cliArgs.size == 1) {
       val bloopVersion = cliArgs.apply(0)
       runLauncher(bloopVersion, skipBspConnection, allJvmOptions)

--- a/launcher/src/test/scala/bloop/launcher/GlobalSettingsSpec.scala
+++ b/launcher/src/test/scala/bloop/launcher/GlobalSettingsSpec.scala
@@ -5,7 +5,7 @@ import scala.concurrent.Promise
 import bloop.bloopgun.util.Environment
 import bloop.internal.build.BuildInfo
 
-object GlobalSettingsSpec extends LauncherBaseSuite("1.3.2", BuildInfo.bspVersion, 9014) {
+object GlobalSettingsSpec extends LauncherBaseSuite(BuildInfo.version, BuildInfo.bspVersion, 9014) {
   val launcherArguments = Array(bloopVersion, "--skip-bsp-connection")
 
   def writeJsonSettings(json: String): Unit = {

--- a/launcher/src/test/scala/bloop/launcher/GlobalSettingsSpec.scala
+++ b/launcher/src/test/scala/bloop/launcher/GlobalSettingsSpec.scala
@@ -1,0 +1,74 @@
+package bloop.launcher
+
+import java.nio.file.Files
+import scala.concurrent.Promise
+import bloop.bloopgun.util.Environment
+import bloop.internal.build.BuildInfo
+
+object GlobalSettingsSpec extends LauncherBaseSuite("1.3.2", BuildInfo.bspVersion, 9014) {
+  val launcherArguments = Array(bloopVersion, "--skip-bsp-connection")
+
+  def writeJsonSettings(json: String): Unit = {
+    val settings = Environment.bloopGlobalSettingsPath
+    Files.createDirectories(settings.getParent())
+    Files.write(settings, json.getBytes())
+    ()
+  }
+
+  def setupLauncherWithGlobalJsonSettings(
+      json: String
+  )(fn: (LauncherRun, LauncherStatus) => Unit): Unit = {
+    writeJsonSettings(json)
+    setUpLauncher(
+      in = System.in,
+      out = System.out,
+      startedServer = Promise[Unit](),
+      shell = shellWithPython
+    ) { run =>
+      val status = run.launcher.cli(launcherArguments)
+      fn(run, status)
+    }
+  }
+
+  def runBspLauncherWithGlobalJsonSettings(json: String)(fn: BspLauncherResult => Unit): Unit = {
+    writeJsonSettings(json)
+    val result = runBspLauncherWithEnvironment(launcherArguments, shellWithPython)
+    fn(result)
+  }
+
+  test("fail to start server when bloop.json has syntax error") {
+    // Create invalid bloop.json file with a parse error.
+    runBspLauncherWithGlobalJsonSettings("{") { result =>
+      assert(result.status == Some(LauncherStatus.FailedToConnectToServer))
+      assertLogsContain(
+        List("Parse JSON file", "unexpected end of input"),
+        result.launcherLogs
+      )
+    }
+  }
+
+  test("fail to start server when bloop.json Java home is invalid") {
+    // Create bloop.json with Java home pointing to non-existent path.
+    val doesnotexist = "does-not-exist"
+    runBspLauncherWithGlobalJsonSettings(s"""{"javaHome": "$doesnotexist"}""") { result =>
+      assert(result.status == Some(LauncherStatus.FailedToConnectToServer))
+      assertLogsContain(
+        List(doesnotexist, "Error when starting server"),
+        result.launcherLogs
+      )
+    }
+  }
+
+  test("bloop.json javaOptions field is respected") {
+    val customOptions = "-Dcustom.options=true"
+    setupLauncherWithGlobalJsonSettings(
+      s"""{"javaOptions": ["${customOptions}"]}"""
+    ) { (run, status) =>
+      assert(status == LauncherStatus.SuccessfulRun)
+      assertLogsContain(
+        List(customOptions),
+        run.logs
+      )
+    }
+  }
+}

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -41,10 +41,6 @@
         "title": "CLI --help",
         "sidebar_label": "CLI --help"
       },
-      "cli/cli-reference": {
-        "title": "CLI --help",
-        "sidebar_label": "CLI --help"
-      },
       "cli/reference": {
         "title": "CLI --help",
         "sidebar_label": "CLI --help"
@@ -141,9 +137,6 @@
       },
       "tools/universal/usage": {
         "title": "tools/universal/usage"
-      },
-      "usage-server": {
-        "title": "usage-server"
       },
       "usage": {
         "title": "Quickstart",


### PR DESCRIPTION
Previously, it was only possible to configure JVM options for the Bloop
server via the `$HOME/.bloop/.jvmopts` file. This commit adds a new way
to globally configure Bloop via `$HOME/.bloop/bloop.json`.
The JSON file supports two fields:

* `javaOptions`: which is equivalent to `$HOME/.bloop/.jvmopts`. For
  backwards compatibility, Bloop continues to respect `.jvmopts` but for
  new usage we should start recommending `bloop.json` instead.
* `javaHome`: to control what Java version the Bloop server should use.
  Currently, it's difficult for users to control exactly what Java
  version is picked when launching Bloop. For example, Java 11 may get
  automatically used by IntelliJ 2020.1 calls the Bloop launcher
  because IntelliJ runs on Java 11 itself.

Parse errors in `~/.bloop/bloop.json` cause the Bloopgun/Launcher
processes to fail.

To simplify manual testing of this feature, Bloopgun now accepts a new
--bloop-version flag to override the default Bloop version. This makes
it possible to `bloopgun/run` from sbt shell without a `publishLocal`
step.