### PR TITLE
Fix AUR installation docs

### DIFF
--- a/docs/tools/aur/install.md
+++ b/docs/tools/aur/install.md
@@ -1,13 +1,13 @@
-With `yaourt`:
+With `yay` (replace by your favorite AUR helper):
 
 ```bash
-yaourt -S bloop
+yay -S bloop
 ```
 
-With `pacaur`:
+If you want to use the [Systemd service](usage.md), also install `bloop-systemd`:
 
 ```bash
-pacaur -S bloop
+yay -S bloop-systemd
 ```
 
 ### Requirements

--- a/docs/tools/aur/usage.md
+++ b/docs/tools/aur/usage.md
@@ -4,8 +4,8 @@ command-line application is used.
 
 ### Running the server in the background
 
-The AUR formula installs a Systemd service in *your user configuration* to
-start up the Bloop server automatically when you log into your machine. This
+The AUR package `bloop-systemd` installs a Systemd service in *your user configuration*
+to start up the Bloop server automatically when you log into your machine. This
 service spares you from the cumbersome process of starting the build server
 before using any build client, enable it with:
 


### PR DESCRIPTION
- Replace outdated AUR helpers by `yay`
- Mention the `bloop-systemd` package

closes #1390