### PR TITLE
Support for Java Modules

### DIFF
--- a/integrations/maven-bloop/src/main/java/scala_maven/ExtendedScalaContinuousCompileMojo.java
+++ b/integrations/maven-bloop/src/main/java/scala_maven/ExtendedScalaContinuousCompileMojo.java
@@ -21,10 +21,6 @@ public class ExtendedScalaContinuousCompileMojo extends ScalaContinuousCompileMo
         return super.getScalaOptions();
     }
 
-    public List<String> getJavacArgs() throws Exception {
-        return super.getJavacOptions();
-    }
-
     public List<File> getCompileSourceDirectories() throws Exception {
         List<String> mainSources = new ArrayList<String>(project.getCompileSourceRoots());
         mainSources.add(FileUtils.pathOf(mainSourceDir, useCanonicalPath));


### PR DESCRIPTION
Currently we only generate config for a maven module if we detect the Scala compiler plugin. With this change, we always generate it, but only add the scala libraries for scala modules. Also try to take into account the compile order from the .pom and any Java compiler args.

I don't think this is perfect by any means (it doesn't compile Neo4j for example due to #1322) , but I think it's better than what we currently have. Might be enough to close #519 though.