### PR TITLE
Ignore empty directory layout in external classes dir

### DIFF
--- a/config/.jvm/src/test/scala/bloop/config/TestPlatform.scala
+++ b/config/.jvm/src/test/scala/bloop/config/TestPlatform.scala
@@ -1,6 +1,21 @@
 package bloop.config
 
+import java.io.InputStreamReader
+import java.io.BufferedReader
+import java.util.stream.Collectors
+
 object TestPlatform {
-  def getResourceAsString(resource: String): String =
-    getClass.getClassLoader.getResourceAsStream(resource).readAllBytes().map(_.toChar).mkString
+  def getResourceAsString(resource: String): String = {
+    val stream = getClass.getClassLoader.getResourceAsStream(resource)
+    if (stream == null) sys.error(s"Missing resource $resource!")
+    else {
+      try {
+        val isr = new InputStreamReader(stream)
+        try {
+          val reader = new BufferedReader(isr)
+          reader.lines().collect(Collectors.joining(System.lineSeparator))
+        } finally (isr.close())
+      } finally stream.close()
+    }
+  }
 }

--- a/shared/src/main/scala/bloop/io/Paths.scala
+++ b/shared/src/main/scala/bloop/io/Paths.scala
@@ -171,7 +171,7 @@ object Paths {
     ()
   }
 
-  def isDirectoryEmpty(path: AbsolutePath): Boolean = {
+  def isDirectoryEmpty(path: AbsolutePath, excludeDirs: Boolean): Boolean = {
     var isEmpty: Boolean = true
     import java.nio.file.NoSuchFileException
     try {
@@ -187,7 +187,7 @@ object Paths {
               directory: Path,
               attributes: BasicFileAttributes
           ): FileVisitResult = {
-            if (path.underlying == directory) FileVisitResult.CONTINUE
+            if (excludeDirs || path.underlying == directory) FileVisitResult.CONTINUE
             else {
               isEmpty = false
               FileVisitResult.TERMINATE


### PR DESCRIPTION
Because the proces owning external classes directories might force the 
 creation of certain empty directories, the process responsible for copying
 directories would consider the external client classes directory was not
 empty and would not copy class files from the internal classes directory.

 This commit fixes that and ignores empty directories in the external 
 classes dir, resulting in the copying process working as expected.