### PR TITLE
Support links in path to javac

### DIFF
--- a/shared/src/main/scala/bloop/io/AbsolutePath.scala
+++ b/shared/src/main/scala/bloop/io/AbsolutePath.scala
@@ -21,6 +21,7 @@ final class AbsolutePath private (val underlying: Path) extends AnyVal {
   def exists: Boolean = Files.exists(underlying)
   def isFile: Boolean = Files.isRegularFile(underlying)
   def isDirectory: Boolean = Files.isDirectory(underlying)
+  def isSameFile(other: AbsolutePath): Boolean = Files.isSameFile(underlying, other.underlying)
   def readAllBytes: Array[Byte] = Files.readAllBytes(underlying)
   def toFile: File = underlying.toFile
   def toBspUri: URI = underlying.toUri


### PR DESCRIPTION
We were using a forked javac process to compile Java sources in cases
where the `java.home` properties and the JVM platform of a project were
different, but pointed to the same file. Instead of comparing the two
paths to decide whether to fork, this commit compares the two files that
are pointed to by the paths.