### PR TITLE
Add sbt scripted test for hydra sbt integration

### DIFF
--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/hydra-support/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/hydra-support/build.sbt
@@ -1,0 +1,19 @@
+import java.nio.file.Paths
+
+val hydraProject = project
+  .settings(
+    InputKey[Unit]("check") := {
+      val home = sys.props("user.home")
+      val hydraLicense = Paths.get(home, ".triplequote", "hydra.license").toFile
+      if (hydraLicense.isFile) {
+        val config = bloopConfigDir.value / s"${thisProject.value.id}.json"
+        val lines = IO.read(config).replaceAll("\\s", "")
+        assert(lines.contains(s"""scala-compiler-${scalaVersion.value}-hydra"""))
+        assert(lines.contains(s"""scala-reflect-${scalaVersion.value}-hydra"""))
+        assert(lines.contains(s"""hydra_${scalaVersion.value}"""))
+      }
+      else {
+        sLog.value.info(s"Test is skipped because $hydraLicense doesn't exist")
+      }
+    }
+  )

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/hydra-support/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/hydra-support/project/plugins.sbt
@@ -1,0 +1,6 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))
+
+resolvers += Resolver.url("Triplequote Plugins Releases",
+  url("https://repo.triplequote.com/artifactory/sbt-plugins-release/"))(Resolver.ivyStylePatterns)
+addSbtPlugin("com.triplequote" % "sbt-hydra" % "2.2.1")
+

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/hydra-support/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/hydra-support/test
@@ -1,0 +1,2 @@
+> bloopInstall
+> hydraProject/check


### PR DESCRIPTION
The test checks that the generated bloop configuration includes the main Hydra
artifacts.