### PR TITLE
Use forked test agent

### DIFF
--- a/frontend/src/main/scala/bloop/testing/TestInternals.scala
+++ b/frontend/src/main/scala/bloop/testing/TestInternals.scala
@@ -32,9 +32,9 @@ import scala.collection.mutable
 import scala.util.control.NonFatal
 
 object TestInternals {
-  private final val sbtOrg = "org.scala-sbt"
+  private final val sbtOrg = "ch.epfl.scala"
   private final val testAgentId = "test-agent"
-  private final val testAgentVersion = "1.2.8"
+  private final val testAgentVersion = "1.4.0-M2+31-debc9a28"
 
   private implicit val logContext: DebugFilter = DebugFilter.Test
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
   val caseAppVersion = "1.2.0-faster-compile-time"
   val sourcecodeVersion = "0.1.4"
   val sbtTestInterfaceVersion = "1.0"
-  val sbtTestAgentVersion = "1.2.8"
+  val sbtTestAgentVersion = "1.4.0-M2+31-debc9a28"
   val junitVersion = "0.11"
   val junitSystemRulesVersion = "1.19.0"
   val graphvizVersion = "0.2.2"
@@ -74,7 +74,7 @@ object Dependencies {
   val caseApp = "ch.epfl.scala" %% "case-app" % caseAppVersion
   val sourcecode = "com.lihaoyi" %% "sourcecode" % sourcecodeVersion
   val sbtTestInterface = "org.scala-sbt" % "test-interface" % sbtTestInterfaceVersion
-  val sbtTestAgent = "org.scala-sbt" % "test-agent" % sbtTestAgentVersion
+  val sbtTestAgent = "ch.epfl.scala" % "test-agent" % sbtTestAgentVersion
   val snailgun = ("me.vican.jorge" %% "snailgun-cli" % snailgunVersion)
   val ztExec = "org.zeroturnaround" % "zt-exec" % ztExecVersion
   val slf4jNop = "org.slf4j" % "slf4j-nop" % "1.7.2"


### PR DESCRIPTION
A fix that prevents test suites to be run twice or more was recently
merged to sbt/sbt, but it hasn't been released yet (see
https://github.com/sbt/sbt/pull/5800).

To avoid waiting for the next sbt release, we manually published the
fixed artifact. This commit makes Bloop use this artifact.