### PR TITLE
Fix build export installation step

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -9,22 +9,13 @@
         "title": "Gradle",
         "sidebar_label": "Gradle"
       },
-      "build-tools/gradle/export": {
-        "title": "build-tools/gradle/export"
-      },
       "build-tools/maven": {
         "title": "Maven",
         "sidebar_label": "Maven"
       },
-      "build-tools/maven/export": {
-        "title": "build-tools/maven/export"
-      },
       "build-tools/mill": {
         "title": "Mill",
         "sidebar_label": "Mill"
-      },
-      "build-tools/mill/export": {
-        "title": "build-tools/mill/export"
       },
       "build-tools/overview": {
         "title": "Overview",
@@ -33,17 +24,6 @@
       "build-tools/sbt": {
         "title": "sbt",
         "sidebar_label": "sbt"
-      },
-      "build-tools/sbt/export": {
-        "title": "build-tools/sbt/export"
-      },
-      "cli-reference": {
-        "title": "CLI --help",
-        "sidebar_label": "CLI --help"
-      },
-      "cli/cli-reference": {
-        "title": "CLI --help",
-        "sidebar_label": "CLI --help"
       },
       "cli/reference": {
         "title": "CLI --help",
@@ -124,12 +104,6 @@
       "tools/homebrew/usage": {
         "title": "tools/homebrew/usage"
       },
-      "tools/nix/install": {
-        "title": "tools/nix/install"
-      },
-      "tools/nix/usage": {
-        "title": "tools/nix/usage"
-      },
       "tools/scoop/install": {
         "title": "tools/scoop/install"
       },
@@ -141,13 +115,6 @@
       },
       "tools/universal/usage": {
         "title": "tools/universal/usage"
-      },
-      "usage-server": {
-        "title": "usage-server"
-      },
-      "usage": {
-        "title": "Quickstart",
-        "sidebar_label": "Quickstart"
       },
       "what-is-bloop": {
         "title": "What is Bloop",

--- a/website/pages/en/setup.js
+++ b/website/pages/en/setup.js
@@ -127,7 +127,7 @@ const ExportBuild = () => {
       <div className="tools-group-all">
         {showCase}
       </div>
-      <div className="step-hidden step-setup">
+      <div id="build-tools" className="step-hidden step-setup">
         {markdownsElement}
       </div>
     </div>

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -8,9 +8,10 @@ function findMarkDownSync(startPath) {
   files.forEach(val => {
     const fPath = path.join(startPath, val);
     const stats = fs.statSync(fPath);
-    if (stats.isDirectory()) {
+    if (stats.isDirectory() || path.extname(fPath).endsWith(".md")) {
+      const title = stats.isDirectory() ? val : path.basename(val, ".md");
       result.push({
-        title: val,
+        title: title,
         path: fPath,
       });
     }
@@ -48,7 +49,7 @@ toolsMD.forEach(tool => {
 
 const buildToolsMD = findMarkDownSync("../out/build-tools/");
 buildToolsMD.forEach(buildTool => {
-  buildTool.guide = loadBuildToolMD(`${buildTool.path}.md`);
+  buildTool.guide = loadBuildToolMD(buildTool.path);
 });
 
 const releaseTableMD = loadMD("../out/release-table.md")


### PR DESCRIPTION
The recent refactoring of the documentation (see #1209) moved the
installation instructions for every individual build tool supported, so
that the directory structure was different than the one for package
managers.

Unfortunately, this broke the JS which displays the installation step
(the documentation for every build tool was no longer found).

This commit restores the previous directory structure, which is
unfortunately not as flat.

Fixes #1220