### PR TITLE
Update documentation for IntelliJ BSP integration.

### DIFF
--- a/docs/build-tools/overview.md
+++ b/docs/build-tools/overview.md
@@ -6,29 +6,38 @@ sidebar_label: Overview
 
 Bloop supports several build tools with varying degree of functionality.
 
-|                          | sbt        | Gradle   | Maven    | Mill       | Bazel | Pants | Fury |
-| ------------------------ | ---------- | -------- | -------- | ---------- | ----- | ----- | ---- |
-| **Build Export**         | ✅         | ✅        | ✅       | ✅         |  ❌    |   ✅ use [Metals fastpass](https://github.com/scalameta/metals) |    ✅   |
-| **Built-in Compile / Test / Run** | ✅ experimental  |          |          |            |       |       | ✅   |
+| Build tool |  **Build export**   | **Built-in Compile / Test / Run** |
+| ---------- | :-----------------: | :-------------------------------: |
+| sbt        |         ✅          |          ✅ experimental          |
+| Gradle     |         ✅          |                                   |
+| Maven      |         ✅          |                                   |
+| Mill       |         ✅          |                                   |
+| Bazel      |         ❌          |                                   |
+| Pants      | 🚧 work-in-progress |                                   |
+| Fury       |         ✅          |                                   |
 
 ## Build Export
 
-The most basic integration is **Build Export**. Build export is a task in your build tool that
-translates your build definitions to Bloop configuration files, which are used by Bloop to compile,
-test and run your Scala code. It provides all you need to get started with Bloop.
+The most basic integration is **Build Export**. Build export is a task in your
+build tool that translates your build definitions to Bloop configuration files,
+which are used by Bloop to compile, test and run your Scala code. It provides
+all you need to get started with Bloop.
 
-Exporting your build is supported by a large array of popular Scala and Java build tools. However,
-it's a tedious process that users must remember to run whenever their build changes (client
-integrations such as [Metals](https://metals.rocks) can export the build automatically, but that's
+Exporting your build is supported by a large array of popular Scala and Java
+build tools. However, it's a tedious process that users must remember to run
+whenever their build changes (client integrations such as
+[Metals](https://metals.rocks) can export the build automatically, but that's
 usually not the case if you're interfacing directly with the bloop CLI).
 
 ## Built-in compile, test and run
 
-**Built-in compile, test and run** is a richer build tool integration that swaps your build tool's
-implementation of `compile`, `test` and `run` by their implementation in Bloop. This integration
-relieves users from exporting the build (build export is automatic) and instead provides a
-transparent build tool integration users are unaware of.
+**Built-in compile, test and run** is a richer build tool integration that swaps
+your build tool's implementation of `compile`, `test` and `run` by their
+implementation in Bloop. This integration relieves users from exporting the
+build (build export is automatic) and instead provides a transparent build tool
+integration users are unaware of.
 
-Whereas built-in integrations are not fully developed yet, a built-in build tool integration for sbt
-is planned for the next release. These integrations will help users benefit from the speed and
-reliability of a more modern Scala toolchain with minimum interference in their current workflow.
+Whereas built-in integrations are not fully developed yet, a built-in build tool
+integration for sbt is planned for the next release. These integrations will
+help users benefit from the speed and reliability of a more modern Scala
+toolchain with minimum interference in their current workflow.

--- a/docs/ides/intellij.md
+++ b/docs/ides/intellij.md
@@ -4,16 +4,13 @@ title: IntelliJ
 sidebar_label: IntelliJ
 ---
 
-IntelliJ is the most popular Scala and Java IDE. It integrates with Bloop via a work-in-progress BSP
-integration with varying degree of functionality.
+IntelliJ is the most widely used Scala and Java IDE. The BSP support that comes
+included with the IntelliJ Scala plugin makes it possible to use Bloop together
+with IntelliJ.
 
-|                              | Build import | Compile        | Test                  | Run                  | Debug                 |
-| ---------------------------- | ------------ | -------------- | --------------------- | -------------------- | --------------------- |
-| **IntelliJ BSP**             | ✅           | ✅             | 🚧 use IntelliJ test | 🚧 use IntelliJ test | 🚧 use IntelliJ test |
-
-At the moment, the BSP integration only supports build import, compiler diagnostics and compilation
-on file save. This functionality is enough to benefit from a shorter and more accurate developer
-workflow. Support for test is planned.
+|                  | Build import | Compile | Test | Run | Debug |
+| ---------------- | :----------: | :-----: | :--: | :-: | :---: |
+| **IntelliJ BSP** |      ✅      |   ✅    |  ✅  | ✅  |  ✅   |
 
 ## Installation requirements
 
@@ -21,61 +18,133 @@ workflow. Support for test is planned.
 1. A build with at least one project in it
 1. You use a [build tool supported by Bloop](build-tools/overview.md)
 1. You have followed the [Installation Guide](/bloop/setup), which means:
-    * The build server is running in the background.
-    * The `bloop` CLI tool is installed in your machine.
-    * You have exported your build to Bloop.
+   - The build server is running in the background.
+   - The `bloop` CLI tool is installed in your machine.
+   - You have exported your build to Bloop.
 
-## Install the experimental bsp integration
+## Installation
 
-1. Install the latest [2018.3 EAP IntelliJ version](https://www.jetbrains.com/community/eap/)
-1. Enable the nightly of the Scala plugin in "Preferences | Languages & Frameworks | Scala | Updates".
-   ![](assets/intellij-nightly-plugin.png)
-1. Click on the "Check for Updates" button next to the "Plugin Update Channel".
-1. Accept IntelliJ's prompt to download and install the Scala nightly release.
-1. Reboot IntelliJ to reload the plugin. The Scala plugin **should now have version 2018.3.530** or higher.
-1. Open the "Find Action" search box (<kbd>Shift</kbd> + <kbd>Ctrl</kbd> + <kbd>A</kbd> or
-<kbd>Shift</kbd> + <kbd>Cmd</kbd> + <kbd>A</kbd>) and type "bsp". An option called "Enable
-experimental bsp support" will show up. Click on it.
+First, install the latest
+[2020.1 IntelliJ IDEA EAP](https://www.jetbrains.com/community/eap/). The 2020.1
+version includes several important fixes for the BSP integration that are not
+available in the 2019.3 version.
 
-The experimental BSP support has now been enabled.
+Next, install the IntelliJ Scala plugin and restart IntelliJ. If everything is
+configured correctly, the Scala plugin should appear under the list of
+"Downloaded" plugins when you open `Preferences > Plugins`.
 
-## Import project via bloop
+![Screenshot of the Plugins view showing the Scala plugin is installed](https://i.imgur.com/hBq2DcS.png)
 
-1. Click on "Import Project", select your project workspace and click OK. A window pops up with all
-   the supported import options. Pick "bsp" and click on "Next". ![](assets/intellij-bsp-import.png)
+At the time of this writing, the version of the Scala plugin is 2020.1.966.
 
-1. The next window shows you the bsp import settings.
-   ![](assets/intellij-bsp-configure.png)
+## Export a Bloop build
 
-   1. If you're a Mac OS/Windows users, find out the bloop binary location (`which bloop` in Mac OS
-   / `where bloop*` in Windows) and set it in the "Bloop executable" field of "Global settings".
-   1. If you want to "Build automatically on file save", check the box above "Project format".
+> Skip this step if you use sbt since it's handled automatically by IntelliJ.
 
-1. Click "Finish". IntelliJ will then load the project. At the end of the process, you should see:
-   ![](assets/intellij-imported-project.png)
+If you use any other build tool than sbt, you first need to export a Bloop build
+following the instructions for your build tool. For an overview of supported
+build tools, see [here](../build-tools/overview.md).
 
-🚀 Congratulations, your build is now imported! If "Build automatically on file save" is not
-enabled, you can trigger a bloop compilation by clicking on "Build | Build project" or its
-associated keystroke.
+## Create new BSP project
+
+After you have exported a Bloop build, run the
+`File > New > Project from existing sources` action to create a new IntelliJ
+project.
+
+![Screenshot of the "Project from existing sources" action](https://i.imgur.com/HBnTnXg.png)
+
+It's important to not use the "open or import" dialogue since it does not allow
+creating a BSP project.
+
+Select a directory that contains the exported Bloop build or root of your sbt
+build.
+
+Next, select "BSP" in the "Import project" dialogue.
+
+![Screenshot of the "Import project" dialogue](https://i.imgur.com/tkKzs7F.png)
+
+If everything works correctly, your window should look like this after the BSP
+import is complete.
+
+![Screenshot of IntelliJ UI after BSP import is complete](https://i.imgur.com/8fmdv0b.png)
+
+🚀 Congratulations, your build is now imported! If "Build automatically on file
+save" is not enabled, you can trigger a bloop compilation by clicking on "Build
+| Build project" or its associated keystroke.
+
+## Compile all projects
+
+Run the "Build project" action to compile all Bloop projects.
+
+![Screen recording showing "build project" in action](https://i.imgur.com/qW7bCc9.gif)
+
+Compile errors and warnings are displayed in the "Build output" view with
+clickable links to the source location.
+
+![Screenshot of a compile error with a clickable link](https://i.imgur.com/TnNxKlX.png)
+
+## Run tests
+
+Go to a test suite and click "Run 'TEST SUITE NAME'".
+
+![Screenshot showing 'Run TEST SUITE' dialogue](https://i.imgur.com/RBz6EyG.png)
+
+IntelliJ may prompt you to select the BSP target in case the source file belongs
+to multiple projects. Select the appropriate project if this prompt comes up. In
+most cases, IntelliJ is able to automatically choose the project.
+
+![Screenshot showing "Choose BSP target" prompt](https://i.imgur.com/8n9X5ZP.png)
+
+IntelliJ respects the working directory, system property and other runtime
+configuration from Bloop. Note that it's not possible manually configure these
+options through the "Edit configurations" window. For example, manual changes
+the working directory in a run configuration will be ignored.
+
+## Build on file save
+
+Enable the "build automatically on file save" option to trigger "build project"
+as soon as you save the file. First, open the BSP settings by opening the "bsp"
+panel on the right and click on the wrench icon.
+
+![Screenshot of the "BSP settings" wrench icon](https://i.imgur.com/QjXwA6o.png)
+
+Next, check the "build automatically on file save" box and select "Apply" to
+save the setting.
+
+![Screenshot of the "BSP" settings](https://i.imgur.com/XRwRvdM.png)
+
+This option is helpful to iterate quickly on changes across multiple files. By
+default, IntelliJ only shows compile errors in the file that you have open. With
+BSP "build automatically on file save", you can see errors in unopened files as
+soon as you save the file.
+
+## Refresh project
+
+Run the "Reimport all BSP projects" action to refresh the build. This step is
+for example needed when you make changes to `build.sbt` to add a new library
+dependency.
 
 ## Known limitations
 
-The IntelliJ BSP integration is work-in-progress and therefore has some well-known limitations.
+The IntelliJ BSP integration is work-in-progress and therefore has some
+well-known limitations.
 
-### Manual bloop export project
+### No sbt file support
 
-IntelliJ does not run `bloopInstall` whenever it detects a change in sbt build files like
-[Metals](build-tools/metals.md) does. Therefore, if you want to re-import your project the following
-two steps are required:
+Error highlighting, code completions and navigation don't work in `build.sbt`.
 
-1. Export your project to Bloop manually.
-1. Click on "Refresh project" as you would normally do to refresh your project.
+![Screenshot showing error highlighting in build.sbt](https://i.imgur.com/islEgDv.png)
 
-### Limited "Go to Definition" in external dependencies
+This functionality has not yet been implemented. There is no inherent limitation
+in Bloop or BSP that prevents this feature from becoming supported.
 
-"Go to Definition" in external dependencies only works in sbt projects when the [Download
-dependencies sources](build-tools/sbt.md#download-dependencies-sources) option is enabled.
-At the moment, this option is not supported in the rest of the supported build tools.
+### Two-step project refresh for non-sbt builds
 
-Note that this only navigation in external dependencies is affected. Navigating your project
-dependencies should work as expected.
+The "refresh all BSP projects" action does not re-export the Bloop build for
+non-sbt builds. If you are using Gradle, Maven or Mill you need to first trigger
+the Bloop export before running the "refresh all BSP projects" action.
+
+The upcoming version of Bloop supports a new `"refreshProjectsCommand"` option
+in the Bloop JSON configuration files that makes it possible to re-export the
+Bloop build from IntelliJ in one step. Contributions are welcome to implement
+this functionality for build tools like Maven, Gradle or Mill.

--- a/docs/ides/overview.md
+++ b/docs/ides/overview.md
@@ -4,19 +4,21 @@ title: Overview
 sidebar_label: Overview
 ---
 
-IDEs can use bloop to compile, test and run Scala code fast via the [Build Server Protocol
-(BSP)](https://github.com/scalacenter/bsp). The protocol allows clients to establish a long-lived
-build session to, for example, receive accurate compilation diagnostics in text editors and IDEs.
+IDEs can use bloop to compile, test and run Scala code fast via the
+[Build Server Protocol (BSP)](https://github.com/scalacenter/bsp). The protocol
+allows clients to establish a long-lived build session to, for example, receive
+accurate compilation diagnostics in text editors and IDEs.
 
 There are two main IDE integrations:
 
 1. [IntelliJ](ides/intellij.md), the most popular Scala and Java IDE.
 1. [Metals](ides/metals.md), a work-in-progress Scala language server that
-supports text editors such as Visual Studio Code, `vim`, Sublime Text and Atom.
+   supports text editors such as Visual Studio Code, `vim`, Sublime Text and
+   Atom.
 
 These IDE integrations support the following BSP actions:
 
-|                              | Build import | Compile        | Test                  | Run                  | Debug                 |
-| ---------------------------- | ------------ | -------------- | --------------------- | -------------------- | --------------------- |
-| **IntelliJ BSP**             | ✅           | ✅             | 🚧 use IntelliJ test | 🚧 use IntelliJ test | 🚧 use IntelliJ test |
-| **Metals**                   | ✅           | ✅             | ✅                   | ✅                   | ✅                   |
+|                  | Build import | Compile | Test | Run | Debug |
+| ---------------- | :----------: | :-----: | :--: | :-: | :---: |
+| **IntelliJ BSP** |      ✅      |   ✅    |  ✅  | ✅  |  ✅   |
+| **Metals**       |      ✅      |   ✅    |  ✅  | ✅  |  ✅   |


### PR DESCRIPTION
Previously, the old IntelliJ documentation mentioned 2018.3, which is an
old version. The new docs recommend IntelliJ 2020.1, which has a lot of
improvements to the BSP integration.