### PR TITLE
Implement jvmRunEnvironment endpoint

### DIFF
--- a/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
@@ -62,7 +62,8 @@ class BspCompileSpec(
           |      "dependencySourcesProvider" : true,
           |      "resourcesProvider" : true,
           |      "buildTargetChangedProvider" : false,
-          |      "jvmTestEnvironmentProvider" : true
+          |      "jvmTestEnvironmentProvider" : true,
+          |      "jvmRunEnvironmentProvider" : true
           |    },
           |    "data" : null
           |  },

--- a/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
@@ -117,7 +117,8 @@ class BspConnectionSpec(
           |      "dependencySourcesProvider" : true,
           |      "resourcesProvider" : true,
           |      "buildTargetChangedProvider" : false,
-          |      "jvmTestEnvironmentProvider" : true
+          |      "jvmTestEnvironmentProvider" : true,
+          |      "jvmRunEnvironmentProvider" : true
           |    },
           |    "data" : null
           |  },

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -14,10 +14,9 @@ import java.nio.file.{Files, Path, Paths}
 import java.util.stream.Collectors
 
 import scala.collection.JavaConverters._
-import ch.epfl.scala.bsp.ScalacOptionsItem
+import ch.epfl.scala.bsp.{JvmEnvironmentItem, ScalacOptionsItem, Uri}
 import bloop.bsp.BloopBspDefinitions.BloopExtraBuildParams
 import io.circe.Json
-import ch.epfl.scala.bsp.Uri
 import bloop.testing.DiffAssertions.TestFailedException
 import bloop.data.SourcesGlobs
 
@@ -98,50 +97,84 @@ class BspProtocolSpec(
     }
   }
 
-  test("check the correct contents of jvm test environment") {
-    TestUtil.withinWorkspace { workspace =>
-      object Sources {
-        val `A.scala` =
-          """/A.scala
-            |object A
+  private def testEnivronmentFetching(
+      workspace: AbsolutePath,
+      extractor: (ManagedBspTestState, TestProject) => (
+          ManagedBspTestState,
+          List[JvmEnvironmentItem]
+      )
+  ) = {
+    object Sources {
+      val `A.scala` =
+        """/A.scala
+          |object A
           """.stripMargin
-      }
+    }
 
-      val logger = new RecordingLogger(ansiCodesSupported = false)
-      val workingDirectory = AbsolutePath.workingDirectory.underlying.resolve("cwd")
-      val jvmOptions = List("-DSOME_OPTION=X", s"-Duser.dir=$workingDirectory")
-      val jvmConfig = Some(Config.JvmConfig(None, jvmOptions))
-      val `A` = TestProject(
-        workspace,
-        "a",
-        List(Sources.`A.scala`),
-        jvmConfig = jvmConfig
+    val logger = new RecordingLogger(ansiCodesSupported = false)
+    val workingDirectory = AbsolutePath.workingDirectory.underlying.resolve("cwd")
+    val jvmOptions = List("-DSOME_OPTION=X", s"-Duser.dir=$workingDirectory")
+    val jvmConfig = Some(Config.JvmConfig(None, jvmOptions))
+    val `A` = TestProject(
+      workspace,
+      "a",
+      List(Sources.`A.scala`),
+      jvmConfig = jvmConfig
+    )
+
+    val projects = List(`A`)
+
+    loadBspState(workspace, projects, logger) { state =>
+      val (stateA: ManagedBspTestState, environmentItems: List[JvmEnvironmentItem]) =
+        extractor(state, `A`)
+      assert(environmentItems.size == 1)
+      assert(stateA.status == ExitStatus.Ok)
+
+      val environmentItem = environmentItems.head
+      assert(environmentItem.environmentVariables.contains("BLOOP_OWNER"))
+      assertNoDiff(
+        "BLOOP_OWNER",
+        environmentItem.environmentVariables.keys.mkString("\n")
+      )
+      assert(
+        Paths.get(environmentItem.workingDirectory).getFileName ==
+          workingDirectory.getFileName()
+      )
+      assert(
+        environmentItem.classpath
+          .exists(_.contains(s"target/${`A`.config.name}"))
+      )
+      assert(
+        environmentItem.classpath.forall(new URI(_).getScheme == "file")
       )
 
-      val projects = List(`A`)
-      loadBspState(workspace, projects, logger) { state =>
-        val (stateA, result) = state.jvmTestEnvironment(`A`, None)
-        assert(stateA.status == ExitStatus.Ok)
-        val environmentItem = result.items.head
-        assert(result.items.size == 1)
-        assert(environmentItem.environmentVariables.contains("BLOOP_OWNER"))
-        assertNoDiff(
-          "BLOOP_OWNER",
-          environmentItem.environmentVariables.keys.mkString("\n")
-        )
-        assert(
-          Paths.get(environmentItem.workingDirectory).getFileName ==
-            workingDirectory.getFileName()
-        )
-        assert(
-          environmentItem.classpath
-            .exists(_.contains(s"target/${`A`.config.name}"))
-        )
-        assert(
-          environmentItem.classpath.forall(new URI(_).getScheme == "file")
-        )
-        assert(environmentItem.jvmOptions == jvmOptions)
-      }
+      assert(environmentItem.jvmOptions == jvmOptions)
+    }
+  }
+
+  test("check the correct contents of jvm test environment") {
+    TestUtil.withinWorkspace { workspace =>
+      testEnivronmentFetching(
+        workspace,
+        (state: ManagedBspTestState, project: TestProject) => {
+          val (stateA, result) = state.jvmTestEnvironment(project, None)
+          val environmentItems = result.items
+          (stateA, environmentItems)
+        }
+      )
+    }
+  }
+
+  test("check the correct contents of jvm run environment") {
+    TestUtil.withinWorkspace { workspace =>
+      testEnivronmentFetching(
+        workspace,
+        (state: ManagedBspTestState, project: TestProject) => {
+          val (stateA, result) = state.jvmRunEnvironment(project, None)
+          val environmentItems = result.items
+          (stateA, environmentItems)
+        }
+      )
     }
   }
 

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -97,7 +97,7 @@ class BspProtocolSpec(
     }
   }
 
-  private def testEnivronmentFetching(
+  private def testEnvironmentFetching(
       workspace: AbsolutePath,
       extractor: (ManagedBspTestState, TestProject) => (
           ManagedBspTestState,
@@ -154,7 +154,7 @@ class BspProtocolSpec(
 
   test("check the correct contents of jvm test environment") {
     TestUtil.withinWorkspace { workspace =>
-      testEnivronmentFetching(
+      testEnvironmentFetching(
         workspace,
         (state: ManagedBspTestState, project: TestProject) => {
           val (stateA, result) = state.jvmTestEnvironment(project, None)
@@ -167,7 +167,7 @@ class BspProtocolSpec(
 
   test("check the correct contents of jvm run environment") {
     TestUtil.withinWorkspace { workspace =>
-      testEnivronmentFetching(
+      testEnvironmentFetching(
         workspace,
         (state: ManagedBspTestState, project: TestProject) => {
           val (stateA, result) = state.jvmRunEnvironment(project, None)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val nailgunCommit = "a2520c1e"
 
   val zincVersion = "1.3.0-M4+32-b1accb96"
-  val bspVersion = "2.0.0-M10"
+  val bspVersion = "2.0.0-M11"
   val javaDebugVersion = "0.21.0+1-7f1080f1"
 
   val scalazVersion = "7.2.20"


### PR DESCRIPTION
This endpoint is a mirror to jvmRunEnvironment. In current bloop
implementation they return exactly the same data. Accpording to this,
I extracted the code to to common functions, both in tests and
BloopBspServices

