### PR TITLE
Fix issues with meta builds not resolving sbt artifacts

### DIFF
--- a/integrations/sbt-bloop/src/main/scala-sbt-0.13/bloop/integrations/sbt/Compat.scala
+++ b/integrations/sbt-bloop/src/main/scala-sbt-0.13/bloop/integrations/sbt/Compat.scala
@@ -12,6 +12,8 @@ object Compat {
   val PluginDiscovery = sbt.PluginDiscovery
   val PluginManagement = sbt.PluginManagement
 
+  val bloopCompatSettings: Seq[Def.Setting[_]] = List()
+
   type CompileResult = sbt.Compiler.CompileResult
 
   implicit def fileToRichFile(file: File): sbt.RichFile = new sbt.RichFile(file)

--- a/integrations/sbt-bloop/src/main/scala-sbt-1.0/bloop/integrations/sbt/Compat.scala
+++ b/integrations/sbt-bloop/src/main/scala-sbt-1.0/bloop/integrations/sbt/Compat.scala
@@ -2,7 +2,7 @@ package bloop.integrations.sbt
 
 import bloop.config.Config
 import sbt.io.syntax.File
-import sbt.{Artifact, Exec, Keys, SettingKey}
+import sbt.{Artifact, Exec, Keys, SettingKey, Def}
 import sbt.librarymanagement.ScalaModuleInfo
 
 object Compat {
@@ -35,6 +35,10 @@ object Compat {
   private final val anyWriter = implicitly[sbt.util.OptJsonWriter[AnyRef]]
   def toAnyRefSettingKey(id: String, m: Manifest[AnyRef]): SettingKey[AnyRef] =
     SettingKey(id)(m, anyWriter)
+
+  val bloopCompatSettings: Seq[Def.Setting[_]] = List(
+    Keys.reresolveSbtArtifacts := true
+  )
 
   import sbt.Task
   def cloneTask[T](task: Task[T]): Task[T] = {

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -161,7 +161,7 @@ object BloopDefaults {
       }
     },
     BloopKeys.bloopSupportedConfigurations := List(Compile, Test, IntegrationTest, Provided)
-  ) ++ Offloader.bloopCompileGlobalSettings
+  ) ++ Offloader.bloopCompileGlobalSettings ++ Compat.bloopCompatSettings
 
   // From the infamous https://stackoverflow.com/questions/40741244/in-sbt-how-to-execute-a-command-in-task
   def runCommandAndRemaining(command: String): State => State = { st: State =>

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/meta-builds/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/meta-builds/build.sbt
@@ -14,19 +14,22 @@ checkMetaBuildInfo in ThisBuild := {
     assert(metaContents.contains("\"sbtVersion\":\""), "Missing sbt version.")
   }
 
+  val directoryName = Keys.baseDirectory.value.getName()
   val bloopMetaDir = Keys.baseDirectory.value./("project")./(".bloop")
-  val metaBuildConfig = bloopMetaDir./("meta-builds-build.json")
+  val metaBuildConfig = bloopMetaDir./(s"$directoryName-build.json")
   check(metaBuildConfig)
 }
 
 val checkSourceJars = taskKey[Unit]("Check source jars are resolved and persisted")
 checkSourceJars in ThisBuild := {
+  val directoryName = Keys.baseDirectory.value.getName()
   def readBareFile(p: java.nio.file.Path): String =
     new String(Files.readAllBytes(p)).replaceAll("\\s", "")
 
   val bloopDir = Keys.baseDirectory.value./("project")./(".bloop")
-  val metaBuildConfig = bloopDir./("meta-builds-build.json")
-  val metaBuildTestConfig = bloopDir./("meta-builds-build-test.json")
+  val metaBuildConfig = bloopDir./(s"$directoryName-build.json")
   val contents = readBareFile(metaBuildConfig.toPath)
+  
   assert(contents.contains("\"classifier\":\"sources\""), "Missing source jar.")
+  assert(contents.contains("\"organization\":\"org.scala-sbt\""), "Missing source jar.")
 }

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/meta-builds/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/meta-builds/test
@@ -1,6 +1,4 @@
 > checkMetaBuildInfo
-$ exists project/.bloop/meta-builds-build.json
--$ exists project/.bloop/meta-builds-build-test.json
 $ copy-file changes/set-sources.sbt project/set-sources.sbt
 > reload
 > checkSourceJars


### PR DESCRIPTION
It seems that due to https://github.com/sbt/sbt/pull/6085/files we will no longer resolve sbt artifacts when running with coursier, which is the default.
sbt will instead try to use artifacts from the launcher, which does not seem to work in case of plugins.
There is an existing issue https://github.com/sbt/sbt/issues/6203, but in the meanitime we can force resolution using:

```scala
Keys.reresolveSbtArtifacts := true
```