### PR TITLE
Documentation: update maven plugin version number

### DIFF
--- a/docs/build-tools/maven.md
+++ b/docs/build-tools/maven.md
@@ -27,7 +27,7 @@ The Bloop plugin for Maven doesn't need to be installed, you can run
 following command.
 
 ```bash
-$ mvn ch.epfl.scala:maven-bloop_2.10:@VERSION@:bloopInstall
+$ mvn ch.epfl.scala:maven-bloop_2.12:@VERSION@:bloopInstall
 ```
 
 Note that the following command uses the latest Bloop stable version


### PR DESCRIPTION
It looks like Bloop is no longer published for Scala 2.10, but it published for Scala 2.12 instead. This edit reflects that change.