### PR TITLE
Bump Hydra version for tests to 2.2.2

### DIFF
--- a/frontend/src/test/scala/bloop/HydraCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/HydraCompileSpec.scala
@@ -19,7 +19,7 @@ object HydraCompileSpec extends BaseCompileSpec {
   private val TriplequoteResolver = MavenRepository(
     "https://repo.triplequote.com/artifactory/libs-release/"
   )
-  private val HydraVersion = "2.2.1"
+  private val HydraVersion = "2.2.2"
 
   object HydraTestProject extends bloop.util.BaseTestProject {
     override protected def mkScalaInstance(

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/hydra-support/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/hydra-support/project/plugins.sbt
@@ -2,5 +2,5 @@ addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))
 
 resolvers += Resolver.url("Triplequote Plugins Releases",
   url("https://repo.triplequote.com/artifactory/sbt-plugins-release/"))(Resolver.ivyStylePatterns)
-addSbtPlugin("com.triplequote" % "sbt-hydra" % "2.2.1")
+addSbtPlugin("com.triplequote" % "sbt-hydra" % "2.2.2")
 


### PR DESCRIPTION
We had a regression in Hydra 2.2.1 and hence it's recommended to use Hydra 2.2.2
with Bloop.