### PR TITLE
Report test projects without test frameworks

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -644,7 +644,7 @@ final class BloopBspServices(
     ): Task[State] = {
       val testFilter = TestInternals.parseFilters(Nil) // Don't support test only for now
       val handler = new BspLoggingEventHandler(id, state.logger, client)
-      Tasks.test(state, List(project), Nil, testFilter, handler, false, mode = RunMode.Normal)
+      Tasks.test(state, List(project), Nil, testFilter, handler, mode = RunMode.Normal)
     }
 
     val originId = params.originId

--- a/frontend/src/main/scala/bloop/dap/DebuggeeRunner.scala
+++ b/frontend/src/main/scala/bloop/dap/DebuggeeRunner.scala
@@ -85,7 +85,6 @@ private final class TestSuiteDebugAdapter(
       Nil,
       filter,
       handler,
-      failIfNoTestFrameworks = true,
       runInParallel = false,
       mode = RunMode.Debug
     )

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -337,17 +337,17 @@ object Interpreter {
     if (lookup.missing.nonEmpty) Task.now(reportMissing(lookup.missing, state))
     else {
       // Projects to test != projects that need compiling
-      val userDefinedProjects = lookup.found
+      val userSelectedProjects = lookup.found
       val (projectsToCompile, projectsToTest) = {
         if (!cmd.cascade) {
           val projectsToTest = {
-            if (!cmd.includeDependencies) userDefinedProjects
-            else userDefinedProjects.flatMap(p => Dag.dfs(state.build.getDagFor(p)))
+            if (!cmd.includeDependencies) userSelectedProjects
+            else userSelectedProjects.flatMap(p => Dag.dfs(state.build.getDagFor(p)))
           }
 
-          (userDefinedProjects, projectsToTest)
+          (userSelectedProjects, projectsToTest)
         } else {
-          val result = Dag.inverseDependencies(state.build.dags, userDefinedProjects)
+          val result = Dag.inverseDependencies(state.build.dags, userSelectedProjects)
           (result.reduced, result.allCascaded)
         }
       }
@@ -365,8 +365,6 @@ object Interpreter {
             )(DebugFilter.Test)
 
             val handler = new LoggingEventHandler(state.logger)
-            val failIfNoFrameworks: Boolean =
-              userDefinedProjects.size == projectsToTest.size
 
             Tasks.test(
               state,
@@ -374,7 +372,6 @@ object Interpreter {
               cmd.args,
               testFilter,
               handler,
-              failIfNoFrameworks,
               cmd.parallel,
               RunMode.Normal
             )

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -90,7 +90,6 @@ object Tasks {
       userTestOptions: List[String],
       testFilter: String => Boolean,
       testEventHandler: TestSuiteEventHandler,
-      failIfNoTestFrameworks: Boolean,
       runInParallel: Boolean = false,
       mode: RunMode
   ): Task[State] = {
@@ -121,7 +120,6 @@ object Tasks {
         userTestOptions,
         testFilter,
         failureHandler,
-        failIfNoTestFrameworks,
         mode
       )
     }

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -46,9 +46,8 @@ object TestTask {
       mode: RunMode
   ): Task[Int] = {
     import state.logger
-    val isTestProject = project.tags.contains(Tag.Test) || project.tags.contains(
-      Tag.IntegrationTest
-    )
+    val isTestProject = project.tags.contains(Tag.Test) ||
+      project.tags.contains(Tag.IntegrationTest)
     def handleEmptyTestFrameworks: Task[Int] = {
       if (isTestProject) {
         logger.error(s"Missing configured test frameworks in ${project.name}")

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -1,7 +1,7 @@
 package bloop.engine.tasks
 
 import bloop.cli.ExitStatus
-import bloop.config.Config
+import bloop.config.{Config, Tag}
 import bloop.data.{Platform, Project}
 import bloop.engine.{Dag, Feedback, State}
 import bloop.engine.tasks.toolchains.ScalaJsToolchain
@@ -43,12 +43,14 @@ object TestTask {
       rawTestOptions: List[String],
       testFilter: String => Boolean,
       handler: LoggingEventHandler,
-      failIfNoTestFrameworks: Boolean,
       mode: RunMode
   ): Task[Int] = {
     import state.logger
+    val isTestProject = project.tags.contains(Tag.Test) || project.tags.contains(
+      Tag.IntegrationTest
+    )
     def handleEmptyTestFrameworks: Task[Int] = {
-      if (failIfNoTestFrameworks) {
+      if (isTestProject) {
         logger.error(s"Missing configured test frameworks in ${project.name}")
         Task.now(1)
       } else {
@@ -65,7 +67,7 @@ object TestTask {
         logger.warn(s"Skipping test for ${project.name} because compiler result is empty")
         Task.now(0)
       } else {
-        if (failIfNoTestFrameworks) {
+        if (isTestProject) {
           logger.error(s"Missing compilation to test ${project.name}")
           Task.now(1)
         } else {

--- a/frontend/src/test/resources/no-test-frameworks/build.sbt
+++ b/frontend/src/test/resources/no-test-frameworks/build.sbt
@@ -1,0 +1,2 @@
+bloopConfigDir in Global := baseDirectory.value / "bloop-config"
+val myProject = project.settings(testFrameworks := Nil)

--- a/frontend/src/test/resources/no-test-frameworks/myProject/src/main/scala/Main.scala
+++ b/frontend/src/test/resources/no-test-frameworks/myProject/src/main/scala/Main.scala
@@ -1,0 +1,1 @@
+class Main

--- a/frontend/src/test/resources/no-test-frameworks/myProject/src/test/scala/Test.scala
+++ b/frontend/src/test/resources/no-test-frameworks/myProject/src/test/scala/Test.scala
@@ -1,0 +1,1 @@
+class Test

--- a/frontend/src/test/resources/no-test-frameworks/project/build.properties
+++ b/frontend/src/test/resources/no-test-frameworks/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.2

--- a/frontend/src/test/resources/no-test-frameworks/project/plugins.sbt
+++ b/frontend/src/test/resources/no-test-frameworks/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop-build-shaded" % "1.0.0-SNAPSHOT")
+updateOptions := updateOptions.value.withLatestSnapshots(false)

--- a/frontend/src/test/resources/no-test-frameworks/project/project/build.properties
+++ b/frontend/src/test/resources/no-test-frameworks/project/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.2

--- a/frontend/src/test/scala/bloop/TestSpec.scala
+++ b/frontend/src/test/scala/bloop/TestSpec.scala
@@ -392,3 +392,25 @@ object JvmTestSpec extends BaseTestSpec("test-project-test", "cross-test-build-s
     }
   }
 }
+
+object NoTestFrameworksSpec extends ProjectBaseSuite("no-test-frameworks") {
+  testProject("must have frameworks in test project", runOnlyOnJava8 = false) { (build, logger) =>
+    val project = build.projectFor("myProject")
+    val testState = build.state.test(project)
+    try {
+      assert(!testState.status.isOk)
+      assert(logger.errors.contains("Missing configured test frameworks in myProject-test"))
+    } catch { case err: AssertionError => logger.dump(); throw err }
+  }
+
+  testProject("non-test projects can have empty frameworks", runOnlyOnJava8 = false) {
+    (rawBuild, logger) =>
+      val build = rawBuild.filterProjectsByName(!_.endsWith("-test"))
+      val project = build.projectFor("myProject")
+      val testState = build.state.test(project)
+      try {
+        assert(testState.status.isOk)
+        assert(logger.warnings.contains("Missing configured test frameworks in myProject"))
+      } catch { case err: AssertionError => logger.dump(); throw err }
+  }
+}

--- a/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
+++ b/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
@@ -45,6 +45,12 @@ trait BloopHelpers {
     def withLogger(logger: Logger): TestBuild = {
       TestBuild(state = state.withLogger(logger), projects)
     }
+    def filterProjectsByName(filter: String => Boolean): TestBuild = {
+      val newBuild = state.state.build
+        .copy(loadedProjects = state.state.build.loadedProjects.filter(p => filter(p.project.name)))
+      val newProjects = projects.filter(p => filter(p.config.name))
+      TestBuild(new TestState(state.state.copy(build = newBuild)), newProjects)
+    }
   }
 
   def populateWorkspace(build: TestBuild, projects: List[TestProject]): AbsolutePath = {


### PR DESCRIPTION
Bloop used to report an error when running the `test` task against a
project that has an empty list of configured test frameworks. This
behavior is not convenient for targets that do not have any test
framework configured, and for which Bloop cannot infer what project (if
any) is the test variant.

This commit changes the test task, so that an error is reported if it is
run against a project that has the test or integration-test tags, and
that has no test frameworks configured. When run against a project that
is not a test project, and that has no test frameworks configured, the
test task will report a warning indicating that no test frameworks were
found.