### PR TITLE
Go back to sbt test-agent artifact

### DIFF
--- a/frontend/src/main/scala/bloop/testing/TestInternals.scala
+++ b/frontend/src/main/scala/bloop/testing/TestInternals.scala
@@ -32,9 +32,9 @@ import scala.collection.mutable
 import scala.util.control.NonFatal
 
 object TestInternals {
-  private final val sbtOrg = "ch.epfl.scala"
+  private final val sbtOrg = "org.scala-sbt"
   private final val testAgentId = "test-agent"
-  private final val testAgentVersion = "1.4.0-M2+31-debc9a28"
+  private final val testAgentVersion = "1.4.4"
 
   private implicit val logContext: DebugFilter = DebugFilter.Test
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val caseAppVersion = "1.2.0-faster-compile-time"
   val sourcecodeVersion = "0.1.4"
   val sbtTestInterfaceVersion = "1.0"
-  val sbtTestAgentVersion = "1.4.0-M2+31-debc9a28"
+  val sbtTestAgentVersion = "1.4.4"
   val junitVersion = "0.11"
   val junitSystemRulesVersion = "1.19.0"
   val graphvizVersion = "0.2.2"
@@ -77,7 +77,7 @@ object Dependencies {
   val caseApp = "ch.epfl.scala" %% "case-app" % caseAppVersion
   val sourcecode = "com.lihaoyi" %% "sourcecode" % sourcecodeVersion
   val sbtTestInterface = "org.scala-sbt" % "test-interface" % sbtTestInterfaceVersion
-  val sbtTestAgent = "ch.epfl.scala" % "test-agent" % sbtTestAgentVersion
+  val sbtTestAgent = "org.scala-sbt" % "test-agent" % sbtTestAgentVersion
   val snailgun = ("me.vican.jorge" %% "snailgun-cli" % snailgunVersion)
   val ztExec = "org.zeroturnaround" % "zt-exec" % ztExecVersion
   val slf4jNop = "org.slf4j" % "slf4j-nop" % "1.7.2"


### PR DESCRIPTION
While waiting for the release of sbt 1.4.0, we published a fork of sbt's
test-agent. Now that sbt 1.4 has been released with the fix that we
needed, we can safely go back to using the mainline artifact.

See #1364
See sbt/sbt#5800, sbt/sbt#5801