### PR TITLE
Add 3.0 to scalaVersionBlacklist for compiler plugin classloading

### DIFF
--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginWhitelist.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginWhitelist.scala
@@ -46,7 +46,8 @@ object CompilerPluginWhitelist {
   )
 
   /** A sequence of versions that are known not to support compiler plugin classloading. */
-  val scalaVersionBlacklist = List("2.10.", "2.11.", "2.12.1", "2.12.2", "2.12.3", "2.12.4", "0.")
+  val scalaVersionBlacklist =
+    List("2.10.", "2.11.", "2.12.1", "2.12.2", "2.12.3", "2.12.4", "0.", "3.")
 
   private implicit val debug = DebugFilter.Compilation
   private val emptyMap = java.util.Collections.emptyMap[String, String]()


### PR DESCRIPTION
While testing new Bloop version in Metals I noticed we were getting a warning about unsupported compiler options.

This was coming from CompilerPluginWhitelist, which I missed. I added `3.`, which will ignore all versions starting with `3.`