### PR TITLE
Integrations: Gradle: Fix: Ignore non bloop capable projects when getting all projects

### DIFF
--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/PluginUtils.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/PluginUtils.scala
@@ -5,7 +5,11 @@ import org.gradle.api.Project
 trait PluginUtils {
   val project: Project
 
-  def canRunBloop: Boolean = {
+  def canRunBloop: Boolean = PluginUtils.canRunBloop(project)
+}
+
+object PluginUtils {
+  def canRunBloop(project: Project): Boolean = {
     val pluginManager = project.getPluginManager
     pluginManager.hasPlugin("scala") || pluginManager.hasPlugin("java")
   }


### PR DESCRIPTION
This is a proposed fix to address the issue in https://github.com/scalacenter/bloop/issues/1472

### Changes
1. Extract and reuse existing function `canRunBloop` to determine if a Gradle sub-project is a bloop capable project or not. 
2. Change all occurrences of  `getAllprojects`  with the newly introduced function.
3. Minor change to replace `map` and then `flatten` with `flatMap`
4. Test