### PR TITLE
Fix incompatibility for actions/download-artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,7 @@ jobs:
         uses: actions/download-artifact@v2.0.6
         with:
           name: bloop-artifacts
+          path: bloop-artifacts
       - name: Set up environment
         run: |
           curl -Lo coursier https://git.io/coursier-cli && chmod +x coursier && ./coursier --help


### PR DESCRIPTION
Based on https://github.com/actions/download-artifact#compatibility-between-v1-and-v2