### PR TITLE
Register Scala generated class files before compiling Java

### DIFF
--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopAnalysisCallback.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopAnalysisCallback.scala
@@ -354,7 +354,14 @@ final class BloopAnalysisCallback(
     }
   }
 
-  override def apiPhaseCompleted(): Unit = ()
+  override def apiPhaseCompleted(): Unit = {
+    /*
+     * Inform the class file manager of the generated Scala classes as soon as
+     * the Zinc API phase has run and collected them so that the class file
+     * invalidation registers these files before compiling Java files incrementally.
+     */
+    manager.generated(classToSource.keysIterator.toArray)
+  }
   override def dependencyPhaseCompleted(): Unit = ()
   override def classesInOutputJar(): java.util.Set[String] = ju.Collections.emptySet()
 

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/ConcurrentAnalysisCallback.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/ConcurrentAnalysisCallback.scala
@@ -373,7 +373,10 @@ final class ConcurrentAnalysisCallback(
     }
   }
 
-  override def apiPhaseCompleted(): Unit = ()
+  override def apiPhaseCompleted(): Unit = {
+    // See [[BloopAnalysisCallback.apiPhaseCompleted]]
+    manager.generated(classToSource.keysIterator.toArray)
+  }
   override def dependencyPhaseCompleted(): Unit = ()
   override def classesInOutputJar(): java.util.Set[String] = ju.Collections.emptySet()
 


### PR DESCRIPTION
Classfiles originating from Scala recompiled sources would be marked as
invalidated until after the Analysis object is created. This caused
issues with the `BloopForkedJavaCompiler`, which creates invalid
classfiles, since these invalid classfiles would be chosen over the new
ones, thus aborting compilation.

This commit changes the analysis callbacks used by Bloop so that the
generated classfiles are pushed to the classfile manager as soon as they
are known. Thanks to this change, no invalid classfiles will be created
for the recompiled sources.