### PR TITLE
Bump to latest Zinc

### DIFF
--- a/backend/src/main/scala/sbt/internal/inc/BloopComponentCompiler.scala
+++ b/backend/src/main/scala/sbt/internal/inc/BloopComponentCompiler.scala
@@ -103,6 +103,17 @@ object BloopComponentCompiler {
       scheduler: ExecutionContext
   ) extends CompilerBridgeProvider {
 
+    private def is213ThatNeedsPreviousZinc(scalaVersion: String): Boolean = {
+      scalaVersion.startsWith("2.13.0") ||
+      scalaVersion.startsWith("2.13.1") ||
+      scalaVersion.startsWith("2.13.2")
+    }
+
+    private def isTooRecentFor213Before3(bridgeSources: ModuleID): Boolean = {
+      bridgeSources.revision == "1.3.0-M4+45-d4354be3" ||
+      bridgeSources.revision == "1.3.0-M4+46-edbe573e"
+    }
+
     /**
      * Defines a richer interface for Scala users that want to pass in an explicit module id.
      *
@@ -111,12 +122,9 @@ object BloopComponentCompiler {
      */
     private def compiledBridge(bridgeSources0: ModuleID, scalaInstance: ScalaInstance): File = {
       val scalaVersion = scalaInstance.version()
-      val requiresPrevZincVersion = bridgeSources0.revision == "1.3.0-M4+45-d4354be3" && {
-        scalaVersion.startsWith("2.13.0") ||
-        scalaVersion.startsWith("2.13.1") ||
-        scalaVersion.startsWith("2.13.2")
-      }
-
+      val requiresPrevZincVersion = isTooRecentFor213Before3(bridgeSources0) && is213ThatNeedsPreviousZinc(
+        scalaVersion
+      )
       val bridgeSources =
         if (!requiresPrevZincVersion) bridgeSources0
         else bridgeSources0.withRevision("1.3.0-M4+42-5daa8ed7")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,10 @@ object Dependencies {
   val nailgunVersion = "ee3c4343"
   // Used to download the python client instead of resolving
   val nailgunCommit = "a2520c1e"
-  val zincVersion = "1.3.0-M4+45-d4354be3"
+
+  // Keep in sync in BloopComponentCompiler
+  val zincVersion = "1.3.0-M4+46-edbe573e"
+
   val bspVersion = "2.0.0-M13"
   val javaDebugVersion = "0.21.0+1-7f1080f1"
 


### PR DESCRIPTION
The new version matches this commit:

  https://github.com/scalacenter/zinc/commit/edbe573e75f7da060f9bd64b12d86fcd59c2c811

This commit fixes an issue where Zinc tries to initialize symbols that
are missing from the classpath. There are legitimate situations where
symbols can be missing from the classpath, such as when Bloop's
configuration files originate from Pants with `strict_deps` enabled, for
instance.

See sbt/zinc#949 and sbt/zinc#950