### PR TITLE
Add ScalaInstance top class loader

### DIFF
--- a/backend/src/main/scala/bloop/ScalaInstance.scala
+++ b/backend/src/main/scala/bloop/ScalaInstance.scala
@@ -47,7 +47,7 @@ final class ScalaInstance private (
       (organization == "org.scala-lang" && version.startsWith("3."))
 
   override lazy val loaderLibraryOnly: ClassLoader =
-    new URLClassLoader(Array(libraryJar.toURI.toURL), ScalaInstance.bootClassLoader)
+    new URLClassLoader(Array(libraryJar.toURI.toURL), ScalaInstance.topClassLoader)
   override lazy val loader: ClassLoader = {
     // For some exceptionally weird reason, we need to load all jars for dotty here
     val jarsToLoad = if (isDotty) allJars else allJars.filterNot(_ == libraryJar)
@@ -114,6 +114,11 @@ object ScalaInstance {
           null
       }
     }
+  }
+
+  private[ScalaInstance] val topClassLoader: ClassLoader = {
+    val bloopClassLoader = getClass.getClassLoader
+    new ScalaInstanceTopLoader(bloopClassLoader, bootClassLoader)
   }
 
   private[ScalaInstance] final val ScalacCompilerName = "scala-compiler"

--- a/backend/src/main/scala/bloop/ScalaInstanceTopLoader.scala
+++ b/backend/src/main/scala/bloop/ScalaInstanceTopLoader.scala
@@ -1,0 +1,39 @@
+package bloop
+
+/**
+ * The parent classloader of the Scala compiler.
+ * It was originally copied and pasted from
+ * https://github.com/lampepfl/dotty/blob/ea65338e06142f41f0e68b23250c8e22b0ba8837/sbt-dotty/src/dotty/tools/sbtplugin/DottyPlugin.scala#L586-L627
+ *
+ * To understand why a custom parent classloader is needed for the compiler,
+ * let us describe some alternatives that wouldn't work.
+ *
+ * - `new URLClassLoader(urls)`:
+ *   The compiler contains sbt phases that callback to sbt using the `xsbti.*`
+ *   interfaces. If `urls` does not contain the sbt interfaces we'll get a
+ *   `ClassNotFoundException` in the compiler when we try to use them, if
+ *   `urls` does contain the interfaces we'll get a `ClassCastException` or a
+ *   `LinkageError` because if the same class is loaded by two different
+ *   classloaders, they are considered distinct by the JVM.
+ *
+ * - `new URLClassLoader(urls, bloopLoader)`:
+ *    Because of the JVM delegation model, this means that we will only load
+ *    a class from `urls` if it's not present in the parent `bloopLoader`, but
+ *    Bloop uses its own version of the scala library which is not the one we
+ *    need to run the compiler.
+ *
+ * Our solution is to implement an URLClassLoader whose parent is
+ * `new ScalaInstanceTopLoader(bloopClassLoader, bootClassLoader)`.
+ * We override `loadClass` to load the `xsbti.*` interfaces from the
+ * `bloopClassLoader` and the JDK classes from the bootClassLoader.
+ */
+class ScalaInstanceTopLoader(bloopClassLoader: ClassLoader, parent: ClassLoader)
+    extends ClassLoader(parent) {
+  override protected def loadClass(name: String, resolve: Boolean): Class[_] = {
+    if (name.startsWith("xsbti.")) {
+      val c = bloopClassLoader.loadClass(name)
+      if (resolve) resolveClass(c)
+      c
+    } else super.loadClass(name, resolve)
+  }
+}


### PR DESCRIPTION
Because the Scala 3 compiler depends directly on `org.scala-sbt:compiler-interface`, it must load the `xsbti.*` classes from the same class loader than Bloop. Otherwise we have `LinkageError` exception.

The current Scala 3 compiler bridge hacks its own class loader to avoid `LinkageError` but this solution is fragile and it won't work with Zinc 1.4.x. This PR makes it possible to remove that hack from the compiler: https://github.com/lampepfl/dotty/pull/10960.

This PR introduces the `ScalaInstanceTopLoader`: the parent of the `ScalaInstance.loader` that loads the `xsbti.*` classes from the Bloop loader.

Similar solutions are already used in:
- https://github.com/sbt/sbt/pull/6199
- https://github.com/lihaoyi/mill/pull/1019 