### PR TITLE
Hot Swap Compilation

### DIFF
--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -193,6 +193,9 @@ object Commands {
       @ExtraName("w")
       @HelpMessage("If set, run the command whenever projects' source files change.")
       watch: Boolean = false,
+      @ExtraName("H")
+      @HelpMessage("Hot Swap Compilation")
+      hotSwapCompilation: Boolean = false,
       @HelpMessage("Ignore arguments starting with `-J` and forward them instead.")
       skipJargs: Boolean = false,
       @ExtraName("O")

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -596,7 +596,16 @@ object Interpreter {
         }
       }
 
-      if (cmd.watch) watch(projects, state)(runTask) else runTask(state)
+      if (cmd.hotSwapCompilation) {
+        val compilationProcess =
+          watch(projects, state)(runCompile(cmd, _, projects, false, cmd.cliOptions.noColor))
+            .runAsync(ExecutionContext.ioScheduler)
+        runTask(state).doOnFinish(_ => Task.delay(compilationProcess.cancel()))
+      } else if (cmd.watch) {
+        watch(projects, state)(runTask)
+      } else {
+        runTask(state)
+      }
     }
   }
 


### PR DESCRIPTION
I would like to use [dcevm](http://dcevm.github.io/) with bloop in order to reload classes without restarting application.

I run my application using command `bloop run <project>`. As I understand this command starts application with classpath `.bloop/root/bloop-bsp-clients-classes/classes-bloop-cli`. But once application started there is no way to update classes in this directory. So dcevm can not discover new class files and update application.

I added new option for hot swap compilation which starts application as well as starts watcher with recompilation. What do you think about that change? Is there some way to achieve this behavior using existing options?

Using new option I start application with following command
```
bloop run root --main main.Class --hot-swap-compilation=true -- -J-XX:HotswapAgent=core -J-javaagent:$JAVA_HOME/lib/hotswap/hotswap-agent.jar=autoHotswap=true
```
and it sees new class files without restart.