### PR TITLE
Handle issues in Gradle artifact resolution

### DIFF
--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -11,8 +11,10 @@ import bloop.integrations.gradle.BloopParameters
 import bloop.integrations.gradle.syntax._
 import org.gradle.api.{GradleException, Project}
 import org.gradle.api.artifacts._
+import org.gradle.api.artifacts.ArtifactView.ViewConfiguration
 import org.gradle.api.artifacts.result.{ComponentArtifactsResult, ResolvedArtifactResult}
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.component.Artifact
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact
@@ -273,9 +275,9 @@ class BloopConverter(parameters: BloopParameters) {
     val artifactType = Attribute.of("artifactType", classOf[String])
     val attributeType = "jar"
     configuration.getIncoming
-      .artifactView(viewConfig => {
+      .artifactView((viewConfig: ViewConfiguration) => {
         viewConfig.setLenient(true)
-        viewConfig.attributes(f => f.attribute(artifactType, attributeType))
+        viewConfig.attributes((f: AttributeContainer) => f.attribute(artifactType, attributeType))
       })
       .getArtifacts
       .asScala

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -9,7 +9,7 @@ import bloop.config.{Config, Tag}
 import bloop.config.Config.{CompileSetup, JavaThenScala, JvmConfig, Mixed, Platform}
 import bloop.integrations.gradle.BloopParameters
 import bloop.integrations.gradle.syntax._
-import org.gradle.api.{GradleException, Project}
+import org.gradle.api.{Action, GradleException, Project}
 import org.gradle.api.artifacts._
 import org.gradle.api.artifacts.ArtifactView.ViewConfiguration
 import org.gradle.api.artifacts.result.{ComponentArtifactsResult, ResolvedArtifactResult}
@@ -275,9 +275,15 @@ class BloopConverter(parameters: BloopParameters) {
     val artifactType = Attribute.of("artifactType", classOf[String])
     val attributeType = "jar"
     configuration.getIncoming
-      .artifactView((viewConfig: ViewConfiguration) => {
-        viewConfig.setLenient(true)
-        viewConfig.attributes((f: AttributeContainer) => f.attribute(artifactType, attributeType))
+      .artifactView(new Action[ViewConfiguration] {
+        override def execute(viewConfig: ViewConfiguration): Unit = {
+          viewConfig.setLenient(true)
+          viewConfig.attributes((f: AttributeContainer) => {
+            f.attribute(artifactType, attributeType)
+            ()
+          })
+          ()
+        }
       })
       .getArtifacts
       .asScala

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -278,9 +278,11 @@ class BloopConverter(parameters: BloopParameters) {
       .artifactView(new Action[ViewConfiguration] {
         override def execute(viewConfig: ViewConfiguration): Unit = {
           viewConfig.setLenient(true)
-          viewConfig.attributes((f: AttributeContainer) => {
-            f.attribute(artifactType, attributeType)
-            ()
+          viewConfig.attributes(new Action[AttributeContainer] {
+            override def execute(attributeContainer: AttributeContainer): Unit = {
+              attributeContainer.attribute(artifactType, attributeType)
+              ()
+            }
           })
           ()
         }


### PR DESCRIPTION
This changes the way artifacts (jars) are resolved so that it copes with unresolvable configurations which can pop-up in complex Gradle projects.

This is mainly because I was getting issues with [Gradle Crossbuild Scala Plugin](https://github.com/prokod/gradle-crossbuild-scala)

The strict dependencies on main sourceset are no longer needed because the classpath handling is more comprehensive.