### PR TITLE
Make jvmTestEnvironment's classpath URI-formatted

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -697,7 +697,9 @@ final class BloopBspServices(
           val environmentEntries = for {
             (id, project) <- projects.toList
             dag = state.build.getDagFor(project)
-            fullClasspath = project.fullClasspath(dag, state.client).map(_.toString)
+            fullClasspath = project
+              .fullClasspath(dag, state.client)
+              .map(_.toBspUri.toString)
             environmentVariables = state.commonOptions.env.toMap
             workingDirectory = project.workingDirectory.toString
             javaOptions <- project.platform match {

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -1,6 +1,7 @@
 package bloop.bsp
 
 import java.io.File
+import java.net.URI
 
 import bloop.engine.State
 import bloop.config.Config
@@ -134,7 +135,10 @@ class BspProtocolSpec(
         )
         assert(
           environmentItem.classpath
-            .exists(_.contains(s"target" + File.separator + s"${`A`.config.name}"))
+            .exists(_.contains(s"target/${`A`.config.name}"))
+        )
+        assert(
+          environmentItem.classpath.forall(new URI(_).getScheme == "file")
         )
         assert(environmentItem.jvmOptions == jvmOptions)
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val nailgunCommit = "a2520c1e"
 
   val zincVersion = "1.3.0-M4+32-b1accb96"
-  val bspVersion = "2.0.0-M9"
+  val bspVersion = "2.0.0-M10"
   val javaDebugVersion = "0.21.0+1-7f1080f1"
 
   val scalazVersion = "7.2.20"


### PR DESCRIPTION
Previously jvmTestEnvironment was returning classpath containing
path-formatted items i.e `/home/user/lib`. Now they're URI-formatted
like `file:///home/user/lib`

It was specified in BSP 2.0.0-M10