### PR TITLE
Remove unnecessary TraceContext creation for root span

### DIFF
--- a/backend/src/main/scala/bloop/tracing/BraveTracer.scala
+++ b/backend/src/main/scala/bloop/tracing/BraveTracer.scala
@@ -1,7 +1,9 @@
 package bloop.tracing
 
 import brave.{Span, Tracer}
+import brave.propagation.SamplingFlags
 import brave.propagation.TraceContext
+import brave.propagation.TraceContextOrSamplingFlags
 import monix.eval.Task
 import monix.execution.misc.NonFatal
 import scala.util.Failure
@@ -137,13 +139,7 @@ object BraveTracer {
       .map(c => tracer.newChild(c))
       .getOrElse(
         if (isDebugTrace) {
-          val c = TraceContext
-            .newBuilder()
-            .traceId(util.Random.nextLong())
-            .spanId(util.Random.nextLong())
-            .debug(true)
-            .build()
-          tracer.newChild(c)
+          tracer.nextSpan(TraceContextOrSamplingFlags.create(SamplingFlags.DEBUG))
         } else {
           tracer.newTrace()
         }


### PR DESCRIPTION
Currently, we manually create a root `TraceContext` in order to set the `debug` sampling flag. This change allows us to directly create a root span instead. What this means practically is that the root span will not have a `parentId` field, instead of the value it would have currently, which is not within the set of `spanId`s, causing certain validations to fail.