### PR TITLE
Fix issue when unknown SHELL was defined

### DIFF
--- a/shared/src/main/scala/bloop/io/Environment.scala
+++ b/shared/src/main/scala/bloop/io/Environment.scala
@@ -21,7 +21,7 @@ object Environment {
    */
   val lineSeparator: String = Option(System.getenv("SHELL")) match {
     case Some(currentShell) if validShells.exists(sh => currentShell.contains(sh)) => "\n"
-    case None => System.getProperty("line.separator", "\n")
+    case _ => System.getProperty("line.separator", "\n")
   }
 
   /**
@@ -67,6 +67,7 @@ object Environment {
     "/bin/pdksh",
     "/bin/posh",
     "/bin/tcsh",
-    "/bin/zsh"
+    "/bin/zsh",
+    "/bin/fish"
   )
 }


### PR DESCRIPTION
Previously line separator would be a non-exhaustive match and could throw an exception if an unknown shell was found. Now it defaults to `System.getProperty("line.separator", "\n")`

Fixes https://github.com/scalacenter/bloop/issues/1460