### PR TITLE
Support remote debugging

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -586,6 +586,9 @@ final class BloopBspServices(
           convert[bsp.ScalaMainClass](main => DebuggeeRunner.forMainClass(projects, main, state))
         case bsp.DebugSessionParamsDataKind.ScalaTestSuites =>
           convert[List[String]](filters => DebuggeeRunner.forTestSuite(projects, filters, state))
+        // TODO incorporate into BSP, maybe?
+        case "scala-attach-remote" =>
+          Right(DebuggeeRunner.forAttachRemote(state))
         case dataKind => Left(JsonRpcResponse.invalidRequest(s"Unsupported data kind: $dataKind"))
       }
     }

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -280,7 +280,8 @@ final class BloopBspServices(
               resourcesProvider = Some(true),
               buildTargetChangedProvider = Some(false),
               jvmTestEnvironmentProvider = Some(true),
-              jvmRunEnvironmentProvider = Some(true)
+              jvmRunEnvironmentProvider = Some(true),
+              canReload = Some(false)
             ),
             None
           )
@@ -586,8 +587,7 @@ final class BloopBspServices(
           convert[bsp.ScalaMainClass](main => DebuggeeRunner.forMainClass(projects, main, state))
         case bsp.DebugSessionParamsDataKind.ScalaTestSuites =>
           convert[List[String]](filters => DebuggeeRunner.forTestSuite(projects, filters, state))
-        // TODO incorporate into BSP, maybe?
-        case "scala-attach-remote" =>
+        case bsp.DebugSessionParamsDataKind.ScalaAttachRemote =>
           Right(DebuggeeRunner.forAttachRemote(state))
         case dataKind => Left(JsonRpcResponse.invalidRequest(s"Unsupported data kind: $dataKind"))
       }

--- a/frontend/src/main/scala/bloop/dap/DebugSession.scala
+++ b/frontend/src/main/scala/bloop/dap/DebugSession.scala
@@ -178,6 +178,9 @@ final class DebugSession(
         response.command = Command.LAUNCH.getName
         attachedPromise.success(())
         super.sendResponse(response)
+      case "attach" =>
+        attachedPromise.success(())
+        super.sendResponse(response)
       case "disconnect" =>
         // we are sending a response manually but the actual handler is also sending one so let's ignore it
         // because our disconnection must be successful as it is basically just cancelling the debuggee

--- a/frontend/src/main/scala/bloop/dap/DebuggeeRunner.scala
+++ b/frontend/src/main/scala/bloop/dap/DebuggeeRunner.scala
@@ -94,6 +94,21 @@ private final class TestSuiteDebugAdapter(
   }
 }
 
+private final class AttachRemoteDebugAdapter(state: State) extends DebuggeeRunner {
+  private lazy val allAnalysis = state.results.allAnalysis
+  override def logger: Logger = state.logger
+
+  override def run(logger: DebugSessionLogger): Task[ExitStatus] = Task(ExitStatus.Ok)
+
+  override def classFilesMappedTo(
+      origin: Path,
+      lines: Array[Int],
+      columns: Array[Int]
+  ): List[Path] = {
+    DebuggeeRunner.classFilesMappedTo(origin, lines, columns, allAnalysis)
+  }
+}
+
 object DebuggeeRunner {
   def forMainClass(
       projects: Seq[Project],
@@ -124,6 +139,9 @@ object DebuggeeRunner {
       case projects => Right(new TestSuiteDebugAdapter(projects, filters, state))
     }
   }
+
+  def forAttachRemote(state: State): DebuggeeRunner =
+    new AttachRemoteDebugAdapter(state)
 
   def classFilesMappedTo(
       origin: Path,

--- a/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
@@ -64,7 +64,8 @@ class BspCompileSpec(
           |      "resourcesProvider" : true,
           |      "buildTargetChangedProvider" : false,
           |      "jvmTestEnvironmentProvider" : true,
-          |      "jvmRunEnvironmentProvider" : true
+          |      "jvmRunEnvironmentProvider" : true,
+          |      "canReload" : false
           |    },
           |    "data" : null
           |  },

--- a/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
@@ -118,7 +118,8 @@ class BspConnectionSpec(
           |      "resourcesProvider" : true,
           |      "buildTargetChangedProvider" : false,
           |      "jvmTestEnvironmentProvider" : true,
-          |      "jvmRunEnvironmentProvider" : true
+          |      "jvmRunEnvironmentProvider" : true,
+          |      "canReload" : false
           |    },
           |    "data" : null
           |  },

--- a/frontend/src/test/scala/bloop/dap/DebugAdapterConnection.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugAdapterConnection.scala
@@ -100,6 +100,13 @@ private[dap] final class DebugAdapterConnection(
     adapter.request(Launch, arguments)
   }
 
+  def attach(hostName: String, port: Int): Task[Unit] = {
+    val arguments = new AttachArguments
+    arguments.hostName = hostName
+    arguments.port = port
+    adapter.request(Attach, arguments)
+  }
+
   def close(): Unit = {
     try socket.close()
     finally {

--- a/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
@@ -20,6 +20,17 @@ import com.microsoft.java.debug.core.protocol.Types.SourceBreakpoint
 import java.nio.file.Path
 import bloop.logging.Logger
 import bloop.logging.NoopLogger
+import monix.reactive.Observer
+import bloop.reporter.ReporterAction
+import bloop.logging.LoggerAction
+import bloop.logging.LoggerAction.LogInfoMessage
+import monix.execution.Ack
+import bloop.logging.ObservedLogger
+import scala.concurrent.Future
+import bloop.data.Platform
+import bloop.engine.tasks.Tasks
+import bloop.engine.tasks.RunMode
+import bloop.engine.State
 
 object DebugServerSpec extends DebugBspBaseSuite {
   private val ServerNotListening = new IllegalStateException("Server is not accepting connections")
@@ -543,6 +554,124 @@ object DebugServerSpec extends DebugBspBaseSuite {
 
       TestUtil.await(FiniteDuration(20, SECONDS), ExecutionContext.ioScheduler)(test)
     }
+  }
+
+  test("attaches to a remote process and sets breakpoint") {
+    TestUtil.withinWorkspace { workspace =>
+      val main =
+        """|/Main.scala
+           |object Main {
+           |  def main(args: Array[String]): Unit = {
+           |    println("Hello, World!")
+           |  }
+           |}
+           |""".stripMargin
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val project = TestProject(workspace, "r", List(main))
+
+      loadBspState(workspace, List(project), logger) { state =>
+        val testState = state.compile(project).toTestState
+        val buildProject = testState.getProjectFor(project)
+        def srcFor(srcName: String) =
+          buildProject.sources.map(_.resolve(srcName)).find(_.exists).get
+        val `Main.scala` = srcFor("Main.scala")
+
+        val breakpoints = {
+          val arguments = new SetBreakpointArguments()
+          val breakpoint = new SourceBreakpoint()
+          breakpoint.line = 3
+          arguments.source = new Types.Source(`Main.scala`.syntax, 0)
+          arguments.sourceModified = false
+          arguments.breakpoints = Array(breakpoint)
+          arguments
+        }
+
+        val attachPort = Promise[Int]()
+
+        val jdkConfig = buildProject.platform match {
+          case jvm: Platform.Jvm => jvm.config
+          case platform => throw new Exception(s"Unsupported platform $platform")
+        }
+
+        val debuggeeLogger = portListeningLogger(testState.state.logger, port => {
+          if (!attachPort.isCompleted) {
+            attachPort.success(port)
+            ()
+          }
+        })
+
+        val remoteProcess: Task[State] = Tasks.runJVM(
+          testState.state.copy(logger = debuggeeLogger),
+          buildProject,
+          jdkConfig,
+          testState.state.commonOptions.workingPath,
+          "Main",
+          Array.empty,
+          skipJargs = false,
+          RunMode.Debug
+        )
+
+        remoteProcess.runAsync(defaultScheduler)
+
+        val attachRemoteProcessRunner =
+          DebuggeeRunner.forAttachRemote(state.compile(project).toTestState.state)
+
+        startDebugServer(attachRemoteProcessRunner) { server =>
+          val test = for {
+            port <- Task.fromFuture(attachPort.future)
+            client <- server.startConnection
+            _ <- client.initialize()
+            _ <- client.attach("localhost", port)
+            breakpoints <- client.setBreakpoints(breakpoints)
+            _ = assert(breakpoints.breakpoints.forall(_.verified))
+            _ <- client.configurationDone()
+            stopped <- client.stopped
+            outputOnBreakpoint <- client.takeCurrentOutput
+            _ <- client.continue(stopped.threadId)
+            _ <- client.exited
+            _ <- client.terminated
+            finalOutput <- client.takeCurrentOutput
+            _ <- Task.fromFuture(client.closedPromise.future)
+          } yield {
+            assert(client.socket.isClosed)
+
+            assertNoDiff(outputOnBreakpoint, "")
+
+            assertNoDiff(
+              finalOutput,
+              ""
+            )
+          }
+
+          TestUtil.await(FiniteDuration(120, SECONDS), ExecutionContext.ioScheduler)(test)
+        }
+      }
+    }
+  }
+
+  private def portListeningLogger(underlying: Logger, listener: Int => Unit): Logger = {
+    val listeningObserver = new Observer[Either[ReporterAction, LoggerAction]] {
+      override def onNext(elem: Either[ReporterAction, LoggerAction]): Future[Ack] = elem match {
+        case Right(action) =>
+          action match {
+            case LogInfoMessage(msg) =>
+              println(msg)
+              if (msg.startsWith(DebugSessionLogger.JDINotificationPrefix)) {
+                val port =
+                  Integer.parseInt(msg.drop(DebugSessionLogger.JDINotificationPrefix.length))
+                listener(port)
+              }
+              Ack.Continue
+            case _ => Ack.Continue
+          }
+        case _ => Ack.Continue
+      }
+      override def onError(ex: Throwable): Unit = throw ex
+      override def onComplete(): Unit = ()
+    }
+
+    ObservedLogger(underlying, listeningObserver)
   }
 
   private def waitForServerEnd(server: TestServer): Task[Boolean] = {

--- a/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
@@ -609,6 +609,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
           "Main",
           Array.empty,
           skipJargs = false,
+          envVars = List.empty,
           RunMode.Debug
         )
 

--- a/frontend/src/test/scala/bloop/dap/DebugTestClient.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugTestClient.scala
@@ -31,6 +31,9 @@ final class DebugTestClient(connect: () => DebugAdapterConnection) {
   def launch(): Task[Unit] =
     activeSession.launch()
 
+  def attach(hostName: String, port: Int): Task[Unit] =
+    activeSession.attach(hostName: String, port: Int)
+
   def exited: Task[Events.ExitedEvent] =
     activeSession.exited
 

--- a/frontend/src/test/scala/bloop/dap/DebugTestEndpoints.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugTestEndpoints.scala
@@ -12,6 +12,7 @@ import com.microsoft.java.debug.core.protocol.Responses.VariablesResponseBody
 private[dap] object DebugTestEndpoints {
   val Initialize = new Request[InitializeArguments, Types.Capabilities]("initialize")
   val Launch = new Request[LaunchArguments, Unit]("launch")
+  val Attach = new Request[AttachArguments, Unit]("attach")
   val Disconnect = new Request[DisconnectArguments, Unit]("disconnect")
   val SetBreakpoints =
     new Request[SetBreakpointArguments, SetBreakpointsResponseBody]("setBreakpoints")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   // Used to download the python client instead of resolving
   val nailgunCommit = "a2520c1e"
   val zincVersion = "1.3.0-M4+45-d4354be3"
-  val bspVersion = "2.0.0-M12"
+  val bspVersion = "2.0.0-M13"
   val javaDebugVersion = "0.21.0+1-7f1080f1"
 
   val scalazVersion = "7.2.20"


### PR DESCRIPTION
A first draft of adding support of remote debugging in bloop.

It seems that a new value for `DebugSessionParamsDataKind ` should be addend to BSP. I'd love your input if this is the way to go and what else needs to be changed or updated.

I have added a "happy path" test so far and I have also done some manual tests using a version of `metals` with necessary changes

![test-workspace-1601236890032](https://user-images.githubusercontent.com/32688476/94374808-08e08080-010f-11eb-8bf2-5d19adfb1f1f.gif)
