### PR TITLE
Add Scala.js 1.0 support

### DIFF
--- a/bridges/scalajs-0.6/src/main/scala/bloop/scalajs/JsBridge.scala
+++ b/bridges/scalajs-0.6/src/main/scala/bloop/scalajs/JsBridge.scala
@@ -24,6 +24,7 @@ import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
 import org.scalajs.jsenv.nodejs.NodeJSEnv
 import org.scalajs.testadapter.TestAdapter
+import scala.concurrent.ExecutionContext
 
 object JsBridge {
   private class Logger(logger: BloopLogger) extends JsLogger {
@@ -57,7 +58,8 @@ object JsBridge {
       runMain: java.lang.Boolean,
       mainClass: Option[String],
       target: Path,
-      logger: BloopLogger
+      logger: BloopLogger,
+      executionContext: ExecutionContext
   ): Unit = {
     val classpathIrFiles = classpath
       .filter(Files.isDirectory(_))
@@ -113,7 +115,7 @@ object JsBridge {
       jsPath: Path,
       baseDirectory: Path,
       logger: BloopLogger,
-      jsdom: java.lang.Boolean,
+      jsConfig: JsConfig,
       env: Map[String, String]
   ): (List[sbt.testing.Framework], () => Unit) = {
     implicit val debugFilter: DebugFilter = DebugFilter.Test
@@ -129,7 +131,7 @@ object JsBridge {
     val fullEnv = Map("NODE_PATH" -> nodeModules) ++ env
 
     val nodeEnv = {
-      if (!jsdom) {
+      if (!jsConfig.jsdom.contains(true)) {
         new CustomNodeEnv(
           NodeJSEnv.Config().withEnv(fullEnv).withExecutable(nodePath),
           customScripts

--- a/bridges/scalajs-1.0/src/main/scala/bloop/scalajs/jsenv/NodeJsEnv.scala
+++ b/bridges/scalajs-1.0/src/main/scala/bloop/scalajs/jsenv/NodeJsEnv.scala
@@ -1,14 +1,17 @@
 package bloop.scalajs.jsenv
 
-import java.nio.file.Path
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, StandardCopyOption}
 
 import bloop.logging.{DebugFilter, Logger}
 import bloop.scalajs.jsenv
+import com.google.common.jimfs.Jimfs
 import com.zaxxer.nuprocess.NuProcessBuilder
 import monix.execution.atomic.AtomicBoolean
 import org.scalajs.jsenv.nodejs.NodeJSEnv.SourceMap
-import org.scalajs.io.{MemVirtualBinaryFile, VirtualBinaryFile}
-import org.scalajs.jsenv.nodejs.{BloopComRun, Support}
+import org.scalajs.jsenv.nodejs.BloopComRun
 import org.scalajs.jsenv.{
   ExternalJSRun,
   Input,
@@ -18,11 +21,13 @@ import org.scalajs.jsenv.{
   RunConfig,
   UnsupportedInputException
 }
+import org.scalajs.jsenv.JSUtils.escapeJS
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{Future, Promise}
 
-// Copy pasted verbatim from Scala.JS environments
+// Copy pasted verbatim from Scala.js source code, added withCwd()
+// Original file: scala-js/nodejs-env/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
 final class NodeJSConfig private (
     val executable: String,
     val args: List[String],
@@ -57,7 +62,7 @@ final class NodeJSConfig private (
 
   /** Forces enabling (true) or disabling (false) source maps. */
   def withSourceMap(sourceMap: Boolean): NodeJSConfig =
-    withSourceMap(if (sourceMap) SourceMap.Enable else SourceMap.Disable)
+    withSourceMap(if (sourceMap) SourceMap.EnableIfAvailable else SourceMap.Disable)
 
   private def copy(
       executable: String = executable,
@@ -93,72 +98,171 @@ object NodeJSConfig {
  */
 final class NodeJSEnv(logger: Logger, config: NodeJSConfig) extends JSEnv {
   override val name: String = "Node.js"
-  private val env: Map[String, String] = Map("NODE_MODULE_CONTEXTS" -> "0") ++ config.env
+  private def env: Map[String, String] = Map("NODE_MODULE_CONTEXTS" -> "0") ++ config.env
 
-  def start(input: Input, runConfig: RunConfig): JSRun = {
+  def start(input: Seq[Input], runConfig: RunConfig): JSRun = {
     NodeJSEnv.validator.validate(runConfig)
-    NodeJSEnv.internalStart(logger, config, env)(initFiles ++ inputFiles(input), runConfig)
+    validateInput(input)
+    internalStart(initFiles ++ input, runConfig)
   }
 
-  def startWithCom(input: Input, runConfig: RunConfig, onMessage: String => Unit): JSComRun = {
+  def startWithCom(input: Seq[Input], runConfig: RunConfig, onMessage: String => Unit): JSComRun = {
     NodeJSEnv.validator.validate(runConfig)
+    validateInput(input)
     BloopComRun.start(runConfig, onMessage) { comLoader =>
-      val files = initFiles ::: (comLoader :: inputFiles(input))
-      NodeJSEnv.internalStart(logger, config, env)(files, runConfig)
+      internalStart(initFiles ++ (Input.Script(comLoader) +: input), runConfig)
     }
   }
 
-  private def initFiles: List[VirtualBinaryFile] = {
-    val base = List(NodeJSEnv.runtimeEnv, Support.fixPercentConsole)
-    config.sourceMap match {
-      case SourceMap.Disable => base
-      case SourceMap.EnableIfAvailable => NodeJSEnv.installSourceMapIfAvailable :: base
-      case SourceMap.Enable => NodeJSEnv.installSourceMap :: base
-    }
+  private def validateInput(input: Seq[Input]): Unit = input.foreach {
+    case _: Input.Script | _: Input.ESModule | _: Input.CommonJSModule =>
+    // ok
+    case _ =>
+      throw new UnsupportedInputException(input)
   }
 
-  private def inputFiles(input: Input) = input match {
-    case Input.ScriptsToLoad(scripts) => scripts
-    case _ => throw new UnsupportedInputException(input)
+  private def internalStart(input: Seq[Input], runConfig: RunConfig): JSRun = {
+    NodeJSEnv.internalStart(logger, config, env)(NodeJSEnv.write(input), runConfig)
+  }
+
+  import NodeJSEnv.installSourceMap
+  import NodeJSEnv.installSourceMapIfAvailable
+
+  private def initFiles: Seq[Input] = config.sourceMap match {
+    case SourceMap.Disable => Nil
+    case SourceMap.EnableIfAvailable => Input.Script(installSourceMapIfAvailable) :: Nil
+    case SourceMap.Enable => Input.Script(installSourceMap) :: Nil
   }
 }
 
 object NodeJSEnv {
+  private lazy val fs = Jimfs.newFileSystem()
   implicit val debugFilter: DebugFilter = DebugFilter.Test
   private lazy val validator = ExternalJSRun.supports(RunConfig.Validator())
 
-  private lazy val installSourceMapIfAvailable: MemVirtualBinaryFile = {
-    MemVirtualBinaryFile.fromStringUTF8(
-      "sourceMapSupport.js",
+  private lazy val installSourceMapIfAvailable = {
+    Files.write(
+      fs.getPath("optionalSourceMapSupport.js"),
       """
         |try {
         |  require('source-map-support').install();
         |} catch (e) {
         |};
-      """.stripMargin
+        """.stripMargin.getBytes(StandardCharsets.UTF_8)
     )
   }
 
-  private lazy val installSourceMap: MemVirtualBinaryFile = {
-    MemVirtualBinaryFile.fromStringUTF8(
-      "sourceMapSupport.js",
-      "require('source-map-support').install();"
+  private lazy val installSourceMap = {
+    Files.write(
+      fs.getPath("sourceMapSupport.js"),
+      "require('source-map-support').install();".getBytes(StandardCharsets.UTF_8)
     )
   }
 
-  private[jsenv] lazy val runtimeEnv: MemVirtualBinaryFile = {
-    MemVirtualBinaryFile.fromStringUTF8(
-      "scalaJSEnvInfo.js",
-      """
-        |__ScalaJSEnv = {
-        |  exitFunction: function(status) { process.exit(status); }
-        |};
-      """.stripMargin
-    )
+  private[jsenv] def write(input: Seq[Input])(out: ByteBuffer): Unit = {
+    def runScript(path: Path): String = {
+      try {
+        val f = path.toFile
+        val pathJS = "\"" + escapeJS(f.getAbsolutePath) + "\""
+        s"""
+          require('vm').runInThisContext(
+            require('fs').readFileSync($pathJS, { encoding: "utf-8" }),
+            { filename: $pathJS, displayErrors: true }
+          )
+        """
+      } catch {
+        case _: UnsupportedOperationException =>
+          val code = new String(Files.readAllBytes(path), StandardCharsets.UTF_8)
+          val codeJS = "\"" + escapeJS(code) + "\""
+          val pathJS = "\"" + escapeJS(path.toString) + "\""
+          s"""
+            require('vm').runInThisContext(
+              $codeJS,
+              { filename: $pathJS, displayErrors: true }
+            )
+          """
+      }
+    }
+
+    def requireCommonJSModule(module: Path): String =
+      s"""require("${escapeJS(toFile(module).getAbsolutePath)}")"""
+
+    def importESModule(module: Path): String =
+      s"""import("${escapeJS(toFile(module).toURI.toASCIIString)}")"""
+
+    def execInputExpr(input: Input): String = input match {
+      case Input.Script(script) => runScript(script)
+      case Input.CommonJSModule(module) => requireCommonJSModule(module)
+      case Input.ESModule(module) => importESModule(module)
+    }
+
+    def println(str: String): Unit = {
+      out.put((str + "\n").getBytes("UTF-8"))
+      ()
+    }
+
+    try {
+      if (!input.exists(_.isInstanceOf[Input.ESModule])) {
+        /* If there is no ES module in the input, we can do everything
+         * synchronously, and directly on the standard input.
+         */
+        for (item <- input)
+          println(execInputExpr(item) + ";")
+      } else {
+        /* If there is at least one ES module, we must asynchronous chain things,
+         * and we must use an actual file to feed code to Node.js (because
+         * `import()` cannot be used from the standard input).
+         */
+        val importChain = input.foldLeft("Promise.resolve()") { (prev, item) =>
+          s"$prev.\n  then(${execInputExpr(item)})"
+        }
+        val importerFileContent = {
+          s"""
+             |$importChain.catch(e => {
+             |  console.error(e);
+             |  process.exit(1);
+             |});
+          """.stripMargin
+        }
+        val f = createTmpFile("importer.js")
+        Files.write(f.toPath, importerFileContent.getBytes(StandardCharsets.UTF_8))
+        println(s"""require("${escapeJS(f.getAbsolutePath)}");""")
+      }
+    } finally {
+      out.flip()
+      ()
+    }
+  }
+
+  private def toFile(path: Path): File = {
+    try {
+      path.toFile
+    } catch {
+      case _: UnsupportedOperationException =>
+        val f = createTmpFile(path.toString)
+        Files.copy(path, f.toPath, StandardCopyOption.REPLACE_EXISTING)
+        f
+    }
+  }
+
+  // tmpSuffixRE and createTmpFile copied from HTMLRunnerBuilder.scala
+
+  private val tmpSuffixRE = """[a-zA-Z0-9-_.]*$""".r
+
+  private def createTmpFile(path: String): File = {
+    /* - createTempFile requires a prefix of at least 3 chars
+     * - we use a safe part of the path as suffix so the extension stays (some
+     *   browsers need that) and there is a clue which file it came from.
+     */
+    val suffix = tmpSuffixRE.findFirstIn(path).orNull
+
+    val f = File.createTempFile("tmp-", suffix)
+    f.deleteOnExit()
+    f
   }
 
   def internalStart(logger: Logger, config: NodeJSConfig, env: Map[String, String])(
-      files: List[VirtualBinaryFile],
+      write: ByteBuffer => Unit,
       runConfig: RunConfig
   ): JSRun = {
     val command = config.executable :: config.args
@@ -168,7 +272,7 @@ object NodeJSEnv {
 
     val executionPromise = Promise[Unit]()
     val builder = new NuProcessBuilder(command.asJava, env.asJava)
-    val handler = new NodeJsHandler(logger, executionPromise, files)
+    val handler = new NodeJsHandler(logger, executionPromise, write)
     builder.setProcessListener(handler)
     config.cwd.foreach(builder.setCwd)
 

--- a/bridges/scalajs-1.0/src/test/scala/bloop/scalajs/ScalaJsToolchainSpec.scala
+++ b/bridges/scalajs-1.0/src/test/scala/bloop/scalajs/ScalaJsToolchainSpec.scala
@@ -51,7 +51,7 @@ class ScalaJsToolchainSpec {
     val resultingState = TestUtil.blockingExecute(action, state, maxDuration * 2)
 
     assertTrue(s"Linking failed: ${logger.getMessages.mkString("\n")}", resultingState.status.isOk)
-    logger.getMessages.assertContain("Inc. optimizer: Batch mode: true", atLevel = "debug")
+    logger.getMessages.assertContain("Optimizer: Batch mode: true", atLevel = "debug")
   }
 
   @Test def canRunScalaJsProject(): Unit = {

--- a/build.sbt
+++ b/build.sbt
@@ -683,7 +683,6 @@ lazy val jsBridge10 = project
     libraryDependencies ++= List(
       Dependencies.scalaJsLinker10,
       Dependencies.scalaJsLogging10,
-      Dependencies.scalaJsIO10,
       Dependencies.scalaJsEnvs10,
       Dependencies.scalaJsEnvNode10,
       Dependencies.scalaJsEnvJsdomNode10,

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -235,6 +235,8 @@ object Project {
         }
       }
 
+    var classpathAdditions = List[Path]()
+
     val setup = project.`scala`.flatMap(_.setup).getOrElse(Config.CompileSetup.empty)
     val compileClasspath = project.classpath.map(AbsolutePath.apply)
     val compileResources = project.resources.toList.flatten.map(AbsolutePath.apply)
@@ -255,6 +257,7 @@ object Project {
         )
       case Some(platform: Config.Platform.Js) =>
         val toolchain = Try(ScalaJsToolchain.resolveToolchain(platform, logger)).toOption
+        classpathAdditions = ScalaJsToolchain.resolveTestArtifacts(platform, logger)
         Platform.Js(platform.config, toolchain, platform.mainClass)
       case Some(platform: Config.Platform.Native) =>
         val toolchain = Try(ScalaNativeToolchain.resolveToolchain(platform, logger)).toOption
@@ -280,7 +283,7 @@ object Project {
       project.workspaceDir.map(AbsolutePath.apply),
       project.dependencies,
       instance,
-      compileClasspath,
+      compileClasspath ++ classpathAdditions.map(AbsolutePath.apply),
       compileResources,
       setup,
       AbsolutePath(project.classesDir),

--- a/frontend/src/main/scala/bloop/engine/tasks/LinkTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/LinkTask.scala
@@ -5,7 +5,7 @@ import bloop.cli.{ExitStatus, OptimizerConfig}
 import bloop.config.Config
 import bloop.data.{Platform, Project}
 import bloop.engine.tasks.toolchains.{ScalaJsToolchain, ScalaNativeToolchain}
-import bloop.engine.{Feedback, State}
+import bloop.engine.{ExecutionContext, Feedback, State}
 import bloop.io.AbsolutePath
 import monix.eval.Task
 
@@ -28,7 +28,9 @@ object LinkTask {
             val fullClasspath = project.fullRuntimeClasspath(dag, state.client).map(_.underlying)
             val config = config0.copy(mode = getOptimizerMode(cmd.optimize, config0.mode))
             toolchain
-              .link(config, project, fullClasspath, true, Some(mainClass), target, state.logger)
+              .link(config, project, fullClasspath, true, Some(mainClass), target, state.logger)(
+                ExecutionContext.ioScheduler
+              )
               .map {
                 case scala.util.Success(_) =>
                   state.withInfo(s"Generated JavaScript file '${target.syntax}'")

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -173,29 +173,30 @@ object TestTask {
         toolchain match {
           case Some(toolchain) =>
             val dag = state.build.getDagFor(project)
-            val fullClasspath =
-              project.fullRuntimeClasspath(dag, state.client).map(_.underlying)
-            toolchain
-              .link(config, project, fullClasspath, false, userMainClass, target, state.logger)(
-                ExecutionContext.ioScheduler
-              )
-              .map {
-                case Success(_) =>
-                  logger.info(s"Generated JavaScript file '${target.syntax}'")
-                  val fnames = project.testFrameworks.map(_.names)
-                  logger.debug(s"Resolving test frameworks: $fnames")
-                  val baseDir = project.baseDirectory
-                  val env = state.commonOptions.env.toMap
-                  Some(
-                    toolchain.discoverTestFrameworks(project, fnames, target, logger, config, env)
-                  )
+            val fullClasspath = project.fullRuntimeClasspath(dag, state.client).map(_.underlying)
 
-                case Failure(ex) =>
-                  ex.printStackTrace()
-                  logger.trace(ex)
-                  logger.error(s"JavaScript linking failed with '${ex.getMessage}'")
-                  None
-              }
+            // Pass in the default scheduler used by this task to the linker
+            Task.deferAction { s =>
+              toolchain
+                .link(config, project, fullClasspath, false, userMainClass, target, s, logger)
+                .map {
+                  case Success(_) =>
+                    logger.info(s"Generated JavaScript file '${target.syntax}'")
+                    val fnames = project.testFrameworks.map(_.names)
+                    logger.debug(s"Resolving test frameworks: $fnames")
+                    val baseDir = project.baseDirectory
+                    val env = state.commonOptions.env.toMap
+                    Some(
+                      toolchain.discoverTestFrameworks(project, fnames, target, logger, config, env)
+                    )
+
+                  case Failure(ex) =>
+                    ex.printStackTrace()
+                    logger.trace(ex)
+                    logger.error(s"JavaScript linking failed with '${ex.getMessage}'")
+                    None
+                }
+            }
 
           case None =>
             val artifactName = ScalaJsToolchain.artifactNameFrom(config.version)

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -3,7 +3,7 @@ package bloop.engine.tasks
 import bloop.cli.ExitStatus
 import bloop.config.{Config, Tag}
 import bloop.data.{Platform, Project}
-import bloop.engine.{Dag, Feedback, State}
+import bloop.engine.{Dag, ExecutionContext, Feedback, State}
 import bloop.engine.tasks.toolchains.ScalaJsToolchain
 import bloop.exec.{Forker, JvmProcessForker}
 import bloop.io.AbsolutePath
@@ -176,7 +176,9 @@ object TestTask {
             val fullClasspath =
               project.fullRuntimeClasspath(dag, state.client).map(_.underlying)
             toolchain
-              .link(config, project, fullClasspath, false, userMainClass, target, state.logger)
+              .link(config, project, fullClasspath, false, userMainClass, target, state.logger)(
+                ExecutionContext.ioScheduler
+              )
               .map {
                 case Success(_) =>
                   logger.info(s"Generated JavaScript file '${target.syntax}'")

--- a/frontend/src/main/scala/bloop/engine/tasks/toolchains/ScalaNativeToolchain.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/toolchains/ScalaNativeToolchain.scala
@@ -82,7 +82,7 @@ object ScalaNativeToolchain extends ToolchainCompanion[ScalaNativeToolchain] {
       DependencyResolution.Artifact("org.scala-native", s"tools_$scalaVersion", platformVersion)
     )
 
-    Some(PlatformData(artifacts, List(), platform.config.toolchain))
+    Some(PlatformData(artifacts, platform.config.toolchain))
   }
 
   def linkTargetFrom(project: Project, config: NativeConfig): AbsolutePath = {

--- a/frontend/src/main/scala/bloop/engine/tasks/toolchains/ScalaNativeToolchain.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/toolchains/ScalaNativeToolchain.scala
@@ -82,7 +82,7 @@ object ScalaNativeToolchain extends ToolchainCompanion[ScalaNativeToolchain] {
       DependencyResolution.Artifact("org.scala-native", s"tools_$scalaVersion", platformVersion)
     )
 
-    Some(PlatformData(artifacts, platform.config.toolchain))
+    Some(PlatformData(artifacts, List(), platform.config.toolchain))
   }
 
   def linkTargetFrom(project: Project, config: NativeConfig): AbsolutePath = {

--- a/frontend/src/test/resources/cross-test-build-scalajs-1.0/build.sbt
+++ b/frontend/src/test/resources/cross-test-build-scalajs-1.0/build.sbt
@@ -7,9 +7,9 @@ lazy val `test-project` =
     .settings(
       name := "test-project",
       // %%% now include Scala Native. It applies to all selected platforms
-      scalaVersion := "2.12.6",
+      scalaVersion := "2.13.1",
       libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test,
-      libraryDependencies += "com.lihaoyi" %%% "utest" % "0.6.6" % Test,
+      libraryDependencies += "com.lihaoyi" %%% "utest" % "0.7.4" % Test,
       testFrameworks += new TestFramework("utest.runner.Framework"),
       testOptions in Test ++= Seq(
         Tests.Exclude("hello.WritingTest" :: Nil),
@@ -20,15 +20,14 @@ lazy val `test-project` =
     )
     .jsConfigure(
       _.enablePlugins(ScalaJSJUnitPlugin).settings(
-        // Make `%%%` whenever there is a version that supports 1.0.0-M5
-        libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % Test,
-        libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.0" % Test,
-        libraryDependencies += "org.specs2" %% "specs2-core" % "4.7.0" % Test
+        libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.1" % Test,
+        libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.14.3" % Test,
+        libraryDependencies += "org.specs2" %%% "specs2-core" % "4.9.2" % Test
       ))
     .jvmSettings(
-      libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.4" % Test,
-      libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.0" % Test,
-      libraryDependencies += "org.specs2" %% "specs2-core" % "4.7.0" % Test,
+      libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.1" % Test,
+      libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.3" % Test,
+      libraryDependencies += "org.specs2" %% "specs2-core" % "4.9.2" % Test,
     )
 
 lazy val `test-project-js` = `test-project`.js

--- a/frontend/src/test/resources/cross-test-build-scalajs-1.0/project/plugins.sbt
+++ b/frontend/src/test/resources/cross-test-build-scalajs-1.0/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0-M5")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.1")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop-build-shaded" % "1.0.0-SNAPSHOT")
 updateOptions := updateOptions.value.withLatestSnapshots(false)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,8 +43,8 @@ object Dependencies {
   val shapelessVersion = "2.3.3-lower-priority-coproduct"
   val scalaNative03Version = "0.3.9"
   val scalaNative04Version = "0.4.0-M2"
-  val scalaJs06Version = "0.6.28"
-  val scalaJs10Version = "1.0.0-M5"
+  val scalaJs06Version = "0.6.32"
+  val scalaJs10Version = "1.0.1"
   val millVersion = "0.3.6"
   val xxHashVersion = "1.3.0"
   val ztVersion = "1.13"
@@ -118,10 +118,9 @@ object Dependencies {
   val scalaJsEnvs06 = "org.scala-js" %% "scalajs-js-envs" % scalaJs06Version % Provided
 
   val scalaJsLinker10 = "org.scala-js" %% "scalajs-linker" % scalaJs10Version % Provided
-  val scalaJsIO10 = "org.scala-js" %% "scalajs-io" % scalaJs10Version % Provided
   val scalaJsEnvs10 = "org.scala-js" %% "scalajs-js-envs" % scalaJs10Version % Provided
   val scalaJsEnvNode10 = "org.scala-js" %% "scalajs-env-nodejs" % scalaJs10Version % Provided
-  val scalaJsEnvJsdomNode10 = "org.scala-js" %% "scalajs-env-jsdom-nodejs" % scalaJs10Version % Provided
+  val scalaJsEnvJsdomNode10 = "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.0.0" % Provided
   val scalaJsSbtTestAdapter10 = "org.scala-js" %% "scalajs-sbt-test-adapter" % scalaJs10Version % Provided
   val scalaJsLogging10 = "org.scala-js" %% "scalajs-logging" % scalaJs10Version % Provided
 


### PR DESCRIPTION
This pull request adds partial support for Scala.js 1.0. Linking works already, but I am getting this stack trace when running tests from Bloop:

```shell
$ bloop test pine-js
[E] Referring to non-existent class org.scalajs.testing.bridge.Bridge
[E]   called from core module module initializers
[E] Referring to non-existent method static org.scalajs.testing.bridge.Bridge.start()void
[E]   called from core module module initializers
org.scalajs.linker.interface.LinkingException: There were linking errors
	at org.scalajs.linker.frontend.BaseLinker.reportErrors$1(BaseLinker.scala:97)
	at org.scalajs.linker.frontend.BaseLinker.$anonfun$analyze$5(BaseLinker.scala:106)
	at scala.util.Success.$anonfun$map$1(Try.scala:255)
	at scala.util.Success.map(Try.scala:213)
	at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
	at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
	at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
[E] JavaScript linking failed with 'There were linking errors'
[W] Missing configured test frameworks in pine-js-test
===============================================
Total duration: 0ms
No test suites were run.
===============================================
```

Also, after upgrading the dependencies in `cross-test-build-scalajs-1.0`, I am now getting this error:

```
sbt:cross-test-build-scalajs-1-0> test-projectJS/test
[info] Compiling 1 Scala source to /home/tim/dev/bloop/frontend/src/test/resources/cross-test-build-scalajs-1.0/test-project/js/target/scala-2.13/test-classes ...
[info] Fast optimizing /home/tim/dev/bloop/frontend/src/test/resources/cross-test-build-scalajs-1.0/test-project/js/target/scala-2.13/test-project-test-fastopt.js
[error] Referring to non-existent class org.specs2.Specification
[error]   called from hello.Specs2Test
[error]   called from core module analyzer
[error] Referring to non-existent class org.specs2.Specification
[error]   called from constructor hello.Specs2Test.<init>()void
[error]   called from static constructor hello.Specs2Test.<clinit>()void
[error]   called from core module analyzer
[error] Referring to non-existent method constructor org.specs2.Specification.<init>()void
[error]   called from constructor hello.Specs2Test.<init>()void
[error]   called from static constructor hello.Specs2Test.<clinit>()void
[error]   called from core module analyzer
[error] There were linking errors
[error] (test-projectJS / Test / fastOptJS) There were linking errors
[error] Total time: 1 s, completed Apr 3, 2020 9:16:14 PM
```

When I comment out the Specs2 test, all remaining tests run successfully.

_Edit:_ Both issues have been resolved.