### PR TITLE
Keep `compiledState` in `Interpreter.compileAnd`

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -213,7 +213,7 @@ object Interpreter {
       else {
         val projectsString = projects.mkString(", ")
         Task.now(
-          state.withDebug(s"Failed compilation for $projectsString. Skipping $nextAction...")(
+          compiled.withDebug(s"Failed compilation for $projectsString. Skipping $nextAction...")(
             DebugFilter.Compilation
           )
         )

--- a/frontend/src/test/scala/bloop/TestSpec.scala
+++ b/frontend/src/test/scala/bloop/TestSpec.scala
@@ -455,3 +455,21 @@ object TestResourcesSpec extends bloop.testing.BaseSuite {
     }
   }
 }
+
+object TestCompileErrorExitCode extends bloop.testing.BaseSuite {
+  test("exit code reflects compilation errors in tests") {
+    TestUtil.withinWorkspace { workspace =>
+      object Sources {
+        val `a/A.scala` =
+          """/a/A.scala
+            |invalid source file""".stripMargin
+      }
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(Sources.`a/A.scala`))
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+      val testState = state.test(`A`)
+      assertEquals(ExitStatus.CompilationError, testState.status)
+    }
+  }
+}


### PR DESCRIPTION
Commands like `bloop test foo` which failed because of a compilation
error were reporting a successful exit code, because
`Interpreter.compileAnd` continued the execution using the state before
compilation. This resulted in the failed exit status being lost.