### PR TITLE
Don't expand resource directory entries in BSP server

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -1032,13 +1032,8 @@ final class BloopBspServices(
       val response = bsp.ResourcesResult(
         projects.iterator.map {
           case (target, project) =>
-            val resources = project.runtimeResources.flatMap { s =>
-              if (s.exists) {
-                val resources = Files.walk(s.underlying).collect(Collectors.toList[Path]).asScala
-                resources.map(r => bsp.Uri(r.toUri()))
-              } else {
-                Seq.empty
-              }
+            val resources = project.runtimeResources.map { s =>
+              bsp.Uri(s.toBspUri)
             }
             bsp.ResourcesItem(target, resources)
         }.toList

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -472,14 +472,7 @@ class BspProtocolSpec(
           assert(resourcesResult.items.size == 1)
           val resources = resourcesResult.items.head
           val resourcePaths = resources.resources.map(_.toPath).toSet
-          val expectedResources = project.config.resources
-            .getOrElse(Seq.empty)
-            .flatMap(
-              dir =>
-                if (Files.exists(dir)) Files.walk(dir).collect(Collectors.toList[Path]).asScala
-                else Seq.empty
-            )
-            .toSet
+          val expectedResources = project.config.resources.getOrElse(Seq.empty).toSet
           assert(resourcePaths == expectedResources)
         }
 


### PR DESCRIPTION
Previously, the Bloop BSP server recursively walked all directory
resource entries and returned individual files. Now, the BSP server
returns the URIs of the directories unchanged and leaves it up to the
client to recursively walk the directories, if necessary.

There's nothing in the BSP spec that says that resource URIs cannot be
directories. The current behavior looses information because client
won't be able to relativize resource items by their enclosing directory.