### PR TITLE
Change use of `localhost` by `127.0.0.1`

### DIFF
--- a/frontend/src/main/scala/bloop/dap/DebugSessionLogger.scala
+++ b/frontend/src/main/scala/bloop/dap/DebugSessionLogger.scala
@@ -57,7 +57,7 @@ final class DebugSessionLogger(
     if (msg.startsWith(JDINotificationPrefix)) {
       if (initialized.compareAndSet(false, true)) {
         val port = Integer.parseInt(msg.drop(JDINotificationPrefix.length))
-        val address = new InetSocketAddress("localhost", port)
+        val address = new InetSocketAddress("127.0.0.1", port)
         listener(address)
       }
     } else {


### PR DESCRIPTION
Looks like in certain environments where a full VPN is enabled, using
`localhost` might cause discovery problems and might make Bloop fail
connect to the debug JVM. So we replace `localhost` with `127.0.0.1`.