### PR TITLE
Remove work-in-progress in relation to Metals

### DIFF
--- a/docs/ides/overview.md
+++ b/docs/ides/overview.md
@@ -12,7 +12,7 @@ accurate compilation diagnostics in text editors and IDEs.
 There are two main IDE integrations:
 
 1. [IntelliJ](ides/intellij.md), the most popular Scala and Java IDE.
-1. [Metals](ides/metals.md), a work-in-progress Scala language server that
+1. [Metals](ides/metals.md), a Scala language server that
    supports text editors such as Visual Studio Code, `vim`, Sublime Text and
    Atom.
 


### PR DESCRIPTION
A while back we made an explicit choice to remove the "work in progress" that we had labeled Metals as across the project. Would it be possible to remove that from here as well to match the documentation across metals and avoid the assumption that Metals is still experimental?

https://github.com/scalameta/metals/blob/f60048577e5da4e442af95f397273f7cac32ce37/website/blog/2019-06-28-thorium.md#no-more-work-in-progress