### PR TITLE
Make sbt docs clearer for multiple projects on initial setup

### DIFF
--- a/docs/build-tools/sbt.md
+++ b/docs/build-tools/sbt.md
@@ -27,6 +27,8 @@ After that, start up sbt or reload your sbt shell to load the plugin.
 
 The sbt command `bloopInstall` exports your sbt build to bloop.
 
+If you have multiple projects, you should run bloopInstall in the projects that aren't dependant on other projects first. For example:  acme-core-server references acme-shared-lib.  So in the acme-shared-lib project run sbt bloopInstall first and then in the acme-core-server run sbt bloopInstall second.
+
 In bloop, an sbt project is represented as a pair of `(sbt project, sbt configuration)` and it's
 written to a configuration directory. The default location of this directory in your workspace is
 `.bloop/` (you may want to add `.bloop/` to your `.gitignore` file).

--- a/docs/build-tools/sbt.md
+++ b/docs/build-tools/sbt.md
@@ -27,13 +27,13 @@ After that, start up sbt or reload your sbt shell to load the plugin.
 
 The sbt command `bloopInstall` exports your sbt build to bloop.
 
-If you have multiple projects, you should run `bloopInstall` in the projects that aren't dependent on other projects first. For example:  acme-core-server references acme-shared-lib.  So in the acme-shared-lib project run `sbt bloopInstall` first and then in the acme-core-server run sbt bloopInstall second.
-
 In bloop, an sbt project is represented as a pair of `(sbt project, sbt configuration)` and it's
 written to a configuration directory. The default location of this directory in your workspace is
 `.bloop/` (you may want to add `.bloop/` to your `.gitignore` file).
 
-For example, a build with a single project `foo` generates two configuration files by
+If you have multiple projects, you should run `bloopInstall` in the projects that aren't dependent on other projects first. For example:  acme-core-server references acme-shared-lib.  So in the acme-shared-lib project run `sbt bloopInstall` first and then in the acme-core-server run sbt bloopInstall second.
+
+In a build with a single project `foo` generates two configuration files by
 default (one per `Compile` and `Test` configuration):
 
 ```bash

--- a/docs/build-tools/sbt.md
+++ b/docs/build-tools/sbt.md
@@ -27,7 +27,7 @@ After that, start up sbt or reload your sbt shell to load the plugin.
 
 The sbt command `bloopInstall` exports your sbt build to bloop.
 
-If you have multiple projects, you should run bloopInstall in the projects that aren't dependent on other projects first. For example:  acme-core-server references acme-shared-lib.  So in the acme-shared-lib project run sbt bloopInstall first and then in the acme-core-server run sbt bloopInstall second.
+If you have multiple projects, you should run `bloopInstall` in the projects that aren't dependent on other projects first. For example:  acme-core-server references acme-shared-lib.  So in the acme-shared-lib project run `sbt bloopInstall` first and then in the acme-core-server run sbt bloopInstall second.
 
 In bloop, an sbt project is represented as a pair of `(sbt project, sbt configuration)` and it's
 written to a configuration directory. The default location of this directory in your workspace is

--- a/docs/build-tools/sbt.md
+++ b/docs/build-tools/sbt.md
@@ -27,7 +27,7 @@ After that, start up sbt or reload your sbt shell to load the plugin.
 
 The sbt command `bloopInstall` exports your sbt build to bloop.
 
-If you have multiple projects, you should run bloopInstall in the projects that aren't dependant on other projects first. For example:  acme-core-server references acme-shared-lib.  So in the acme-shared-lib project run sbt bloopInstall first and then in the acme-core-server run sbt bloopInstall second.
+If you have multiple projects, you should run bloopInstall in the projects that aren't dependent on other projects first. For example:  acme-core-server references acme-shared-lib.  So in the acme-shared-lib project run sbt bloopInstall first and then in the acme-core-server run sbt bloopInstall second.
 
 In bloop, an sbt project is represented as a pair of `(sbt project, sbt configuration)` and it's
 written to a configuration directory. The default location of this directory in your workspace is


### PR DESCRIPTION
It took me a while to figure this out and I'm hoping it might save other people some time.