### PR TITLE
Fix bloopInstall in Maven when dirs don't exist

### DIFF
--- a/integrations/maven-bloop/src/main/java/bloop/integrations/maven/BloopMojo.java
+++ b/integrations/maven-bloop/src/main/java/bloop/integrations/maven/BloopMojo.java
@@ -55,6 +55,12 @@ public class BloopMojo extends ExtendedScalaContinuousCompileMojo {
     @Parameter(property = "bloop.classpathOptions.filterLibrary", defaultValue = "true")
     private boolean classpathOptionsFilterLibrary;
 
+    @Parameter(property = "bloop.secondaryCacheDir", defaultValue = "${session.executionRootDirectory}/.bloop/cache")
+    private File secondaryCacheDir;
+
+    @Parameter(property = "skip", defaultValue = "false")
+    private boolean skip;
+
     @Parameter
     private AppLauncher[] launchers;
 

--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -48,7 +48,10 @@ object MojoImplementation {
 
   def writeCompileAndTestConfiguration(mojo: BloopMojo, session: MavenSession, log: Log): Unit = {
     import scala.collection.JavaConverters._
-    def abs(file: File): Path = file.toPath().toRealPath().toAbsolutePath()
+    def abs(file: File): Path = {
+      file.mkdirs()
+      file.toPath().toRealPath().toAbsolutePath()
+    }
 
     val root = new File(session.getExecutionRootDirectory())
     val project = mojo.getProject()


### PR DESCRIPTION
* Add some more properties, which may be nonsense just to get it to bloopInstall to run

* toRealPath requires the directory to exist, which it wont always, particularly if a module is just resources and no code.