### PR TITLE
Support runtime JDK config

### DIFF
--- a/config/src/main/scala-2.11-13/bloop/config/ConfigCodecs.scala
+++ b/config/src/main/scala-2.11-13/bloop/config/ConfigCodecs.scala
@@ -157,6 +157,7 @@ object ConfigCodecs {
   private case class jvm(
       config: Config.JvmConfig,
       mainClass: MainClass,
+      runtimeConfig: Option[Config.JvmConfig],
       classpath: Option[List[Path]],
       resources: Option[List[Path]]
   ) extends JsoniterPlatform
@@ -173,8 +174,8 @@ object ConfigCodecs {
       def encodeValue(x: Config.Platform, out: JsonWriter): Unit = {
         codec.encodeValue(
           x match {
-            case Config.Platform.Jvm(config, mainClass, classpath, resources) =>
-              jvm(config, MainClass(mainClass), classpath, resources)
+            case Config.Platform.Jvm(config, mainClass, runtimeConfig, classpath, resources) =>
+              jvm(config, MainClass(mainClass), runtimeConfig, classpath, resources)
             case Config.Platform.Js(config, mainClass) => js(config, MainClass(mainClass))
             case Config.Platform.Native(config, mainClass) => native(config, MainClass(mainClass))
           },
@@ -183,10 +184,11 @@ object ConfigCodecs {
       }
       def decodeValue(in: JsonReader, default: Config.Platform): Config.Platform = {
         codec.decodeValue(in, null) match {
-          case jvm(config, mainClass, classpath, resources) =>
+          case jvm(config, mainClass, runtimeConfig, classpath, resources) =>
             Config.Platform.Jvm(
               config,
               mainClass.mainClass,
+              runtimeConfig,
               classpath,
               resources
             )

--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -103,7 +103,7 @@ object Config {
   }
 
   object Platform {
-    val default: Platform = Jvm(JvmConfig.empty, None, None, None)
+    val default: Platform = Jvm(JvmConfig.empty, None, None, None, None)
 
     object Js { val name: String = "js" }
     case class Js(override val config: JsConfig, override val mainClass: Option[String])
@@ -115,6 +115,7 @@ object Config {
     case class Jvm(
         override val config: JvmConfig,
         override val mainClass: Option[String],
+        runtimeConfig: Option[JvmConfig],
         classpath: Option[List[Path]],
         resources: Option[List[Path]]
     ) extends Platform(Jvm.name) {
@@ -285,10 +286,12 @@ object Config {
       val resources = Some(List(PlatformFiles.resolve(outDir, "resource1.xml")))
 
       val platform = {
-        val jdkPath = PlatformFiles.getPath("/usr/lib/jvm/java-8-jdk")
+        val jdk8Path = PlatformFiles.getPath("/usr/lib/jvm/java-8-jdk")
+        val jdk11Path = PlatformFiles.getPath("/usr/lib/jvm/java-11-jdk")
         Platform.Jvm(
-          JvmConfig(Some(jdkPath), Nil),
+          JvmConfig(Some(jdk8Path), Nil),
           Some("module.Main"),
+          Some(JvmConfig(Some(jdk11Path), Nil)),
           Some(classpath),
           resources
         )

--- a/docs/assets/bloop-schema.json
+++ b/docs/assets/bloop-schema.json
@@ -53,6 +53,33 @@
             ]
           }
         },
+        "runtimeConfig": {
+          "$id": "/properties/project/properties/jvmPlatform/properties/runtimeConfig",
+          "type": "object",
+          "properties": {
+            "home": {
+              "$id": "/properties/project/properties/jvmPlatform/properties/runtimeConfig/properties/home",
+              "type": "string",
+              "title": "The Java Home Schema ",
+              "default": "",
+              "examples": [
+                "/usr/lib/jvm/java-8-jdk"
+              ]
+            },
+            "options": {
+              "$id": "/properties/project/properties/jvmPlatform/properties/runtimeConfig/properties/options",
+              "type": "array",
+              "title": "The JVM Options Schema",
+              "default": "",
+              "examples": [
+                "-Xms2g",
+                "-Xmx6g",
+                "-XX:MaxInlineLevel=20",
+                "-XX:ReservedCodeCacheSize=512m"
+              ]
+            }
+          }
+        },
         "classpath": {
           "$id": "/properties/project/properties/jvmPlatform/properties/classpath",
           "type": "array",

--- a/frontend/src/main/scala/bloop/data/Platform.scala
+++ b/frontend/src/main/scala/bloop/data/Platform.scala
@@ -13,6 +13,7 @@ object Platform {
       config: JdkConfig,
       toolchain: JvmToolchain,
       userMainClass: Option[String],
+      runtimeConfig: Option[JdkConfig],
       classpath: List[AbsolutePath],
       resources: List[AbsolutePath]
   ) extends Platform

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -562,7 +562,8 @@ object Interpreter {
                     if (!state.status.isOk) Task.now(state)
                     else Tasks.runNativeOrJs(state, project, cwd, mainClass, args)
                 }
-              case Platform.Jvm(javaEnv, _, _, _, _) =>
+              case jvm: Platform.Jvm =>
+                val javaEnv = project.runtimeJdkConfig.getOrElse(jvm.config)
                 Tasks.runJVM(
                   state,
                   project,

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -136,7 +136,7 @@ object CompileTask {
               project.out,
               newScalacOptions.toArray,
               project.javacOptions.toArray,
-              project.jdkConfig.flatMap(_.javacBin),
+              project.compileJdkConfig.flatMap(_.javacBin),
               project.compileOrder,
               project.classpathOptions,
               lastSuccessful.previous,

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -60,7 +60,7 @@ object Tasks {
         logger.debug(s"Setting up the console classpath with ${entries.mkString(", ")}")(
           DebugFilter.All
         )
-        val javacBin = project.jdkConfig.flatMap(_.javacBin)
+        val javacBin = project.runtimeJdkConfig.flatMap(_.javacBin)
         val loader = ClasspathUtilities.makeLoader(entries, instance)
         val compiler =
           state.compilerCache.get(instance, javacBin).scalac.asInstanceOf[AnalyzingCompiler]

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -158,7 +158,8 @@ object TestTask {
     import state.logger
     implicit val logContext: DebugFilter = DebugFilter.Test
     project.platform match {
-      case Platform.Jvm(env, _, _, _, _) =>
+      case Platform.Jvm(compileConfig, _, _, runtimeConfig, _, _) =>
+        val env = runtimeConfig.getOrElse(compileConfig)
         val dag = state.build.getDagFor(project)
         val classpath = project.fullRuntimeClasspath(dag, state.client)
         val forker = JvmProcessForker(env, classpath, mode)

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -113,13 +113,17 @@ class BspProtocolSpec(
 
     val logger = new RecordingLogger(ansiCodesSupported = false)
     val workingDirectory = AbsolutePath.workingDirectory.underlying.resolve("cwd")
-    val jvmOptions = List("-DSOME_OPTION=X", s"-Duser.dir=$workingDirectory")
+    val workingDirectoryOption = List(s"-Duser.dir=$workingDirectory")
+    val jvmOptions = List("-DSOME_OPTION=X") ++ workingDirectoryOption
     val jvmConfig = Some(Config.JvmConfig(None, jvmOptions))
+    val runtimeJvmOptions = List("-DOTHER_OPTION=Y") ++ workingDirectoryOption
+    val runtimeJvmConfig = Some(Config.JvmConfig(None, runtimeJvmOptions))
     val `A` = TestProject(
       workspace,
       "a",
       List(Sources.`A.scala`),
-      jvmConfig = jvmConfig
+      jvmConfig = jvmConfig,
+      runtimeJvmConfig = runtimeJvmConfig
     )
 
     val projects = List(`A`)
@@ -148,7 +152,7 @@ class BspProtocolSpec(
         environmentItem.classpath.forall(new URI(_).getScheme == "file")
       )
 
-      assert(environmentItem.jvmOptions == jvmOptions)
+      assert(environmentItem.jvmOptions == runtimeJvmOptions)
     }
   }
 

--- a/frontend/src/test/scala/bloop/util/TestProject.scala
+++ b/frontend/src/test/scala/bloop/util/TestProject.scala
@@ -104,6 +104,7 @@ abstract class BaseTestProject {
       resources: List[String] = Nil,
       runtimeResources: Option[List[String]] = None,
       jvmConfig: Option[Config.JvmConfig] = None,
+      runtimeJvmConfig: Option[Config.JvmConfig] = None,
       order: Config.CompileOrder = Config.Mixed,
       jars: Array[AbsolutePath] = Array(),
       sourcesGlobs: List[Config.SourcesGlobs] = Nil
@@ -158,6 +159,7 @@ abstract class BaseTestProject {
     val platform = Config.Platform.Jvm(
       javaConfig,
       None,
+      runtimeJvmConfig,
       Some(runtimeClasspath),
       runtimeResourcesList
     )

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -442,7 +442,8 @@ class BloopConverter(parameters: BloopParameters) {
       Option(currentJDK).map(_.getJavaHome.toPath)
     })
     Some(
-      Platform.Jvm(JvmConfig(jdkPath, projectJvmOptions), mainClass, Some(runtimeClasspath), None)
+      Platform
+        .Jvm(JvmConfig(jdkPath, projectJvmOptions), mainClass, None, Some(runtimeClasspath), None)
     )
   }
 

--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -157,7 +157,7 @@ object MojoImplementation {
         val `scala` = Some(Config.Scala(mojo.getScalaOrganization(), mojo.getScalaArtifactID(), mojo.getScalaVersion(), scalacArgs, allScalaJars, analysisOut, Some(compileSetup)))
         val javaHome = Some(abs(mojo.getJavaHome().getParentFile.getParentFile))
         val mainClass = if (launcher.getMainClass().isEmpty) None else Some(launcher.getMainClass())
-        val platform = Some(Config.Platform.Jvm(Config.JvmConfig(javaHome, launcher.getJvmArgs().toList), mainClass, None, None))
+        val platform = Some(Config.Platform.Jvm(Config.JvmConfig(javaHome, launcher.getJvmArgs().toList), mainClass, None, None, None))
         // Resources in Maven require
         val resources = Some(resources0.asScala.toList.flatMap(a => Option(a.getTargetPath).toList).map(classesDir.resolve))
         val project = Config.Project(name, baseDirectory, Some(root.toPath), sourceDirs, None, None, fullDependencies, classpath, out, classesDir, resources, `scala`, java, sbt, test, platform, resolution, Some(tags))

--- a/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
+++ b/integrations/mill-bloop/src/main/scala/bloop/integrations/mill/MillBloop.scala
@@ -60,6 +60,7 @@ object Bloop extends ExternalModule {
           options = module.forkArgs().toList
         ),
         mainClass = module.mainClass(),
+        runtimeConfig = None,
         classpath = None,
         resources = None
       )

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -792,7 +792,7 @@ object BloopDefaults {
         val workingDir = if (isForkedExecution) Keys.baseDirectory.value else rootBaseDirectory
         val extraJavaOptions = List(s"-Duser.dir=${workingDir.getAbsolutePath}")
         val config = Config.JvmConfig(Some(javaHome.toPath), (extraJavaOptions ++ javaOptions).toList)
-        Config.Platform.Jvm(config, mainClass, None, None)
+        Config.Platform.Jvm(config, mainClass, None, None, None)
       }
     }
     // FORMAT: ON


### PR DESCRIPTION
Previously, Bloop would support only a single JDK configuration per
project, which would apply to both compile-time and runtime. However,
some tools (e.g. Pants) support defining a different JDK configuration
for compile-time and runtime.

To be able to export faithfully builds from these tools, Bloop needs to
support this kind of configuration as well. This commit adds a new
field, `runtimeConfig`, to JVM projects' `platform` configuration, which
has the same schema as the existing `config`.

The `config` is used to configure the compile-time configuration,
whereas `runtimeConfig` is used for runtime. When `runtimeConfig`
doesn't exist, Bloop falls back to `config`.