### PR TITLE
Add Gradle Android plugin support

### DIFF
--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/SemVer.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/SemVer.scala
@@ -1,0 +1,84 @@
+package bloop.integrations.gradle
+
+import scala.util.Try
+
+object SemVer {
+
+  case class Version(
+      major: Int,
+      minor: Int,
+      patch: Int,
+      releaseCandidate: Option[Int],
+      milestone: Option[Int]
+  ) {
+    def >(that: Version): Boolean = {
+      this.major > that.major ||
+      (this.major == that.major && this.minor > that.minor) ||
+      (this.major == that.major && this.minor == that.minor && this.patch > that.patch) ||
+      // 3.0.0-RC1 > 3.0.0-M1
+      this.releaseCandidate.isDefined && that.milestone.isDefined ||
+      // 3.0.0 > 3.0.0-M2 and 3.0.0 > 3.0.0-RC1
+      (this.milestone.isEmpty && this.releaseCandidate.isEmpty && (that.milestone.isDefined || that.releaseCandidate.isDefined)) ||
+      // 3.0.0-RC2 > 3.0.0-RC1
+      comparePreRelease(that, (v: Version) => v.releaseCandidate) ||
+      // 3.0.0-M2 > 3.0.0-M1
+      comparePreRelease(that, (v: Version) => v.milestone)
+
+    }
+
+    def >=(that: Version): Boolean = this > that || this == that
+
+    def <(that: Version): Boolean = !(this >= that)
+
+    def <=(that: Version): Boolean = !(this > that)
+
+    private def comparePreRelease(
+        that: Version,
+        preRelease: Version => Option[Int]
+    ): Boolean = {
+      val thisPrerelease = preRelease(this)
+      val thatPrerelease = preRelease(that)
+      this.major == that.major && this.minor == that.minor && this.patch == that.patch &&
+      thisPrerelease.isDefined && thatPrerelease.isDefined && thisPrerelease
+        .zip(thatPrerelease)
+        .exists { case (a, b) => a > b }
+    }
+
+    override def toString: String =
+      List(
+        Some(s"$major.$minor.$patch"),
+        releaseCandidate.map(s => s"-RC$s"),
+        milestone.map(s => s"-M$s")
+      ).flatten.mkString("")
+
+  }
+
+  object Version {
+    def fromString(version: String): Version = {
+      val Array(major, minor, patch) =
+        version.replaceAll("(-|\\+).+$", "").split('.').map(_.toInt)
+
+      val prereleaseString = version.stripPrefix(s"$major.$minor.$patch")
+
+      def fromSuffix(name: String) = {
+        if (prereleaseString.startsWith(name))
+          Try(
+            prereleaseString.stripPrefix(name).replaceAll("\\-.*", "").toInt
+          ).toOption
+        else None
+      }
+      val releaseCandidate = fromSuffix("-RC")
+      val milestone = fromSuffix("-M")
+
+      Version(major, minor, patch, releaseCandidate, milestone)
+    }
+  }
+
+  def isCompatibleVersion(minimumVersion: String, version: String): Boolean = {
+    Version.fromString(version) >= Version.fromString(minimumVersion)
+  }
+
+  def isLaterVersion(earlierVersion: String, laterVersion: String): Boolean = {
+    Version.fromString(laterVersion) > Version.fromString(earlierVersion)
+  }
+}

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/BloopInstallTask.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/BloopInstallTask.scala
@@ -9,7 +9,10 @@ import bloop.integrations.gradle.model.BloopConverter.SourceSetDep
 import bloop.integrations.gradle.syntax._
 import org.gradle.api.tasks.{SourceSet, TaskAction}
 import org.gradle.api.{DefaultTask, Project}
+import com.android.builder.model.SourceProvider
+import com.android.build.gradle.api.BaseVariant
 
+import scala.collection.JavaConverters._
 import scala.util.{Failure, Success}
 
 /**
@@ -29,13 +32,15 @@ class BloopInstallTask extends DefaultTask with PluginUtils with TaskLogging {
   def run(): Unit = {
     if (canRunBloop) runBloopPlugin()
     else {
-      info(s"Ignoring 'bloopInstall' on non-Scala and non-Java project '${project.getName}'")
+      info(
+        s"Ignoring 'bloopInstall' on non-Scala, non-Java, non-Android project '${project.getName}'"
+      )
     }
   }
 
   def runBloopPlugin(): Unit = {
     val parameters = extension.createParameters
-    val converter = new BloopConverter(parameters)
+    val converter = new BloopConverter(parameters, info)
     val targetDir: File = parameters.targetDir
     info(s"Generating Bloop configuration to ${targetDir.getAbsolutePath}")
 
@@ -44,29 +49,104 @@ class BloopInstallTask extends DefaultTask with PluginUtils with TaskLogging {
       Files.createDirectory(targetDir.toPath)
     }
 
+    if (hasJavaScalaPlugin)
+      ScalaJavaInstall.install(project, targetDir, converter, info)
+
+    if (hasAndroidPlugin)
+      AndroidInstall.install(project, targetDir, converter, info)
+  }
+}
+
+object ScalaJavaInstall {
+
+  def install(
+      project: Project,
+      targetDir: File,
+      converter: BloopConverter,
+      info: String => Unit
+  ): Unit = {
     for (sourceSet <- project.allSourceSets) {
       val projectName = converter.getProjectName(project, sourceSet)
       generateBloopConfiguration(
+        project,
         projectName,
         sourceSet,
         targetDir,
-        converter
+        converter,
+        info
       )
     }
   }
 
   private def generateBloopConfiguration(
+      project: Project,
       projectName: String,
       sourceSet: SourceSet,
       targetDir: File,
-      converter: BloopConverter
+      converter: BloopConverter,
+      info: String => Unit
   ): Unit = {
     val targetFile = targetDir / s"$projectName.json"
     // Let's keep the error message as similar to the one in the sbt plugin as possible
     info(s"Generated ${targetFile.getAbsolutePath}")
-    converter.toBloopConfig(project, sourceSet, targetDir) match {
+    converter.toBloopConfig(projectName, project, sourceSet, targetDir) match {
       case Failure(reason) =>
         info(s"Skipping ${project.getName}/${sourceSet.getName} because: $reason")
+      case Success(bloopConfig) =>
+        bloop.config.write(bloopConfig, targetFile.toPath)
+    }
+  }
+}
+
+object AndroidInstall {
+
+  def install(
+      project: Project,
+      targetDir: File,
+      converter: BloopConverter,
+      info: String => Unit
+  ): Unit = {
+    for (variant <- project.androidVariants) {
+      generateBloopConfiguration(project, variant, targetDir, converter, info)
+      val testVariant = variant.getTestVariant()
+      if (testVariant != null)
+        generateBloopConfiguration(project, testVariant, targetDir, converter, info)
+    }
+  }
+
+  private def generateBloopConfiguration(
+      project: Project,
+      variant: BaseVariant,
+      targetDir: File,
+      converter: BloopConverter,
+      info: String => Unit
+  ): Unit = {
+    val projectName = converter.getAndroidProjectName(project, variant)
+    generateBloopConfiguration(
+      project,
+      projectName,
+      variant,
+      variant.getSourceSets.asScala.toList,
+      targetDir,
+      converter,
+      info
+    )
+  }
+
+  private def generateBloopConfiguration(
+      project: Project,
+      projectName: String,
+      variant: BaseVariant,
+      sourceProviders: List[SourceProvider],
+      targetDir: File,
+      converter: BloopConverter,
+      info: String => Unit
+  ): Unit = {
+    val targetFile = targetDir / s"$projectName.json"
+    info(s"Generated ${targetFile.getAbsolutePath}")
+    converter.toBloopConfig(projectName, project, variant, sourceProviders, targetDir) match {
+      case Failure(reason) =>
+        info(s"Skipping ${project.getName} because: $reason")
       case Success(bloopConfig) =>
         bloop.config.write(bloopConfig, targetFile.toPath)
     }

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/ConfigureBloopInstallTask.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/ConfigureBloopInstallTask.scala
@@ -25,7 +25,7 @@ class ConfigureBloopInstallTask extends DefaultTask with PluginUtils with TaskLo
   def run(): Unit = {
     installTask match {
       case Some(task) =>
-        if (canRunBloop) {
+        if (hasJavaScalaPlugin) {
           // Guard to avoid accessing java-related information (source sets) for non-Java projects
           project.allSourceSets.foreach(addSourceSetAsInputs(task, _))
         }

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/PluginUtils.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/PluginUtils.scala
@@ -6,11 +6,25 @@ trait PluginUtils {
   val project: Project
 
   def canRunBloop: Boolean = PluginUtils.canRunBloop(project)
+
+  def hasJavaScalaPlugin: Boolean = PluginUtils.hasJavaScalaPlugin(project)
+
+  def hasAndroidPlugin: Boolean = PluginUtils.hasAndroidPlugin(project)
 }
 
 object PluginUtils {
   def canRunBloop(project: Project): Boolean = {
+    hasJavaScalaPlugin(project) ||
+    hasAndroidPlugin(project)
+  }
+  def hasJavaScalaPlugin(project: Project): Boolean = {
     val pluginManager = project.getPluginManager
-    pluginManager.hasPlugin("scala") || pluginManager.hasPlugin("java")
+    pluginManager.hasPlugin("scala") ||
+    pluginManager.hasPlugin("java")
+  }
+  def hasAndroidPlugin(project: Project): Boolean = {
+    val pluginManager = project.getPluginManager
+    pluginManager.hasPlugin("com.android.library") ||
+    pluginManager.hasPlugin("com.android.application")
   }
 }

--- a/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
+++ b/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
@@ -47,9 +47,28 @@ abstract class ConfigGenerationSuite extends BaseConfigSuite {
   private val testProjectDir_ = new TemporaryFolder()
   @Rule def testProjectDir: TemporaryFolder = testProjectDir_
 
-  @Test def worksWithAndroidPlugin(): Unit = {
-    // This version has to match with Dependencies#gradleAndroidPluginVersion.  Currently can't test multiple versions.
+  @Test def worksWithAndroidPlugin_3_4(): Unit = {
+    worksWithAndroidPlugin("3.4.0")
+  }
+
+  @Test def worksWithAndroidPlugin_3_5(): Unit = {
+    worksWithAndroidPlugin("3.5.0")
+  }
+
+  @Test def worksWithAndroidPlugin_3_6(): Unit = {
+    worksWithAndroidPlugin("3.6.0")
+  }
+
+  @Test def worksWithAndroidPlugin_4_0(): Unit = {
+    worksWithAndroidPlugin("4.0.0")
+  }
+
+  @Test def worksWithAndroidPlugin_4_1(): Unit = {
     worksWithAndroidPlugin("4.1.0")
+  }
+
+  @Test def worksWithAndroidPlugin_4_2(): Unit = {
+    worksWithAndroidPlugin("4.2.0")
   }
 
   private def worksWithAndroidPlugin(androidToolsVersion: String): Unit = {
@@ -74,7 +93,6 @@ abstract class ConfigGenerationSuite extends BaseConfigSuite {
            |buildscript {
            |  repositories {
            |    google()
-           |    jcenter()
            |  }
            |  dependencies {
            |    classpath 'com.android.tools.build:gradle:$androidToolsVersion'
@@ -106,7 +124,6 @@ abstract class ConfigGenerationSuite extends BaseConfigSuite {
            |buildscript {
            |  repositories {
            |    google()
-           |    jcenter()
            |  }
            |  dependencies {
            |    classpath 'com.android.tools.build:gradle:$androidToolsVersion'
@@ -140,7 +157,6 @@ abstract class ConfigGenerationSuite extends BaseConfigSuite {
            |buildscript {
            |  repositories {
            |    google()
-           |    jcenter()
            |  }
            |  dependencies {
            |    classpath 'com.android.tools.build:gradle:$androidToolsVersion'

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -533,12 +533,16 @@ object BuildImplementation {
       sbtbuildinfo.BuildInfoPlugin.buildInfoScopedSettings(Test) ++ List(
         Keys.fork in Test := true,
         Keys.resolvers ++= List(
-          MavenRepository("Gradle releases", "https://repo.gradle.org/gradle/libs-releases-local/")
+          MavenRepository("Gradle releases", "https://repo.gradle.org/gradle/libs-releases-local/"),
+          MavenRepository("Android plugin", "https://maven.google.com/"),
+          MavenRepository("trove4j dependency", "https://jcenter.bintray.com/"),
+          MavenRepository("Android dependencies", "https://repo.spring.io/plugins-release/")
         ),
         Keys.libraryDependencies ++= List(
           Dependencies.gradleCore,
           Dependencies.gradleToolingApi,
-          Dependencies.groovy
+          Dependencies.groovy,
+          Dependencies.gradleAndroidPlugin
         ),
         Keys.publishLocal := Keys.publishLocal.dependsOn(Keys.publishM2).value,
         Keys.unmanagedJars.in(Compile) := unmanagedJarsWithGradleApi.value,

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -535,7 +535,6 @@ object BuildImplementation {
         Keys.resolvers ++= List(
           MavenRepository("Gradle releases", "https://repo.gradle.org/gradle/libs-releases-local/"),
           MavenRepository("Android plugin", "https://maven.google.com/"),
-          MavenRepository("trove4j dependency", "https://jcenter.bintray.com/"),
           MavenRepository("Android dependencies", "https://repo.spring.io/plugins-release/")
         ),
         Keys.libraryDependencies ++= List(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
   val mavenScalaPluginVersion = "4.5.3"
   val gradleVersion = "5.0"
   val groovyVersion = "2.5.4"
-  val gradleAndroidPluginVersion = "4.1.0"
+  val gradleAndroidPluginVersion = "4.2.0"
   val ipcsocketVersion = "1.0.1"
   val monixVersion = "2.3.3"
   val circeVersion = "0.9.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,6 +35,7 @@ object Dependencies {
   val mavenScalaPluginVersion = "4.5.3"
   val gradleVersion = "5.0"
   val groovyVersion = "2.5.4"
+  val gradleAndroidPluginVersion = "4.1.0"
   val ipcsocketVersion = "1.0.1"
   val monixVersion = "2.3.3"
   val circeVersion = "0.9.3"
@@ -103,6 +104,8 @@ object Dependencies {
     "org.gradle" % "gradle-dependency-management" % gradleVersion % Provided
   val gradleToolingApi = "org.gradle" % "gradle-tooling-api" % gradleVersion % Provided
   val groovy = "org.codehaus.groovy" % "groovy" % groovyVersion % Provided
+  val gradleAndroidPlugin =
+    "com.android.tools.build" % "gradle" % gradleAndroidPluginVersion % Provided
 
   val monix = "io.monix" %% "monix" % monixVersion
   val jsoniterCore =


### PR DESCRIPTION
This is an attempt at supporting the Gradle Android plugin.

The Android plugin appears to use its own way of managing sourcesets/variants/flavors etc. so there's not huge amounts of commonality between it and the Java/Scala plugins that can be exploited.  Instead I've duplicated a lot of code from the current handling of Java/Scala plugin.  I think this is actually a good thing as just in the few Android SDK versions I've tested, the API has changed and I think it'll be easier to support if the code paths are separate.

There are a few caveats here...
1) Android uses VariantTransforms to handle dependencies on java only (i.e. none Android) Gradle projects.  These transforms have to be applied when Gradle creates the classpath and the transforms require the project's output jar file to exist.  To be clear - this is only to do with dependencies from Android projects onto java-only projects (i.e. where you have the source present), not general maven dependencies i.e. junit.  Because of this, any java-only projects that are a part of the Android projects must be assembled first using Gradle `./gradlew nonAndroidProjectName::assemble` or `BloopInstall` will throw an exception.  Once they are assembled, the jar will exist, bloopInstall can be run and then Bloop will happily ignore this jar and manage compilation across all the projects: android and java-only.  I'm still looking into whether there is some way round this as I don't think assembling should be required to query Gradle for the classpath.

2) Android manages UI layout/setup using XML files stored in the project's `res` sub directory.  It "compiles" these XML files into java class files using the [AAPT2](https://developer.android.com/studio/command-line/aapt2) tool and packages them into an `R.jar`.  This allows these UI resources to be accessed as java code by the rest of the project.  I don't see a way round this and I imagine most Android projects contain UI.  It means that `./gradlew assemble` has to be run on all Android projects containing Android resources before Bloop can use the `R.jar`.  The export to Bloop will work fine but compilation will fail if the project has UI and `./gradlew assemble` has not been run.  Then whenever these resource files are changed, the user has to run `./gradlew assemble` to update the `R.jar` and be able to use them in Metals/Bloop.  I guess ideally Bloop would would directly support AAPT2 which I think is just a question of watching the `res` dir for `xml` files and calling AAPT2 on the file that's changed.

3) A BuildConfig record is often defined within the project's `build.gradle` file. e.g.
```groovy
    defaultConfig {
        buildConfigField "long", "TIMESTAMP", System.currentTimeMillis() + "L"
    }
```
Gradle will compile this into a `build/generated/source/buildConfig/variant` directory as `BuildConfig.java`.  This class is then accessible from source code (e.g. `BuildConfig.TIMESTAMP` is available from java code).  Again `./gradlew assemble` is required to create `BuildConfig.java` initially and then Bloop will happily make use of it.  I don't see a way round this.

4) All variants are exported - release & debug.  I'm not sure if this is wanted?

5) I've only tested on v4.0.0 and v4.1.0.

Because of points 1, 2 and 3, I'm not sure how useful this PR is at this stage.  If (2) could be solved then it would make this more viable.  I don't know if Bloop actually needs to support AAPT2 - it might be possible to use something like the [filewatcher](https://marketplace.visualstudio.com/items?itemName=appulate.filewatcher) VSCode extension to call `./gradlew assemble` or `AAPT2` on file change.

