### PR TITLE
Hide fine-grained Zipkin traces behind system property

### DIFF
--- a/backend/src/main/scala/bloop/BloopClassFileManager.scala
+++ b/backend/src/main/scala/bloop/BloopClassFileManager.scala
@@ -182,24 +182,21 @@ final class BloopClassFileManager(
             clientReporter: Reporter,
             clientTracer: BraveTracer
         ) => {
-          clientTracer.traceTask("copy new products to external classes dir")(
-            { _ =>
-              val config = ParallelOps.CopyConfiguration(5, CopyMode.ReplaceExisting, Set.empty)
-              ParallelOps
-                .copyDirectories(config)(
-                  newClassesDir,
-                  clientExternalClassesDir.underlying,
-                  inputs.ioScheduler,
-                  inputs.logger,
-                  enableCancellation = false
-                )
-                .map { walked =>
-                  readOnlyCopyBlacklist.++=(walked.target)
-                  ()
-                }
-            },
-            verbose = true
-          )
+          clientTracer.traceTaskVerbose("copy new products to external classes dir") { _ =>
+            val config = ParallelOps.CopyConfiguration(5, CopyMode.ReplaceExisting, Set.empty)
+            ParallelOps
+              .copyDirectories(config)(
+                newClassesDir,
+                clientExternalClassesDir.underlying,
+                inputs.ioScheduler,
+                inputs.logger,
+                enableCancellation = false
+              )
+              .map { walked =>
+                readOnlyCopyBlacklist.++=(walked.target)
+                ()
+              }
+          }
         }
       )
     } else {

--- a/backend/src/main/scala/bloop/BloopClassFileManager.scala
+++ b/backend/src/main/scala/bloop/BloopClassFileManager.scala
@@ -182,21 +182,24 @@ final class BloopClassFileManager(
             clientReporter: Reporter,
             clientTracer: BraveTracer
         ) => {
-          clientTracer.traceTask("copy new products to external classes dir") { _ =>
-            val config = ParallelOps.CopyConfiguration(5, CopyMode.ReplaceExisting, Set.empty)
-            ParallelOps
-              .copyDirectories(config)(
-                newClassesDir,
-                clientExternalClassesDir.underlying,
-                inputs.ioScheduler,
-                inputs.logger,
-                enableCancellation = false
-              )
-              .map { walked =>
-                readOnlyCopyBlacklist.++=(walked.target)
-                ()
-              }
-          }
+          clientTracer.traceTask("copy new products to external classes dir")(
+            { _ =>
+              val config = ParallelOps.CopyConfiguration(5, CopyMode.ReplaceExisting, Set.empty)
+              ParallelOps
+                .copyDirectories(config)(
+                  newClassesDir,
+                  clientExternalClassesDir.underlying,
+                  inputs.ioScheduler,
+                  inputs.logger,
+                  enableCancellation = false
+                )
+                .map { walked =>
+                  readOnlyCopyBlacklist.++=(walked.target)
+                  ()
+                }
+            },
+            verbose = true
+          )
         }
       )
     } else {

--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -334,7 +334,7 @@ object Compiler {
     val scalaInstance = compileInputs.scalaInstance
     val classpathOptions = compileInputs.classpathOptions
     val compilers = compileInputs.compilerCache.get(scalaInstance, compileInputs.javacBin)
-    val inputs = tracer.trace("creating zinc inputs")(_ => getInputs(compilers))
+    val inputs = tracer.trace("creating zinc inputs")(_ => getInputs(compilers), verbose = true)
 
     // We don't need nanosecond granularity, we're happy with milliseconds
     def elapsed: Long = ((System.nanoTime() - start).toDouble / 1e6).toLong
@@ -406,33 +406,36 @@ object Compiler {
               clientLogger: Logger
           ): Task[Unit] = Task.defer {
             val descriptionMsg = s"Updating external classes dir with read only $clientClassesDir"
-            clientTracer.traceTask(descriptionMsg) { _ =>
-              Task.defer {
-                clientLogger.debug(descriptionMsg)
-                val invalidatedClassFiles =
-                  allInvalidatedClassFilesForProject.iterator.map(_.toPath).toSet
-                val invalidatedExtraProducts =
-                  allInvalidatedExtraCompileProducts.iterator.map(_.toPath).toSet
-                val invalidatedInThisProject = invalidatedClassFiles ++ invalidatedExtraProducts
-                val blacklist = invalidatedInThisProject ++ readOnlyCopyBlacklist.iterator
-                val config =
-                  ParallelOps.CopyConfiguration(5, CopyMode.ReplaceIfMetadataMismatch, blacklist)
-                val lastCopy = ParallelOps.copyDirectories(config)(
-                  readOnlyClassesDir,
-                  clientClassesDir.underlying,
-                  compileInputs.ioScheduler,
-                  compileInputs.logger,
-                  enableCancellation = false
-                )
-
-                lastCopy.map { fs =>
-                  clientLogger.debug(
-                    s"Finished copying classes from $readOnlyClassesDir to $clientClassesDir"
+            clientTracer.traceTask(descriptionMsg)(
+              { _ =>
+                Task.defer {
+                  clientLogger.debug(descriptionMsg)
+                  val invalidatedClassFiles =
+                    allInvalidatedClassFilesForProject.iterator.map(_.toPath).toSet
+                  val invalidatedExtraProducts =
+                    allInvalidatedExtraCompileProducts.iterator.map(_.toPath).toSet
+                  val invalidatedInThisProject = invalidatedClassFiles ++ invalidatedExtraProducts
+                  val blacklist = invalidatedInThisProject ++ readOnlyCopyBlacklist.iterator
+                  val config =
+                    ParallelOps.CopyConfiguration(5, CopyMode.ReplaceIfMetadataMismatch, blacklist)
+                  val lastCopy = ParallelOps.copyDirectories(config)(
+                    readOnlyClassesDir,
+                    clientClassesDir.underlying,
+                    compileInputs.ioScheduler,
+                    compileInputs.logger,
+                    enableCancellation = false
                   )
-                  ()
+
+                  lastCopy.map { fs =>
+                    clientLogger.debug(
+                      s"Finished copying classes from $readOnlyClassesDir to $clientClassesDir"
+                    )
+                    ()
+                  }
                 }
-              }
-            }
+              },
+              verbose = true
+            )
           }
 
           def persistAnalysis(analysis: CompileAnalysis, out: AbsolutePath): Task[Unit] = {

--- a/backend/src/main/scala/bloop/io/ClasspathHasher.scala
+++ b/backend/src/main/scala/bloop/io/ClasspathHasher.scala
@@ -97,11 +97,11 @@ object ClasspathHasher {
                   Option(cacheMetadataJar.get(file)) match {
                     case Some((metadata, hashHit)) if metadata == currentMetadata => hashHit
                     case _ =>
-                      tracer.trace(s"computing hash ${filePath.toAbsolutePath.toString}") { _ =>
+                      tracer.trace(s"computing hash ${filePath.toAbsolutePath.toString}")({ _ =>
                         val newHash = FileHash.of(file, ByteHasher.hashFileContents(file))
                         cacheMetadataJar.put(file, (currentMetadata, newHash))
                         newHash
-                      }
+                      }, verbose = true)
                   }
                 }
               }
@@ -151,81 +151,90 @@ object ClasspathHasher {
       }
     }
 
-    tracer.traceTask("computing hashes") { tracer =>
-      val acquiredByOtherTasks = new mutable.ListBuffer[Task[Unit]]()
-      val acquiredByThisHashingProcess = new mutable.ListBuffer[AcquiredTask]()
+    tracer.traceTask("computing hashes")(
+      { tracer =>
+        val acquiredByOtherTasks = new mutable.ListBuffer[Task[Unit]]()
+        val acquiredByThisHashingProcess = new mutable.ListBuffer[AcquiredTask]()
 
-      def acquireHashingEntry(entry: File, entryIdx: Int): Unit = {
-        if (isCancelled.get) ()
-        else {
-          val entryPromise = Promise[FileHash]()
-          val promise = hashingPromises.putIfAbsent(entry, entryPromise)
-          if (promise == null) { // The hashing is done by this process
-            acquiredByThisHashingProcess.+=(AcquiredTask(entry, entryIdx, entryPromise))
-          } else { // The hashing is acquired by another process, wait on its result
-            acquiredByOtherTasks.+=(
-              Task.fromFuture(promise.future).flatMap { hash =>
-                if (hash == BloopStamps.cancelledHash) {
-                  if (cancelCompilation.isCompleted) Task.now(())
-                  else {
-                    // If the process that acquired it cancels the computation, try acquiring it again
-                    logger
-                      .warn(s"Unexpected hash computation of $entry was cancelled, restarting...")
-                    Task.fork(Task.eval(acquireHashingEntry(entry, entryIdx)))
-                  }
-                } else {
-                  Task.now {
-                    // Save the result hash in its index
-                    classpathHashes(entryIdx) = hash
-                    ()
-                  }
+        def acquireHashingEntry(entry: File, entryIdx: Int): Unit = {
+          if (isCancelled.get) ()
+          else {
+            val entryPromise = Promise[FileHash]()
+            val promise = hashingPromises.putIfAbsent(entry, entryPromise)
+            if (promise == null) { // The hashing is done by this process
+              acquiredByThisHashingProcess.+=(AcquiredTask(entry, entryIdx, entryPromise))
+            } else { // The hashing is acquired by another process, wait on its result
+              acquiredByOtherTasks.+=(
+                Task.fromFuture(promise.future).flatMap {
+                  hash =>
+                    if (hash == BloopStamps.cancelledHash) {
+                      if (cancelCompilation.isCompleted) Task.now(())
+                      else {
+                        // If the process that acquired it cancels the computation, try acquiring it again
+                        logger
+                          .warn(
+                            s"Unexpected hash computation of $entry was cancelled, restarting..."
+                          )
+                        Task.fork(Task.eval(acquireHashingEntry(entry, entryIdx)))
+                      }
+                    } else {
+                      Task.now {
+                        // Save the result hash in its index
+                        classpathHashes(entryIdx) = hash
+                        ()
+                      }
+                    }
                 }
-              }
-            )
-          }
-        }
-      }
-
-      val initEntries = Task {
-        classpath.zipWithIndex.foreach {
-          case t @ (absoluteEntry, idx) =>
-            val entry = absoluteEntry.toFile
-            acquireHashingEntry(entry, idx)
-        }
-      }.doOnCancel(Task { isCancelled.compareAndSet(false, true); () })
-
-      // Let's first turn the obtained hash tasks into an observable, don't allow cancellation
-      val acquiredTask = Observable.fromIterable(acquiredByThisHashingProcess)
-
-      val cancelableAcquiredTask = Task.create[Unit] { (scheduler, cb) =>
-        val (out, consumerSubscription) = parallelConsumer.createSubscriber(cb, scheduler)
-        val _ = acquiredTask.subscribe(out)
-        Cancelable { () =>
-          isCancelled.compareAndSet(false, true); ()
-        }
-      }
-
-      initEntries.flatMap { _ =>
-        cancelableAcquiredTask
-          .doOnCancel(Task { isCancelled.compareAndSet(false, true); () })
-          .flatMap { _ =>
-            if (isCancelled.get || cancelCompilation.isCompleted) {
-              cancelCompilation.trySuccess(())
-              Task.now(Left(()))
-            } else {
-              Task.sequence(acquiredByOtherTasks.toList).map { _ =>
-                val hasCancelledHash = classpathHashes.exists(_.hash() == BloopStamps.cancelledHash)
-                if (hasCancelledHash || isCancelled.get || cancelCompilation.isCompleted) {
-                  cancelCompilation.trySuccess(())
-                  Left(())
-                } else {
-                  Right(classpathHashes.toVector)
-                }
-              }
+              )
             }
           }
-      }
-    }
+        }
+
+        val initEntries = Task {
+          classpath.zipWithIndex.foreach {
+            case t @ (absoluteEntry, idx) =>
+              val entry = absoluteEntry.toFile
+              acquireHashingEntry(entry, idx)
+          }
+        }.doOnCancel(Task { isCancelled.compareAndSet(false, true); () })
+
+        // Let's first turn the obtained hash tasks into an observable, don't allow cancellation
+        val acquiredTask = Observable.fromIterable(acquiredByThisHashingProcess)
+
+        val cancelableAcquiredTask = Task.create[Unit] { (scheduler, cb) =>
+          val (out, consumerSubscription) = parallelConsumer.createSubscriber(cb, scheduler)
+          val _ = acquiredTask.subscribe(out)
+          Cancelable { () =>
+            isCancelled.compareAndSet(false, true); ()
+          }
+        }
+
+        initEntries.flatMap {
+          _ =>
+            cancelableAcquiredTask
+              .doOnCancel(Task { isCancelled.compareAndSet(false, true); () })
+              .flatMap {
+                _ =>
+                  if (isCancelled.get || cancelCompilation.isCompleted) {
+                    cancelCompilation.trySuccess(())
+                    Task.now(Left(()))
+                  } else {
+                    Task.sequence(acquiredByOtherTasks.toList).map { _ =>
+                      val hasCancelledHash =
+                        classpathHashes.exists(_.hash() == BloopStamps.cancelledHash)
+                      if (hasCancelledHash || isCancelled.get || cancelCompilation.isCompleted) {
+                        cancelCompilation.trySuccess(())
+                        Left(())
+                      } else {
+                        Right(classpathHashes.toVector)
+                      }
+                    }
+                  }
+              }
+        }
+      },
+      verbose = true
+    )
   }
 
   private[this] val definedMacrosJarCache = new ConcurrentHashMap[File, (JarMetadata, Boolean)]()

--- a/backend/src/main/scala/bloop/tracing/BraveTracer.scala
+++ b/backend/src/main/scala/bloop/tracing/BraveTracer.scala
@@ -26,10 +26,33 @@ final class BraveTracer private (
   }
 
   def trace[T](name: String, tags: (String, String)*)(
-      thunk: BraveTracer => T,
-      verbose: Boolean = false
+      thunk: BraveTracer => T
   ): T = {
-    if (!verbose || BraveTracer.verboseTrace) {
+    traceInternal(name, verbose = false, tags: _*)(thunk)
+  }
+
+  def traceVerbose[T](name: String, tags: (String, String)*)(
+      thunk: BraveTracer => T
+  ): T = {
+    traceInternal(name, verbose = true, tags: _*)(thunk)
+  }
+
+  def traceTask[T](name: String, tags: (String, String)*)(
+      thunk: BraveTracer => Task[T]
+  ): Task[T] = {
+    traceTaskInternal(name, verbose = false, tags: _*)(thunk)
+  }
+
+  def traceTaskVerbose[T](name: String, tags: (String, String)*)(
+      thunk: BraveTracer => Task[T]
+  ): Task[T] = {
+    traceTaskInternal(name, verbose = true, tags: _*)(thunk)
+  }
+
+  private def traceInternal[T](name: String, verbose: Boolean, tags: (String, String)*)(
+      thunk: BraveTracer => T
+  ): T = {
+    if (!verbose || BraveTracer.isVerboseTrace) {
       val newTracer = startNewChildTracer(name, tags: _*)
       try thunk(newTracer) // Don't catch and report errors in spans
       catch {
@@ -47,11 +70,10 @@ final class BraveTracer private (
     }
   }
 
-  def traceTask[T](name: String, tags: (String, String)*)(
-      thunk: BraveTracer => Task[T],
-      verbose: Boolean = false
+  private def traceTaskInternal[T](name: String, verbose: Boolean, tags: (String, String)*)(
+      thunk: BraveTracer => Task[T]
   ): Task[T] = {
-    if (!verbose || BraveTracer.verboseTrace) {
+    if (!verbose || BraveTracer.isVerboseTrace) {
       val newTracer = startNewChildTracer(name, tags: _*)
       thunk(newTracer)
         .doOnCancel(Task(newTracer.terminate()))
@@ -89,8 +111,8 @@ object BraveTracer {
   val zipkinServerUrl = Option(System.getProperty("zipkin.server.url")).getOrElse(
     "http://127.0.0.1:9411/api/v2/spans"
   )
-  val debugTrace = Properties.propOrFalse("zipkin.trace.debug")
-  val verboseTrace = Properties.propOrFalse("zipkin.trace.verbose")
+  val isDebugTrace = Properties.propOrFalse("bloop.trace.debug")
+  val isVerboseTrace = Properties.propOrFalse("bloop.trace.verbose")
 
   val sender = URLConnectionSender.create(zipkinServerUrl)
   val jsonVersion = if (zipkinServerUrl.contains("/api/v1")) {
@@ -114,7 +136,7 @@ object BraveTracer {
     val newParentTrace = ctx
       .map(c => tracer.newChild(c))
       .getOrElse(
-        if (debugTrace) {
+        if (isDebugTrace) {
           val c = TraceContext
             .newBuilder()
             .traceId(util.Random.nextLong())

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopNameHashing.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopNameHashing.scala
@@ -145,80 +145,64 @@ private final class BloopNameHashing(
       lookup: Lookup,
       output: Output
   )(implicit equivS: Equiv[XStamp]): InitialChanges = {
-    tracer.trace("detecting initial changes")(
-      { tracer =>
-        // Copy pasting from IncrementalCommon to optimize/remove IO work
-        import IncrementalCommon.{isBinaryModified, findExternalAnalyzedClass}
-        val previous = previousAnalysis.stamps
-        val previousRelations = previousAnalysis.relations
+    tracer.traceVerbose("detecting initial changes") { tracer =>
+      // Copy pasting from IncrementalCommon to optimize/remove IO work
+      import IncrementalCommon.{isBinaryModified, findExternalAnalyzedClass}
+      val previous = previousAnalysis.stamps
+      val previousRelations = previousAnalysis.relations
 
-        val hashesMap = uniqueInputs.sources.map(kv => kv.source.toFile -> kv.hash).toMap
-        val sourceChanges = tracer.trace("source changes")(
-          {
-            _ =>
-              lookup.changedSources(previousAnalysis).getOrElse {
-                val previousSources = previous.allSources.toSet
-                new UnderlyingChanges[File] {
-                  private val inBoth = previousSources & sources
-                  val removed = previousSources -- inBoth
-                  val added = sources -- inBoth
-                  val (changed, unmodified) = inBoth.partition { f =>
-                    import sbt.internal.inc.Hash
-                    // We compute hashes via xxHash in Bloop, so we adapt them to the zinc hex format
-                    val newStamp = hashesMap
-                      .get(f)
-                      .map(bloopHash => BloopStamps.fromBloopHashToZincHash(bloopHash))
-                      .getOrElse(BloopStamps.forHash(f))
-                    !equivS.equiv(previous.source(f), newStamp)
-                  }
-                }
-              }
-          },
-          verbose = true
-        )
-
-        // Unnecessary to compute removed products because we can ensure read-only classes dir is untouched
-        val removedProducts = Set.empty[File]
-        val changedBinaries: Set[File] = tracer.trace("changed binaries")(
-          { _ =>
-            lookup.changedBinaries(previousAnalysis).getOrElse {
-              val detectChange =
-                isBinaryModified(false, lookup, previous, stamps, previousRelations, log)
-              previous.allBinaries.filter(detectChange).toSet
+      val hashesMap = uniqueInputs.sources.map(kv => kv.source.toFile -> kv.hash).toMap
+      val sourceChanges = tracer.traceVerbose("source changes") { _ =>
+        lookup.changedSources(previousAnalysis).getOrElse {
+          val previousSources = previous.allSources.toSet
+          new UnderlyingChanges[File] {
+            private val inBoth = previousSources & sources
+            val removed = previousSources -- inBoth
+            val added = sources -- inBoth
+            val (changed, unmodified) = inBoth.partition { f =>
+              import sbt.internal.inc.Hash
+              // We compute hashes via xxHash in Bloop, so we adapt them to the zinc hex format
+              val newStamp = hashesMap
+                .get(f)
+                .map(bloopHash => BloopStamps.fromBloopHashToZincHash(bloopHash))
+                .getOrElse(BloopStamps.forHash(f))
+              !equivS.equiv(previous.source(f), newStamp)
             }
-          },
-          verbose = true
-        )
+          }
+        }
+      }
 
-        val externalApiChanges: APIChanges = tracer.trace("external api changes")(
-          {
-            _ =>
-              val incrementalExternalChanges = {
-                val previousAPIs = previousAnalysis.apis
-                val externalFinder = findExternalAnalyzedClass(lookup) _
-                detectAPIChanges(
-                  previousAPIs.allExternals,
-                  previousAPIs.externalAPI,
-                  externalFinder
-                )
-              }
+      // Unnecessary to compute removed products because we can ensure read-only classes dir is untouched
+      val removedProducts = Set.empty[File]
+      val changedBinaries: Set[File] = tracer.traceVerbose("changed binaries") { _ =>
+        lookup.changedBinaries(previousAnalysis).getOrElse {
+          val detectChange =
+            isBinaryModified(false, lookup, previous, stamps, previousRelations, log)
+          previous.allBinaries.filter(detectChange).toSet
+        }
+      }
 
-              val changedExternalClassNames = incrementalExternalChanges.allModified.toSet
-              if (!lookup
-                    .shouldDoIncrementalCompilation(changedExternalClassNames, previousAnalysis))
-                new APIChanges(Nil)
-              else incrementalExternalChanges
-          },
-          verbose = true
-        )
+      val externalApiChanges: APIChanges = tracer.traceVerbose("external api changes") { _ =>
+        val incrementalExternalChanges = {
+          val previousAPIs = previousAnalysis.apis
+          val externalFinder = findExternalAnalyzedClass(lookup) _
+          detectAPIChanges(
+            previousAPIs.allExternals,
+            previousAPIs.externalAPI,
+            externalFinder
+          )
+        }
 
-        val init =
-          InitialChanges(sourceChanges, removedProducts, changedBinaries, externalApiChanges)
-        profiler.registerInitial(init)
-        init
-      },
-      verbose = true
-    )
+        val changedExternalClassNames = incrementalExternalChanges.allModified.toSet
+        if (!lookup.shouldDoIncrementalCompilation(changedExternalClassNames, previousAnalysis))
+          new APIChanges(Nil)
+        else incrementalExternalChanges
+      }
+
+      val init = InitialChanges(sourceChanges, removedProducts, changedBinaries, externalApiChanges)
+      profiler.registerInitial(init)
+      init
+    }
   }
 
   def recompileClasses(

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -172,14 +172,11 @@ object CompileTask {
           }
 
           val waitOnReadClassesDir = {
-            compileProjectTracer.traceTask("wait on populating products")(
-              { _ =>
-                // This task is memoized and started by the compilation that created
-                // it, so this execution blocks until it's run or completes right away
-                lastSuccessful.populatingProducts
-              },
-              verbose = true
-            )
+            compileProjectTracer.traceTaskVerbose("wait on populating products") { _ =>
+              // This task is memoized and started by the compilation that created
+              // it, so this execution blocks until it's run or completes right away
+              lastSuccessful.populatingProducts
+            }
           }
 
           // Block on the task associated with this result that sets up the read-only classes dir
@@ -418,18 +415,15 @@ object CompileTask {
       // Blacklist ensure final dir doesn't contain class files that don't map to source files
       val blacklist = products.invalidatedCompileProducts.iterator.map(_.toPath).toSet
       val config = ParallelOps.CopyConfiguration(5, CopyMode.NoReplace, blacklist)
-      val task = tracer.traceTask("preparing new read-only classes directory")(
-        { _ =>
-          ParallelOps.copyDirectories(config)(
-            products.readOnlyClassesDir,
-            products.newClassesDir,
-            ExecutionContext.ioScheduler,
-            logger,
-            enableCancellation = false
-          )
-        },
-        verbose = true
-      )
+      val task = tracer.traceTaskVerbose("preparing new read-only classes directory") { _ =>
+        ParallelOps.copyDirectories(config)(
+          products.readOnlyClassesDir,
+          products.newClassesDir,
+          ExecutionContext.ioScheduler,
+          logger,
+          enableCancellation = false
+        )
+      }
 
       task.map(rs => ()).memoize
     }

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -172,11 +172,14 @@ object CompileTask {
           }
 
           val waitOnReadClassesDir = {
-            compileProjectTracer.traceTask("wait on populating products") { _ =>
-              // This task is memoized and started by the compilation that created
-              // it, so this execution blocks until it's run or completes right away
-              lastSuccessful.populatingProducts
-            }
+            compileProjectTracer.traceTask("wait on populating products")(
+              { _ =>
+                // This task is memoized and started by the compilation that created
+                // it, so this execution blocks until it's run or completes right away
+                lastSuccessful.populatingProducts
+              },
+              verbose = true
+            )
           }
 
           // Block on the task associated with this result that sets up the read-only classes dir
@@ -415,15 +418,18 @@ object CompileTask {
       // Blacklist ensure final dir doesn't contain class files that don't map to source files
       val blacklist = products.invalidatedCompileProducts.iterator.map(_.toPath).toSet
       val config = ParallelOps.CopyConfiguration(5, CopyMode.NoReplace, blacklist)
-      val task = tracer.traceTask("preparing new read-only classes directory") { _ =>
-        ParallelOps.copyDirectories(config)(
-          products.readOnlyClassesDir,
-          products.newClassesDir,
-          ExecutionContext.ioScheduler,
-          logger,
-          enableCancellation = false
-        )
-      }
+      val task = tracer.traceTask("preparing new read-only classes directory")(
+        { _ =>
+          ParallelOps.copyDirectories(config)(
+            products.readOnlyClassesDir,
+            products.newClassesDir,
+            ExecutionContext.ioScheduler,
+            logger,
+            enableCancellation = false
+          )
+        },
+        verbose = true
+      )
 
       task.map(rs => ()).memoize
     }

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
@@ -168,80 +168,87 @@ object CompileBundle {
       options: CommonOptions
   ): Task[CompileBundle] = {
     import inputs.{project, dag, dependentProducts}
-    tracer.traceTask(s"computing bundle ${project.name}") { tracer =>
-      val compileDependenciesData = {
-        tracer.trace("dependency classpath") { _ =>
-          CompileDependenciesData.compute(
-            project.rawClasspath.toArray,
-            dependentProducts
-          )
+    tracer.traceTask(s"computing bundle ${project.name}")(
+      { tracer =>
+        val compileDependenciesData = {
+          tracer.trace("dependency classpath")({ _ =>
+            CompileDependenciesData.compute(
+              project.rawClasspath.toArray,
+              dependentProducts
+            )
+          }, verbose = true)
         }
-      }
 
-      // Dependency classpath is not yet complete, but the hashes only cares about jars
-      import bloop.engine.ExecutionContext.ioScheduler
-      import compileDependenciesData.dependencyClasspath
-      val out = options.ngout
-      val classpathHashesTask = bloop.io.ClasspathHasher
-        .hash(dependencyClasspath, 10, cancelCompilation, ioScheduler, logger, tracer, out)
-        .executeOn(ioScheduler)
-
-      val sourceHashesTask = tracer.traceTask("discovering and hashing sources") { _ =>
-        bloop.io.SourceHasher
-          .findAndHashSourcesInProject(project, 20, cancelCompilation, ioScheduler)
-          .map(res => res.map(_.sortBy(_.source.syntax)))
+        // Dependency classpath is not yet complete, but the hashes only cares about jars
+        import bloop.engine.ExecutionContext.ioScheduler
+        import compileDependenciesData.dependencyClasspath
+        val out = options.ngout
+        val classpathHashesTask = bloop.io.ClasspathHasher
+          .hash(dependencyClasspath, 10, cancelCompilation, ioScheduler, logger, tracer, out)
           .executeOn(ioScheduler)
-      }
 
-      logger.debug(s"Computing sources and classpath hashes for ${project.name}")
-      Task.mapBoth(classpathHashesTask, sourceHashesTask) {
-        case (Left(_), _) => CancelledCompileBundle
-        case (_, Left(_)) => CancelledCompileBundle
-        case (Right(classpathHashes), Right(sourceHashes)) =>
-          val originPath = project.origin.path.syntax
-          val originHash = project.origin.hash
-          val (javaSources, scalaSources) = {
-            import scala.collection.mutable.ListBuffer
-            val javaSources = new ListBuffer[AbsolutePath]()
-            val scalaSources = new ListBuffer[AbsolutePath]()
-            sourceHashes.foreach { hashed =>
-              val source = hashed.source
-              val sourceName = source.underlying.getFileName().toString
-              if (sourceName.endsWith(".scala")) {
-                scalaSources += source
-              } else if (sourceName.endsWith(".java")) {
-                javaSources += source
-              } else ()
+        val sourceHashesTask = tracer.traceTask("discovering and hashing sources")(
+          { _ =>
+            bloop.io.SourceHasher
+              .findAndHashSourcesInProject(project, 20, cancelCompilation, ioScheduler)
+              .map(res => res.map(_.sortBy(_.source.syntax)))
+              .executeOn(ioScheduler)
+          },
+          verbose = true
+        )
+
+        logger.debug(s"Computing sources and classpath hashes for ${project.name}")
+        Task.mapBoth(classpathHashesTask, sourceHashesTask) {
+          case (Left(_), _) => CancelledCompileBundle
+          case (_, Left(_)) => CancelledCompileBundle
+          case (Right(classpathHashes), Right(sourceHashes)) =>
+            val originPath = project.origin.path.syntax
+            val originHash = project.origin.hash
+            val (javaSources, scalaSources) = {
+              import scala.collection.mutable.ListBuffer
+              val javaSources = new ListBuffer[AbsolutePath]()
+              val scalaSources = new ListBuffer[AbsolutePath]()
+              sourceHashes.foreach { hashed =>
+                val source = hashed.source
+                val sourceName = source.underlying.getFileName().toString
+                if (sourceName.endsWith(".scala")) {
+                  scalaSources += source
+                } else if (sourceName.endsWith(".java")) {
+                  javaSources += source
+                } else ()
+              }
+              javaSources.toList -> scalaSources.toList
             }
-            javaSources.toList -> scalaSources.toList
-          }
 
-          val scalacOptions = project.scalacOptions.toVector
-          val scalaJars = project.scalaInstance.toVector.flatMap(_.allJars.map(_.getAbsolutePath()))
-          val inputs = UniqueCompileInputs(
-            sourceHashes.toVector,
-            classpathHashes,
-            scalacOptions,
-            scalaJars,
-            originPath
-          )
+            val scalacOptions = project.scalacOptions.toVector
+            val scalaJars =
+              project.scalaInstance.toVector.flatMap(_.allJars.map(_.getAbsolutePath()))
+            val inputs = UniqueCompileInputs(
+              sourceHashes.toVector,
+              classpathHashes,
+              scalacOptions,
+              scalaJars,
+              originPath
+            )
 
-          new SuccessfulCompileBundle(
-            project,
-            clientExternalClassesDir,
-            compileDependenciesData,
-            javaSources,
-            scalaSources,
-            inputs,
-            cancelCompilation,
-            reporter,
-            logger,
-            mirror,
-            lastSuccessful,
-            lastResult,
-            tracer
-          )
-      }
-    }
+            new SuccessfulCompileBundle(
+              project,
+              clientExternalClassesDir,
+              compileDependenciesData,
+              javaSources,
+              scalaSources,
+              inputs,
+              cancelCompilation,
+              reporter,
+              logger,
+              mirror,
+              lastSuccessful,
+              lastResult,
+              tracer
+            )
+        }
+      },
+      verbose = true
+    )
   }
 }

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
@@ -168,87 +168,80 @@ object CompileBundle {
       options: CommonOptions
   ): Task[CompileBundle] = {
     import inputs.{project, dag, dependentProducts}
-    tracer.traceTask(s"computing bundle ${project.name}")(
-      { tracer =>
-        val compileDependenciesData = {
-          tracer.trace("dependency classpath")({ _ =>
-            CompileDependenciesData.compute(
-              project.rawClasspath.toArray,
-              dependentProducts
-            )
-          }, verbose = true)
+    tracer.traceTaskVerbose(s"computing bundle ${project.name}") { tracer =>
+      val compileDependenciesData = {
+        tracer.traceVerbose("dependency classpath") { _ =>
+          CompileDependenciesData.compute(
+            project.rawClasspath.toArray,
+            dependentProducts
+          )
         }
+      }
 
-        // Dependency classpath is not yet complete, but the hashes only cares about jars
-        import bloop.engine.ExecutionContext.ioScheduler
-        import compileDependenciesData.dependencyClasspath
-        val out = options.ngout
-        val classpathHashesTask = bloop.io.ClasspathHasher
-          .hash(dependencyClasspath, 10, cancelCompilation, ioScheduler, logger, tracer, out)
+      // Dependency classpath is not yet complete, but the hashes only cares about jars
+      import bloop.engine.ExecutionContext.ioScheduler
+      import compileDependenciesData.dependencyClasspath
+      val out = options.ngout
+      val classpathHashesTask = bloop.io.ClasspathHasher
+        .hash(dependencyClasspath, 10, cancelCompilation, ioScheduler, logger, tracer, out)
+        .executeOn(ioScheduler)
+
+      val sourceHashesTask = tracer.traceTaskVerbose("discovering and hashing sources") { _ =>
+        bloop.io.SourceHasher
+          .findAndHashSourcesInProject(project, 20, cancelCompilation, ioScheduler)
+          .map(res => res.map(_.sortBy(_.source.syntax)))
           .executeOn(ioScheduler)
+      }
 
-        val sourceHashesTask = tracer.traceTask("discovering and hashing sources")(
-          { _ =>
-            bloop.io.SourceHasher
-              .findAndHashSourcesInProject(project, 20, cancelCompilation, ioScheduler)
-              .map(res => res.map(_.sortBy(_.source.syntax)))
-              .executeOn(ioScheduler)
-          },
-          verbose = true
-        )
-
-        logger.debug(s"Computing sources and classpath hashes for ${project.name}")
-        Task.mapBoth(classpathHashesTask, sourceHashesTask) {
-          case (Left(_), _) => CancelledCompileBundle
-          case (_, Left(_)) => CancelledCompileBundle
-          case (Right(classpathHashes), Right(sourceHashes)) =>
-            val originPath = project.origin.path.syntax
-            val originHash = project.origin.hash
-            val (javaSources, scalaSources) = {
-              import scala.collection.mutable.ListBuffer
-              val javaSources = new ListBuffer[AbsolutePath]()
-              val scalaSources = new ListBuffer[AbsolutePath]()
-              sourceHashes.foreach { hashed =>
-                val source = hashed.source
-                val sourceName = source.underlying.getFileName().toString
-                if (sourceName.endsWith(".scala")) {
-                  scalaSources += source
-                } else if (sourceName.endsWith(".java")) {
-                  javaSources += source
-                } else ()
-              }
-              javaSources.toList -> scalaSources.toList
+      logger.debug(s"Computing sources and classpath hashes for ${project.name}")
+      Task.mapBoth(classpathHashesTask, sourceHashesTask) {
+        case (Left(_), _) => CancelledCompileBundle
+        case (_, Left(_)) => CancelledCompileBundle
+        case (Right(classpathHashes), Right(sourceHashes)) =>
+          val originPath = project.origin.path.syntax
+          val originHash = project.origin.hash
+          val (javaSources, scalaSources) = {
+            import scala.collection.mutable.ListBuffer
+            val javaSources = new ListBuffer[AbsolutePath]()
+            val scalaSources = new ListBuffer[AbsolutePath]()
+            sourceHashes.foreach { hashed =>
+              val source = hashed.source
+              val sourceName = source.underlying.getFileName().toString
+              if (sourceName.endsWith(".scala")) {
+                scalaSources += source
+              } else if (sourceName.endsWith(".java")) {
+                javaSources += source
+              } else ()
             }
+            javaSources.toList -> scalaSources.toList
+          }
 
-            val scalacOptions = project.scalacOptions.toVector
-            val scalaJars =
-              project.scalaInstance.toVector.flatMap(_.allJars.map(_.getAbsolutePath()))
-            val inputs = UniqueCompileInputs(
-              sourceHashes.toVector,
-              classpathHashes,
-              scalacOptions,
-              scalaJars,
-              originPath
-            )
+          val scalacOptions = project.scalacOptions.toVector
+          val scalaJars = project.scalaInstance.toVector.flatMap(_.allJars.map(_.getAbsolutePath()))
+          val inputs = UniqueCompileInputs(
+            sourceHashes.toVector,
+            classpathHashes,
+            scalacOptions,
+            scalaJars,
+            originPath
+          )
 
-            new SuccessfulCompileBundle(
-              project,
-              clientExternalClassesDir,
-              compileDependenciesData,
-              javaSources,
-              scalaSources,
-              inputs,
-              cancelCompilation,
-              reporter,
-              logger,
-              mirror,
-              lastSuccessful,
-              lastResult,
-              tracer
-            )
-        }
-      },
-      verbose = true
-    )
+          new SuccessfulCompileBundle(
+            project,
+            clientExternalClassesDir,
+            compileDependenciesData,
+            javaSources,
+            scalaSources,
+            inputs,
+            cancelCompilation,
+            reporter,
+            logger,
+            mirror,
+            lastSuccessful,
+            lastResult,
+            tracer
+          )
+      }
+    }
   }
 }

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginWhitelist.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginWhitelist.scala
@@ -95,62 +95,56 @@ object CompilerPluginWhitelist {
           // Use an array with the same indices to be able to update results in a thread-safe way
           val cachePluginResults = new Array[Boolean](pluginCompilerFlags.size)
 
-          tracer.traceTask("enabling plugin caching")(
-            { tracer =>
-              // Consumers are processed with `foreachParallel`, so we side-effect on `cachePluginResults`
-              val parallelConsumer = {
-                Consumer.foreachParallelAsync[WorkItem](parallelUnits) {
-                  case WorkItem(pluginCompilerFlag, idx, p) =>
-                    shouldCachePlugin(pluginCompilerFlag, tracer, logger).materialize.map {
-                      case scala.util.Success(cache) =>
-                        p.success(cache)
-                        pluginPromises.remove(pluginCompilerFlag)
-                        cachePluginResults(idx) = cache
-                      case scala.util.Failure(t) => p.failure(t)
-                    }
-                }
-              }
-
-              val acquiredByOtherTasks = new mutable.ListBuffer[Task[Unit]]()
-              val acquiredByThisInvocation = new mutable.ListBuffer[WorkItem]()
-
-              // Acquire or stash a work item if it was picked up by another process
-              pluginCompilerFlags.zipWithIndex.foreach {
-                case (pluginCompilerFlag, idx) =>
-                  val shouldCachePromise = Promise[Boolean]()
-                  val promise = pluginPromises.putIfAbsent(pluginCompilerFlag, shouldCachePromise)
-                  if (promise != null) {
-                    acquiredByOtherTasks.+=(Task.fromFuture(promise.future).map { cache =>
+          tracer.traceTaskVerbose("enabling plugin caching") { tracer =>
+            // Consumers are processed with `foreachParallel`, so we side-effect on `cachePluginResults`
+            val parallelConsumer = {
+              Consumer.foreachParallelAsync[WorkItem](parallelUnits) {
+                case WorkItem(pluginCompilerFlag, idx, p) =>
+                  shouldCachePlugin(pluginCompilerFlag, tracer, logger).materialize.map {
+                    case scala.util.Success(cache) =>
+                      p.success(cache)
+                      pluginPromises.remove(pluginCompilerFlag)
                       cachePluginResults(idx) = cache
-                    })
-                  } else {
-                    acquiredByThisInvocation.+=(
-                      WorkItem(pluginCompilerFlag, idx, shouldCachePromise)
-                    )
+                    case scala.util.Failure(t) => p.failure(t)
                   }
               }
+            }
 
-              Observable
-                .fromIterable(acquiredByThisInvocation.toList)
-                .consumeWith(parallelConsumer)
-                .flatMap {
-                  _ =>
-                    // Then, we block on those tasks that were picked up by different invocations
-                    val blockingBatches = {
-                      acquiredByOtherTasks.toList
-                        .grouped(parallelUnits)
-                        .map(group => Task.gatherUnordered(group))
-                    }
+            val acquiredByOtherTasks = new mutable.ListBuffer[Task[Unit]]()
+            val acquiredByThisInvocation = new mutable.ListBuffer[WorkItem]()
 
-                    Task.sequence(blockingBatches).map(_.flatten).map { _ =>
-                      val enableCacheFlag = cachePluginResults.forall(_ == true)
-                      if (!enableCacheFlag) scalacOptions
-                      else "-Ycache-plugin-class-loader:last-modified" :: scalacOptions
-                    }
+            // Acquire or stash a work item if it was picked up by another process
+            pluginCompilerFlags.zipWithIndex.foreach {
+              case (pluginCompilerFlag, idx) =>
+                val shouldCachePromise = Promise[Boolean]()
+                val promise = pluginPromises.putIfAbsent(pluginCompilerFlag, shouldCachePromise)
+                if (promise != null) {
+                  acquiredByOtherTasks.+=(Task.fromFuture(promise.future).map { cache =>
+                    cachePluginResults(idx) = cache
+                  })
+                } else {
+                  acquiredByThisInvocation.+=(WorkItem(pluginCompilerFlag, idx, shouldCachePromise))
                 }
-            },
-            verbose = true
-          )
+            }
+
+            Observable
+              .fromIterable(acquiredByThisInvocation.toList)
+              .consumeWith(parallelConsumer)
+              .flatMap { _ =>
+                // Then, we block on those tasks that were picked up by different invocations
+                val blockingBatches = {
+                  acquiredByOtherTasks.toList
+                    .grouped(parallelUnits)
+                    .map(group => Task.gatherUnordered(group))
+                }
+
+                Task.sequence(blockingBatches).map(_.flatten).map { _ =>
+                  val enableCacheFlag = cachePluginResults.forall(_ == true)
+                  if (!enableCacheFlag) scalacOptions
+                  else "-Ycache-plugin-class-loader:last-modified" :: scalacOptions
+                }
+              }
+          }
         }
     }
 


### PR DESCRIPTION
This change introduces a way to hide some verbose fine-grained zipkin traces with a `bloop.trace.verbose` system property which defaults to `false`. This reduces the number of spans in a given trace around the neighborhood of 80% by culling some traces when the amount of time spent in those traced operations is very low, think microseconds or a few milliseconds in a compile taking a few seconds.

@olafurpg