### PR TITLE
Handle jvmOptions without -J prefix in debugSession/start request

### DIFF
--- a/frontend/src/main/scala/bloop/dap/DebuggeeRunner.scala
+++ b/frontend/src/main/scala/bloop/dap/DebuggeeRunner.scala
@@ -40,14 +40,18 @@ private final class MainClassDebugAdapter(
 
   def run(debugLogger: DebugSessionLogger): Task[ExitStatus] = {
     val workingDir = state.commonOptions.workingPath
+    // TODO: https://github.com/scalacenter/bloop/issues/1456
+    // Metals used to add the `-J` prefix but it is not needed anymore
+    // So we cautiously strip it off
+    val jvmOptions = mainClass.jvmOptions.map(_.stripPrefix("-J"))
     val runState = Tasks.runJVM(
       state.copy(logger = debugLogger),
       project,
       env,
       workingDir,
       mainClass.`class`,
-      (mainClass.arguments ++ mainClass.jvmOptions).toArray,
-      skipJargs = false,
+      mainClass.arguments.toArray,
+      jvmOptions.toArray,
       mainClass.environmentVariables,
       RunMode.Debug
     )

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -85,6 +85,7 @@ object TestTask {
             discoverTestSuites(state, project, configuredFrameworks, compileAnalysis, testFilter)
           val discoveredFrameworks = suites.iterator.filterNot(_._2.isEmpty).map(_._1).toList
           val (userJvmOptions, userTestOptions) = rawTestOptions.partition(_.startsWith("-J"))
+          val jvmOptions = userJvmOptions.map(_.stripPrefix("-J"))
           val frameworkArgs = considerFrameworkArgs(discoveredFrameworks, userTestOptions, logger)
           val args = project.testOptions.arguments ++ frameworkArgs
           logger.debug(s"Running test suites with arguments: $args")
@@ -93,7 +94,7 @@ object TestTask {
             case DiscoveredTestFrameworks.Jvm(frameworks, forker, loader) =>
               val opts = state.commonOptions
               // FORMAT: OFF
-              TestInternals.execute(cwd, forker, loader, suites, args, userJvmOptions, handler, logger, opts)
+              TestInternals.execute(cwd, forker, loader, suites, args, jvmOptions, handler, logger, opts)
               // FORMAT: ON
             case DiscoveredTestFrameworks.Js(frameworks, closeResources) =>
               val cancelled: AtomicBoolean = AtomicBoolean(false)

--- a/frontend/src/main/scala/bloop/exec/JvmProcessForker.scala
+++ b/frontend/src/main/scala/bloop/exec/JvmProcessForker.scala
@@ -33,44 +33,24 @@ trait JvmProcessForker {
   /**
    * Run the main function in class `className`, passing it `args`
    *
-   * @param cwd            The directory in which to start the forked JVM
-   * @param mainClass      The fully qualified name of the class to run
-   * @param args0          The arguments to pass to the main method. If they contain args
-   *                       starting with `-J`, they will be interpreted as jvm options.
-   * @param skipJargs      Skip the interpretation of `-J` options in `args`.
-   * @param logger         Where to log the messages from execution
-   * @param opts           The options to run the program with
-   * @param extraClasspath Paths to append to the classpath before running
+   * @param cwd             The directory in which to start the forked JVM
+   * @param mainClass       The fully qualified name of the class to run
+   * @param args            The arguments to pass to the main method.
+   * @param jvmOptions      The java options to pass to the jvm.
+   * @param logger          Where to log the messages from execution
+   * @param opts            The options to run the program with
+   * @param extraClasspath  Paths to append to the classpath before running
    * @return 0 if the execution exited successfully, a non-zero number otherwise
-   *
-   *
    */
-  final def runMain(
-      cwd: AbsolutePath,
-      mainClass: String,
-      args0: Array[String],
-      skipJargs: Boolean,
-      envVars: List[String],
-      logger: Logger,
-      opts: CommonOptions,
-      extraClasspath: Array[AbsolutePath] = Array.empty
-  ): Task[Int] = {
-    val (userJvmOptions, userArgs) =
-      if (skipJargs) (Array.empty[String], args0)
-      else args0.partition(_.startsWith("-J"))
-
-    runMain(cwd, mainClass, userArgs, userJvmOptions, envVars, logger, opts, extraClasspath)
-  }
-
   def runMain(
       cwd: AbsolutePath,
       mainClass: String,
       args: Array[String],
-      jargs: Array[String],
+      jvmOptions: Array[String],
       envVars: List[String],
       logger: Logger,
       opts: CommonOptions,
-      extraClasspath: Array[AbsolutePath]
+      extraClasspath: Array[AbsolutePath] = Array.empty
   ): Task[Int]
 }
 
@@ -117,8 +97,7 @@ final class JvmForker(config: JdkConfig, classpath: Array[AbsolutePath]) extends
       opts: CommonOptions,
       extraClasspath: Array[AbsolutePath]
   ): Task[Int] = {
-
-    val jvmOptions = jargs.map(_.stripPrefix("-J")) ++ config.javaOptions
+    val jvmOptions = jargs ++ config.javaOptions
     val fullClasspath = classpath ++ extraClasspath
     val fullClasspathStr = fullClasspath.map(_.syntax).mkString(File.pathSeparator)
     envVars.map(_.split("=")).collect {

--- a/frontend/src/main/scala/bloop/testing/TestInternals.scala
+++ b/frontend/src/main/scala/bloop/testing/TestInternals.scala
@@ -107,7 +107,7 @@ object TestInternals {
    * @param classLoader      The class loader used for discovering the tests
    * @param discovered       The test tasks that were discovered, grouped by their `Framework`
    * @param args             The test arguments to pass to the framework
-   * @param userJvmOptions   The jvm options to run tests with.
+   * @param jvmOptions       The jvm options to run tests with.
    * @param testEventHandler Handler that reacts on messages from the testing frameworks
    * @param logger           Logger receiving test output
    * @param opts             The options to run the program with
@@ -118,7 +118,7 @@ object TestInternals {
       classLoader: ClassLoader,
       discovered: Map[Framework, List[TaskDef]],
       args: List[Config.TestArgument],
-      userJvmOptions: List[String],
+      jvmOptions: List[String],
       testEventHandler: TestSuiteEventHandler,
       logger: Logger,
       opts: CommonOptions
@@ -130,7 +130,7 @@ object TestInternals {
 
     val server = new TestServer(logger, testEventHandler, classLoader, discovered, args, opts)
     val forkMain = classOf[sbt.ForkMain].getCanonicalName
-    val arguments = userJvmOptions.toArray ++ Array(server.port.toString)
+    val arguments = Array(server.port.toString)
     val testAgentJars = agentFiles.filter(_.underlying.toString.endsWith(".jar"))
     logger.debug("Test agent JARs: " + testAgentJars.mkString(", "))
 
@@ -139,7 +139,16 @@ object TestInternals {
     val listener = server.listenToTests
     val runner = {
       val runTask =
-        forker.runMain(cwd, forkMain, arguments, false, Nil, logger, opts, testAgentJars)
+        forker.runMain(
+          cwd,
+          forkMain,
+          arguments,
+          jvmOptions.toArray,
+          Nil,
+          logger,
+          opts,
+          testAgentJars
+        )
       runTask.map(exitCode => Forker.exitStatus(exitCode).code)
     }
 

--- a/frontend/src/test/scala/bloop/ForkerSpec.scala
+++ b/frontend/src/test/scala/bloop/ForkerSpec.scala
@@ -61,7 +61,7 @@ class ForkerSpec {
           cwd,
           mainClass,
           args,
-          skipJargs = false,
+          Array.empty,
           envVars = Nil,
           logger.asVerbose,
           opts,


### PR DESCRIPTION
To unblock the issue https://github.com/scalameta/metals/issues/2489 in Metals, Bloop must handle `jvmOptions` without the `-J` prefix in the `debugSession/start` request.

For instance the following `scalaMainClass` is correct and Bloop should be able to execute it:
```
"data": {
    "class": "ch.epfl.scala.index.server.Server",
    "arguments": [],
    "jvmOptions": [
      "-Djna.nosys\u003dtrue"
    ],
    "environmentVariables": []
  }
```
