### PR TITLE
Update Dotty to Scala 3

### DIFF
--- a/backend/src/main/scala/bloop/ScalaInstance.scala
+++ b/backend/src/main/scala/bloop/ScalaInstance.scala
@@ -42,7 +42,9 @@ final class ScalaInstance private (
   }
 
   /** Is this `ScalaInstance` using Dotty? */
-  def isDotty: Boolean = organization == "ch.epfl.lamp" && version.startsWith("0.")
+  def isDotty: Boolean =
+    (organization == "ch.epfl.lamp" && version.startsWith("0.")) ||
+      (organization == "org.scala-lang" && version.startsWith("3."))
 
   override lazy val loaderLibraryOnly: ClassLoader =
     new URLClassLoader(Array(libraryJar.toURI.toURL), ScalaInstance.bootClassLoader)
@@ -55,7 +57,8 @@ final class ScalaInstance private (
   import ScalaInstance.ScalacCompilerName
   private def isJar(filename: String): Boolean = filename.endsWith(".jar")
   private def hasScalaCompilerName(filename: String): Boolean =
-    filename.startsWith(ScalacCompilerName) || (isDotty && filename.startsWith("dotty-compiler"))
+    filename.startsWith(ScalacCompilerName) ||
+      (isDotty && (filename.startsWith("dotty-compiler") || filename.startsWith("scala3-compiler")))
   private def hasScalaLibraryName(filename: String): Boolean =
     filename.startsWith("scala-library")
 

--- a/backend/src/main/scala/sbt/internal/inc/BloopComponentCompiler.scala
+++ b/backend/src/main/scala/sbt/internal/inc/BloopComponentCompiler.scala
@@ -52,7 +52,7 @@ object BloopComponentCompiler {
       // Defaults to bridge for 2.13 for Scala versions bigger than 2.13.x
       scalaVersion match {
         case sc if (sc startsWith "0.") => "dotty-sbt-bridge"
-        case sc if (sc startsWith "3.0.") => "dotty-sbt-bridge"
+        case sc if (sc startsWith "3.0.") => "scala3-sbt-bridge"
         case sc if (sc startsWith "2.10.") => "compiler-bridge_2.10"
         case sc if (sc startsWith "2.11.") => "compiler-bridge_2.11"
         case sc if (sc startsWith "2.12.") => "compiler-bridge_2.12"

--- a/frontend/src/test/scala/bloop/ScalaVersionsSpec.scala
+++ b/frontend/src/test/scala/bloop/ScalaVersionsSpec.scala
@@ -18,7 +18,7 @@ object ScalaVersionsSpec extends bloop.testing.BaseSuite {
     def compileProjectFor(scalaVersion: String): Task[Unit] = Task {
       TestUtil.withinWorkspace { workspace =>
         val (compilerOrg, compilerArtifact) = {
-          if (scalaVersion.startsWith("3.")) "org.scala-lang" -> "scala3-compiler_3.0.0-M2"
+          if (scalaVersion.startsWith("3.")) "org.scala-lang" -> "scala3-compiler_3.0.0-M1"
           else "org.scala-lang" -> "scala-compiler"
         }
 
@@ -69,7 +69,7 @@ object ScalaVersionsSpec extends bloop.testing.BaseSuite {
     val `2.12` = compileProjectFor("2.12.9")
     val `2.13` = compileProjectFor("2.13.2")
     val `2.13.3` = compileProjectFor("2.13.3")
-    val LatestDotty = compileProjectFor("3.0.0-M2-bin-20201031-1ab76c1-NIGHTLY")
+    val LatestDotty = compileProjectFor("3.0.0-M1")
     val all = {
       if (TestUtil.isJdk8) List(`2.10`, `2.11`, `2.12`, `2.13`, `2.13.3`, LatestDotty)
       else List(`2.12`, `2.13`, `2.13.3`)

--- a/frontend/src/test/scala/bloop/ScalaVersionsSpec.scala
+++ b/frontend/src/test/scala/bloop/ScalaVersionsSpec.scala
@@ -18,7 +18,7 @@ object ScalaVersionsSpec extends bloop.testing.BaseSuite {
     def compileProjectFor(scalaVersion: String): Task[Unit] = Task {
       TestUtil.withinWorkspace { workspace =>
         val (compilerOrg, compilerArtifact) = {
-          if (scalaVersion.startsWith("0.")) "ch.epfl.lamp" -> "dotty-compiler_0.20"
+          if (scalaVersion.startsWith("3.")) "org.scala-lang" -> "scala3-compiler_3.0.0-M2"
           else "org.scala-lang" -> "scala-compiler"
         }
 
@@ -30,7 +30,7 @@ object ScalaVersionsSpec extends bloop.testing.BaseSuite {
         }
 
         val source = {
-          if (compilerArtifact.contains("dotty-compiler")) {
+          if (compilerArtifact.contains("scala3-compiler")) {
             """/main/scala/Foo.scala
               |class Foo { val x: String | Int = 1 }
             """.stripMargin
@@ -69,7 +69,7 @@ object ScalaVersionsSpec extends bloop.testing.BaseSuite {
     val `2.12` = compileProjectFor("2.12.9")
     val `2.13` = compileProjectFor("2.13.2")
     val `2.13.3` = compileProjectFor("2.13.3")
-    val LatestDotty = compileProjectFor("0.20.0-bin-20191005-d67af24-NIGHTLY")
+    val LatestDotty = compileProjectFor("3.0.0-M2-bin-20201031-1ab76c1-NIGHTLY")
     val all = {
       if (TestUtil.isJdk8) List(`2.10`, `2.11`, `2.12`, `2.13`, `2.13.3`, LatestDotty)
       else List(`2.12`, `2.13`, `2.13.3`)

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -337,9 +337,9 @@ class BspMetalsClientSpec(
         workspace,
         "A",
         dummyFooSources,
-        scalaVersion = Some("3.0.0-M2-bin-20201031-1ab76c1-NIGHTLY"),
+        scalaVersion = Some("3.0.0-M1"),
         scalaOrg = Some("org.scala-lang"),
-        scalaCompiler = Some("scala3-compiler_3.0.0-M2")
+        scalaCompiler = Some("scala3-compiler_3.0.0-M1")
       )
       val projects = List(`A`)
       val configDir = TestProject.populateWorkspace(workspace, projects)
@@ -365,9 +365,9 @@ class BspMetalsClientSpec(
         workspace,
         "A",
         dummyFooSources,
-        scalaVersion = Some("3.0.0-M2-bin-20201031-1ab76c1-NIGHTLY"),
+        scalaVersion = Some("3.0.0-M1"),
         scalaOrg = Some("org.scala-lang"),
-        scalaCompiler = Some("scala3-compiler_3.0.0-M2")
+        scalaCompiler = Some("scala3-compiler_3.0.0-M1")
       )
       val projects = List(`A`)
       val configDir = TestProject.populateWorkspace(workspace, projects)
@@ -391,10 +391,10 @@ class BspMetalsClientSpec(
         workspace,
         "A",
         dummyFooSources,
-        scalaVersion = Some("3.0.0-M2-bin-20201031-1ab76c1-NIGHTLY"),
+        scalaVersion = Some("3.0.0-M1"),
         scalacOptions = defaultScalacOptions,
         scalaOrg = Some("org.scala-lang"),
-        scalaCompiler = Some("scala3-compiler_3.0.0-M2")
+        scalaCompiler = Some("scala3-compiler_3.0.0-M1")
       )
       val projects = List(`A`)
       val configDir = TestProject.populateWorkspace(workspace, projects)

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -337,9 +337,9 @@ class BspMetalsClientSpec(
         workspace,
         "A",
         dummyFooSources,
-        scalaVersion = Some("0.23.0-RC1"),
-        scalaOrg = Some("ch.epfl.lamp"),
-        scalaCompiler = Some("dotty-compiler_0.23")
+        scalaVersion = Some("3.0.0-M2-bin-20201031-1ab76c1-NIGHTLY"),
+        scalaOrg = Some("org.scala-lang"),
+        scalaCompiler = Some("scala3-compiler_3.0.0-M2")
       )
       val projects = List(`A`)
       val configDir = TestProject.populateWorkspace(workspace, projects)
@@ -365,9 +365,9 @@ class BspMetalsClientSpec(
         workspace,
         "A",
         dummyFooSources,
-        scalaVersion = Some("0.23.0-RC1"),
-        scalaOrg = Some("ch.epfl.lamp"),
-        scalaCompiler = Some("dotty-compiler_0.23")
+        scalaVersion = Some("3.0.0-M2-bin-20201031-1ab76c1-NIGHTLY"),
+        scalaOrg = Some("org.scala-lang"),
+        scalaCompiler = Some("scala3-compiler_3.0.0-M2")
       )
       val projects = List(`A`)
       val configDir = TestProject.populateWorkspace(workspace, projects)
@@ -391,10 +391,10 @@ class BspMetalsClientSpec(
         workspace,
         "A",
         dummyFooSources,
-        scalaVersion = Some("0.23.0-RC1"),
+        scalaVersion = Some("3.0.0-M2-bin-20201031-1ab76c1-NIGHTLY"),
         scalacOptions = defaultScalacOptions,
-        scalaOrg = Some("ch.epfl.lamp"),
-        scalaCompiler = Some("dotty-compiler_0.23")
+        scalaOrg = Some("org.scala-lang"),
+        scalaCompiler = Some("scala3-compiler_3.0.0-M2")
       )
       val projects = List(`A`)
       val configDir = TestProject.populateWorkspace(workspace, projects)


### PR DESCRIPTION
Fixes https://github.com/scalacenter/bloop/issues/1394

There was recent change, which moved Dotty back to Scala organisation and renamed artifacts to use `scala3` instead of Dotty.

I see there is also one small issue in the zinc fork: https://github.com/scalacenter/zinc/blob/topic/bloop-rebase-next-2.0/internal/zinc-classpath/src/main/scala/sbt/internal/inc/ScalaInstance.scala#L123

I have no idea how to properly update the zinc used in Bloop, I don't see any main branch or how things can be released.