### PR TITLE
Make `bloop about` and `bloop help` always succeed

### DIFF
--- a/frontend/src/main/scala/bloop/cli/Validate.scala
+++ b/frontend/src/main/scala/bloop/cli/Validate.scala
@@ -6,6 +6,7 @@ import java.nio.file.Files
 import bloop.bsp.BspServer
 import bloop.io.AbsolutePath
 import bloop.util.CrossPlatform
+import bloop.util.Environment
 import bloop.engine.{Action, Exit, Feedback, Print, Run, State}
 
 import monix.eval.Task
@@ -78,7 +79,8 @@ object Validate {
    */
   def validateBuildForCLICommands(state: State, report: String => Unit): Task[State] = {
     val configDirectory = state.build.origin
-    if (state.build.origin.isDirectory) {
+    if (state.build.origin.isDirectory &&
+        state.build.origin != Environment.defaultBloopDirectory) {
       state.build.traces match {
         case Nil => Task.now(state)
         case x :: xs =>

--- a/frontend/src/main/scala/bloop/engine/Feedback.scala
+++ b/frontend/src/main/scala/bloop/engine/Feedback.scala
@@ -65,7 +65,7 @@ object Feedback {
   }
 
   def missingConfigDirectory(configDirectory: AbsolutePath): String =
-    s"""Missing configuration directory in $configDirectory.
+    s"""Missing valid Bloop build in $configDirectory.
        |
        |  1. Did you run bloop outside of the working directory of your build?
        |     If so, change your current directory or point directly to your `.bloop` directory via `--config-dir`.

--- a/frontend/src/main/scala/bloop/engine/caches/StateCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/StateCache.scala
@@ -9,6 +9,7 @@ import bloop.cli.CommonOptions
 import bloop.engine.{Build, BuildLoader, State, ClientPool}
 import bloop.io.AbsolutePath
 import bloop.cli.ExitStatus
+import bloop.util.Environment
 
 import monix.eval.Task
 
@@ -91,6 +92,7 @@ final class StateCache(cache: ConcurrentHashMap[AbsolutePath, StateCache.CachedS
       clientSettings: Option[WorkspaceSettings]
   ): Task[State] = {
     val empty = Build(from, Nil)
+    if (from == Environment.defaultBloopDirectory) return Task.now(createState(empty))
     val previousState = getStateFor(from, client, pool, commonOptions, logger)
     val build = previousState.map(_.build).getOrElse(empty)
 

--- a/frontend/src/main/scala/bloop/util/Environment.scala
+++ b/frontend/src/main/scala/bloop/util/Environment.scala
@@ -1,0 +1,7 @@
+package bloop.util
+
+import bloop.io.AbsolutePath
+
+object Environment {
+  def defaultBloopDirectory: AbsolutePath = AbsolutePath.homeDirectory.resolve(".bloop")
+}

--- a/shared/src/main/scala/bloop/io/AbsolutePath.scala
+++ b/shared/src/main/scala/bloop/io/AbsolutePath.scala
@@ -29,6 +29,8 @@ final class AbsolutePath private (val underlying: Path) extends AnyVal {
 object AbsolutePath {
   implicit def workingDirectory: AbsolutePath =
     new AbsolutePath(NioPaths.get(sys.props("user.dir")))
+  def homeDirectory: AbsolutePath =
+    new AbsolutePath(NioPaths.get(sys.props("user.home")))
   def apply(uri: URI): AbsolutePath = apply(NioPaths.get(uri))
   def apply(file: File)(implicit cwd: AbsolutePath): AbsolutePath = apply(file.toPath)(cwd)
   def apply(path: String)(implicit cwd: AbsolutePath): AbsolutePath = apply(NioPaths.get(path))(cwd)


### PR DESCRIPTION
Previously, running `bloop help` or `bloop about` could fail when executed in a workspace that contained invalid `.bloop/*.json` config files. This can for example happen in the `$HOME` directory with `.bloop/bloop.json` global settings.  This commit refactors the `bloop help` and `bloop about` commands so that they print out a message and don't attempt to load the workspace JSON files.

Fixes #1249 