### PR TITLE
Remove unused bsp submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,3 @@
 	path = benchmark-bridge
 	url = https://github.com/scalacenter/compiler-benchmark
 	branch = bloop-updated-2
-[submodule "bsp"]
-	path = bsp
-	url = https://github.com/scalacenter/bsp.git
-	branch = master


### PR DESCRIPTION
Previously, it was useful for quick interation of the BSP protocol, which is much more stable today.