### PR TITLE
Change the semanticdb flag to -Xsemanticdb starting from 3.0.0-M3

### DIFF
--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -360,6 +360,12 @@ object Project {
     val workspaceDir = project.workspaceDirectory.getOrElse(configDir.getParent)
     val isDotty = project.scalaInstance.exists(_.isDotty)
 
+    def isAtLeastScala3M3(version: String) = {
+      version.startsWith("3.") &&
+      version != "3.0.0-M1"
+      version != "3.0.0-M2"
+    }
+
     def enableSemanticdb(options: List[String], pluginPath: AbsolutePath): List[String] = {
       val baseSemanticdbOptions = List(
         "-P:semanticdb:failures:warning",
@@ -377,7 +383,14 @@ object Project {
     }
 
     def enableDottySemanticdb(options: List[String]) = {
-      val ysemanticdb = if (!options.contains("-Ysemanticdb")) List("-Ysemanticdb") else Nil
+      val semanticdbFlag =
+        if (project.scalaInstance.exists(instance => isAtLeastScala3M3(instance.version))) {
+          "-Xsemanticdb"
+        } else {
+          "-Ysemanticdb"
+        }
+
+      val ysemanticdb = if (!options.contains(semanticdbFlag)) List(semanticdbFlag) else Nil
       val sourceRoot =
         if (!options.contains("-sourceroot")) List("-sourceroot", workspaceDir.toString()) else Nil
       options ++ ysemanticdb ++ sourceRoot

--- a/frontend/src/test/scala/bloop/ScalaVersionsSpec.scala
+++ b/frontend/src/test/scala/bloop/ScalaVersionsSpec.scala
@@ -18,7 +18,7 @@ object ScalaVersionsSpec extends bloop.testing.BaseSuite {
     def compileProjectFor(scalaVersion: String): Task[Unit] = Task {
       TestUtil.withinWorkspace { workspace =>
         val (compilerOrg, compilerArtifact) = {
-          if (scalaVersion.startsWith("3.")) "org.scala-lang" -> "scala3-compiler_3.0.0-M1"
+          if (scalaVersion.startsWith("3.")) "org.scala-lang" -> "scala3-compiler_3.0.0-M3"
           else "org.scala-lang" -> "scala-compiler"
         }
 
@@ -69,7 +69,7 @@ object ScalaVersionsSpec extends bloop.testing.BaseSuite {
     val `2.12` = compileProjectFor("2.12.9")
     val `2.13` = compileProjectFor("2.13.2")
     val `2.13.3` = compileProjectFor("2.13.3")
-    val LatestDotty = compileProjectFor("3.0.0-M1")
+    val LatestDotty = compileProjectFor("3.0.0-M3")
     val all = {
       if (TestUtil.isJdk8) List(`2.10`, `2.11`, `2.12`, `2.13`, `2.13.3`, LatestDotty)
       else List(`2.12`, `2.13`, `2.13.3`)

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -337,9 +337,9 @@ class BspMetalsClientSpec(
         workspace,
         "A",
         dummyFooSources,
-        scalaVersion = Some("3.0.0-M1"),
+        scalaVersion = Some("3.0.0-M3"),
         scalaOrg = Some("org.scala-lang"),
-        scalaCompiler = Some("scala3-compiler_3.0.0-M1")
+        scalaCompiler = Some("scala3-compiler_3.0.0-M3")
       )
       val projects = List(`A`)
       val configDir = TestProject.populateWorkspace(workspace, projects)
@@ -365,9 +365,9 @@ class BspMetalsClientSpec(
         workspace,
         "A",
         dummyFooSources,
-        scalaVersion = Some("3.0.0-M1"),
+        scalaVersion = Some("3.0.0-M3"),
         scalaOrg = Some("org.scala-lang"),
-        scalaCompiler = Some("scala3-compiler_3.0.0-M1")
+        scalaCompiler = Some("scala3-compiler_3.0.0-M3")
       )
       val projects = List(`A`)
       val configDir = TestProject.populateWorkspace(workspace, projects)
@@ -382,19 +382,19 @@ class BspMetalsClientSpec(
     }
   }
 
-  test("compile producing Semanticdb with scala3 when -Ysemanticdb setting is already present") {
+  test("compile producing Semanticdb with scala3 when -Xsemanticdb setting is already present") {
     TestUtil.withinWorkspace { workspace =>
       val defaultScalacOptions = List(
-        "-Ysemanticdb"
+        "-Xsemanticdb"
       )
       val `A` = TestProject(
         workspace,
         "A",
         dummyFooSources,
-        scalaVersion = Some("3.0.0-M1"),
+        scalaVersion = Some("3.0.0-M3"),
         scalacOptions = defaultScalacOptions,
         scalaOrg = Some("org.scala-lang"),
-        scalaCompiler = Some("scala3-compiler_3.0.0-M1")
+        scalaCompiler = Some("scala3-compiler_3.0.0-M3")
       )
       val projects = List(`A`)
       val configDir = TestProject.populateWorkspace(workspace, projects)


### PR DESCRIPTION
-Ysemanticdb flag should be still avialable, but it does no longer work, which is why we needed to change it now.