### PR TITLE
Fix broken URL in $id of bloop-schema.json

### DIFF
--- a/docs/assets/bloop-schema.json
+++ b/docs/assets/bloop-schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://scalacenter.github.io/bloop/docson/bloop-schema.json",
+  "$id": "https://scalacenter.github.io/bloop/docs/assets/bloop-schema.json",
   "type": "object",
   "title": "Bloop configuration file ",
   "description": "The JSON Schema for the bloop configuration file.",


### PR DESCRIPTION
The new URL is apparently `https://scalacenter.github.io/bloop/docs/assets/bloop-schema.json`