### PR TITLE
Use swoval file tree views for source monitoring

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,7 @@ lazy val backend = project
       Dependencies.sourcecode,
       Dependencies.monix,
       Dependencies.directoryWatcher,
+      Dependencies.swovalFiles,
       Dependencies.zt,
       Dependencies.brave,
       Dependencies.zipkinSender,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -86,6 +86,7 @@ object Dependencies {
   val junit = "com.novocode" % "junit-interface" % junitVersion
   val graphviz = "guru.nidi" % "graphviz-java" % graphvizVersion
   val directoryWatcher = "ch.epfl.scala" % "directory-watcher" % directoryWatcherVersion
+  val swovalFiles = "com.swoval" % "file-tree-views" % "2.1.4"
   val difflib = "com.googlecode.java-diff-utils" % "diffutils" % difflibVersion
   val junitSystemRules = "com.github.stefanbirkner" % "system-rules" % junitSystemRulesVersion
 


### PR DESCRIPTION
The directory watcher library used by bloop is not well optimized for
mac os. When I use metals via coc.nvim, I find that the `~` command
often stops working in my sbt projects. The reason is likely that
directory watcher is exhausting the file watching resources provided by
the OS. The swoval file tree views library originally started out as a
fork of directory watcher to fix its resource management issues. It can
be used almost as a drop in replacement for directory watcher though the
api is somewhat different.

The problem is that the directory watcher is written to
implement the java nio watchservice which is itself based on inotify but
the apple file event system is very different from inotify so there is
an impedence mismatch. The inotify api only works on a particular path.
In mac os, the main file watching api watches the root of a file system
tree. This means that if you want to watch two subdirectories foo/bar
and foo/bar/baz, there is no need to create separate event streams for
foo/bar and foo/bar/baz, the events for foo/bar/baz will be
automatically detected by the stream for foo/bar. The swoval library
verifies that each path that is registered is not covered by an existing
stream. It also removes redundant streams if a new stream is opened that
covers an existing stream. Filtering of unwanted subdirectories of a
root directory is handled at the jvm application level.This stream
management is critical because mac os does not allow unlimited numbers
of streams. When adding a recursive directory watch to a
DirectoryWatcher, it creates a watch stream for every subdirectory which
can quickly cause os to stop accepting new watches. It also creates a
new thread for every subdirectory. Swoval will use one thread to handle
events for all of the directories that it is watching.

To minimize any potential downstream impact of this change, I made the
swoval file tree watcher still emit directory watcher
DirectoryChangeEvents. There isn't a 1:1 mapping from a
DirectoryChangeEvent to a swoval data structure anyway so it was
convenient to continue using it.