### PR TITLE
Fix issues when starting console within workspaces that include a space

### DIFF
--- a/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
@@ -607,7 +607,7 @@ class BloopgunCli(
       else {
         def processAmmoniteOutFile: Int = {
           val contents = new String(Files.readAllBytes(cmdOutFile), StandardCharsets.UTF_8)
-          val replCoursierCmd = contents.trim.split(" ")
+          val replCoursierCmd = contents.trim.split("\n")
           if (replCoursierCmd.length == 0) {
             logger.error("Unexpected empty REPL command after running console in Bloop server!")
             1

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -287,7 +287,12 @@ object Interpreter {
 
                   val ammArgs = "--" :: cmd.args
 
-                  val ammoniteCmd = (coursierCmd ++ coursierClasspathArgs ++ ammArgs).mkString(" ")
+                  /**
+                   * Whenever `console` is run an extra `--out-file` parameter is added.
+                   * That file is later used to write a coursier command to and Bloopgun uses it
+                   * to download and run Ammonite.
+                   */
+                  val ammoniteCmd = (coursierCmd ++ coursierClasspathArgs ++ ammArgs).mkString("\n")
                   cmd.outFile match {
                     case None => Task.now(state.withInfo(ammoniteCmd))
                     case Some(outFile) =>


### PR DESCRIPTION
When running the `console` command an additional `--out-file` parameter is added by Bloopgun, which Bloop will write an ammonite command to. This command would hover be written as arguments separated by spaces, which makes it not work in case of workspaces containing spaces. Here, I change it to newline to avoid the issue.

Fixes https://github.com/scalacenter/bloop/issues/1448