### PR TITLE
Use correct working directory in BSP `buildTarget/jvmTestEnvironment`

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -699,7 +699,7 @@ final class BloopBspServices(
             dag = state.build.getDagFor(project)
             fullClasspath = project.fullClasspath(dag, state.client).map(_.toString)
             environmentVariables = state.commonOptions.env.toMap
-            workingDirectory = state.commonOptions.workingDirectory
+            workingDirectory = project.workingDirectory.toString
             javaOptions <- project.platform match {
               case Platform.Jvm(config, _, _) => Some(config.javaOptions.toList)
               case _ => None

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -107,7 +107,8 @@ class BspProtocolSpec(
       }
 
       val logger = new RecordingLogger(ansiCodesSupported = false)
-      val jvmOptions = List("-DSOME_OPTION=X")
+      val workingDirectory = AbsolutePath.workingDirectory.underlying.resolve("cwd")
+      val jvmOptions = List("-DSOME_OPTION=X", s"-Duser.dir=$workingDirectory")
       val jvmConfig = Some(Config.JvmConfig(None, jvmOptions))
       val `A` = TestProject(
         workspace,
@@ -127,7 +128,10 @@ class BspProtocolSpec(
           "BLOOP_OWNER",
           environmentItem.environmentVariables.keys.mkString("\n")
         )
-        assert(Paths.get(environmentItem.workingDirectory).getFileName.toString == "frontend")
+        assert(
+          Paths.get(environmentItem.workingDirectory).getFileName ==
+            workingDirectory.getFileName()
+        )
         assert(
           environmentItem.classpath
             .exists(_.contains(s"target" + File.separator + s"${`A`.config.name}"))


### PR DESCRIPTION
Previously, the JVM Test Environment request used
`state.commonOptions.workingDirectory` as the working directory,
resulting in IntelliJ using the incorrect working directory when
running tests for workspaces that configure the working directory via
`-Duser.dir=/path/to/cwd`. This commit fixes the issue so that
IntelliJ uses the correct working directory when running tests.