### PR TITLE
Support runtime classpath for JVM projects

### DIFF
--- a/config/src/main/scala-2.11-13/bloop/config/ConfigCodecs.scala
+++ b/config/src/main/scala-2.11-13/bloop/config/ConfigCodecs.scala
@@ -165,7 +165,12 @@ object ConfigCodecs {
   }
 
   private sealed trait JsoniterPlatform
-  private case class jvm(config: Config.JvmConfig, mainClass: MainClass) extends JsoniterPlatform
+  private case class jvm(
+      config: Config.JvmConfig,
+      mainClass: MainClass,
+      classpath: Option[List[Path]],
+      resources: Option[List[Path]]
+  ) extends JsoniterPlatform
   private case class js(config: Config.JsConfig, mainClass: MainClass) extends JsoniterPlatform
   private case class native(config: Config.NativeConfig, mainClass: MainClass)
       extends JsoniterPlatform
@@ -183,7 +188,8 @@ object ConfigCodecs {
       def encodeValue(x: Config.Platform, out: JsonWriter): Unit = {
         codec.encodeValue(
           x match {
-            case Config.Platform.Jvm(config, mainClass) => jvm(config, MainClass(mainClass))
+            case Config.Platform.Jvm(config, mainClass, classpath, resources) =>
+              jvm(config, MainClass(mainClass), resources, classpath)
             case Config.Platform.Js(config, mainClass) => js(config, MainClass(mainClass))
             case Config.Platform.Native(config, mainClass) => native(config, MainClass(mainClass))
           },
@@ -192,7 +198,13 @@ object ConfigCodecs {
       }
       def decodeValue(in: JsonReader, default: Config.Platform): Config.Platform = {
         codec.decodeValue(in, null) match {
-          case jvm(config, mainClass) => Config.Platform.Jvm(config, mainClass.mainClass)
+          case jvm(config, mainClass, classpath, resources) =>
+            Config.Platform.Jvm(
+              config,
+              mainClass.mainClass,
+              classpath,
+              resources
+            )
           case js(config, mainClass) => Config.Platform.Js(config, mainClass.mainClass)
           case native(config, mainClass) => Config.Platform.Native(config, mainClass.mainClass)
         }

--- a/docs/assets/bloop-schema.json
+++ b/docs/assets/bloop-schema.json
@@ -52,6 +52,35 @@
               "your.app.Main"
             ]
           }
+        },
+        "classpath": {
+          "$id": "/properties/project/properties/jvmPlatform/properties/classpath",
+          "type": "array",
+          "items": {
+            "$id": "/properties/project/properties/jvmPlatform/properties/classpath/items",
+            "type": "string",
+            "title": "An example of a runtime JVM classpath item",
+            "default": "",
+            "examples": [
+              "/home/user/.ivy/cache/jsoniter-scala.jar",
+              "/home/user/.ivy/cache/cats.jar",
+              "/home/user/.ivy/cache/monix.jar"
+            ]
+          }
+        },
+        "resources": {
+          "$id": "/properties/project/properties/jvmPlatform/properties/resources",
+          "type": "array",
+          "items": {
+            "$id": "/properties/project/properties/jvmPlatform/properties/mainClass/resources",
+            "type": "string",
+            "title": "An example of a runtime JVM resource item",
+            "default": "",
+            "examples": [
+              "/home/user/my-project/resources/log4j2.properties",
+              "/home/user/my-project/resources/logback.xml"
+            ]
+          }
         }
       }
     },

--- a/frontend/src/it/scala/bloop/CommunityBuild.scala
+++ b/frontend/src/it/scala/bloop/CommunityBuild.scala
@@ -141,7 +141,7 @@ abstract class CommunityBuild(val buildpressHomeDir: AbsolutePath) {
         testOptions = Config.TestOptions.empty,
         out = dummyClassesDir,
         analysisOut = analysisOut,
-        platform = Project.defaultPlatform(initialState.logger),
+        platform = Project.defaultPlatform(initialState.logger, Nil, Nil),
         sbt = None,
         resolution = None,
         tags = Nil,

--- a/frontend/src/main/scala/bloop/data/Platform.scala
+++ b/frontend/src/main/scala/bloop/data/Platform.scala
@@ -2,6 +2,7 @@ package bloop.data
 
 import bloop.config.Config
 import bloop.engine.tasks.toolchains.{JvmToolchain, ScalaJsToolchain, ScalaNativeToolchain}
+import bloop.io.AbsolutePath
 
 sealed trait Platform {
   def userMainClass: Option[String]
@@ -11,7 +12,9 @@ object Platform {
   final case class Jvm(
       config: JdkConfig,
       toolchain: JvmToolchain,
-      userMainClass: Option[String]
+      userMainClass: Option[String],
+      classpath: List[AbsolutePath],
+      resources: List[AbsolutePath]
   ) extends Platform
 
   final case class Js(

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -297,7 +297,7 @@ object Interpreter {
                     scalaVersion
                   )
 
-                  val classpath = project.fullClasspath(dag, state.client)
+                  val classpath = project.fullRuntimeClasspath(dag, state.client)
                   val coursierClasspathArgs =
                     classpath.flatMap(elem => Seq("--extra-jars", elem.syntax))
 
@@ -529,7 +529,7 @@ object Interpreter {
                 val target = ScalaJsToolchain.linkTargetFrom(project, config)
                 LinkTask.linkMainWithJs(cmd, project, state, mainClass, target, platform)
 
-              case Platform.Jvm(_, _, _) =>
+              case _: Platform.Jvm =>
                 val msg = Feedback.noLinkFor(project)
                 Task.now(state.withError(msg, ExitStatus.InvalidCommandLineOption))
             }
@@ -578,7 +578,7 @@ object Interpreter {
                     if (!state.status.isOk) Task.now(state)
                     else Tasks.runNativeOrJs(state, project, cwd, mainClass, args)
                 }
-              case Platform.Jvm(javaEnv, _, _) =>
+              case Platform.Jvm(javaEnv, _, _, _, _) =>
                 Tasks.runJVM(
                   state,
                   project,

--- a/frontend/src/main/scala/bloop/engine/tasks/LinkTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/LinkTask.scala
@@ -25,7 +25,7 @@ object LinkTask {
           case Some(msg) => Task.now(state.withError(msg, ExitStatus.LinkingError))
           case None =>
             val dag = state.build.getDagFor(project)
-            val fullClasspath = project.fullClasspath(dag, state.client).map(_.underlying)
+            val fullClasspath = project.fullRuntimeClasspath(dag, state.client).map(_.underlying)
             val config = config0.copy(mode = getOptimizerMode(cmd.optimize, config0.mode))
             toolchain
               .link(config, project, fullClasspath, true, Some(mainClass), target, state.logger)
@@ -59,7 +59,7 @@ object LinkTask {
           case Some(msg) => Task.now(state.withError(msg, ExitStatus.LinkingError))
           case None =>
             val dag = state.build.getDagFor(project)
-            val fullClasspath = project.fullClasspath(dag, state.client).map(_.underlying)
+            val fullClasspath = project.fullRuntimeClasspath(dag, state.client).map(_.underlying)
             val config = config0.copy(mode = getOptimizerMode(cmd.optimize, config0.mode))
             toolchain.link(config, project, fullClasspath, mainClass, target, state.logger) map {
               case scala.util.Success(_) =>

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -55,7 +55,7 @@ object Tasks {
     project.scalaInstance match {
       case Some(instance) =>
         val dag = state.build.getDagFor(project)
-        val classpath = project.fullClasspath(dag, state.client)
+        val classpath = project.fullRuntimeClasspath(dag, state.client)
         val entries = classpath.map(_.underlying.toFile).toSeq
         logger.debug(s"Setting up the console classpath with ${entries.mkString(", ")}")(
           DebugFilter.All
@@ -164,7 +164,7 @@ object Tasks {
       mode: RunMode
   ): Task[State] = {
     val dag = state.build.getDagFor(project)
-    val classpath = project.fullClasspath(dag, state.client)
+    val classpath = project.fullRuntimeClasspath(dag, state.client)
     val forker = JvmProcessForker(config, classpath, mode)
     val runTask =
       forker.runMain(cwd, fqn, args, skipJargs, state.logger, state.commonOptions)

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -158,9 +158,9 @@ object TestTask {
     import state.logger
     implicit val logContext: DebugFilter = DebugFilter.Test
     project.platform match {
-      case Platform.Jvm(env, _, _) =>
+      case Platform.Jvm(env, _, _, _, _) =>
         val dag = state.build.getDagFor(project)
-        val classpath = project.fullClasspath(dag, state.client)
+        val classpath = project.fullRuntimeClasspath(dag, state.client)
         val forker = JvmProcessForker(env, classpath, mode)
         val testLoader = forker.newClassLoader(Some(TestInternals.filteredLoader))
         val frameworks = project.testFrameworks.flatMap(
@@ -173,7 +173,8 @@ object TestTask {
         toolchain match {
           case Some(toolchain) =>
             val dag = state.build.getDagFor(project)
-            val fullClasspath = project.fullClasspath(dag, state.client).map(_.underlying)
+            val fullClasspath =
+              project.fullRuntimeClasspath(dag, state.client).map(_.underlying)
             toolchain
               .link(config, project, fullClasspath, false, userMainClass, target, state.logger)
               .map {

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileDependenciesData.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileDependenciesData.scala
@@ -23,7 +23,7 @@ case class CompileDependenciesData(
   ): Array[AbsolutePath] = {
     // Important: always place new classes dir before read-only classes dir
     val classesDirs = Array(newClassesDir, readOnlyClassesDir)
-    val resources = project.pickValidResources
+    val resources = Project.pickValidResources(project.resources)
     resources ++ classesDirs ++ dependencyClasspath
   }
 }
@@ -59,11 +59,12 @@ object CompileDependenciesData {
           if (newClassesDir == readOnlyClassesDir) Array(newClassesDir)
           else Array(newClassesDir, readOnlyClassesDir)
         }
+        val resources = Project.pickValidResources(project.resources)
 
         dependentClassesDir.put(genericClassesDir, classesDirs.map(AbsolutePath(_)))
         dependentInvalidatedClassFiles.++=(products.invalidatedCompileProducts)
         dependentGeneratedClassFilePaths.++=(products.generatedRelativeClassFilePaths.iterator)
-        dependentResources.put(genericClassesDir, project.pickValidResources)
+        dependentResources.put(genericClassesDir, resources)
     }
 
     val addedResources = new mutable.HashSet[AbsolutePath]()

--- a/frontend/src/test/scala/bloop/ConsoleSpec.scala
+++ b/frontend/src/test/scala/bloop/ConsoleSpec.scala
@@ -39,7 +39,7 @@ object ConsoleSpec extends BaseSuite {
 
       val projectB = state.getProjectFor(`B`)
       val dagB = state.getDagFor(`B`)
-      val classpathB = projectB.fullClasspath(dagB, state.client)
+      val classpathB = projectB.fullRuntimeClasspath(dagB, state.client)
       val coursierClasspathArgs =
         classpathB.flatMap(elem => Seq("--extra-jars", elem.syntax))
       val expectedCommand =

--- a/frontend/src/test/scala/bloop/DagSpec.scala
+++ b/frontend/src/test/scala/bloop/DagSpec.scala
@@ -25,7 +25,7 @@ class DagSpec {
   def dummyProject(name: String, dependencies: List[String]): Project =
     Project(name, dummyPath, None, dependencies, Some(dummyInstance), Nil, Nil, compileOptions,
       dummyPath, Nil, Nil, Nil, Nil, None, Nil, Config.TestOptions.empty, dummyPath, dummyPath,
-      Project.defaultPlatform(logger), None, None, Nil, dummyOrigin)
+      Project.defaultPlatform(logger, Nil, Nil), None, None, Nil, dummyOrigin)
   // format: ON
 
   private object TestProjects {

--- a/frontend/src/test/scala/bloop/ForkerSpec.scala
+++ b/frontend/src/test/scala/bloop/ForkerSpec.scala
@@ -50,7 +50,7 @@ class ForkerSpec {
     TestUtil.checkAfterCleanCompilation(runnableProject, dependencies) { state =>
       val project = TestUtil.getProject(TestUtil.RootProject, state)
       val env = JdkConfig.default
-      val classpath = project.fullClasspath(state.build.getDagFor(project), state.client)
+      val classpath = project.fullRuntimeClasspath(state.build.getDagFor(project), state.client)
       val config = JvmProcessForker(env, classpath)
       val logger = new RecordingLogger
       val opts = state.commonOptions.copy(env = TestUtil.runAndTestProperties)

--- a/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
+++ b/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
@@ -162,6 +162,11 @@ trait BloopHelpers {
       TestUtil.interpreterTask(runTask, state).map(new TestState(_))
     }
 
+    def run(project: TestProject, watch: Boolean = false): TestState = {
+      val runTask = Run(Commands.Run(List(project.config.name), watch = watch))
+      new TestState(TestUtil.blockingExecute(runTask, state))
+    }
+
     def console(project: TestProject, args: List[String]): TestState = {
       val compileTask = Run(Commands.Console(List(project.config.name), args = args))
       new TestState(TestUtil.blockingExecute(compileTask, state))

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -359,7 +359,8 @@ object TestUtil {
   ): Project = {
     val origin = syntheticOriginFor(baseDir)
     val baseDirectory = projectDir(baseDir.underlying, name)
-    val ProjectArchetype(srcs, out, _, classes) = createProjectArchetype(baseDir.underlying, name)
+    val ProjectArchetype(srcs, out, _, classes, _) =
+      createProjectArchetype(baseDir.underlying, name)
     val tempDir = baseDirectory.resolve("tmp")
     Files.createDirectories(tempDir)
     Files.createDirectories(classes.underlying)
@@ -393,7 +394,7 @@ object TestUtil {
       testOptions = Config.TestOptions.empty,
       out = out,
       analysisOut = out.resolve(Config.Project.analysisFileName(name)),
-      platform = Project.defaultPlatform(logger, Some(jdkConfig)),
+      platform = Project.defaultPlatform(logger, classpath, Nil, Some(jdkConfig)),
       sbt = None,
       resolution = None,
       tags = Nil,
@@ -405,7 +406,8 @@ object TestUtil {
       sourceDir: AbsolutePath,
       targetDir: AbsolutePath,
       resourcesDir: AbsolutePath,
-      classesDir: AbsolutePath
+      classesDir: AbsolutePath,
+      runtimeResourcesDir: AbsolutePath
   )
 
   def createProjectArchetype(base: Path, name: String): ProjectArchetype = {
@@ -413,15 +415,18 @@ object TestUtil {
     val target = targetDir(base, name)
     val resourcesDir = base.resolve("resources")
     val classes = classesDir(base, name)
+    val runtimeResources = base.resolve("runtime-resources")
     Files.createDirectories(sourceDir)
     Files.createDirectories(target)
     Files.createDirectories(resourcesDir)
     Files.createDirectories(classes)
+    Files.createDirectories(runtimeResources)
     ProjectArchetype(
       AbsolutePath(sourceDir),
       AbsolutePath(target),
       AbsolutePath(resourcesDir),
-      AbsolutePath(classes)
+      AbsolutePath(classes),
+      AbsolutePath(runtimeResources)
     )
   }
 

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -288,7 +288,7 @@ class BloopConverter(parameters: BloopParameters) {
       }
 
     val jdkPath = projectJdkPath.orElse(defaultJdkPath)
-    Some(Platform.Jvm(JvmConfig(jdkPath, projectJvmOptions), mainClass))
+    Some(Platform.Jvm(JvmConfig(jdkPath, projectJvmOptions), mainClass, None, None))
   }
 
   def getTestConfig(sourceSet: SourceSet): Option[Config.Test] = {

--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -130,7 +130,7 @@ object MojoImplementation {
         val `scala` = Some(Config.Scala(mojo.getScalaOrganization(), mojo.getScalaArtifactID(), mojo.getScalaVersion(), scalacArgs, allScalaJars, analysisOut, Some(compileSetup)))
         val javaHome = Some(abs(mojo.getJavaHome().getParentFile.getParentFile))
         val mainClass = if (launcher.getMainClass().isEmpty) None else Some(launcher.getMainClass())
-        val platform = Some(Config.Platform.Jvm(Config.JvmConfig(javaHome, launcher.getJvmArgs().toList), mainClass))
+        val platform = Some(Config.Platform.Jvm(Config.JvmConfig(javaHome, launcher.getJvmArgs().toList), mainClass, None, None))
         // Resources in Maven require
         val resources = Some(resources0.asScala.toList.flatMap(a => Option(a.getTargetPath).toList).map(classesDir.resolve))
         val project = Config.Project(name, baseDirectory, Some(root.toPath), sourceDirs, None, None, dependencyNames, classpath, out, classesDir, resources, `scala`, java, sbt, test, platform, resolution, Some(tags))

--- a/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
+++ b/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
@@ -59,7 +59,9 @@ object Bloop extends ExternalModule {
           home = T.ctx().env.get("JAVA_HOME").map(s => Path(s).toNIO),
           options = module.forkArgs().toList
         ),
-        mainClass = module.mainClass()
+        mainClass = module.mainClass(),
+        classpath = None,
+        resources = None
       )
     }
 

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -792,7 +792,7 @@ object BloopDefaults {
         val workingDir = if (isForkedExecution) Keys.baseDirectory.value else rootBaseDirectory
         val extraJavaOptions = List(s"-Duser.dir=${workingDir.getAbsolutePath}")
         val config = Config.JvmConfig(Some(javaHome.toPath), (extraJavaOptions ++ javaOptions).toList)
-        Config.Platform.Jvm(config, mainClass)
+        Config.Platform.Jvm(config, mainClass, None, None)
       }
     }
     // FORMAT: ON


### PR DESCRIPTION
Most build tools use a different classpath for compiling and running JVM
projects. This commit adds fields to represent the runtime classpath of
JVM projects in the Bloop configuration file.

The following fields are added to the JVM platform:

 * `classpath`, which represents the runtime classpath of the project.
 * `resources`, which represents the resources available to the project
   at runtime.

When one of these fields is missing, Bloop will fallback to the field
with the same name in project definition.

Fixes #1233