### PR TITLE
Add buildTargets/jvmEnvironment endpoint

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -864,13 +864,10 @@ final class BloopBspServices(
   private def toBuildTargetId(project: Project): bsp.BuildTargetIdentifier =
     bsp.BuildTargetIdentifier(project.bspUri)
 
-  private def toJvmBuildTarget(project: Project): bsp.JvmBuildTarget = {
-    project.jdkConfig match {
-      case Some(jdk) =>
-        val javaHome = bsp.Uri(jdk.javaHome.toBspUri)
-        bsp.JvmBuildTarget(Some(javaHome), None)
-      case None =>
-        bsp.JvmBuildTarget(None, None)
+  private def toJvmBuildTarget(project: Project): Option[bsp.JvmBuildTarget] = {
+    project.jdkConfig.map { jdk =>
+      val javaHome = bsp.Uri(jdk.javaHome.toBspUri)
+      bsp.JvmBuildTarget(Some(javaHome), None)
     }
   }
 

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -2,6 +2,7 @@ package bloop.bsp
 
 import java.io.InputStream
 import java.net.URI
+import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.nio.file.{FileSystems, Files, Path}
@@ -863,6 +864,13 @@ final class BloopBspServices(
   private def toBuildTargetId(project: Project): bsp.BuildTargetIdentifier =
     bsp.BuildTargetIdentifier(project.bspUri)
 
+  private def toJvmBuildTarget(project: Project): bsp.JvmBuildTarget = {
+    val javaHome = Option(System.getProperty("java.home")).map(s => bsp.Uri(Paths.get(s).toUri))
+    val javaVersion = Option(System.getProperty("java.vm.specification.version"))
+
+    bsp.JvmBuildTarget(javaHome, javaVersion)
+  }
+
   def toScalaBuildTarget(project: Project, instance: ScalaInstance): bsp.ScalaBuildTarget = {
     def toBinaryScalaVersion(version: String): String = {
       version.split('.').take(2).mkString(".")
@@ -880,7 +888,8 @@ final class BloopBspServices(
       scalaVersion = instance.version,
       scalaBinaryVersion = toBinaryScalaVersion(instance.version),
       platform = platform,
-      jars = jars
+      jars = jars,
+      jvmBuildTarget = toJvmBuildTarget(project)
     )
   }
 

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -865,10 +865,13 @@ final class BloopBspServices(
     bsp.BuildTargetIdentifier(project.bspUri)
 
   private def toJvmBuildTarget(project: Project): bsp.JvmBuildTarget = {
-    val javaHome = Option(System.getProperty("java.home")).map(s => bsp.Uri(Paths.get(s).toUri))
-    val javaVersion = Option(System.getProperty("java.vm.specification.version"))
-
-    bsp.JvmBuildTarget(javaHome, javaVersion)
+    project.jdkConfig match {
+      case Some(jdk) =>
+        val javaHome = bsp.Uri(jdk.javaHome.toBspUri)
+        bsp.JvmBuildTarget(Some(javaHome), None)
+      case None =>
+        bsp.JvmBuildTarget(None, None)
+    }
   }
 
   def toScalaBuildTarget(project: Project, instance: ScalaInstance): bsp.ScalaBuildTarget = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val nailgunCommit = "a2520c1e"
 
   val zincVersion = "1.3.0-M4+32-b1accb96"
-  val bspVersion = "2.0.0-M7"
+  val bspVersion = "2.0.0-M7+6-d2366ddb-SNAPSHOT"
   val javaDebugVersion = "0.21.0+1-7f1080f1"
 
   val scalazVersion = "7.2.20"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val nailgunCommit = "a2520c1e"
 
   val zincVersion = "1.3.0-M4+32-b1accb96"
-  val bspVersion = "2.0.0-M7+6-d2366ddb-SNAPSHOT"
+  val bspVersion = "2.0.0-M8"
   val javaDebugVersion = "0.21.0+1-7f1080f1"
 
   val scalazVersion = "7.2.20"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val nailgunCommit = "a2520c1e"
 
   val zincVersion = "1.3.0-M4+32-b1accb96"
-  val bspVersion = "2.0.0-M8"
+  val bspVersion = "2.0.0-M9"
   val javaDebugVersion = "0.21.0+1-7f1080f1"
 
   val scalazVersion = "7.2.20"


### PR DESCRIPTION
Depends on https://github.com/build-server-protocol/build-server-protocol/pull/113
Just implements the new endpoint, to currently be exactly the same as jvmTestEnvironment.
Fills in new optional parameters javaHome and javaVersion, currently based on the jvm that bloop is running on. In future we may allow to customize it through Config.Project