### PR TITLE
Increase default stack size.

### DIFF
--- a/bloopgun/src/main/scala/bloop/bloopgun/util/Environment.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/util/Environment.scala
@@ -87,7 +87,7 @@ object Environment {
 
   // TODO: Add more options to better tweak GC based on benchmarks
   val PerformanceSensitiveOptsForBloop = List(
-    "-Xss1m",
+    "-Xss4m",
     "-XX:MaxInlineLevel=20", // Specific option for faster C2, ignored by GraalVM
     "-XX:+UseParallelGC" // Full parallel GC is the best choice for Scala compilation
   )


### PR DESCRIPTION
This commit increases the default stack size from 1m to 4m to overcome a
StackOverflowException that we hit on while compiling a Java codebase
using the Lombok annotation processor.