### PR TITLE
Don't show message about unsupported Scala version for Scala 3

### DIFF
--- a/frontend/src/main/scala/bloop/engine/BuildLoader.scala
+++ b/frontend/src/main/scala/bloop/engine/BuildLoader.scala
@@ -217,7 +217,8 @@ object BuildLoader {
     // Recognize 2.12.8-abdcddd as supported if 2.12.8 exists in supported versions
     val isUnsupportedVersion = !supportedScalaVersions.exists(scalaVersion.startsWith(_))
     if (isUnsupportedVersion) {
-      logger.debug(Feedback.skippedUnsupportedScalaMetals(scalaVersion))(DebugFilter.All)
+      if (!scalaVersion.startsWith("3."))
+        logger.debug(Feedback.skippedUnsupportedScalaMetals(scalaVersion))(DebugFilter.All)
       Coeval.now(enableMetals(None))
     } else {
       Coeval.eval {


### PR DESCRIPTION
Scala 3 in contrast to Scala 2 does not need to download the semanticdb plugin separately, but only to enable the -Xsemanticdb flag.