### PR TITLE
Fix bugs with non-stable CLI classes directories

### DIFF
--- a/backend/src/main/scala/bloop/CompileBackgroundTasks.scala
+++ b/backend/src/main/scala/bloop/CompileBackgroundTasks.scala
@@ -5,12 +5,14 @@ import monix.eval.Task
 import bloop.io.AbsolutePath
 import bloop.tracing.BraveTracer
 import bloop.reporter.Reporter
+import bloop.logging.Logger
 
 abstract class CompileBackgroundTasks {
   def trigger(
       clientClassesDir: AbsolutePath,
-      reporter: Reporter,
-      tracer: BraveTracer
+      clientReporter: Reporter,
+      clientTracer: BraveTracer,
+      clientLogger: Logger
   ): Task[Unit]
 }
 
@@ -20,8 +22,9 @@ object CompileBackgroundTasks {
     new CompileBackgroundTasks {
       def trigger(
           clientClassesDir: AbsolutePath,
-          reporter: Reporter,
-          tracer: BraveTracer
+          clientReporter: Reporter,
+          clientTracer: BraveTracer,
+          clientLogger: Logger
       ): Task[Unit] = Task.now(())
     }
   }

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -192,7 +192,12 @@ object CompileTask {
                 // Post compilation tasks use tracer, so terminate right after they have
                 val postCompilationTasks =
                   backgroundTasks
-                    .trigger(externalUserClassesDir, reporter.underlying, compileProjectTracer)
+                    .trigger(
+                      externalUserClassesDir,
+                      reporter.underlying,
+                      compileProjectTracer,
+                      logger
+                    )
                     .doOnFinish(_ => Task(compileProjectTracer.terminate()))
                 postCompilationTasks.runAsync(ExecutionContext.ioScheduler)
               }

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
@@ -283,7 +283,7 @@ object CompileGraph {
                   case s: Compiler.Result.Success =>
                     // Wait on new classes to be populated for correctness
                     val runningBackgroundTasks = s.backgroundTasks
-                      .trigger(externalClassesDir, reporter, bundle.tracer)
+                      .trigger(externalClassesDir, reporter, bundle.tracer, logger)
                       .runAsync(ExecutionContext.ioScheduler)
                     Task.now(results.copy(runningBackgroundTasks = runningBackgroundTasks))
                   case _: Compiler.Result.Cancelled =>

--- a/frontend/src/test/scala/bloop/util/TestProject.scala
+++ b/frontend/src/test/scala/bloop/util/TestProject.scala
@@ -42,7 +42,8 @@ final case class TestProject(
     // Default on stable CLI directory, imitating [[ClientInfo.CliClientInfo]]
     val classesDir = config.classesDir
     val classesDirName = classesDir.getFileName()
-    val projectDirName = s"$classesDirName-${CliClientInfo.id}"
+    val cliSuffix = CliClientInfo.generateDirName(true)
+    val projectDirName = s"$classesDirName-$cliSuffix"
     clientClassesRootDir.resolve(projectDirName)
   }
 


### PR DESCRIPTION
Before these fixes, using concurrent CLI clients would produce several
bugs. These bugs are completely addressed with these fixes, that I
tested manually.

Fixes https://github.com/scalacenter/bloop/issues/1181
Fixes https://github.com/scalacenter/bloop/issues/1189 (a dupe of the above)

Running the script in the first bug report, which starts 10
background bloop clients to run a main class works perfectly now.