### PR TITLE
Fixed providing jvm options in DAP

### DIFF
--- a/frontend/src/main/scala/bloop/dap/DebuggeeRunner.scala
+++ b/frontend/src/main/scala/bloop/dap/DebuggeeRunner.scala
@@ -46,7 +46,7 @@ private final class MainClassDebugAdapter(
       env,
       workingDir,
       mainClass.`class`,
-      mainClass.arguments.toArray,
+      (mainClass.arguments ++ mainClass.jvmOptions).toArray,
       skipJargs = false,
       RunMode.Debug
     )

--- a/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
@@ -129,7 +129,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
     }
   }
 
-  test("accepts argumetns and jvm options") {
+  test("accepts arguments and jvm options") {
     TestUtil.withinWorkspace { workspace =>
       val main =
         """|/main/scala/Main.scala


### PR DESCRIPTION
Issue: `jvmOptions` in `ScalaMainClass` have been ignored while running a debug session.

Note: not really sure, if the testing is done elegant enough, or can even be put into already existing `test`.