### PR TITLE
Carry underlying error in `GlobalError`

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -186,7 +186,9 @@ object Compiler {
   object Result {
     final case object Empty extends Result with CacheHashCode
     final case class Blocked(on: List[String]) extends Result with CacheHashCode
-    final case class GlobalError(problem: String) extends Result with CacheHashCode
+    final case class GlobalError(problem: String, err: Option[Throwable])
+        extends Result
+        with CacheHashCode
 
     final case class Success(
         inputs: UniqueCompileInputs,
@@ -223,7 +225,8 @@ object Compiler {
 
     object NotOk {
       def unapply(result: Result): Option[Result] = result match {
-        case f @ (Failed(_, _, _, _) | Cancelled(_, _, _) | Blocked(_) | GlobalError(_)) => Some(f)
+        case f @ (Failed(_, _, _, _) | Cancelled(_, _, _) | Blocked(_) | GlobalError(_, _)) =>
+          Some(f)
         case _ => None
       }
     }

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -469,7 +469,7 @@ final class BloopBspServices(
             case Compiler.Result.Success(_, _, _, _, _, _, _) =>
               previouslyFailedCompilations.remove(p)
               Nil
-            case Compiler.Result.GlobalError(problem) => List(problem)
+            case Compiler.Result.GlobalError(problem, _) => List(problem)
             case Compiler.Result.Cancelled(problems, elapsed, _) =>
               List(reportError(p, problems, elapsed))
             case f @ Compiler.Result.Failed(problems, t, elapsed, _) =>

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
@@ -107,7 +107,7 @@ final case class SuccessfulCompileBundle(
   def prepareSourcesAndInstance: Either[ResultBundle, CompileSourcesAndInstance] = {
     import monix.execution.CancelableFuture
     def earlyError(msg: String): ResultBundle =
-      ResultBundle(Compiler.Result.GlobalError(msg), None, None)
+      ResultBundle(Compiler.Result.GlobalError(msg, None), None, None)
     def empty: ResultBundle = {
       val last = Some(LastSuccessfulResult.empty(project))
       ResultBundle(Compiler.Result.Empty, last, None)

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
@@ -154,7 +154,7 @@ object CompileGraph {
     ): Task[Dag[PartialCompileResult]] = {
       val errInfo = err.map(e => s": ${errorToString(e)}").getOrElse("")
       val finalErrorMsg = s"$errorMsg$errInfo"
-      val failedResult = Compiler.Result.GlobalError(errorMsg)
+      val failedResult = Compiler.Result.GlobalError(errorMsg, err)
       val failed = Task.now(ResultBundle(failedResult, None, None))
       Task.now(Leaf(PartialFailure(inputs.project, FailedOrCancelledPromise, failed)))
     }
@@ -331,7 +331,8 @@ object CompileGraph {
               case DeduplicationResult.DeduplicationError(t) =>
                 rawLogger.trace(t)
                 val failedDeduplicationResult = Compiler.Result.GlobalError(
-                  s"Unexpected error while deduplicating compilation for ${inputs.project.name}: ${t.getMessage}"
+                  s"Unexpected error while deduplicating compilation for ${inputs.project.name}: ${t.getMessage}",
+                  Some(t)
                 )
 
                 /*

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileResult.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileResult.scala
@@ -130,8 +130,9 @@ object FinalNormalCompileResult {
       res.result.fromCompiler match {
         case Compiler.Result.Failed(_, Some(err), _, _) =>
           Some((res.project, Right(err)))
-        case Compiler.Result.GlobalError(problem) =>
-          Some((res.project, Left(problem)))
+        case Compiler.Result.GlobalError(problem, errOpt) =>
+          val err = errOpt.map(Right(_)).getOrElse(Left(problem))
+          Some((res.project, err))
         case _ => None
       }
     }
@@ -160,7 +161,7 @@ object FinalCompileResult {
 
               s"${projectName} (success$mode ${ms}ms)"
             case Compiler.Result.Blocked(on) => s"${projectName} (blocked on ${on.mkString(", ")})"
-            case Compiler.Result.GlobalError(problem) =>
+            case Compiler.Result.GlobalError(problem, _) =>
               s"${projectName} (failed with global error ${problem})"
             case Compiler.Result.Failed(problems, t, ms, _) =>
               val extra = t match {


### PR DESCRIPTION
Previously, `GlobalError` contained only an error message, which means
that the exception causing a `GlobalError`, if any, was lost along with
the information it contains.

This commit adds an optional field holding the underlying exception,
which will be logged when present.