### PR TITLE
Add `tags` to Bloop configuration

### DIFF
--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -245,12 +245,13 @@ object Config {
       sbt: Option[Sbt],
       test: Option[Test],
       platform: Option[Platform],
-      resolution: Option[Resolution]
+      resolution: Option[Resolution],
+      tags: Option[List[String]]
   )
 
   object Project {
     // FORMAT: OFF
-    private[bloop] val empty: Project = Project("", emptyPath, None, List(), None, None, List(), List(),  emptyPath, emptyPath, None, None, None, None, None, None, None)
+    private[bloop] val empty: Project = Project("", emptyPath, None, List(), None, None, List(), List(),  emptyPath, emptyPath, None, None, None, None, None, None, None, None)
     // FORMAT: ON
 
     def analysisFileName(projectName: String) = s"$projectName-analysis.bin"
@@ -259,7 +260,7 @@ object Config {
   case class File(version: String, project: Project)
   object File {
     // We cannot have the version coming from the build tool
-    final val LatestVersion = "1.1.2"
+    final val LatestVersion = "1.4.0"
     private[bloop] val empty = File(LatestVersion, Project.empty)
 
     private[bloop] def dummyForTests: File = {
@@ -313,7 +314,8 @@ object Config {
         Some(Sbt("1.1.0", Nil)),
         Some(Test(List(), TestOptions(Nil, Nil))),
         Some(platform),
-        Some(Resolution(Nil))
+        Some(Resolution(Nil)),
+        None
       )
 
       File(LatestVersion, project)

--- a/config/src/main/scala/bloop/config/Tag.scala
+++ b/config/src/main/scala/bloop/config/Tag.scala
@@ -1,0 +1,13 @@
+package bloop.config
+
+object Tag {
+
+  /** A tag marking integration test targets. */
+  final val IntegrationTest = "integration-test"
+
+  /** A tag marking library targets. */
+  final val Library = "library"
+
+  /** A tag marking test targets. */
+  final val Test = "test"
+}

--- a/docs/assets/bloop-schema.json
+++ b/docs/assets/bloop-schema.json
@@ -580,6 +580,25 @@
               "$ref": "#/definitions/nativePlatform"
             }
           ]
+        },
+        "tags": {
+          "$id": "/properties/project/properties/tags",
+          "type": "array",
+          "title": "The Tags Schema",
+          "description": "The tags associated with that project",
+          "examples": [
+              ["test"],
+              ["library", "cross-platform"]
+          ],
+          "items": {
+            "$id": "/properties/project/properties/tags/items",
+            "type": "string",
+            "title": "A tag associated with that project",
+            "examples": [
+              "test",
+              "library"
+            ]
+          }
         }
       }
     }

--- a/frontend/src/it/scala/bloop/CommunityBuild.scala
+++ b/frontend/src/it/scala/bloop/CommunityBuild.scala
@@ -144,7 +144,8 @@ abstract class CommunityBuild(val buildpressHomeDir: AbsolutePath) {
         platform = Project.defaultPlatform(initialState.logger),
         sbt = None,
         resolution = None,
-        origin = origin
+        tags = Nil,
+        origin = origin,
       )
 
       val newLoaded = LoadedProject.RawProject(rootProject) :: allProjectsInBuild

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -914,11 +914,6 @@ final class BloopBspServices(
           val targets = bsp.WorkspaceBuildTargetsResult(
             projects.map { p =>
               val id = toBuildTargetId(p)
-              val tag = {
-                if (p.name.endsWith("-test") && build.getProjectFor(s"${p.name}-test").isEmpty)
-                  bsp.BuildTargetTag.Test
-                else bsp.BuildTargetTag.Library
-              }
               val deps = p.dependencies.iterator.flatMap(build.getProjectFor(_).toList)
               val extra = p.scalaInstance.map(i => encodeScalaBuildTarget(toScalaBuildTarget(p, i)))
               val capabilities = bsp.BuildTargetCapabilities(
@@ -934,7 +929,7 @@ final class BloopBspServices(
                 id = id,
                 displayName = Some(p.name),
                 baseDirectory = Some(bsp.Uri(p.baseDirectory.toBspUri)),
-                tags = List(tag),
+                tags = p.tags,
                 languageIds = languageIds,
                 dependencies = deps.map(toBuildTargetId).toList,
                 capabilities = capabilities,

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -52,6 +52,7 @@ final case class Project(
     platform: Platform,
     sbt: Option[Config.Sbt],
     resolution: Option[Config.Resolution],
+    tags: List[String],
     origin: Origin
 ) {
 
@@ -238,6 +239,8 @@ object Project {
 
     val sourceRoots = project.sourceRoots.map(_.map(AbsolutePath.apply))
 
+    val tags = project.tags.getOrElse(Nil)
+
     Project(
       project.name,
       AbsolutePath(project.directory),
@@ -260,6 +263,7 @@ object Project {
       platform,
       sbt,
       resolution,
+      tags,
       origin
     )
   }

--- a/frontend/src/test/scala/bloop/DagSpec.scala
+++ b/frontend/src/test/scala/bloop/DagSpec.scala
@@ -25,7 +25,7 @@ class DagSpec {
   def dummyProject(name: String, dependencies: List[String]): Project =
     Project(name, dummyPath, None, dependencies, Some(dummyInstance), Nil, Nil, compileOptions,
       dummyPath, Nil, Nil, Nil, Nil, None, Nil, Config.TestOptions.empty, dummyPath, dummyPath,
-      Project.defaultPlatform(logger), None, None, dummyOrigin)
+      Project.defaultPlatform(logger), None, None, Nil, dummyOrigin)
   // format: ON
 
   private object TestProjects {

--- a/frontend/src/test/scala/bloop/util/TestProject.scala
+++ b/frontend/src/test/scala/bloop/util/TestProject.scala
@@ -157,7 +157,8 @@ abstract class BaseTestProject {
       sbt = None,
       test = Some(testConfig),
       platform = Some(platform),
-      resolution = None
+      resolution = None,
+      tags = None
     )
 
     TestProject(config, Some(directDependencies))

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -396,6 +396,7 @@ object TestUtil {
       platform = Project.defaultPlatform(logger, Some(jdkConfig)),
       sbt = None,
       resolution = None,
+      tags = Nil,
       origin = origin
     )
   }
@@ -499,7 +500,7 @@ object TestUtil {
     val classesDir = Files.createDirectory(outDir.resolve("classes"))
 
     // format: OFF
-    val configFileG = bloop.config.Config.File(Config.File.LatestVersion, Config.Project("g", baseDir, Option(baseDir), Nil, None, None, List("g"), Nil, outDir, classesDir, None, None, None, None, None, None, None))
+    val configFileG = bloop.config.Config.File(Config.File.LatestVersion, Config.Project("g", baseDir, Option(baseDir), Nil, None, None, List("g"), Nil, outDir, classesDir, None, None, None, None, None, None, None, None))
     bloop.config.write(configFileG, jsonTargetG)
     // format: ON
 

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -5,7 +5,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.Files
 
-import bloop.config.Config
+import bloop.config.{Config, Tag}
 import bloop.config.Config.{CompileSetup, JavaThenScala, JvmConfig, Mixed, Platform}
 import bloop.integrations.gradle.BloopParameters
 import bloop.integrations.gradle.model.BloopConverter.SourceSetDep
@@ -209,6 +209,10 @@ class BloopConverter(parameters: BloopParameters) {
       val modules = (nonProjectDependencies.map(artifactToConfigModule(_, project)) ++
         additionalArtifacts.map(artifactToConfigModule(_, project))).distinct
 
+      val tags =
+        if (sourceSet.getName == SourceSet.TEST_SOURCE_SET_NAME) List(Tag.Test)
+        else List(Tag.Library)
+
       for {
         scalaConfig <- getScalaConfig(project, sourceSet, compileArtifacts)
         resolution = Config.Resolution(modules)
@@ -229,7 +233,8 @@ class BloopConverter(parameters: BloopParameters) {
           sbt = None,
           test = getTestConfig(sourceSet),
           platform = getPlatform(project, sourceSet, isTestSourceSet),
-          resolution = Some(resolution)
+          resolution = Some(resolution),
+          tags = Some(tags)
         )
       } yield Config.File(Config.File.LatestVersion, bloopProject)
     }

--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -3,7 +3,7 @@ package bloop.integrations.maven
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
 import java.util
-import bloop.config.Config
+import bloop.config.{Config, Tag}
 import org.apache.maven.execution.MavenSession
 import org.apache.maven.model.Resource
 import org.apache.maven.plugin.logging.Log
@@ -120,6 +120,8 @@ object MojoImplementation {
         (projectDependencies.map(u => abs(new File(u))) ++ cp).toList
       }
 
+      val tags = if (configuration == "test") List(Tag.Test) else List(Tag.Library)
+
       // FORMAT: OFF
       val config = {
         val sbt = None
@@ -131,7 +133,7 @@ object MojoImplementation {
         val platform = Some(Config.Platform.Jvm(Config.JvmConfig(javaHome, launcher.getJvmArgs().toList), mainClass))
         // Resources in Maven require
         val resources = Some(resources0.asScala.toList.flatMap(a => Option(a.getTargetPath).toList).map(classesDir.resolve))
-        val project = Config.Project(name, baseDirectory, Some(root.toPath), sourceDirs, None, None, dependencyNames, classpath, out, classesDir, resources, `scala`, java, sbt, test, platform, resolution)
+        val project = Config.Project(name, baseDirectory, Some(root.toPath), sourceDirs, None, None, dependencyNames, classpath, out, classesDir, resources, `scala`, java, sbt, test, platform, resolution, Some(tags))
         Config.File(Config.File.LatestVersion, project)
       }
       // FORMAT: ON

--- a/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
+++ b/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
@@ -5,6 +5,7 @@ import _root_.mill.define._
 import _root_.mill.scalalib._
 import _root_.mill.eval.Evaluator
 import ammonite.ops._
+import bloop.config.Tag
 import bloop.config.util.ConfigUtil
 @deprecated("1.3.0", "See http://www.lihaoyi.com/mill/page/contrib-modules.html#bloop")
 object Bloop extends ExternalModule {
@@ -94,6 +95,7 @@ object Bloop extends ExternalModule {
 
     val classpath = T.task(transitiveClasspath(module)() ++ ivyDepsClasspath())
     val resources = T.task(module.resources().map(_.path.toNIO).toList)
+    val tags = module match { case _: TestModule => List(Tag.Test); case _ => List(Tag.Library) }
 
     val project = T.task {
       Config.Project(
@@ -113,7 +115,8 @@ object Bloop extends ExternalModule {
         sbt = None,
         test = testConfig(),
         platform = Some(platform()),
-        resolution = None
+        resolution = None,
+        tags = Some(tags)
       )
     }
 

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -3,7 +3,7 @@ package bloop.integrations.sbt
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 
-import bloop.config.Config
+import bloop.config.{Config, Tag}
 import bloop.config.util.ConfigUtil
 import bloop.integration.sbt.Feedback
 import sbt.{
@@ -866,6 +866,11 @@ object BloopDefaults {
     val hasConfigSettings = productDirectoriesUndeprecatedKey.?.value.isDefined
     val projectName = projectNameFromString(project.id, configuration, logger)
     val currentSbtUniverse = BloopKeys.bloopGlobalUniqueId.value
+    val tags = configuration match {
+      case IntegrationTest => List(Tag.IntegrationTest)
+      case Test => List(Tag.Test)
+      case _ => List(Tag.Library)
+    }
 
     lazy val generated = Option(targetNamesToConfigs.get(projectName))
     if (isMetaBuild && configuration == Test) inlinedTask[Option[File]](None)
@@ -1017,7 +1022,8 @@ object BloopDefaults {
 
             val sbt = None // Written by `postGenerate` instead
             val project = Config.Project(projectName, baseDirectory, Option(buildBaseDirectory.toPath), sources, None, None, dependenciesAndAggregates,
-              classpath, out, classesDir, resources, Some(`scala`), Some(java), sbt, Some(testOptions), Some(platform), resolution)
+              classpath, out, classesDir, resources, Some(`scala`), Some(java), sbt, Some(testOptions), Some(platform), resolution,
+              Some(tags))
             Config.File(Config.File.LatestVersion, project)
           }
           // format: ON


### PR DESCRIPTION
This field is used to add tags to the build target described by a given
configuration file. The tags of this target will then be exposed via the
`tags` property of BSP.

Currently, the existing integrations set the `test` tag for test
targets, and the `library` tag for all other targets.