### PR TITLE
Force source generation for cached 'sbt bloopGenerate'

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -877,8 +877,11 @@ object BloopDefaults {
     else if (!hasConfigSettings) inlinedTask[Option[File]](None)
     else if (generated.isDefined && generated.get.fromSbtUniverseId == currentSbtUniverse) {
       Def.task {
+        // Force source generators on this task manually
+        Keys.managedSources.value
+
         // Force classpath to force side-effects downstream to fully simulate `bloopGenerate`
-        val _ = emulateDependencyClasspath.value.map(_.toPath.toAbsolutePath).toList
+        val _ = emulateDependencyClasspath.value
         generated.map(_.outPath.toFile)
       }
     } else {


### PR DESCRIPTION
Closes #1257 

I think the result is really nice, because:
- I run `~bloopInstall` in the background
- Any time I change a source file, `bloopInstall` is not triggered (those files are not watched by the source generation nor by `bloopInstall`)
- Any time I change a template file,  `bloopInstall` is triggered, and the generated sources are updated, the bloop config is not updated because it is already cached
- If I change the sbt settings, Metals propose me to import the build, and it overwrites the bloop config
- Most of the time I dont even need to reload my sbt shell in the background