### PR TITLE
Workaround releasing issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -939,5 +939,5 @@ addCommandAlias(
     .mkString(";", ";", "")
 )
 
-val allReleaseActions = List("releaseEarlyAllModules", "releaseSonatypeBundle")
+val allReleaseActions = List("releaseEarlyAllModules", "sonatypeBundleRelease")
 addCommandAlias("releaseBloop", allReleaseActions.mkString(";", ";", ""))


### PR DESCRIPTION
The release was calling the task `sonatypeBundleRelease`, which doesn't
exist (a command with the same name exists, however). To fix it, we call
the command `sonatypeBundleRelease`.

Fixes #1320