### PR TITLE
Fetch tags when cloning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           submodules: true
+          fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: ${{ matrix.jdk }}
@@ -110,6 +111,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           submodules: true
+          fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: ${{ matrix.jdk }}
@@ -154,6 +156,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           submodules: true
+          fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: ${{ matrix.jdk }}
@@ -219,6 +222,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           submodules: true
+          fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: ${{ matrix.jdk }}


### PR DESCRIPTION
Newer versions of the GitHub action `actions/checkout` do not fetch all
tags when cloning, preventing us from computing the current version
number correctly. This can be seen from the most recent releases to
Maven Central, that have as version number `0.0.0-1-<sha>`.

This commit fixes the issue by performing a deep clone.