### PR TITLE
Fix issues with scala-collection-compat missing in bloopgun

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -427,7 +427,7 @@ lazy val bloopgunShaded = project
     fork in Test := true,
     bloopGenerate in Compile := None,
     bloopGenerate in Test := None,
-    libraryDependencies += Dependencies.scalaXml
+    libraryDependencies ++= List(Dependencies.scalaXml, Dependencies.scalaCollectionCompat)
   )
 
 lazy val launcher: Project = project
@@ -460,7 +460,8 @@ lazy val launcherShaded = project
     libraryDependencies ++= List(
       "net.java.dev.jna" % "jna" % "4.5.0",
       "net.java.dev.jna" % "jna-platform" % "4.5.0",
-      Dependencies.scalaXml
+      Dependencies.scalaXml,
+      Dependencies.scalaCollectionCompat
     )
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -73,6 +73,7 @@ object Dependencies {
   val coursierCache = "io.get-coursier" %% "coursier-cache" % coursierVersion
   val coursierScalaz = "io.get-coursier" %% "coursier-scalaz-interop" % coursierVersion
   val scalaXml = "org.scala-lang.modules" %% "scala-xml" % scalaXmlVersion
+  val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.2"
   val shapeless = "ch.epfl.scala" %% "shapeless" % shapelessVersion
   val caseApp = "ch.epfl.scala" %% "case-app" % caseAppVersion
   val sourcecode = "com.lihaoyi" %% "sourcecode" % sourcecodeVersion


### PR DESCRIPTION
Fixes https://github.com/scalacenter/bloop/issues/1463

scala-collection-compat is brought in by coursier and since `scala` is added to be ingored when shading, it never ends up properly on the classpath of bloopgun. This fixes the issues by adding the dependency directly. It's binary compatible, so it should not be an issue in case of conflicts.