### PR TITLE
Drop coursier '--scala-version' when launching bloop console 

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -278,9 +278,7 @@ object Interpreter {
                     "launch",
                     s"com.lihaoyi:ammonite_$scalaVersion:$ammVersion",
                     "--main-class",
-                    "ammonite.Main",
-                    "--scala-version",
-                    scalaVersion
+                    "ammonite.Main"
                   )
 
                   val classpath = project.fullRuntimeClasspath(dag, state.client)

--- a/frontend/src/test/scala/bloop/ConsoleSpec.scala
+++ b/frontend/src/test/scala/bloop/ConsoleSpec.scala
@@ -43,7 +43,7 @@ object ConsoleSpec extends BaseSuite {
       val coursierClasspathArgs =
         classpathB.flatMap(elem => Seq("--extra-jars", elem.syntax))
       val expectedCommand =
-        s"coursier launch com.lihaoyi:ammonite_2.12.8:latest.release --main-class ammonite.Main --scala-version 2.12.8 ${coursierClasspathArgs
+        s"coursier launch com.lihaoyi:ammonite_2.12.8:latest.release --main-class ammonite.Main ${coursierClasspathArgs
           .mkString(" ")} ${("--" :: ammArgs).mkString(" ")}"
 
       assertNoDiff(


### PR DESCRIPTION
Fixes #1301 (`bloop console` exits with ClassNotFound exception).

Note, I manually tested 2.13 and 2.12 with this change. I'm not sure this ever worked for 2.11 or 2.10?
