### PR TITLE
Add trailing slash only when necessary in manifest

### DIFF
--- a/frontend/src/main/scala/bloop/exec/JvmProcessForker.scala
+++ b/frontend/src/main/scala/bloop/exec/JvmProcessForker.scala
@@ -194,7 +194,7 @@ final class JvmForker(config: JdkConfig, classpath: Array[AbsolutePath]) extends
     // https://docs.oracle.com/javase/7/docs/technotes/guides/jar/jar.html
     val syntax = path.toBspUri.toURL.getPath
     val separatorAdded = {
-      if (syntax.endsWith(".jar")) {
+      if (syntax.endsWith(".jar") || syntax.endsWith(File.separator)) {
         syntax
       } else {
         syntax + File.separator


### PR DESCRIPTION
When creating a manifest JAR, `JvmProcessForker` would add a trailing
slash to all the directory entries. While this trailing slash is
apparently necessary, it would be added also to entries that already
have a trailing slash. As a result, the path to resources resolved from
a directory entry ending with a double slash would contain this double
slash.