### PR TITLE
Add workpace settings for Zipkin traces

### DIFF
--- a/backend/src/main/scala/bloop/tracing/BraveTracer.scala
+++ b/backend/src/main/scala/bloop/tracing/BraveTracer.scala
@@ -1,36 +1,33 @@
 package bloop.tracing
 
-import bloop.tracing.BraveTracer.traceEndAnnotation
-import bloop.tracing.BraveTracer.traceStartAnnotation
-import brave.{Span, Tracer}
 import brave.propagation.SamplingFlags
 import brave.propagation.TraceContext
 import brave.propagation.TraceContextOrSamplingFlags
+import brave.Span
+import brave.Tracer
 import monix.eval.Task
 import monix.execution.misc.NonFatal
-import scala.util.Failure
 import scala.util.Properties
-import scala.util.Success
-import java.util.concurrent.TimeUnit
-import zipkin2.codec.SpanBytesEncoder.{JSON_V1, JSON_V2}
+import zipkin2.codec.SpanBytesEncoder.JSON_V1
+import zipkin2.codec.SpanBytesEncoder.JSON_V2
 
 final class BraveTracer private (
     tracer: Tracer,
     val currentSpan: Span,
-    closeCurrentSpan: () => Unit
+    closeCurrentSpan: () => Unit,
+    traceProperties: TraceProperties
 ) {
   def startNewChildTracer(name: String, tags: (String, String)*): BraveTracer = {
-    import brave.propagation.TraceContext
     val span = tags.foldLeft(tracer.newChild(currentSpan.context).name(name)) {
       case (span, (tagKey, tagValue)) => span.tag(tagKey, tagValue)
     }
 
     span.start()
-    traceStartAnnotation.foreach(span.annotate)
+    TraceProperties.TraceStartAnnotation.getOrGlobal(traceProperties).foreach(span.annotate)
     new BraveTracer(tracer, span, () => {
-      traceEndAnnotation.foreach(span.annotate)
+      TraceProperties.TraceEndAnnotation.getOrGlobal(traceProperties).foreach(span.annotate)
       span.finish()
-    })
+    }, traceProperties)
   }
 
   def trace[T](name: String, tags: (String, String)*)(
@@ -60,7 +57,7 @@ final class BraveTracer private (
   private def traceInternal[T](name: String, verbose: Boolean, tags: (String, String)*)(
       thunk: BraveTracer => T
   ): T = {
-    if (!verbose || BraveTracer.isVerboseTrace) {
+    if (!verbose || TraceProperties.Verbose.getOrGlobal(traceProperties)) {
       val newTracer = startNewChildTracer(name, tags: _*)
       try thunk(newTracer) // Don't catch and report errors in spans
       catch {
@@ -81,7 +78,7 @@ final class BraveTracer private (
   private def traceTaskInternal[T](name: String, verbose: Boolean, tags: (String, String)*)(
       thunk: BraveTracer => Task[T]
   ): Task[T] = {
-    if (!verbose || BraveTracer.isVerboseTrace) {
+    if (!verbose || TraceProperties.Verbose.getOrGlobal(traceProperties)) {
       val newTracer = startNewChildTracer(name, tags: _*)
       thunk(newTracer)
         .doOnCancel(Task(newTracer.terminate()))
@@ -107,47 +104,57 @@ final class BraveTracer private (
   /** Create an independent tracer that propagates this current context
    * and that whose completion in zipkin will happen independently. This
    * is ideal for tracing background tasks that outlive their parent trace. */
-  def toIndependentTracer(name: String, tags: (String, String)*): BraveTracer =
-    BraveTracer(name, Some(currentSpan.context), tags: _*)
+  def toIndependentTracer(
+      name: String,
+      traceProperties: TraceProperties,
+      tags: (String, String)*
+  ): BraveTracer =
+    BraveTracer(name, traceProperties, Some(currentSpan.context), tags: _*)
 }
 
 object BraveTracer {
   import brave._
-  import brave.sampler.Sampler
   import zipkin2.reporter.AsyncReporter
   import zipkin2.reporter.urlconnection.URLConnectionSender
-  val zipkinServerUrl = Option(System.getProperty("zipkin.server.url")).getOrElse(
-    "http://127.0.0.1:9411/api/v2/spans"
-  )
-  val isDebugTrace = Properties.propOrFalse("bloop.trace.debug")
-  val isVerboseTrace = Properties.propOrFalse("bloop.trace.verbose")
-  val localServiceName = Properties.propOrElse("bloop.trace.localServiceName", "bloop")
-  val traceStartAnnotation = Properties.propOrNone("bloop.trace.traceStartAnnotation")
-  val traceEndAnnotation = Properties.propOrNone("bloop.trace.traceEndAnnotation")
 
-  val sender = URLConnectionSender.create(zipkinServerUrl)
-  val jsonVersion = if (zipkinServerUrl.contains("/api/v1")) {
-    JSON_V1
-  } else {
-    JSON_V2
-  }
-  val spanReporter = AsyncReporter.builder(sender).build(jsonVersion)
   def apply(name: String, tags: (String, String)*): BraveTracer = {
-    BraveTracer(name, None, tags: _*)
+    BraveTracer(name, TraceProperties.Global.properties, None, tags: _*)
   }
 
-  def apply(name: String, ctx: Option[TraceContext], tags: (String, String)*): BraveTracer = {
-    import java.util.concurrent.TimeUnit
+  def apply(
+      name: String,
+      traceProperties: TraceProperties,
+      tags: (String, String)*
+  ): BraveTracer = {
+    BraveTracer(name, traceProperties, None, tags: _*)
+  }
+
+  def apply(
+      name: String,
+      traceProperties: TraceProperties,
+      ctx: Option[TraceContext],
+      tags: (String, String)*
+  ): BraveTracer = {
+
+    val url = TraceProperties.ZipkinServerUrl.getOrGlobal(traceProperties)
+    val sender = URLConnectionSender.create(url)
+    val jsonVersion = if (url.contains("/api/v1")) {
+      JSON_V1
+    } else {
+      JSON_V2
+    }
+    val spanReporter = AsyncReporter.builder(sender).build(jsonVersion)
+
     val tracing = Tracing
       .newBuilder()
-      .localServiceName(localServiceName)
+      .localServiceName(TraceProperties.LocalServiceName.getOrGlobal(traceProperties))
       .spanReporter(spanReporter)
       .build()
     val tracer = tracing.tracer()
     val newParentTrace = ctx
       .map(c => tracer.newChild(c))
       .getOrElse(
-        if (isDebugTrace) {
+        if (TraceProperties.Debug.getOrGlobal(traceProperties)) {
           tracer.nextSpan(TraceContextOrSamplingFlags.create(SamplingFlags.DEBUG))
         } else {
           tracer.newTrace()
@@ -157,13 +164,13 @@ object BraveTracer {
       case (span, (tagKey, tagValue)) => span.tag(tagKey, tagValue)
     }
     rootSpan.start()
-    traceStartAnnotation.foreach(rootSpan.annotate)
+    TraceProperties.TraceStartAnnotation.getOrGlobal(traceProperties).foreach(rootSpan.annotate)
     val closeEverything = () => {
-      traceEndAnnotation.foreach(rootSpan.annotate)
+      TraceProperties.TraceEndAnnotation.getOrGlobal(traceProperties).foreach(rootSpan.annotate)
       rootSpan.finish()
       tracing.close()
       spanReporter.flush()
     }
-    new BraveTracer(tracer, rootSpan, closeEverything)
+    new BraveTracer(tracer, rootSpan, closeEverything, traceProperties)
   }
 }

--- a/backend/src/main/scala/bloop/tracing/BraveTracer.scala
+++ b/backend/src/main/scala/bloop/tracing/BraveTracer.scala
@@ -145,7 +145,7 @@ object BraveTracer {
     val newParentTrace = ctx
       .map(c => tracer.newChild(c))
       .getOrElse(
-        if (properties.debug) {
+        if (properties.debugTracing) {
           tracer.nextSpan(TraceContextOrSamplingFlags.create(SamplingFlags.DEBUG))
         } else {
           tracer.newTrace()

--- a/backend/src/main/scala/bloop/tracing/TraceProperties.scala
+++ b/backend/src/main/scala/bloop/tracing/TraceProperties.scala
@@ -3,75 +3,32 @@ package bloop.tracing
 import scala.util.Properties
 
 case class TraceProperties(
-    zipkinServerUrl: Option[String],
-    debug: Option[Boolean],
-    verbose: Option[Boolean],
-    localServiceName: Option[String],
+    serverUrl: String,
+    debug: Boolean,
+    verbose: Boolean,
+    localServiceName: String,
     traceStartAnnotation: Option[String],
     traceEndAnnotation: Option[String]
 )
+
 object TraceProperties {
+  val default: TraceProperties = {
+    val debug = Properties.propOrFalse("bloop.trace.debug")
+    val verbose = Properties.propOrFalse("bloop.trace.verbose")
+    val localServiceName = Properties.propOrElse("bloop.trace.localServiceName", "bloop")
+    val traceStartAnnotation = Properties.propOrNone("bloop.trace.traceStartAnnotation")
+    val traceEndAnnotation = Properties.propOrNone("bloop.trace.traceEndAnnotation")
 
-  sealed abstract case class Property[A](key: String) {
-    def getOrGlobal(properties: TraceProperties): A
-  }
-  object ZipkinServerUrl extends Property[String]("zipkin.server.url") {
-    override def getOrGlobal(properties: TraceProperties): String =
-      properties.zipkinServerUrl.getOrElse(Global.zipkinServerUrl)
-  }
-  object Debug extends Property[Boolean]("bloop.trace.debug") {
-    override def getOrGlobal(properties: TraceProperties): Boolean =
-      properties.debug.getOrElse(Global.debug)
-  }
-  object Verbose extends Property[Boolean]("bloop.trace.verbose") {
-    override def getOrGlobal(properties: TraceProperties): Boolean =
-      properties.verbose.getOrElse(Global.verbose)
-  }
-  object LocalServiceName extends Property[String]("bloop.trace.localServiceName") {
-    override def getOrGlobal(properties: TraceProperties): String =
-      properties.localServiceName.getOrElse(Global.localServiceName)
-  }
-  object TraceStartAnnotation extends Property[Option[String]]("bloop.trace.traceStartAnnotation") {
-    override def getOrGlobal(properties: TraceProperties): Option[String] =
-      properties.traceStartAnnotation.orElse(Global.traceStartAnnotation)
-  }
-  object TraceEndAnnotation extends Property[Option[String]]("bloop.trace.traceEndAnnotation") {
-    override def getOrGlobal(properties: TraceProperties): Option[String] =
-      properties.traceEndAnnotation.orElse(Global.traceEndAnnotation)
-  }
+    val traceServerUrl = Properties.propOrElse(
+      "zipkin.server.url",
+      Properties.propOrElse("bloop.trace.server.url", "http://127.0.0.1:9411/api/v2/spans")
+    )
 
-  val default: TraceProperties = TraceProperties(
-    Some("http://127.0.0.1:9411/api/v2/spans"),
-    Some(false),
-    Some(false),
-    Some("bloop"),
-    None,
-    None
-  )
-
-  object Global {
-
-    val zipkinServerUrl: String =
-      Properties.propOrElse(TraceProperties.ZipkinServerUrl.key, default.zipkinServerUrl.get)
-
-    val debug: Boolean = Properties.propOrFalse(TraceProperties.Debug.key)
-
-    val verbose: Boolean = Properties.propOrFalse(TraceProperties.Verbose.key)
-
-    val localServiceName: String =
-      Properties.propOrElse(TraceProperties.LocalServiceName.key, default.localServiceName.get)
-
-    val traceStartAnnotation: Option[String] =
-      Properties.propOrNone(TraceProperties.TraceStartAnnotation.key)
-
-    val traceEndAnnotation: Option[String] =
-      Properties.propOrNone(TraceProperties.TraceEndAnnotation.key)
-
-    val properties: TraceProperties = TraceProperties(
-      Some(zipkinServerUrl),
-      Some(debug),
-      Some(verbose),
-      Some(localServiceName),
+    TraceProperties(
+      traceServerUrl,
+      debug,
+      verbose,
+      localServiceName,
       traceStartAnnotation,
       traceEndAnnotation
     )

--- a/backend/src/main/scala/bloop/tracing/TraceProperties.scala
+++ b/backend/src/main/scala/bloop/tracing/TraceProperties.scala
@@ -4,6 +4,8 @@ import scala.util.Properties
 
 case class TraceProperties(
     serverUrl: String,
+    // Note: `debug` corresponds to a sampling flag sent to Zipkin server,
+    // while `verbose` determines if we send certain spans marked as verbose spans
     debug: Boolean,
     verbose: Boolean,
     localServiceName: String,

--- a/backend/src/main/scala/bloop/tracing/TraceProperties.scala
+++ b/backend/src/main/scala/bloop/tracing/TraceProperties.scala
@@ -1,0 +1,79 @@
+package bloop.tracing
+
+import scala.util.Properties
+
+case class TraceProperties(
+    zipkinServerUrl: Option[String],
+    debug: Option[Boolean],
+    verbose: Option[Boolean],
+    localServiceName: Option[String],
+    traceStartAnnotation: Option[String],
+    traceEndAnnotation: Option[String]
+)
+object TraceProperties {
+
+  sealed abstract case class Property[A](key: String) {
+    def getOrGlobal(properties: TraceProperties): A
+  }
+  object ZipkinServerUrl extends Property[String]("zipkin.server.url") {
+    override def getOrGlobal(properties: TraceProperties): String =
+      properties.zipkinServerUrl.getOrElse(Global.zipkinServerUrl)
+  }
+  object Debug extends Property[Boolean]("bloop.trace.debug") {
+    override def getOrGlobal(properties: TraceProperties): Boolean =
+      properties.debug.getOrElse(Global.debug)
+  }
+  object Verbose extends Property[Boolean]("bloop.trace.verbose") {
+    override def getOrGlobal(properties: TraceProperties): Boolean =
+      properties.verbose.getOrElse(Global.verbose)
+  }
+  object LocalServiceName extends Property[String]("bloop.trace.localServiceName") {
+    override def getOrGlobal(properties: TraceProperties): String =
+      properties.localServiceName.getOrElse(Global.localServiceName)
+  }
+  object TraceStartAnnotation extends Property[Option[String]]("bloop.trace.traceStartAnnotation") {
+    override def getOrGlobal(properties: TraceProperties): Option[String] =
+      properties.traceStartAnnotation.orElse(Global.traceStartAnnotation)
+  }
+  object TraceEndAnnotation extends Property[Option[String]]("bloop.trace.traceEndAnnotation") {
+    override def getOrGlobal(properties: TraceProperties): Option[String] =
+      properties.traceEndAnnotation.orElse(Global.traceEndAnnotation)
+  }
+
+  val default: TraceProperties = TraceProperties(
+    Some("http://127.0.0.1:9411/api/v2/spans"),
+    Some(false),
+    Some(false),
+    Some("bloop"),
+    None,
+    None
+  )
+
+  object Global {
+
+    val zipkinServerUrl: String =
+      Properties.propOrElse(TraceProperties.ZipkinServerUrl.key, default.zipkinServerUrl.get)
+
+    val debug: Boolean = Properties.propOrFalse(TraceProperties.Debug.key)
+
+    val verbose: Boolean = Properties.propOrFalse(TraceProperties.Verbose.key)
+
+    val localServiceName: String =
+      Properties.propOrElse(TraceProperties.LocalServiceName.key, default.localServiceName.get)
+
+    val traceStartAnnotation: Option[String] =
+      Properties.propOrNone(TraceProperties.TraceStartAnnotation.key)
+
+    val traceEndAnnotation: Option[String] =
+      Properties.propOrNone(TraceProperties.TraceEndAnnotation.key)
+
+    val properties: TraceProperties = TraceProperties(
+      Some(zipkinServerUrl),
+      Some(debug),
+      Some(verbose),
+      Some(localServiceName),
+      traceStartAnnotation,
+      traceEndAnnotation
+    )
+  }
+}

--- a/backend/src/main/scala/bloop/tracing/TraceProperties.scala
+++ b/backend/src/main/scala/bloop/tracing/TraceProperties.scala
@@ -4,9 +4,7 @@ import scala.util.Properties
 
 case class TraceProperties(
     serverUrl: String,
-    // Note: `debug` corresponds to a sampling flag sent to Zipkin server,
-    // while `verbose` determines if we send certain spans marked as verbose spans
-    debug: Boolean,
+    debugTracing: Boolean,
     verbose: Boolean,
     localServiceName: String,
     traceStartAnnotation: Option[String],
@@ -15,20 +13,20 @@ case class TraceProperties(
 
 object TraceProperties {
   val default: TraceProperties = {
-    val debug = Properties.propOrFalse("bloop.trace.debug")
-    val verbose = Properties.propOrFalse("bloop.trace.verbose")
-    val localServiceName = Properties.propOrElse("bloop.trace.localServiceName", "bloop")
-    val traceStartAnnotation = Properties.propOrNone("bloop.trace.traceStartAnnotation")
-    val traceEndAnnotation = Properties.propOrNone("bloop.trace.traceEndAnnotation")
+    val verbose = Properties.propOrFalse("bloop.tracing.verbose")
+    val debugTracing = Properties.propOrFalse("bloop.tracing.debug")
+    val localServiceName = Properties.propOrElse("bloop.tracing.localServiceName", "bloop")
+    val traceStartAnnotation = Properties.propOrNone("bloop.tracing.traceStartAnnotation")
+    val traceEndAnnotation = Properties.propOrNone("bloop.tracing.traceEndAnnotation")
 
     val traceServerUrl = Properties.propOrElse(
       "zipkin.server.url",
-      Properties.propOrElse("bloop.trace.server.url", "http://127.0.0.1:9411/api/v2/spans")
+      Properties.propOrElse("bloop.tracing.server.url", "http://127.0.0.1:9411/api/v2/spans")
     )
 
     TraceProperties(
       traceServerUrl,
-      debug,
+      debugTracing,
       verbose,
       localServiceName,
       traceStartAnnotation,

--- a/frontend/src/it/scala/bloop/CommunityBuild.scala
+++ b/frontend/src/it/scala/bloop/CommunityBuild.scala
@@ -3,11 +3,12 @@ package bloop
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import java.nio.file.attribute.FileTime
+
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import bloop.cli.{Commands, ExitStatus}
 import bloop.config.Config
-import bloop.data.{Origin, Project, LoadedProject}
+import bloop.data.{LoadedProject, Origin, Project, WorkspaceSettings}
 import bloop.engine.{
   Action,
   Build,
@@ -92,7 +93,8 @@ abstract class CommunityBuild(val buildpressHomeDir: AbsolutePath) {
   def loadStateForBuild(configDirectory: AbsolutePath, logger: Logger): State = {
     assert(configDirectory.exists, "Does not exist: " + configDirectory)
     val loadedProjects = BuildLoader.loadSynchronously(configDirectory, logger)
-    val build = Build(configDirectory, loadedProjects)
+    val workspaceSettings = WorkspaceSettings.readFromFile(configDirectory, logger)
+    val build = Build(configDirectory, loadedProjects, workspaceSettings)
     val state = State.forTests(build, compilerCache, logger)
     state.copy(results = ResultsCache.emptyForTests)
   }

--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -1,26 +1,16 @@
 package bloop
 
-import bloop.data.ClientInfo
+import _root_.monix.eval.Task
+import bloop.cli.CliParsers.cliParser
 import bloop.cli.{CliOptions, Commands, ExitStatus}
-import bloop.cli.CliParsers.{
-  OptionsParser,
-  cliParser,
-  coParser,
-  inputStreamRead,
-  pathParser,
-  printStreamRead,
-  propertiesParser
-}
-import bloop.engine.{Action, Build, BuildLoader, Exit, Interpreter, NoPool, Print, Run, State}
-import bloop.engine.tasks.Tasks
+import bloop.data.{ClientInfo, WorkspaceSettings}
+import bloop.engine._
 import bloop.io.AbsolutePath
 import bloop.logging.BloopLogger
 import caseapp.{CaseApp, RemainingArgs}
 import jline.console.ConsoleReader
-import _root_.monix.eval.Task
 
 import scala.annotation.tailrec
-import scala.concurrent.Promise
 
 object Bloop extends CaseApp[CliOptions] {
   private val reader = consoleReader()
@@ -36,7 +26,8 @@ object Bloop extends CaseApp[CliOptions] {
     logger.warn("Please refer to our documentation for more information.")
     val client = ClientInfo.CliClientInfo(useStableCliDirs = true, () => true)
     val loadedProjects = BuildLoader.loadSynchronously(configDirectory, logger)
-    val build = Build(configDirectory, loadedProjects)
+    val workspaceSettings = WorkspaceSettings.readFromFile(configDirectory, logger)
+    val build = Build(configDirectory, loadedProjects, workspaceSettings)
     val state = State(build, client, NoPool, options.common, logger)
     run(state, options)
   }

--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -1,16 +1,26 @@
 package bloop
 
-import _root_.monix.eval.Task
-import bloop.cli.CliParsers.cliParser
+import bloop.data.ClientInfo
 import bloop.cli.{CliOptions, Commands, ExitStatus}
-import bloop.data.{ClientInfo, WorkspaceSettings}
-import bloop.engine._
+import bloop.cli.CliParsers.{
+  cliParser,
+  coParser,
+  inputStreamRead,
+  pathParser,
+  printStreamRead,
+  propertiesParser,
+  OptionsParser
+}
+import bloop.engine.{Action, Build, BuildLoader, Exit, Interpreter, NoPool, Print, Run, State}
+import bloop.engine.tasks.Tasks
 import bloop.io.AbsolutePath
 import bloop.logging.BloopLogger
 import caseapp.{CaseApp, RemainingArgs}
 import jline.console.ConsoleReader
-
+import _root_.monix.eval.Task
+import bloop.data.WorkspaceSettings
 import scala.annotation.tailrec
+import scala.concurrent.Promise
 
 object Bloop extends CaseApp[CliOptions] {
   private val reader = consoleReader()

--- a/frontend/src/main/scala/bloop/bsp/BloopBspDefinitions.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspDefinitions.scala
@@ -1,11 +1,10 @@
 package bloop.bsp
 
-import scala.meta.jsonrpc.Endpoint
-
 import ch.epfl.scala.bsp.Uri
-
-import io.circe.{RootEncoder, Decoder}
 import io.circe.derivation._
+import io.circe.{Decoder, RootEncoder}
+
+import scala.meta.jsonrpc.Endpoint
 
 object BloopBspDefinitions {
   final case class BloopExtraBuildParams(

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -1,43 +1,60 @@
 package bloop.bsp
 
+import java.io.InputStream
 import java.net.URI
-import java.nio.file.{FileSystems, Files, Path}
+import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
+import java.nio.file.{FileSystems, Files, Path}
+import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.Collectors
+
+import bloop.io.ServerHandle
+import bloop.util.JavaRuntime
 import bloop.bsp.BloopBspDefinitions.BloopExtraBuildParams
+import bloop.{CompileMode, Compiler, ScalaInstance}
 import bloop.cli.{Commands, ExitStatus, Validate}
 import bloop.dap.{DebugServer, DebuggeeRunner, StartedDebugServer}
-import bloop.data.ClientInfo.BspClientInfo
-import bloop.data._
-import bloop.engine._
-import bloop.engine.tasks.compilation.CompileClientStore
-import bloop.engine.tasks.toolchains.{ScalaJsToolchain, ScalaNativeToolchain}
+import bloop.data.{ClientInfo, JdkConfig, Platform, Project, WorkspaceSettings}
+import bloop.engine.{Aggregate, Dag, Interpreter, State}
 import bloop.engine.tasks.{CompileTask, RunMode, Tasks, TestTask}
-import bloop.exec.Forker
+import bloop.engine.tasks.toolchains.{ScalaJsToolchain, ScalaNativeToolchain}
 import bloop.internal.build.BuildInfo
 import bloop.io.{AbsolutePath, RelativePath}
-import bloop.logging.{BloopLogger, BspServerLogger, DebugFilter}
+import bloop.logging.{BspServerLogger, DebugFilter, Logger}
 import bloop.reporter.{BspProjectReporter, ProblemPerPhase, ReporterConfig, ReporterInputs}
 import bloop.testing.{BspLoggingEventHandler, TestInternals}
-import bloop.tracing.TraceProperties
-import bloop.util.JavaRuntime
-import bloop.{Compiler, ScalaInstance}
 import ch.epfl.scala.bsp
 import ch.epfl.scala.bsp.ScalaBuildTarget.encodeScalaBuildTarget
-import ch.epfl.scala.bsp.{BuildTargetIdentifier, MessageType, ShowMessageParams, endpoints}
-import io.circe.{Decoder, Json}
+import ch.epfl.scala.bsp.{
+  BuildTargetIdentifier,
+  JvmEnvironmentItem,
+  MessageType,
+  ShowMessageParams,
+  endpoints
+}
+
+import scala.meta.jsonrpc.{JsonRpcClient, Response => JsonRpcResponse, Services => JsonRpcServices}
 import monix.eval.Task
-import monix.execution.atomic.{AtomicBoolean, AtomicInt}
-import monix.execution.{Cancelable, Scheduler}
-import monix.reactive.subjects.BehaviorSubject
-import scala.collection.JavaConverters._
+import monix.reactive.Observer
+import monix.execution.Scheduler
+import monix.execution.atomic.AtomicInt
+import monix.execution.atomic.AtomicBoolean
+
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
+import scala.collection.JavaConverters._
 import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration
-import scala.meta.jsonrpc.{JsonRpcClient, Response => JsonRpcResponse, Services => JsonRpcServices}
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
+import monix.execution.Cancelable
+import io.circe.{Decoder, Json}
+import bloop.engine.Feedback
+import monix.reactive.subjects.BehaviorSubject
+import bloop.engine.tasks.compilation.CompileClientStore
+import bloop.data.ClientInfo.BspClientInfo
+import bloop.exec.Forker
+import bloop.logging.BloopLogger
 
 final class BloopBspServices(
     callSiteState: State,

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -200,19 +200,12 @@ final class BloopBspServices(
     val currentWorkspaceSettings = WorkspaceSettings.readFromFile(configDir, callSiteState.logger)
     val currentRefreshProjectsCommand: Option[List[String]] =
       currentWorkspaceSettings.flatMap(_.refreshProjectsCommand)
-    val currentTraceProperties = currentWorkspaceSettings
-      .map(_.traceProperties)
-      .getOrElse(TraceProperties.Global.properties)
+    val currentTraceSettings = currentWorkspaceSettings.flatMap(_.traceSettings)
 
     val isMetals = params.displayName.contains("Metals")
     val isIntelliJ = params.displayName.contains("IntelliJ")
+    val refreshProjectsCommand = if (isIntelliJ) currentRefreshProjectsCommand else None
 
-    val refreshProjectsCommand =
-      if (isIntelliJ) {
-        currentRefreshProjectsCommand
-      } else {
-        None
-      }
     val client = ClientInfo.BspClientInfo(
       params.displayName,
       params.version,
@@ -243,7 +236,7 @@ final class BloopBspServices(
               Some(semanticDBVersion),
               Some(supportedScalaVersions),
               currentRefreshProjectsCommand,
-              currentTraceProperties
+              currentTraceSettings
             )
           }
       }

--- a/frontend/src/main/scala/bloop/data/TraceSettings.scala
+++ b/frontend/src/main/scala/bloop/data/TraceSettings.scala
@@ -4,7 +4,7 @@ import bloop.tracing.TraceProperties
 
 case class TraceSettings(
     serverUrl: Option[String],
-    debug: Option[Boolean],
+    debugTracing: Option[Boolean],
     verbose: Option[Boolean],
     localServiceName: Option[String],
     traceStartAnnotation: Option[String],
@@ -16,7 +16,7 @@ object TraceSettings {
     val default = TraceProperties.default
     TraceProperties(
       settings.serverUrl.getOrElse(default.serverUrl),
-      settings.debug.getOrElse(default.debug),
+      settings.debugTracing.getOrElse(default.debugTracing),
       settings.verbose.getOrElse(default.verbose),
       settings.localServiceName.getOrElse(default.localServiceName),
       settings.traceStartAnnotation.orElse(default.traceStartAnnotation),
@@ -27,7 +27,7 @@ object TraceSettings {
   def fromProperties(properties: TraceProperties): TraceSettings = {
     TraceSettings(
       serverUrl = Some(properties.serverUrl),
-      debug = Some(properties.debug),
+      debugTracing = Some(properties.debugTracing),
       verbose = Some(properties.verbose),
       localServiceName = Some(properties.localServiceName),
       traceStartAnnotation = properties.traceStartAnnotation,

--- a/frontend/src/main/scala/bloop/data/TraceSettings.scala
+++ b/frontend/src/main/scala/bloop/data/TraceSettings.scala
@@ -1,0 +1,37 @@
+package bloop.data
+
+import bloop.tracing.TraceProperties
+
+case class TraceSettings(
+    serverUrl: Option[String],
+    debug: Option[Boolean],
+    verbose: Option[Boolean],
+    localServiceName: Option[String],
+    traceStartAnnotation: Option[String],
+    traceEndAnnotation: Option[String]
+)
+
+object TraceSettings {
+  def toProperties(settings: TraceSettings): TraceProperties = {
+    val default = TraceProperties.default
+    TraceProperties(
+      settings.serverUrl.getOrElse(default.serverUrl),
+      settings.debug.getOrElse(default.debug),
+      settings.verbose.getOrElse(default.verbose),
+      settings.localServiceName.getOrElse(default.localServiceName),
+      settings.traceStartAnnotation.orElse(default.traceStartAnnotation),
+      settings.traceEndAnnotation.orElse(default.traceEndAnnotation)
+    )
+  }
+
+  def fromProperties(properties: TraceProperties): TraceSettings = {
+    TraceSettings(
+      serverUrl = Some(properties.serverUrl),
+      debug = Some(properties.debug),
+      verbose = Some(properties.verbose),
+      localServiceName = Some(properties.localServiceName),
+      traceStartAnnotation = properties.traceStartAnnotation,
+      traceEndAnnotation = properties.traceEndAnnotation
+    )
+  }
+}

--- a/frontend/src/main/scala/bloop/data/WorkspaceSettings.scala
+++ b/frontend/src/main/scala/bloop/data/WorkspaceSettings.scala
@@ -4,15 +4,13 @@ import bloop.logging.Logger
 import bloop.logging.DebugFilter
 import bloop.io.AbsolutePath
 import bloop.io.RelativePath
-
 import scala.util.Try
 import scala.util.Failure
 import scala.util.Success
-
 import java.nio.file.Files
-
+import bloop.tracing.TraceProperties
 import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, WriterConfig}
-import com.github.plokhotnyuk.jsoniter_scala.macros.{JsonCodecMaker, CodecMakerConfig}
+import com.github.plokhotnyuk.jsoniter_scala.macros.{CodecMakerConfig, JsonCodecMaker}
 
 /**
  * Defines the settings of a given workspace. A workspace is a URI that has N
@@ -38,7 +36,8 @@ import com.github.plokhotnyuk.jsoniter_scala.macros.{JsonCodecMaker, CodecMakerC
 case class WorkspaceSettings(
     semanticDBVersion: Option[String],
     supportedScalaVersions: Option[List[String]],
-    refreshProjectsCommand: Option[List[String]]
+    refreshProjectsCommand: Option[List[String]],
+    traceProperties: TraceProperties
 ) {
   def withSemanticdbSettings: Option[(WorkspaceSettings, SemanticdbSettings)] =
     (semanticDBVersion, supportedScalaVersions) match {
@@ -54,7 +53,12 @@ object WorkspaceSettings {
       semanticDBVersion: String,
       supportedScalaVersions: List[String]
   ): WorkspaceSettings = {
-    WorkspaceSettings(Some(semanticDBVersion), Some(supportedScalaVersions), None)
+    WorkspaceSettings(
+      Some(semanticDBVersion),
+      Some(supportedScalaVersions),
+      None,
+      TraceProperties.Global.properties
+    )
   }
 
   /** Represents the supported changes in the workspace. */

--- a/frontend/src/main/scala/bloop/engine/Build.scala
+++ b/frontend/src/main/scala/bloop/engine/Build.scala
@@ -1,21 +1,20 @@
 package bloop.engine
 
-import bloop.data.{Origin, Project, LoadedProject, WorkspaceSettings}
+import bloop.data.{LoadedProject, Origin, Project, WorkspaceSettings}
 import bloop.engine.Dag.DagResult
-import bloop.io.AbsolutePath
+import bloop.io.{AbsolutePath, ByteHasher}
 import bloop.logging.Logger
 import bloop.util.CacheHashCode
-import bloop.io.ByteHasher
-import bloop.logging.DebugFilter
+import monix.eval.Task
 
 import scala.collection.mutable
 
-import monix.eval.Task
-
 final case class Build private (
     origin: AbsolutePath,
-    loadedProjects: List[LoadedProject]
+    loadedProjects: List[LoadedProject],
+    workspaceSettings: Option[WorkspaceSettings]
 ) extends CacheHashCode {
+
   private val stringToProjects: Map[String, Project] =
     loadedProjects.map(lp => lp.project.name -> lp.project).toMap
   private[bloop] val DagResult(dags, missingDeps, traces) = Dag.fromMap(stringToProjects)

--- a/frontend/src/main/scala/bloop/engine/caches/StateCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/StateCache.scala
@@ -91,7 +91,7 @@ final class StateCache(cache: ConcurrentHashMap[AbsolutePath, StateCache.CachedS
       createState: Build => State,
       clientSettings: Option[WorkspaceSettings]
   ): Task[State] = {
-    val empty = Build(from, Nil)
+    val empty = Build(from, Nil, None)
     if (from == Environment.defaultBloopDirectory) return Task.now(createState(empty))
     val previousState = getStateFor(from, client, pool, commonOptions, logger)
     val build = previousState.map(_.build).getOrElse(empty)
@@ -127,7 +127,7 @@ final class StateCache(cache: ConcurrentHashMap[AbsolutePath, StateCache.CachedS
                 val newBuild = state.build.copy(loadedProjects = untouched ++ newProjects)
                 state.copy(build = newBuild)
               // Create a new state since there was no previous one
-              case None => createState(Build(from, newProjects))
+              case None => createState(Build(from, newProjects, settings))
             }
             cache.put(from, StateCache.CachedState.fromState(newState))
             newState

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -26,6 +26,7 @@ import monix.execution.CancelableFuture
 import monix.reactive.{MulticastStrategy, Observable}
 import scala.collection.mutable
 import scala.concurrent.Promise
+import bloop.data.WorkspaceSettings
 
 object CompileTask {
   private implicit val logContext: DebugFilter = DebugFilter.Compilation
@@ -49,11 +50,11 @@ object CompileTask {
       case bspClient: ClientInfo.BspClientInfo => bspClient.uniqueId
     }
 
-    val traceProperties = state.build.workspaceSettings.map(_.traceProperties)
+    val traceProperties = WorkspaceSettings.tracePropertiesFrom(state.build.workspaceSettings)
 
     val rootTracer = BraveTracer(
       s"compile $topLevelTargets (transitively)",
-      traceProperties.getOrElse(TraceProperties.Global.properties),
+      traceProperties,
       "bloop.version" -> BuildInfo.version,
       "zinc.version" -> BuildInfo.zincVersion,
       "build.uri" -> originUri.syntax,
@@ -63,7 +64,7 @@ object CompileTask {
 
     val bgTracer = rootTracer.toIndependentTracer(
       s"background IO work after compiling $topLevelTargets (transitively)",
-      traceProperties.getOrElse(TraceProperties.Global.properties),
+      traceProperties,
       "bloop.version" -> BuildInfo.version,
       "zinc.version" -> BuildInfo.zincVersion,
       "build.uri" -> originUri.syntax,

--- a/frontend/src/test/scala/bloop/BuildLoaderSpec.scala
+++ b/frontend/src/test/scala/bloop/BuildLoaderSpec.scala
@@ -13,6 +13,7 @@ import bloop.tracing.TraceProperties
 import monix.eval.Task
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException
 import scala.util.Try
+import bloop.data.TraceSettings
 
 object BuildLoaderSpec extends BaseSuite {
   testLoad("don't reload if nothing changes") { (testBuild, logger) =>
@@ -253,18 +254,26 @@ object BuildLoaderSpec extends BaseSuite {
         None,
         None,
         None,
-        TraceProperties(
-          zipkinServerUrl = Some("http://127.0.0.2"),
-          debug = Some(false),
-          verbose = Some(false),
-          localServiceName = Some("42"),
-          traceStartAnnotation = Some("start"),
-          traceEndAnnotation = Some("end")
+        Some(
+          TraceSettings(
+            serverUrl = Some("http://127.0.0.2"),
+            debug = Some(false),
+            verbose = Some(false),
+            localServiceName = Some("42"),
+            traceStartAnnotation = Some("start"),
+            traceEndAnnotation = Some("end")
+          )
         )
       )
+
       val state1 = loadState(workspace1, Nil, logger, Some(settings1))
       TestUtil.withinWorkspace { workspace2 =>
-        val settings2 = settings1.copy(traceProperties = TraceProperties.default)
+        val settings2 = settings1.copy(
+          traceSettings = Some(
+            TraceSettings.fromProperties(TraceProperties.default)
+          )
+        )
+
         val state2 = loadState(workspace2, Nil, logger, Some(settings2))
         assert(state1.build.workspaceSettings.isDefined)
         assert(state2.build.workspaceSettings.isDefined)

--- a/frontend/src/test/scala/bloop/BuildLoaderSpec.scala
+++ b/frontend/src/test/scala/bloop/BuildLoaderSpec.scala
@@ -2,7 +2,6 @@ package bloop
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-
 import bloop.engine.{Build, BuildLoader, State}
 import bloop.io.{AbsolutePath, Paths}
 import bloop.logging.{Logger, RecordingLogger}
@@ -10,7 +9,7 @@ import bloop.util.TestUtil
 import bloop.testing.BaseSuite
 import bloop.data.WorkspaceSettings
 import bloop.internal.build.BuildInfo
-
+import bloop.tracing.TraceProperties
 import monix.eval.Task
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException
 import scala.util.Try
@@ -244,6 +243,33 @@ object BuildLoaderSpec extends BaseSuite {
       val failedState = Try(TestUtil.loadTestProject(state.build.origin.underlying, logger))
       assert(failedState.isFailure)
       assert(failedState.failed.get.getMessage.contains("Failed to load project from"))
+    }
+  }
+
+  test("build respects different trace properties in separate workspaces") {
+    TestUtil.withinWorkspace { workspace1 =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val settings1 = WorkspaceSettings(
+        None,
+        None,
+        None,
+        TraceProperties(
+          zipkinServerUrl = Some("http://127.0.0.2"),
+          debug = Some(false),
+          verbose = Some(false),
+          localServiceName = Some("42"),
+          traceStartAnnotation = Some("start"),
+          traceEndAnnotation = Some("end")
+        )
+      )
+      val state1 = loadState(workspace1, Nil, logger, Some(settings1))
+      TestUtil.withinWorkspace { workspace2 =>
+        val settings2 = settings1.copy(traceProperties = TraceProperties.default)
+        val state2 = loadState(workspace2, Nil, logger, Some(settings2))
+        assert(state1.build.workspaceSettings.isDefined)
+        assert(state2.build.workspaceSettings.isDefined)
+        assert(state1.build.workspaceSettings.get != state2.build.workspaceSettings.get)
+      }
     }
   }
 

--- a/frontend/src/test/scala/bloop/BuildLoaderSpec.scala
+++ b/frontend/src/test/scala/bloop/BuildLoaderSpec.scala
@@ -257,7 +257,7 @@ object BuildLoaderSpec extends BaseSuite {
         Some(
           TraceSettings(
             serverUrl = Some("http://127.0.0.2"),
-            debug = Some(false),
+            debugTracing = Some(false),
             verbose = Some(false),
             localServiceName = Some("42"),
             traceStartAnnotation = Some("start"),

--- a/frontend/src/test/scala/bloop/TracerSpec.scala
+++ b/frontend/src/test/scala/bloop/TracerSpec.scala
@@ -2,7 +2,7 @@ package bloop
 
 import bloop.tracing.BraveTracer
 import bloop.testing.BaseSuite
-
+import bloop.tracing.TraceProperties
 import monix.eval.Task
 
 object TracerSpec extends BaseSuite {
@@ -21,7 +21,10 @@ object TracerSpec extends BaseSuite {
         Thread.sleep(250)
       }
       Thread.sleep(750)
-      val tracer2 = tracer.toIndependentTracer(s"independent encode ${id}")
+      val tracer2 = tracer.toIndependentTracer(
+        s"independent encode ${id}",
+        TraceProperties.Global.properties
+      )
       tracer.terminate()
       tracer2.trace(s"previous independent child ${id}") { _ =>
         Thread.sleep(750)

--- a/frontend/src/test/scala/bloop/TracerSpec.scala
+++ b/frontend/src/test/scala/bloop/TracerSpec.scala
@@ -8,7 +8,7 @@ import monix.eval.Task
 object TracerSpec extends BaseSuite {
   test("forty clients can send zipkin traces concurrently") {
     def sendTrace(id: String): Unit = {
-      val tracer = BraveTracer(s"encode ${id}")
+      val tracer = BraveTracer(s"encode ${id}", TraceProperties.default)
       Thread.sleep(700)
       tracer.trace(s"previous child ${id}") { tracer =>
         Thread.sleep(500)
@@ -23,7 +23,7 @@ object TracerSpec extends BaseSuite {
       Thread.sleep(750)
       val tracer2 = tracer.toIndependentTracer(
         s"independent encode ${id}",
-        TraceProperties.Global.properties
+        TraceProperties.default
       )
       tracer.terminate()
       tracer2.trace(s"previous independent child ${id}") { _ =>

--- a/frontend/src/test/scala/bloop/bsp/BspIntellijClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspIntellijClientSpec.scala
@@ -3,6 +3,7 @@ package bloop.bsp
 import bloop.cli.BspProtocol
 import bloop.data.WorkspaceSettings
 import bloop.logging.RecordingLogger
+import bloop.tracing.TraceProperties
 import bloop.util.{CrossPlatform, TestProject, TestUtil}
 import ch.epfl.scala.bsp.WorkspaceBuildTargetsResult
 
@@ -50,7 +51,12 @@ class BspIntellijClientSpec(
       }
 
       val workspaceSettings =
-        WorkspaceSettings(None, None, refreshProjectsCommand = Some(refreshProjectsCommand))
+        WorkspaceSettings(
+          None,
+          None,
+          refreshProjectsCommand = Some(refreshProjectsCommand),
+          TraceProperties.default
+        )
       WorkspaceSettings.writeToFile(configDir, workspaceSettings, logger)
 
       loadBspState(workspace, initialProjects, logger, bspClientName = "IntelliJ") { state =>

--- a/frontend/src/test/scala/bloop/bsp/BspIntellijClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspIntellijClientSpec.scala
@@ -6,6 +6,7 @@ import bloop.logging.RecordingLogger
 import bloop.tracing.TraceProperties
 import bloop.util.{CrossPlatform, TestProject, TestUtil}
 import ch.epfl.scala.bsp.WorkspaceBuildTargetsResult
+import bloop.data.TraceSettings
 
 object LocalBspIntellijClientSpec extends BspIntellijClientSpec(BspProtocol.Local)
 object TcpBspIntellijClientSpec extends BspIntellijClientSpec(BspProtocol.Tcp)
@@ -50,13 +51,13 @@ class BspIntellijClientSpec(
         }
       }
 
-      val workspaceSettings =
-        WorkspaceSettings(
-          None,
-          None,
-          refreshProjectsCommand = Some(refreshProjectsCommand),
-          TraceProperties.default
-        )
+      val workspaceSettings = WorkspaceSettings(
+        None,
+        None,
+        refreshProjectsCommand = Some(refreshProjectsCommand),
+        Some(TraceSettings.fromProperties(TraceProperties.default))
+      )
+
       WorkspaceSettings.writeToFile(configDir, workspaceSettings, logger)
 
       loadBspState(workspace, initialProjects, logger, bspClientName = "IntelliJ") { state =>

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -56,13 +56,7 @@ class BspMetalsClientSpec(
              |    "semanticDBVersion": "4.2.0",
              |    "supportedScalaVersions": [
              |        "2.12.8"
-             |    ],
-             |    "traceProperties": {
-             |        "zipkinServerUrl": "http://127.0.0.1:9411/api/v2/spans",
-             |        "debug": false,
-             |        "verbose": false,
-             |        "localServiceName": "bloop"
-             |    }
+             |    ]
              |}
              |""".stripMargin
         )
@@ -102,13 +96,7 @@ class BspMetalsClientSpec(
              |    "semanticDBVersion": "4.2.0",
              |    "supportedScalaVersions": [
              |        "2.12.8"
-             |    ],
-             |    "traceProperties": {
-             |        "zipkinServerUrl": "http://127.0.0.1:9411/api/v2/spans",
-             |        "debug": false,
-             |        "verbose": false,
-             |        "localServiceName": "bloop"
-             |    }
+             |    ]
              |}
              |""".stripMargin
         )
@@ -155,13 +143,7 @@ class BspMetalsClientSpec(
              |    "semanticDBVersion": "4.2.0",
              |    "supportedScalaVersions": [
              |        "2.12.8"
-             |    ],
-             |    "traceProperties": {
-             |        "zipkinServerUrl": "http://127.0.0.1:9411/api/v2/spans",
-             |        "debug": false,
-             |        "verbose": false,
-             |        "localServiceName": "bloop"
-             |    }
+             |    ]
              |}
              |""".stripMargin
         )
@@ -211,13 +193,7 @@ class BspMetalsClientSpec(
              |    "semanticDBVersion": "4.2.0",
              |    "supportedScalaVersions": [
              |        "2.12.8"
-             |    ],
-             |    "traceProperties": {
-             |        "zipkinServerUrl": "http://127.0.0.1:9411/api/v2/spans",
-             |        "debug": false,
-             |        "verbose": false,
-             |        "localServiceName": "bloop"
-             |    }
+             |    ]
              |}
              |""".stripMargin
         )

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -56,7 +56,13 @@ class BspMetalsClientSpec(
              |    "semanticDBVersion": "4.2.0",
              |    "supportedScalaVersions": [
              |        "2.12.8"
-             |    ]
+             |    ],
+             |    "traceProperties": {
+             |        "zipkinServerUrl": "http://127.0.0.1:9411/api/v2/spans",
+             |        "debug": false,
+             |        "verbose": false,
+             |        "localServiceName": "bloop"
+             |    }
              |}
              |""".stripMargin
         )
@@ -96,7 +102,13 @@ class BspMetalsClientSpec(
              |    "semanticDBVersion": "4.2.0",
              |    "supportedScalaVersions": [
              |        "2.12.8"
-             |    ]
+             |    ],
+             |    "traceProperties": {
+             |        "zipkinServerUrl": "http://127.0.0.1:9411/api/v2/spans",
+             |        "debug": false,
+             |        "verbose": false,
+             |        "localServiceName": "bloop"
+             |    }
              |}
              |""".stripMargin
         )
@@ -143,7 +155,13 @@ class BspMetalsClientSpec(
              |    "semanticDBVersion": "4.2.0",
              |    "supportedScalaVersions": [
              |        "2.12.8"
-             |    ]
+             |    ],
+             |    "traceProperties": {
+             |        "zipkinServerUrl": "http://127.0.0.1:9411/api/v2/spans",
+             |        "debug": false,
+             |        "verbose": false,
+             |        "localServiceName": "bloop"
+             |    }
              |}
              |""".stripMargin
         )
@@ -193,7 +211,13 @@ class BspMetalsClientSpec(
              |    "semanticDBVersion": "4.2.0",
              |    "supportedScalaVersions": [
              |        "2.12.8"
-             |    ]
+             |    ],
+             |    "traceProperties": {
+             |        "zipkinServerUrl": "http://127.0.0.1:9411/api/v2/spans",
+             |        "debug": false,
+             |        "verbose": false,
+             |        "localServiceName": "bloop"
+             |    }
              |}
              |""".stripMargin
         )

--- a/frontend/src/test/scala/bloop/io/ClasspathHasherSpec.scala
+++ b/frontend/src/test/scala/bloop/io/ClasspathHasherSpec.scala
@@ -14,6 +14,7 @@ import scala.concurrent.Promise
 import monix.eval.Task
 
 import sbt.internal.inc.bloop.internal.BloopStamps
+import bloop.tracing.TraceProperties
 
 object ClasspathHasherSpec extends bloop.testing.BaseSuite {
   ignore("cancellation works OK") {
@@ -21,7 +22,7 @@ object ClasspathHasherSpec extends bloop.testing.BaseSuite {
     val logger = new RecordingLogger()
     val cancelPromise = Promise[Unit]()
     val cancelPromise2 = Promise[Unit]()
-    val tracer = BraveTracer("cancels-correctly-test")
+    val tracer = BraveTracer("cancels-correctly-test", TraceProperties.default)
     val jars =
       Array(
         DependencyResolution.Artifact("org.apache.spark", "spark-core_2.11", "2.4.4"),

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -243,7 +243,8 @@ object TestUtil {
           settings
         )
     }
-    val build = Build(configDirectory, transformedProjects)
+    val workspaceSettings = WorkspaceSettings.readFromFile(configDirectory, logger)
+    val build = Build(configDirectory, transformedProjects, workspaceSettings)
     val state = State.forTests(build, TestUtil.getCompilerCache(logger), logger)
     val state1 = state.copy(commonOptions = state.commonOptions.copy(env = runAndTestProperties))
     if (!emptyResults) state1 else state1.copy(results = ResultsCache.emptyForTests)
@@ -320,7 +321,7 @@ object TestUtil {
           makeProject(temp, name, sources, deps, instance1, jdkConfig, logger, order, extraJars)
       }
       val loaded = projects.map(p => LoadedProject.RawProject(p))
-      val build = Build(temp, loaded.toList)
+      val build = Build(temp, loaded.toList, None)
       val state = State.forTests(build, TestUtil.getCompilerCache(logger), logger)
       try op(state)
       catch {

--- a/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
+++ b/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
@@ -4,11 +4,11 @@ import java.io.File
 import java.net.URLClassLoader
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
-
 import bloop.cli.Commands
 import bloop.config.Config.Platform.Jvm
 import bloop.config.{Config, Tag}
 import bloop.config.Config.{CompileSetup, JavaThenScala, Mixed, Platform}
+import bloop.data.WorkspaceSettings
 import bloop.engine.{Build, Run, State}
 import bloop.io.AbsolutePath
 import bloop.logging.BloopLogger
@@ -19,7 +19,6 @@ import org.junit._
 import org.junit.Assert._
 import org.junit.rules.TemporaryFolder
 import bloop.engine.BuildLoader
-
 import scala.collection.JavaConverters._
 
 /*
@@ -1586,7 +1585,8 @@ abstract class ConfigGenerationSuite {
     assert(Files.exists(configDir.toPath), "Does not exist: " + configDir)
     val configDirectory = AbsolutePath(configDir)
     val loadedProjects = BuildLoader.loadSynchronously(configDirectory, logger)
-    val build = Build(configDirectory, loadedProjects)
+    val workspaceSettings = WorkspaceSettings.readFromFile(configDirectory, logger)
+    val build = Build(configDirectory, loadedProjects, workspaceSettings)
     State.forTests(build, TestUtil.getCompilerCache(logger), logger)
   }
 


### PR DESCRIPTION
Previously, it was only possible to customize the Zipkin integration globally via system properties.
This PR will make it possible to configure Zipkin integration properties per-workspace via `bloop.settings.json`. The motivation for this change is to make it possible to track compile/test metrics for Bloop only when working in a specific codebase.