### PR TITLE
Update Maven Bloop Scala version to 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -584,8 +584,8 @@ lazy val sbtBloop013Shaded =
 lazy val mavenBloop = project
   .in(integrations / "maven-bloop")
   .disablePlugins(ScriptedPlugin)
-  .dependsOn(jsonConfig210)
-  .settings(name := "maven-bloop", scalaVersion := Scala210Version)
+  .dependsOn(jsonConfig212)
+  .settings(name := "maven-bloop", scalaVersion := Scala212Version)
   .settings(BuildDefaults.mavenPluginBuildSettings)
 
 lazy val gradleBloop211 = project


### PR DESCRIPTION
It seems that under 2.10 `Config.Platform.Jvm(Config.JvmConfig(javaHome, launcher.getJvmArgs().toList), mainClass, None, None)` is serialized as:

```json
        "platform" : {
            "name" : "jvm",
            "config" : {
                "home" : "/usr/lib/jvm/java-11-openjdk",
                "options" : [
                ]
            },
            "mainClass" : [
            ],
            "classpath" : [
            ],
            "resources" : [
            ]
        },
```

and under 2.12 it is:
```json
        "platform": {
            "name": "jvm",
            "config": {
                "home": "/usr/lib/jvm/java-11-openjdk",
                "options": [
                    
                ]
            },
            "mainClass": [
                
            ]
        },
```

With the 2.10 version the classpath does not contain the scala library and because of that anything we try fails to run:
https://github.com/scalameta/metals/issues/1805

I don't know the reason why we are keeping the maven plugin at 2.10, but this seemed like a good opportunity to upgrade.