### PR TITLE
Swap `classpath` and `resources` arguments

### DIFF
--- a/config/src/main/scala-2.11-13/bloop/config/ConfigCodecs.scala
+++ b/config/src/main/scala-2.11-13/bloop/config/ConfigCodecs.scala
@@ -189,7 +189,7 @@ object ConfigCodecs {
         codec.encodeValue(
           x match {
             case Config.Platform.Jvm(config, mainClass, classpath, resources) =>
-              jvm(config, MainClass(mainClass), resources, classpath)
+              jvm(config, MainClass(mainClass), classpath, resources)
             case Config.Platform.Js(config, mainClass) => js(config, MainClass(mainClass))
             case Config.Platform.Native(config, mainClass) => native(config, MainClass(mainClass))
           },


### PR DESCRIPTION
The `classpath` and `resources` were swapped, resulting in a wrong
config.

Fixes #1247