### PR TITLE
Removed note in gradle docs about duplicate project names

### DIFF
--- a/docs/build-tools/gradle.md
+++ b/docs/build-tools/gradle.md
@@ -149,16 +149,3 @@ enable Bloop in all projects by default, you can selectively enable bloop with:
 ```groovy
 apply plugin: 'bloop'
 ```
-
-## Well-known issues
-
-### Dealing with project name conflicts
-
-Gradle project names are disambiguate by the path in which they are defined, even if the build
-contains projects with the same simple name. In the bloop gradle plugin, simple project names have a
-one-to-one equivalence with bloop project names. As a results, some name conflicts can occur when
-there are two projects named `web` defined in `a/web` and `b/web`.
-
-For the moment, there is not an official solution to this problem. If you want to help out fix it,
-there is an open pull request proposing a solution that needs to be rebased and changed according to
-feedback. If you feel like helping out, please comment in the ticket.


### PR DESCRIPTION
Fixed in 334b096080a11eef7b61cd37e686c00bbd2346b0