### PR TITLE
Add release notes for 1.4.5

### DIFF
--- a/notes/v1.4.5.md
+++ b/notes/v1.4.5.md
@@ -1,0 +1,47 @@
+# bloop `v1.4.5`
+
+Bloop v1.4.5 is a bugfix release.
+
+## Installing Bloop
+
+For more details about installing Bloop, please see [Bloop's Installation
+Guide][install-guide]
+
+## Merged pull requests
+
+Here's a list of pull requests that were merged:
+
+- Add 3.0 to scalaVersionBlacklist for compiler plugin classloading [#1396]
+- Support runtime JDK config [#1387]
+- Update Dotty to Scala 3 [#1393]
+- Fix AUR installation docs [#1392]
+- Reuse Zipkin reporter between tasks [#1386]
+- Support remote debugging [#1378]
+- Start debug session with user-provided environment variables [#1268]
+- Handle Gradle jvm args and mainClass [#1379]
+- Print logs in case of bsp connection issues [#1374]
+- Bump prismjs from 1.20.0 to 1.21.0 in /website [#1352]
+- Handle issues in Gradle artifact resolution [#1369]
+- Support for Java Modules [#1370]
+- Select last `user.dir` when inferring cwd [#1368]
+
+[#1396]: https://github.com/scalacenter/bloop/pull/1396
+[#1393]: https://github.com/scalacenter/bloop/pull/1393
+[#1392]: https://github.com/scalacenter/bloop/pull/1392
+[#1386]: https://github.com/scalacenter/bloop/pull/1386
+[#1378]: https://github.com/scalacenter/bloop/pull/1378
+[#1268]: https://github.com/scalacenter/bloop/pull/1268
+[#1379]: https://github.com/scalacenter/bloop/pull/1379
+[#1374]: https://github.com/scalacenter/bloop/pull/1374
+[#1352]: https://github.com/scalacenter/bloop/pull/1352
+[#1369]: https://github.com/scalacenter/bloop/pull/1369
+[#1370]: https://github.com/scalacenter/bloop/pull/1370
+[#1368]: https://github.com/scalacenter/bloop/pull/1368
+[#1387]: https://github.com/scalacenter/bloop/pull/1387
+[install-guide]: https://scalacenter.github.io/bloop/setup
+
+## Contributors
+
+According to `git shortlog -sn --no-merges v1.4.4..v1.4.5`, the following people
+have contributed to this `v1.4.5` release: Arthur McGibbon, Pavol Vidlicka,
+Martin Duhem, Tomasz Godzik, Aleksei Alefirov, Guillaume Raffin and Mark Dixon.


### PR DESCRIPTION
I repurposed the script in Metals to generate the release notes here. Not sure if anyone is interested in putting it into Bloop itself, but the script is available here: https://gist.github.com/tgodzik/e4d4bf84db2f18e5cef143acd6730d5f