### PR TITLE
Ensure we don't hash directory when using globs

### DIFF
--- a/frontend/src/main/scala/bloop/io/SourceHasher.scala
+++ b/frontend/src/main/scala/bloop/io/SourceHasher.scala
@@ -75,7 +75,8 @@ object SourceHasher {
       def visitFile(file: Path, attributes: BasicFileAttributes): FileVisitResult = {
         if (isCancelled.get) FileVisitResult.TERMINATE
         else {
-          if (!matches(file)) ()
+          // `visitFile` can be called on a directory if we reach the max depth.
+          if (attributes.isDirectory || !matches(file)) ()
           else observer.onNext(file)
           FileVisitResult.CONTINUE
         }

--- a/frontend/src/test/scala/bloop/io/SourcesGlobsSpec.scala
+++ b/frontend/src/test/scala/bloop/io/SourcesGlobsSpec.scala
@@ -19,7 +19,8 @@ object SourcesGlobsSpec extends bloop.testing.BaseSuite {
       filenames: List[String],
       includeGlobs: List[String],
       excludeGlobs: List[String],
-      expectedFilenames: String
+      expectedFilenames: String,
+      walkDepth: Option[Int] = None
   )(implicit filename: sourcecode.File, line: sourcecode.Line): Unit =
     test(name) {
       TestUtil.withinWorkspace { workspace =>
@@ -37,7 +38,7 @@ object SourcesGlobsSpec extends bloop.testing.BaseSuite {
         val sourcesGlobs = SourcesGlobs.fromStrings(
           name,
           globDirectory,
-          None,
+          walkDepth,
           if (includeGlobs.isEmpty) List("glob:**")
           else includeGlobs,
           excludeGlobs,
@@ -158,4 +159,12 @@ object SourcesGlobsSpec extends bloop.testing.BaseSuite {
     )
   }
 
+  checkGlobs(
+    "file too deep",
+    List("src/main/scala/pkg/source.scala"),
+    List("glob:src/main/scala/*"),
+    Nil,
+    "",
+    Some(4)
+  )
 }


### PR DESCRIPTION
Globs allow us to define the maximum depth to search for source files.
When we reach this maximum depth, the `Files.walkFileTree` will call
`visitFile` on directories that cannot be traversed.

Previously, we were adding these directories to the list of items to
hash, which would cause an exception to be thrown.