### PR TITLE
Fix #1358: Run test classes only once

### DIFF
--- a/frontend/src/main/scala/bloop/testing/TestInternals.scala
+++ b/frontend/src/main/scala/bloop/testing/TestInternals.scala
@@ -236,9 +236,11 @@ object TestInternals {
 
   def getFingerprints(
       frameworks: Seq[Framework]
-  ): (Set[PrintInfo[SubclassFingerprint]], Set[PrintInfo[AnnotatedFingerprint]]) = {
-    val subclasses = mutable.Set.empty[PrintInfo[SubclassFingerprint]]
-    val annotated = mutable.Set.empty[PrintInfo[AnnotatedFingerprint]]
+  ): (List[PrintInfo[SubclassFingerprint]], List[PrintInfo[AnnotatedFingerprint]]) = {
+    // The tests need to be run with the first matching framework, so we use a LinkedHashSet
+    // to keep the ordering of `frameworks`.
+    val subclasses = mutable.LinkedHashSet.empty[PrintInfo[SubclassFingerprint]]
+    val annotated = mutable.LinkedHashSet.empty[PrintInfo[AnnotatedFingerprint]]
     for {
       framework <- frameworks
       fingerprint <- framework.fingerprints()
@@ -248,15 +250,15 @@ object TestInternals {
       case ann: AnnotatedFingerprint =>
         annotated += ((ann.annotationName, ann.isModule, framework, ann))
     }
-    (subclasses.toSet, annotated.toSet)
+    (subclasses.toList, annotated.toList)
   }
 
   // Slightly adapted from sbt/sbt
   def matchingFingerprints(
-      subclassPrints: Set[PrintInfo[SubclassFingerprint]],
-      annotatedPrints: Set[PrintInfo[AnnotatedFingerprint]],
+      subclassPrints: List[PrintInfo[SubclassFingerprint]],
+      annotatedPrints: List[PrintInfo[AnnotatedFingerprint]],
       d: Discovered
-  ): Set[PrintInfo[Fingerprint]] = {
+  ): List[PrintInfo[Fingerprint]] = {
     defined(subclassPrints, d.baseClasses, d.isModule) ++
       defined(annotatedPrints, d.annotations, d.isModule)
   }
@@ -302,10 +304,10 @@ object TestInternals {
 
   // Slightly adapted from sbt/sbt
   private def defined[T <: Fingerprint](
-      in: Set[PrintInfo[T]],
+      in: List[PrintInfo[T]],
       names: Set[String],
       IsModule: Boolean
-  ): Set[PrintInfo[T]] = {
+  ): List[PrintInfo[T]] = {
     in collect { case info @ (name, IsModule, _, _) if names(name) => info }
   }
 

--- a/frontend/src/test/resources/custom-test-framework/build.sbt
+++ b/frontend/src/test/resources/custom-test-framework/build.sbt
@@ -1,0 +1,13 @@
+bloopConfigDir in Global := baseDirectory.value / "bloop-config"
+lazy val framework = project
+  .in(file("framework"))
+  .settings(
+    libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0"
+  )
+
+lazy val test = project
+  .in(file("test"))
+  .dependsOn(framework)
+  .settings(
+    testFrameworks += TestFramework("foo.Framework")
+  )

--- a/frontend/src/test/resources/custom-test-framework/framework/src/main/scala/foo/Framework.scala
+++ b/frontend/src/test/resources/custom-test-framework/framework/src/main/scala/foo/Framework.scala
@@ -1,0 +1,31 @@
+package foo
+
+import sbt.testing._
+
+trait Test
+trait Test2
+case class SCFingerprint(superclassName: String) extends SubclassFingerprint {
+  def isModule: Boolean = false
+  def requireNoArgConstructor: Boolean = false
+}
+
+class Framework extends sbt.testing.Framework {
+  def name(): String = "My awesome framework"
+  def runner(args: Array[String], remoteArgs: Array[String], testClassLoader: ClassLoader): Runner = new Runner(args, remoteArgs)
+  def fingerprints(): Array[Fingerprint] =
+    Array(SCFingerprint("foo.Test"), SCFingerprint("foo.Test2"))
+}
+
+class Runner(val args: Array[String], val remoteArgs: Array[String]) extends sbt.testing.Runner {
+  override def done(): String = ""
+  override def tasks(tasks: Array[TaskDef]): Array[Task] = tasks.map { t =>
+    new Task {
+      def execute(handler: EventHandler, loggers: Array[Logger]): Array[Task] = {
+        loggers.foreach(l => l.info("Running task: " + t.fullyQualifiedName()))
+        Array.empty
+      }
+      def tags(): Array[String] = Array.empty
+      def taskDef(): TaskDef = t
+    }
+  }
+}

--- a/frontend/src/test/resources/custom-test-framework/project/build.properties
+++ b/frontend/src/test/resources/custom-test-framework/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.2

--- a/frontend/src/test/resources/custom-test-framework/project/plugins.sbt
+++ b/frontend/src/test/resources/custom-test-framework/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop-build-shaded" % "1.0.0-SNAPSHOT")
+updateOptions := updateOptions.value.withLatestSnapshots(false)

--- a/frontend/src/test/resources/custom-test-framework/project/project/build.properties
+++ b/frontend/src/test/resources/custom-test-framework/project/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.2

--- a/frontend/src/test/resources/custom-test-framework/test/src/test/scala/foo/MyTest.scala
+++ b/frontend/src/test/resources/custom-test-framework/test/src/test/scala/foo/MyTest.scala
@@ -1,0 +1,2 @@
+package foo
+class MyTest extends Test with Test2

--- a/frontend/src/test/scala/bloop/TestSpec.scala
+++ b/frontend/src/test/scala/bloop/TestSpec.scala
@@ -473,3 +473,16 @@ object TestCompileErrorExitCode extends bloop.testing.BaseSuite {
     }
   }
 }
+
+object MultiFingerprintMatch extends BaseTestSpec("test-test", "custom-test-framework") {
+  val expectedFullTestsOutput: String =
+    """|Running task: foo.MyTest
+       |Execution took ???
+       |No test suite was run
+       |
+       |===============================================
+       |Total duration: ???
+       |
+       |===============================================
+       |""".stripMargin
+}


### PR DESCRIPTION
Bloop was collecting all the test fingerprint, and creating a test task
for every matching fingerprint. This meant that test classes would be
run as many times as they have matching fingerprints.

Bloop now follows the same behavior as sbt, which will run the test with
the first matching framework.

Fixes #1358