### PR TITLE
Fix brew formula for future releases

### DIFF
--- a/project/ReleaseUtils.scala
+++ b/project/ReleaseUtils.scala
@@ -124,7 +124,7 @@ object ReleaseUtils {
        |
        |  depends_on "bash-completion"
        |  depends_on "coursier/formulas/coursier"
-       |  depends_on :java => "1.8+"
+       |  depends_on :java => "openjdk@8+"
        |
        |  resource "bash_completions" do
        |    url "${artifacts.bashAutocompletions.url}"


### PR DESCRIPTION
Follow up from https://github.com/scalacenter/homebrew-bloop/pull/11

homebrew-bloop is being regenerated with the new releases