### PR TITLE
Don't consider CLI classes directory an orphan directory

### DIFF
--- a/backend/src/main/scala/bloop/io/ParallelOps.scala
+++ b/backend/src/main/scala/bloop/io/ParallelOps.scala
@@ -74,7 +74,7 @@ object ParallelOps {
       scheduler: Scheduler,
       logger: Logger,
       enableCancellation: Boolean
-  ): Task[FileWalk] = {
+  ): Task[FileWalk] = Task.defer {
     val isCancelled = AtomicBoolean(false)
 
     import scala.collection.mutable

--- a/frontend/src/main/scala/bloop/bsp/BspServer.scala
+++ b/frontend/src/main/scala/bloop/bsp/BspServer.scala
@@ -143,10 +143,9 @@ object BspServer {
               TimeUnit.MILLISECONDS,
               new Runnable {
                 override def run(): Unit = {
-                  ClientInfo.deleteOrphanClientBspDirectories(
-                    () => askCurrentBspClients,
-                    logger
-                  )
+                  val ngout = state.commonOptions.ngout
+                  val ngerr = state.commonOptions.ngerr
+                  ClientInfo.deleteOrphanClientBspDirectories(askCurrentBspClients, ngout, ngerr)
                 }
               }
             )

--- a/frontend/src/main/scala/bloop/engine/State.scala
+++ b/frontend/src/main/scala/bloop/engine/State.scala
@@ -56,9 +56,9 @@ object State {
 
   private[bloop] def forTests(build: Build, compilerCache: CompilerCache, logger: Logger): State = {
     val opts = CommonOptions.default
+    val cwd = opts.workingPath
     val clientInfo = ClientInfo.CliClientInfo(useStableCliDirs = true, () => true)
-    val results =
-      ResultsCache.load(build, opts.workingPath, cleanOrphanedInternalDirs = false, logger)
+    val results = ResultsCache.load(build, cwd, cleanOrphanedInternalDirs = false, logger)
     State(build, results, compilerCache, clientInfo, NoPool, opts, ExitStatus.Ok, logger)
   }
 
@@ -69,8 +69,8 @@ object State {
       opts: CommonOptions,
       logger: Logger
   ): State = {
-    val results =
-      ResultsCache.load(build, opts.workingPath, cleanOrphanedInternalDirs = true, logger)
+    val cwd = opts.workingPath
+    val results = ResultsCache.load(build, cwd, cleanOrphanedInternalDirs = true, logger)
     val compilerCache = getCompilerCache(logger)
     State(build, results, compilerCache, client, pool, opts, ExitStatus.Ok, logger)
   }

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -60,7 +60,7 @@ object CompileTask {
       cancelCompilation: Promise[Unit],
       store: CompileClientStore,
       rawLogger: UseSiteLogger
-  ): Task[State] = {
+  ): Task[State] = Task.defer {
     import bloop.data.ClientInfo
     import bloop.internal.build.BuildInfo
     val originUri = state.build.origin

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginWhitelist.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginWhitelist.scala
@@ -75,8 +75,9 @@ object CompilerPluginWhitelist {
       logger: Logger,
       tracer: BraveTracer,
       parallelUnits: Int
-  ): Task[List[String]] = {
+  ): Task[List[String]] = Task.defer {
     case class WorkItem(pluginFlag: String, idx: Int, result: Promise[Boolean])
+
     val actualScalaVersion = scalaVersion.split('-').headOption
     val blacklistedVersions = scalaVersionBlacklist.find { v =>
       actualScalaVersion.exists { userVersion =>


### PR DESCRIPTION
This commit fixes a bug in the logic deleting the orphan bsp classes
directories that was not updated when the CLI client classes dir was
moved to behave like just a normal bsp client classes dir.

This bug could have produced important problems such as
`ClassNotFoundException`s when starting a new connection while a bloop
CLI command is running.

I don't think this issue is directly related with the metals connection
issues but it might.