### PR TITLE
Workaround Windows publishing issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,14 @@ jobs:
           echo $JAVA_HOME
           "$JAVA_HOME\bin\gu.cmd" install native-image
         shell: bash
+      - name: Pre-load sbt with bash
+        # FIXME: This step shouldn't be necessary, but sbt fails to find
+        # org.scala-lang.modules#scala-xml_2.12;1.2.0!scala-xml_2.12.jar when launched with
+        # cmd.
+        # Keep the sbt version in sync with `sbt-ci-release.bat`.
+        run: |
+          sbt -sbt-version 1.3.3 version
+        shell: bash
       - name: Publish GraalVM Native artifacts
         run: >-
           "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" &&

--- a/bin/sbt-ci-release.bat
+++ b/bin/sbt-ci-release.bat
@@ -1,1 +1,2 @@
+Rem Keep ci.yaml in sync with the sbt version
 sbt -sbt-version 1.3.3 bloopgun/graalvm-native-image:packageBin


### PR DESCRIPTION
The native image binaries publishing on Windows is currently broken
because of an issue where sbt fails to find
org.scala-lang.modules#scala-xml_2.12;1.2.0!scala-xml_2.12.jar when sbt
is started with `cmd` rather than `bash`.

To workaround this issue, we launch sbt a first time with `bash`, and
then do the publishing with `cmd`.

Why it fails with `cmd` is a mystery to me.