### PR TITLE
Select last `user.dir` when inferring cwd

### DIFF
--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -78,7 +78,7 @@ final case class Project(
   def workingDirectory: AbsolutePath = {
     val customWorkingDirectory = platform match {
       case jvm: Platform.Jvm =>
-        jvm.config.javaOptions.collectFirst {
+        jvm.config.javaOptions.reverseIterator.collectFirst {
           case option if option.startsWith("-Duser.dir=") =>
             AbsolutePath(option.stripPrefix("-Duser.dir="))
         }


### PR DESCRIPTION
Bloop tries to guess the current working directory to use from the java
options. Before, it'd incorrectly use the first `user.dir` and not look
for further occurrences. It turns out that the JVM will use the last
occurrence of this property instead.