### PR TITLE
Don't create the hydra.license file for PRs external to the repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,7 @@ jobs:
           curl -Lo coursier https://git.io/coursier-cli && chmod +x coursier && ./coursier --help
           yarn --help
           java -version
-          mkdir -p $HOME/.triplequote && echo "$HYDRA_LICENSE" > "$HOME/.triplequote/hydra.license"
-          echo "$HOME"
-          echo "$HOME/.triplequote/hydra.license" | wc -c
+          [[ $HYDRA_LICENSE == floating-key=* ]] && mkdir -p $HOME/.triplequote && echo "$HYDRA_LICENSE" > "$HOME/.triplequote/hydra.license" || echo "Hydra license file was not created"
         shell: bash
       - name: Check formatting
         if: matrix.os != 'windows-latest'


### PR DESCRIPTION
The Hydra tests are skipped if the hydra.license doesn't exist. If a PR is
opened from an external repo, repositories' secrets cannot be decripted and
hence the hydra.license file should not be created because its content would be
wrong.