### PR TITLE
Update setup-scala action to v10 and setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: ${{ matrix.jdk }}
       - uses: actions/setup-node@v1
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: ${{ matrix.jdk }}
       - name: Publish GraalVM Native artifacts
@@ -154,7 +154,7 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: ${{ matrix.jdk }}
       - name: Install GraalVM Native Image
@@ -219,7 +219,7 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: ${{ matrix.jdk }}
       - uses: actions/setup-node@v1


### PR DESCRIPTION
Curently the CI is broken,  the change was similar in the scalameta repositories.