### PR TITLE
Support Java semanticDB plugin

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -293,24 +293,13 @@ object Compiler {
       if (isFatalWarningsEnabled)
         inputs.reporter.enableFatalWarnings()
 
-      // targetroot is currently needed here because classes out dir varies per BSP client
-      val javaPluginIdx = inputs.javacOptions.indexWhere(f =>
-        f.contains("-Xplugin:") && f.contains("semanticdb") && !f.contains("-targetroot:")
-      )
-      val substitutedJavaOptions = if (javaPluginIdx > -1) {
-        val newJavacOptions = inputs.javacOptions.clone()
-        newJavacOptions(javaPluginIdx) =
-          s"${inputs.javacOptions(javaPluginIdx)} -targetroot:$newClassesDir"
-        newJavacOptions
-      } else inputs.javacOptions
-
       CompileOptions
         .create()
         .withClassesDirectory(newClassesDir.toFile)
         .withSources(sources.map(_.toFile))
         .withClasspath(classpath)
         .withScalacOptions(optionsWithoutFatalWarnings)
-        .withJavacOptions(substitutedJavaOptions)
+        .withJavacOptions(inputs.javacOptions)
         .withClasspathOptions(inputs.classpathOptions)
         .withOrder(inputs.compileOrder)
     }

--- a/frontend/src/main/scala/bloop/bsp/BloopBspDefinitions.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspDefinitions.scala
@@ -11,7 +11,8 @@ object BloopBspDefinitions {
       ownsBuildFiles: Option[Boolean],
       clientClassesRootDir: Option[Uri],
       semanticdbVersion: Option[String],
-      supportedScalaVersions: Option[List[String]]
+      supportedScalaVersions: Option[List[String]],
+      javaSemanticdbVersion: Option[String]
   )
 
   object BloopExtraBuildParams {
@@ -19,7 +20,8 @@ object BloopBspDefinitions {
       ownsBuildFiles = None,
       clientClassesRootDir = None,
       semanticdbVersion = None,
-      supportedScalaVersions = None
+      supportedScalaVersions = None,
+      javaSemanticdbVersion = None
     )
 
     val encoder: RootEncoder[BloopExtraBuildParams] = deriveEncoder

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -247,18 +247,23 @@ final class BloopBspServices(
       if (!isMetals) {
         currentWorkspaceSettings
       } else {
-        extraBuildParams
-          .flatMap(extra => extra.semanticdbVersion)
-          .map { semanticDBVersion =>
-            val supportedScalaVersions =
-              extraBuildParams.toList.flatMap(_.supportedScalaVersions.toList.flatten)
+        val javaSemanticDBVersion = extraBuildParams.flatMap(_.javaSemanticdbVersion)
+        val scalaSemanticDBVersion = extraBuildParams.flatMap(_.semanticdbVersion)
+        val supportedScalaVersions =
+          if (scalaSemanticDBVersion.nonEmpty)
+            extraBuildParams.map(_.supportedScalaVersions.toList.flatten)
+          else None
+        if (javaSemanticDBVersion.nonEmpty || scalaSemanticDBVersion.nonEmpty)
+          Some(
             WorkspaceSettings(
-              Some(semanticDBVersion),
-              Some(supportedScalaVersions),
+              javaSemanticDBVersion,
+              scalaSemanticDBVersion,
+              supportedScalaVersions,
               currentRefreshProjectsCommand,
               currentTraceSettings
             )
-          }
+          )
+        else None
       }
     }
 

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -359,7 +359,6 @@ object Project {
       logger: Logger
   ): Project = {
     val workspaceDir = project.workspaceDirectory.getOrElse(configDir.getParent)
-    val genericClassesDir = project.genericClassesDir
     val isDotty = project.scalaInstance.exists(_.isDotty)
 
     def isAtLeastScala3M3(version: String) = {

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -401,8 +401,7 @@ object Project {
     def enableJavaSemanticdbOptions(options: List[String]): List[String] = {
       if (hasJavaSemanticDBEnabledInCompilerOptions(options)) options
       else
-        // targetroot is added in Compiler.scala as it depends on Bloop client.
-        s"-Xplugin:semanticdb -sourceroot:${workspaceDir}" :: options
+        s"-Xplugin:semanticdb -sourceroot:${workspaceDir} -targetroot:javac-classes-directory" :: options
     }
 
     def enableJavaSemanticdbClasspath(

--- a/frontend/src/main/scala/bloop/data/SemanticdbSettings.scala
+++ b/frontend/src/main/scala/bloop/data/SemanticdbSettings.scala
@@ -1,6 +1,8 @@
 package bloop.data
 
+case class JavaSemanticdbSettings(semanticDBVersion: String)
+case class ScalaSemanticdbSettings(semanticDBVersion: String, supportedScalaVersions: List[String])
 case class SemanticdbSettings(
-    semanticDBVersion: String,
-    supportedScalaVersions: List[String]
+    javaSemanticdbSettings: Option[JavaSemanticdbSettings],
+    scalaSemanticdbSettings: Option[ScalaSemanticdbSettings]
 )

--- a/frontend/src/main/scala/bloop/engine/Build.scala
+++ b/frontend/src/main/scala/bloop/engine/Build.scala
@@ -109,10 +109,10 @@ final case class Build private (
           case Some(LoadedProject.ConfiguredProject(project, original, settings)) =>
             findUpdateSettingsAction(Some(settings), settingsForReload) match {
               case Build.AvoidReload(_) =>
-                val options = project.scalacOptions
-                val reattemptConfiguration = newSettings.nonEmpty && {
-                  !Project.hasSemanticDBEnabledInCompilerOptions(project.scalacOptions)
-                }
+                // TODO - should this be || or && ??
+                val reattemptConfiguration = newSettings.nonEmpty &&
+                  (!Project.hasScalaSemanticDBEnabledInCompilerOptions(project.scalacOptions) ||
+                    !Project.hasJavaSemanticDBEnabledInCompilerOptions(project.javacOptions))
 
                 if (reattemptConfiguration) {
                   invalidateProject(project, None)
@@ -193,7 +193,8 @@ final case class Build private (
   ): Build.UpdateSettingsAction = {
     (currentSettings, newSettings) match {
       case (Some(currentSettings), Some(newSettings))
-          if currentSettings.semanticDBVersion != newSettings.semanticDBVersion =>
+          if currentSettings.semanticDBVersion != newSettings.semanticDBVersion ||
+            currentSettings.javaSemanticDBVersion != newSettings.javaSemanticDBVersion =>
         Build.ForceReload(newSettings, List(WorkspaceSettings.SemanticDBVersionChange))
       case (Some(_), Some(newSettings)) => Build.AvoidReload(Some(newSettings))
       case (None, Some(newSettings)) =>

--- a/frontend/src/main/scala/bloop/engine/Build.scala
+++ b/frontend/src/main/scala/bloop/engine/Build.scala
@@ -109,7 +109,6 @@ final case class Build private (
           case Some(LoadedProject.ConfiguredProject(project, original, settings)) =>
             findUpdateSettingsAction(Some(settings), settingsForReload) match {
               case Build.AvoidReload(_) =>
-                // TODO - should this be || or && ??
                 val reattemptConfiguration = newSettings.nonEmpty &&
                   (!Project.hasScalaSemanticDBEnabledInCompilerOptions(project.scalacOptions) ||
                     !Project.hasJavaSemanticDBEnabledInCompilerOptions(project.javacOptions))

--- a/frontend/src/main/scala/bloop/engine/BuildLoader.scala
+++ b/frontend/src/main/scala/bloop/engine/BuildLoader.scala
@@ -5,6 +5,9 @@ import bloop.io.Paths.AttributedPath
 import bloop.io.AbsolutePath
 import bloop.logging.{DebugFilter, Logger}
 import bloop.io.ByteHasher
+import bloop.data.JavaSemanticdbSettings
+import bloop.data.ScalaSemanticdbSettings
+import bloop.data.SemanticdbSettings
 import bloop.data.WorkspaceSettings
 import bloop.data.LoadedProject
 import bloop.engine.caches.SemanticDBCache
@@ -68,12 +71,12 @@ object BuildLoader {
         settingsForLoad.flatMap(_.withSemanticdbSettings) match {
           case None =>
             Task.now(projectsRequiringMetalsTransformation.map(LoadedProject.RawProject(_)))
-          case Some((settings, semanticdb)) =>
+          case Some((settings, semanticdb: SemanticdbSettings)) =>
             resolveSemanticDBForProjects(
               projectsRequiringMetalsTransformation,
               configDir,
-              semanticdb.semanticDBVersion,
-              semanticdb.supportedScalaVersions,
+              semanticdb.javaSemanticdbSettings,
+              semanticdb.scalaSemanticdbSettings,
               logger
             ).map { transformedProjects =>
               transformedProjects.map {
@@ -102,44 +105,32 @@ object BuildLoader {
   private def resolveSemanticDBForProjects(
       rawProjects: List[Project],
       configDir: AbsolutePath,
-      semanticDBVersion: String,
-      supportedScalaVersions: List[String],
+      javaSemanticSettings: Option[JavaSemanticdbSettings],
+      scalaSemanticdbSettings: Option[ScalaSemanticdbSettings],
       logger: Logger
   ): Task[List[(Project, Option[Project])]] = {
-    val projectsWithNoScalaConfig = new mutable.ListBuffer[Project]()
-    val groupedProjectsPerScalaVersion = new mutable.HashMap[String, List[Project]]()
-    rawProjects.foreach { project =>
-      project.scalaInstance match {
-        case None => projectsWithNoScalaConfig.+=(project)
-        case Some(instance) =>
-          val scalaVersion = instance.version
-          groupedProjectsPerScalaVersion.get(scalaVersion) match {
-            case Some(projects) =>
-              groupedProjectsPerScalaVersion.put(scalaVersion, project :: projects)
-            case None => groupedProjectsPerScalaVersion.put(scalaVersion, project :: Nil)
-          }
-      }
-    }
 
-    val enableMetalsInProjectsTask = groupedProjectsPerScalaVersion.toList.map {
-      case (scalaVersion, projects) =>
-        val coeval = tryEnablingSemanticDB(
+    // java only projects are keyed on None
+    val projectsByScalaVersion = rawProjects.groupBy(_.scalaInstance.map(_.version))
+
+    val enableMetalsInProjectsTask = projectsByScalaVersion.toList.map {
+      case (scalaVersionOpt, projects) =>
+        tryEnablingSemanticDB(
           projects,
           configDir,
-          scalaVersion,
-          semanticDBVersion,
-          supportedScalaVersions,
+          javaSemanticSettings,
+          scalaVersionOpt.flatMap(scalaVersion =>
+            scalaSemanticdbSettings.map(f => (scalaVersion, f))
+          ),
           logger
-        ) { (plugin: Option[AbsolutePath]) =>
-          projects.map(p => Project.enableMetalsSettings(p, configDir, plugin, logger) -> Some(p))
-        }
-        coeval.task
+        ) { (scalaPlugin: Option[AbsolutePath], javaPlugin: Option[AbsolutePath]) =>
+          projects.map(p =>
+            Project.enableMetalsSettings(p, configDir, scalaPlugin, javaPlugin, logger) -> Some(p)
+          )
+        }.task
     }
 
-    Task.gatherUnordered(enableMetalsInProjectsTask).map { pps =>
-      // Add projects with Metals settings enabled + projects with no scala config at all
-      pps.flatten ++ projectsWithNoScalaConfig.toList.map(_ -> None)
-    }
+    Task.gatherUnordered(enableMetalsInProjectsTask).map(_.flatten)
   }
 
   /**
@@ -172,32 +163,73 @@ object BuildLoader {
       val project = loadProject(f.bytes, f.origin, logger)
       settings.flatMap(_.withSemanticdbSettings) match {
         case None => LoadedProject.RawProject(project)
-        case Some((settings, semanticdb)) =>
-          project.scalaInstance match {
-            case None => LoadedProject.RawProject(project)
-            case Some(instance) =>
-              val scalaVersion = instance.version
-              val coeval = tryEnablingSemanticDB(
-                List(project),
-                configDir,
-                scalaVersion,
-                semanticdb.semanticDBVersion,
-                semanticdb.supportedScalaVersions,
-                logger
-              ) { (plugin: Option[AbsolutePath]) =>
-                LoadedProject.ConfiguredProject(
-                  Project.enableMetalsSettings(project, configDir, plugin, logger),
-                  project,
-                  settings
-                )
-              }
-
-              // Run coeval, we rethrow but note that `tryEnablingSemanticDB` handles errors
-              coeval.run match {
-                case Left(value) => throw value
-                case Right(value) => value
-              }
+        case Some((settings, semanticdb: SemanticdbSettings)) =>
+          val scalaSemanticdbVersionAndSettings = for {
+            version <- project.scalaInstance.map(_.version)
+            settings <- semanticdb.scalaSemanticdbSettings
+          } yield (version, settings)
+          val coeval = tryEnablingSemanticDB(
+            List(project),
+            configDir,
+            semanticdb.javaSemanticdbSettings,
+            scalaSemanticdbVersionAndSettings,
+            logger
+          ) { (scalaPlugin: Option[AbsolutePath], javaPlugin: Option[AbsolutePath]) =>
+            LoadedProject.ConfiguredProject(
+              Project.enableMetalsSettings(project, configDir, scalaPlugin, javaPlugin, logger),
+              project,
+              settings
+            )
           }
+
+          // Run coeval, we rethrow but note that `tryEnablingSemanticDB` handles errors
+          coeval.run match {
+            case Left(value) => throw value
+            case Right(value) => value
+          }
+      }
+    }
+  }
+
+  private def tryEnablingJavaSemanticDB(
+      projects: List[Project],
+      javaSemanticSettings: JavaSemanticdbSettings,
+      logger: Logger
+  ): Option[AbsolutePath] = {
+    SemanticDBCache.fetchJavaPlugin(javaSemanticSettings.semanticDBVersion, logger) match {
+      case Right(path) =>
+        logger.debug(Feedback.configuredMetalsJavaProjects(projects))(DebugFilter.All)
+        Some(path)
+      case Left(cause) =>
+        logger.displayWarningToUser(Feedback.failedMetalsJavaConfiguration(cause))
+        None
+    }
+  }
+  private def tryEnablingScalaSemanticDB(
+      projects: List[Project],
+      scalaVersion: String,
+      scalaSemanticdbSettings: ScalaSemanticdbSettings,
+      logger: Logger
+  ): Option[AbsolutePath] = {
+    // Recognize 2.12.8-abdcddd as supported if 2.12.8 exists in supported versions
+    val isUnsupportedVersion =
+      !scalaSemanticdbSettings.supportedScalaVersions.exists(scalaVersion.startsWith(_))
+    if (isUnsupportedVersion) {
+      if (!scalaVersion.startsWith("3."))
+        logger.debug(Feedback.skippedUnsupportedScalaMetals(scalaVersion))(DebugFilter.All)
+      None
+    } else {
+      SemanticDBCache.fetchScalaPlugin(
+        scalaVersion,
+        scalaSemanticdbSettings.semanticDBVersion,
+        logger
+      ) match {
+        case Right(path) =>
+          logger.debug(Feedback.configuredMetalsScalaProjects(projects))(DebugFilter.All)
+          Some(path)
+        case Left(cause) =>
+          logger.displayWarningToUser(Feedback.failedMetalsScalaConfiguration(scalaVersion, cause))
+          None
       }
     }
   }
@@ -205,30 +237,37 @@ object BuildLoader {
   private def tryEnablingSemanticDB[T](
       projects: List[Project],
       configDir: AbsolutePath,
-      scalaVersion: String,
-      semanticDBVersion: String,
-      supportedScalaVersions: List[String],
+      javaSemanticSettings: Option[JavaSemanticdbSettings],
+      scalaSemanticdbVersionAndSettings: Option[(String, ScalaSemanticdbSettings)],
       logger: Logger
   )(
-      enableMetals: Option[AbsolutePath] => T
+      enableMetals: (Option[AbsolutePath], Option[AbsolutePath]) => T
   ): Coeval[T] = {
-    // Recognize 2.12.8-abdcddd as supported if 2.12.8 exists in supported versions
-    val isUnsupportedVersion = !supportedScalaVersions.exists(scalaVersion.startsWith(_))
-    if (isUnsupportedVersion) {
-      if (!scalaVersion.startsWith("3."))
-        logger.debug(Feedback.skippedUnsupportedScalaMetals(scalaVersion))(DebugFilter.All)
-      Coeval.now(enableMetals(None))
-    } else {
-      Coeval.eval {
-        SemanticDBCache.fetchPlugin(scalaVersion, semanticDBVersion, logger) match {
-          case Right(path) =>
-            logger.debug(Feedback.configuredMetalsProjects(projects))(DebugFilter.All)
-            enableMetals(Some(path))
-          case Left(cause) =>
-            logger.displayWarningToUser(Feedback.failedMetalsConfiguration(scalaVersion, cause))
-            enableMetals(None)
-        }
-      }
+    Coeval.eval {
+      if (javaSemanticSettings.nonEmpty) {
+        val javaSemanticdbPath =
+          tryEnablingJavaSemanticDB(projects, javaSemanticSettings.get, logger)
+        if (scalaSemanticdbVersionAndSettings.nonEmpty) {
+          val scalaSemanticdbPath =
+            tryEnablingScalaSemanticDB(
+              projects,
+              scalaSemanticdbVersionAndSettings.get._1,
+              scalaSemanticdbVersionAndSettings.get._2,
+              logger
+            )
+          enableMetals(scalaSemanticdbPath, javaSemanticdbPath)
+        } else enableMetals(None, javaSemanticdbPath)
+      } else if (scalaSemanticdbVersionAndSettings.nonEmpty) {
+        val scalaSemanticdbPath =
+          tryEnablingScalaSemanticDB(
+            projects,
+            scalaSemanticdbVersionAndSettings.get._1,
+            scalaSemanticdbVersionAndSettings.get._2,
+            logger
+          )
+        enableMetals(scalaSemanticdbPath, None)
+      } else
+        enableMetals(None, None)
     }
   }
 

--- a/frontend/src/main/scala/bloop/engine/Feedback.scala
+++ b/frontend/src/main/scala/bloop/engine/Feedback.scala
@@ -99,10 +99,14 @@ object Feedback {
     projects.map(p => s"'${p.name}'").mkString(", ")
   def skippedUnsupportedScalaMetals(scalaVersion: String): String =
     s"Skipped configuration of SemanticDB in unsupported $scalaVersion projects"
-  def configuredMetalsProjects(projects: Traversable[Project]): String =
-    s"Configured SemanticDB in projects ${pprint(projects)}"
-  def failedMetalsConfiguration(version: String, cause: String): String =
-    s"Stopped configuration of SemanticDB in Scala $version projects: $cause"
+  def configuredMetalsScalaProjects(projects: Traversable[Project]): String =
+    s"Configured Scala SemanticDB in projects ${pprint(projects)}"
+  def configuredMetalsJavaProjects(projects: Traversable[Project]): String =
+    s"Configured Java SemanticDB in projects ${pprint(projects)}"
+  def failedMetalsScalaConfiguration(version: String, cause: String): String =
+    s"Stopped configuration of Scala SemanticDB in $version projects: $cause"
+  def failedMetalsJavaConfiguration(cause: String): String =
+    s"Stopped configuration of Java SemanticDB in projects: $cause"
 
   def detectedJdkWithoutJDI(error: Throwable): String = {
     s"""Debugging is not supported because Java Debug Interface couldn't be resolved in detected JDK ${JavaRuntime.home}: '${error.getMessage}'. To enable it, check manually that you're running on a JDK and JDI is supported.

--- a/frontend/src/test/scala/bloop/bsp/BspIntellijClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspIntellijClientSpec.scala
@@ -54,6 +54,7 @@ class BspIntellijClientSpec(
       val workspaceSettings = WorkspaceSettings(
         None,
         None,
+        None,
         refreshProjectsCommand = Some(refreshProjectsCommand),
         Some(TraceSettings.fromProperties(TraceProperties.default))
       )

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -46,7 +46,8 @@ class BspMetalsClientSpec(
         ownsBuildFiles = None,
         clientClassesRootDir = None,
         semanticdbVersion = Some(semanticdbVersion),
-        supportedScalaVersions = Some(List(testedScalaVersion))
+        supportedScalaVersions = Some(List(testedScalaVersion)),
+        javaSemanticdbVersion = Some("0.2.0")
       )
 
       loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
@@ -54,6 +55,7 @@ class BspMetalsClientSpec(
         assertNoDiffInSettingsFile(
           configDir,
           """|{
+             |    "javaSemanticDBVersion": "0.2.0",
              |    "semanticDBVersion": "4.2.0",
              |    "supportedScalaVersions": [
              |        "2.12.8"
@@ -72,6 +74,12 @@ class BspMetalsClientSpec(
              |-Yrangepos
              |""".stripMargin
         )
+        assertJavacOptions(
+          state,
+          `A`,
+          """|-Xplugin:semanticdb -sourceroot:$workspace
+             |""".stripMargin
+        )
       }
     }
   }
@@ -87,13 +95,15 @@ class BspMetalsClientSpec(
         ownsBuildFiles = None,
         clientClassesRootDir = None,
         semanticdbVersion = Some(semanticdbVersion),
-        supportedScalaVersions = Some(List("2.12.8"))
+        supportedScalaVersions = Some(List("2.12.8")),
+        javaSemanticdbVersion = Some("0.2.0")
       )
 
       loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
         assertNoDiffInSettingsFile(
           configDir,
           """|{
+             |    "javaSemanticDBVersion": "0.2.0",
              |    "semanticDBVersion": "4.2.0",
              |    "supportedScalaVersions": [
              |        "2.12.8"
@@ -134,13 +144,15 @@ class BspMetalsClientSpec(
         ownsBuildFiles = None,
         clientClassesRootDir = None,
         semanticdbVersion = Some(semanticdbVersion),
-        supportedScalaVersions = Some(List(testedScalaVersion))
+        supportedScalaVersions = Some(List(testedScalaVersion)),
+        javaSemanticdbVersion = Some("0.2.0")
       )
 
       loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
         assertNoDiffInSettingsFile(
           configDir,
           """|{
+             |    "javaSemanticDBVersion": "0.2.0",
              |    "semanticDBVersion": "4.2.0",
              |    "supportedScalaVersions": [
              |        "2.12.8"
@@ -184,13 +196,15 @@ class BspMetalsClientSpec(
         ownsBuildFiles = None,
         clientClassesRootDir = None,
         semanticdbVersion = Some(semanticdbVersion),
-        supportedScalaVersions = Some(List(testedScalaVersion))
+        supportedScalaVersions = Some(List(testedScalaVersion)),
+        javaSemanticdbVersion = Some("0.2.0")
       )
 
       loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
         assertNoDiffInSettingsFile(
           configDir,
           """|{
+             |    "javaSemanticDBVersion": "0.2.0",
              |    "semanticDBVersion": "4.2.0",
              |    "supportedScalaVersions": [
              |        "2.12.8"
@@ -208,11 +222,13 @@ class BspMetalsClientSpec(
   test("should save workspace settings with cached build") {
     TestUtil.withinWorkspace { workspace =>
       val semanticdbVersion = "4.2.0"
+      val javaSemanticdbVersion = "0.2.0"
       val extraParams = BloopExtraBuildParams(
         ownsBuildFiles = None,
         clientClassesRootDir = None,
         semanticdbVersion = Some(semanticdbVersion),
-        supportedScalaVersions = Some(List(testedScalaVersion))
+        supportedScalaVersions = Some(List(testedScalaVersion)),
+        javaSemanticdbVersion = Some(javaSemanticdbVersion)
       )
       val `A` = TestProject(workspace, "A", Nil)
       val projects = List(`A`)
@@ -220,14 +236,15 @@ class BspMetalsClientSpec(
       val logger = new RecordingLogger(ansiCodesSupported = false)
       WorkspaceSettings.writeToFile(
         configDir,
-        WorkspaceSettings.fromSemanticdbSettings(semanticdbVersion, List(testedScalaVersion)),
+        WorkspaceSettings.fromSemanticdbSettings(javaSemanticdbVersion, semanticdbVersion, List(testedScalaVersion)),
         logger
       )
 
       def checkSettings: Unit = {
         assert(configDir.resolve(WorkspaceSettings.settingsFileName).exists)
         val settings = WorkspaceSettings.readFromFile(configDir, logger)
-        assert(settings.isDefined && settings.get.semanticDBVersion.get == semanticdbVersion)
+        assert(settings.isDefined && settings.get.semanticDBVersion.isDefined && settings.get.semanticDBVersion.get == semanticdbVersion)
+        assert(settings.isDefined && settings.get.javaSemanticDBVersion.isDefined && settings.get.javaSemanticDBVersion.get == javaSemanticdbVersion)
       }
 
       loadBspState(workspace, projects, logger, "Metals")(_ => checkSettings)
@@ -246,6 +263,7 @@ class BspMetalsClientSpec(
       val logger = new RecordingLogger(ansiCodesSupported = false)
 
       def createClient(
+          javaSemanticdbVersion: String,
           semanticdbVersion: String,
           clientName: String = "normalClient"
       ): Task[UnmanagedBspTestState] = {
@@ -254,7 +272,8 @@ class BspMetalsClientSpec(
             ownsBuildFiles = None,
             clientClassesRootDir = None,
             semanticdbVersion = Some(semanticdbVersion),
-            supportedScalaVersions = Some(List(testedScalaVersion))
+            supportedScalaVersions = Some(List(testedScalaVersion)),
+            javaSemanticdbVersion = Some(javaSemanticdbVersion)
           )
           val bspLogger = new BspClientLogger(logger)
           val bspCommand = createBspCommand(configDir)
@@ -277,11 +296,13 @@ class BspMetalsClientSpec(
         }
       }
 
+      val javaNormalClientsVersion = "0.2.0"
+      val javaMetalsVersion = "0.1.0"
       val normalClientsVersion = "4.2.0"
       val metalsClientVersion = "4.1.11"
-      val client1 = createClient(normalClientsVersion)
-      val client2 = createClient(normalClientsVersion)
-      val metalsClient = createClient(metalsClientVersion, "Metals")
+      val client1 = createClient(javaNormalClientsVersion, normalClientsVersion)
+      val client2 = createClient(javaNormalClientsVersion, normalClientsVersion)
+      val metalsClient = createClient(javaMetalsVersion, metalsClientVersion, "Metals")
 
       val allClients = Random.shuffle(List(client1, client2, metalsClient))
       TestUtil.await(FiniteDuration(20, "s"), ExecutionContext.ioScheduler) {
@@ -290,44 +311,47 @@ class BspMetalsClientSpec(
 
       assert(configDir.resolve(WorkspaceSettings.settingsFileName).exists)
       val settings = WorkspaceSettings.readFromFile(configDir, logger)
-      assert(settings.isDefined && settings.get.semanticDBVersion.get == metalsClientVersion)
+      assert(settings.isDefined && settings.get.semanticDBVersion.isDefined && settings.get.semanticDBVersion.get == metalsClientVersion)
+      assert(settings.isDefined && settings.get.javaSemanticDBVersion.isDefined && settings.get.javaSemanticDBVersion.get == javaMetalsVersion)
     }
   }
 
   test("compile with semanticDB") {
     TestUtil.withinWorkspace { workspace =>
-      val `A` = TestProject(workspace, "A", dummyFooSources)
+      val `A` = TestProject(workspace, "A", dummyFooScalaAndBarJavaSources)
       val projects = List(`A`)
       val configDir = TestProject.populateWorkspace(workspace, projects)
       val logger = new RecordingLogger(ansiCodesSupported = false)
       WorkspaceSettings.writeToFile(
         configDir,
-        WorkspaceSettings.fromSemanticdbSettings("4.2.0", List(testedScalaVersion)),
-        logger
-      )
-      val bspState = loadBspState(workspace, projects, logger) { state =>
-        val compiledState = state.compile(`A`).toTestState
-        assert(compiledState.status == ExitStatus.Ok)
-        assertSemanticdbFileFor("Foo.scala", compiledState)
-      }
-    }
-  }
-
-  test("compile with semanticDB using cached plugin") {
-    TestUtil.withinWorkspace { workspace =>
-      val `A` = TestProject(workspace, "A", dummyFooSources)
-      val projects = List(`A`)
-      val configDir = TestProject.populateWorkspace(workspace, projects)
-      val logger = new RecordingLogger(ansiCodesSupported = false)
-      WorkspaceSettings.writeToFile(
-        configDir,
-        WorkspaceSettings.fromSemanticdbSettings("4.1.11", List(testedScalaVersion)),
+        WorkspaceSettings.fromSemanticdbSettings("0.2.0", "4.2.0", List(testedScalaVersion)),
         logger
       )
       loadBspState(workspace, projects, logger) { state =>
         val compiledState = state.compile(`A`).toTestState
         assert(compiledState.status == ExitStatus.Ok)
         assertSemanticdbFileFor("Foo.scala", compiledState)
+        assertSemanticdbFileFor("Bar.java", compiledState)
+      }
+    }
+  }
+
+  test("compile with semanticDB using cached plugin") {
+    TestUtil.withinWorkspace { workspace =>
+      val `A` = TestProject(workspace, "A", dummyFooScalaAndBarJavaSources)
+      val projects = List(`A`)
+      val configDir = TestProject.populateWorkspace(workspace, projects)
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      WorkspaceSettings.writeToFile(
+        configDir,
+        WorkspaceSettings.fromSemanticdbSettings("0.2.0", "4.1.11", List(testedScalaVersion)),
+        logger
+      )
+      loadBspState(workspace, projects, logger) { state =>
+        val compiledState = state.compile(`A`).toTestState
+        assert(compiledState.status == ExitStatus.Ok)
+        assertSemanticdbFileFor("Foo.scala", compiledState)
+        assertSemanticdbFileFor("Bar.java", compiledState)
       }
     }
   }
@@ -337,7 +361,7 @@ class BspMetalsClientSpec(
       val `A` = TestProject(
         workspace,
         "A",
-        dummyFooSources,
+        dummyFooScalaAndBarJavaSources,
         scalaVersion = Some("3.0.0-M3"),
         scalaOrg = Some("org.scala-lang"),
         scalaCompiler = Some("scala3-compiler_3.0.0-M3")
@@ -347,7 +371,7 @@ class BspMetalsClientSpec(
       val logger = new RecordingLogger(ansiCodesSupported = false)
       WorkspaceSettings.writeToFile(
         configDir,
-        WorkspaceSettings.fromSemanticdbSettings("4.3.0", List()),
+        WorkspaceSettings.fromSemanticdbSettings("0.2.0", "4.3.0", List()),
         logger
       )
       loadBspState(workspace, projects, logger) { state =>
@@ -355,6 +379,7 @@ class BspMetalsClientSpec(
         assertExitStatus(compiledState, ExitStatus.Ok)
         assertValidCompilationState(compiledState, projects)
         assertSemanticdbFileFor("Foo.scala", compiledState)
+        assertSemanticdbFileFor("Bar.java", compiledState)
         assertSuccessfulCompilation(compiledState, projects, isNoOp = false)
       }
     }
@@ -365,7 +390,7 @@ class BspMetalsClientSpec(
       val `A` = TestProject(
         workspace,
         "A",
-        dummyFooSources,
+        dummyFooScalaAndBarJavaSources,
         scalaVersion = Some("3.0.0-M3"),
         scalaOrg = Some("org.scala-lang"),
         scalaCompiler = Some("scala3-compiler_3.0.0-M3")
@@ -379,6 +404,7 @@ class BspMetalsClientSpec(
         assertValidCompilationState(compiledState, projects)
         assertSuccessfulCompilation(compiledState, projects, isNoOp = false)
         assertNoSemanticdbFileFor("Foo.scala", compiledState)
+        assertNoSemanticdbFileFor("Bar.java", compiledState)
       }
     }
   }
@@ -391,7 +417,7 @@ class BspMetalsClientSpec(
       val `A` = TestProject(
         workspace,
         "A",
-        dummyFooSources,
+        dummyFooScalaSources,
         scalaVersion = Some("3.0.0-M3"),
         scalacOptions = defaultScalacOptions,
         scalaOrg = Some("org.scala-lang"),
@@ -402,7 +428,7 @@ class BspMetalsClientSpec(
       val logger = new RecordingLogger(ansiCodesSupported = false)
       WorkspaceSettings.writeToFile(
         configDir,
-        WorkspaceSettings.fromSemanticdbSettings("4.3.0", List()),
+        WorkspaceSettings.fromSemanticdbSettings("0.2.0", "4.3.0", List()),
         logger
       )
       loadBspState(workspace, projects, logger) { state =>
@@ -417,7 +443,7 @@ class BspMetalsClientSpec(
 
   test("save settings and compile with semanticDB") {
     TestUtil.withinWorkspace { workspace =>
-      val `A` = TestProject(workspace, "A", dummyFooSources)
+      val `A` = TestProject(workspace, "A", dummyFooScalaAndBarJavaSources)
       val projects = List(`A`)
       val configDir = TestProject.populateWorkspace(workspace, projects)
       val logger = new RecordingLogger(ansiCodesSupported = false)
@@ -425,21 +451,31 @@ class BspMetalsClientSpec(
         ownsBuildFiles = None,
         clientClassesRootDir = None,
         semanticdbVersion = Some("4.2.0"),
-        supportedScalaVersions = Some(List(testedScalaVersion))
+        supportedScalaVersions = Some(List(testedScalaVersion)),
+        javaSemanticdbVersion = Some("0.2.0")
       )
       loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
         val compiledState = state.compile(`A`).toTestState
         assert(compiledState.status == ExitStatus.Ok)
         assertSemanticdbFileFor("Foo.scala", compiledState)
+        assertSemanticdbFileFor("Bar.java", compiledState)
       }
     }
   }
 
-  private val dummyFooSources = List(
+  private val dummyFooScalaSources = List(
     """/Foo.scala
       |class Foo
           """.stripMargin
   )
+
+  private val dummyBarJavaSources = List(
+    """/Bar.java
+      |class Bar {}
+          """.stripMargin
+  )
+
+  private val dummyFooScalaAndBarJavaSources = dummyFooScalaSources ++ dummyBarJavaSources
 
   private def semanticdbFile(sourceFileName: String, state: TestState) = {
     val projectA = state.build.getProjectFor("A").get
@@ -470,6 +506,31 @@ class BspMetalsClientSpec(
     assertNoDiff(
       readFile(settingsFile),
       expected
+    )
+  }
+
+  private def assertJavacOptions(
+      state: ManagedBspTestState,
+      project: TestProject,
+      unorderedExpectedOptions: String
+  ): Unit = {
+    // Not the best way to obtain workspace but valid for tests
+    val workspaceDir = project.config.workspaceDir
+      .map(AbsolutePath(_))
+      .getOrElse(state.underlying.build.origin.getParent)
+      .syntax
+    // plugin is on classpath so no need for full path to jar like scala plugin
+    val javacOptions = state.javacOptions(project)._2.items.flatMap(_.options)
+
+    val expectedOptions = unorderedExpectedOptions
+      .replace("$workspace", workspaceDir)
+      .splitLines
+      .filterNot(_.isEmpty)
+      .sorted
+      .mkString(lineSeparator)
+    assertNoDiff(
+      javacOptions.sorted.mkString(lineSeparator),
+      expectedOptions
     )
   }
 

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -47,7 +47,7 @@ class BspMetalsClientSpec(
         clientClassesRootDir = None,
         semanticdbVersion = Some(semanticdbVersion),
         supportedScalaVersions = Some(List(testedScalaVersion)),
-        javaSemanticdbVersion = Some("0.2.0")
+        javaSemanticdbVersion = Some("0.5.7")
       )
 
       loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
@@ -55,7 +55,7 @@ class BspMetalsClientSpec(
         assertNoDiffInSettingsFile(
           configDir,
           """|{
-             |    "javaSemanticDBVersion": "0.2.0",
+             |    "javaSemanticDBVersion": "0.5.7",
              |    "semanticDBVersion": "4.2.0",
              |    "supportedScalaVersions": [
              |        "2.12.8"
@@ -77,7 +77,7 @@ class BspMetalsClientSpec(
         assertJavacOptions(
           state,
           `A`,
-          """|-Xplugin:semanticdb -sourceroot:$workspace
+          """|-Xplugin:semanticdb -sourceroot:$workspace -targetroot:javac-classes-directory
              |""".stripMargin
         )
       }
@@ -96,14 +96,14 @@ class BspMetalsClientSpec(
         clientClassesRootDir = None,
         semanticdbVersion = Some(semanticdbVersion),
         supportedScalaVersions = Some(List("2.12.8")),
-        javaSemanticdbVersion = Some("0.2.0")
+        javaSemanticdbVersion = Some("0.5.7")
       )
 
       loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
         assertNoDiffInSettingsFile(
           configDir,
           """|{
-             |    "javaSemanticDBVersion": "0.2.0",
+             |    "javaSemanticDBVersion": "0.5.7",
              |    "semanticDBVersion": "4.2.0",
              |    "supportedScalaVersions": [
              |        "2.12.8"
@@ -145,14 +145,14 @@ class BspMetalsClientSpec(
         clientClassesRootDir = None,
         semanticdbVersion = Some(semanticdbVersion),
         supportedScalaVersions = Some(List(testedScalaVersion)),
-        javaSemanticdbVersion = Some("0.2.0")
+        javaSemanticdbVersion = Some("0.5.7")
       )
 
       loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
         assertNoDiffInSettingsFile(
           configDir,
           """|{
-             |    "javaSemanticDBVersion": "0.2.0",
+             |    "javaSemanticDBVersion": "0.5.7",
              |    "semanticDBVersion": "4.2.0",
              |    "supportedScalaVersions": [
              |        "2.12.8"
@@ -197,14 +197,14 @@ class BspMetalsClientSpec(
         clientClassesRootDir = None,
         semanticdbVersion = Some(semanticdbVersion),
         supportedScalaVersions = Some(List(testedScalaVersion)),
-        javaSemanticdbVersion = Some("0.2.0")
+        javaSemanticdbVersion = Some("0.5.7")
       )
 
       loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
         assertNoDiffInSettingsFile(
           configDir,
           """|{
-             |    "javaSemanticDBVersion": "0.2.0",
+             |    "javaSemanticDBVersion": "0.5.7",
              |    "semanticDBVersion": "4.2.0",
              |    "supportedScalaVersions": [
              |        "2.12.8"
@@ -222,7 +222,7 @@ class BspMetalsClientSpec(
   test("should save workspace settings with cached build") {
     TestUtil.withinWorkspace { workspace =>
       val semanticdbVersion = "4.2.0"
-      val javaSemanticdbVersion = "0.2.0"
+      val javaSemanticdbVersion = "0.5.7"
       val extraParams = BloopExtraBuildParams(
         ownsBuildFiles = None,
         clientClassesRootDir = None,
@@ -296,7 +296,7 @@ class BspMetalsClientSpec(
         }
       }
 
-      val javaNormalClientsVersion = "0.2.0"
+      val javaNormalClientsVersion = "0.5.7"
       val javaMetalsVersion = "0.1.0"
       val normalClientsVersion = "4.2.0"
       val metalsClientVersion = "4.1.11"
@@ -324,7 +324,7 @@ class BspMetalsClientSpec(
       val logger = new RecordingLogger(ansiCodesSupported = false)
       WorkspaceSettings.writeToFile(
         configDir,
-        WorkspaceSettings.fromSemanticdbSettings("0.2.0", "4.2.0", List(testedScalaVersion)),
+        WorkspaceSettings.fromSemanticdbSettings("0.5.7", "4.2.0", List(testedScalaVersion)),
         logger
       )
       loadBspState(workspace, projects, logger) { state =>
@@ -344,7 +344,7 @@ class BspMetalsClientSpec(
       val logger = new RecordingLogger(ansiCodesSupported = false)
       WorkspaceSettings.writeToFile(
         configDir,
-        WorkspaceSettings.fromSemanticdbSettings("0.2.0", "4.1.11", List(testedScalaVersion)),
+        WorkspaceSettings.fromSemanticdbSettings("0.5.7", "4.1.11", List(testedScalaVersion)),
         logger
       )
       loadBspState(workspace, projects, logger) { state =>
@@ -371,7 +371,7 @@ class BspMetalsClientSpec(
       val logger = new RecordingLogger(ansiCodesSupported = false)
       WorkspaceSettings.writeToFile(
         configDir,
-        WorkspaceSettings.fromSemanticdbSettings("0.2.0", "4.3.0", List()),
+        WorkspaceSettings.fromSemanticdbSettings("0.5.7", "4.3.0", List()),
         logger
       )
       loadBspState(workspace, projects, logger) { state =>
@@ -428,7 +428,7 @@ class BspMetalsClientSpec(
       val logger = new RecordingLogger(ansiCodesSupported = false)
       WorkspaceSettings.writeToFile(
         configDir,
-        WorkspaceSettings.fromSemanticdbSettings("0.2.0", "4.3.0", List()),
+        WorkspaceSettings.fromSemanticdbSettings("0.5.7", "4.3.0", List()),
         logger
       )
       loadBspState(workspace, projects, logger) { state =>
@@ -452,7 +452,7 @@ class BspMetalsClientSpec(
         clientClassesRootDir = None,
         semanticdbVersion = Some("4.2.0"),
         supportedScalaVersions = Some(List(testedScalaVersion)),
-        javaSemanticdbVersion = Some("0.2.0")
+        javaSemanticdbVersion = Some("0.5.7")
       )
       loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
         val compiledState = state.compile(`A`).toTestState

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -204,7 +204,8 @@ class BspProtocolSpec(
         ownsBuildFiles = None,
         Some(Uri(userClientClassesRootDir.toBspUri)),
         semanticdbVersion = None,
-        supportedScalaVersions = None
+        supportedScalaVersions = None,
+        javaSemanticdbVersion = None
       )
 
       // Start first client and query for scalac options which creates client classes dirs


### PR DESCRIPTION
Allows the SourceGraph LSIF java plugin to be specified by Metals just like the Scala SemanticDB plugin can be

@olafurpg You mentioned that the output files will have to be deleted by Bloop as the plugin doesn't remove them.  Is this purely for when Java files are deleted so their matching `META-INF/**/JavaClassName.semanticdb` is also deleted?  I haven't done this and I'm not really sure where to start here.  Do you know if there is similar functionality in Bloop already for this - e.g. wiping the equivalent class files when their source files are deleted?  And if so where that is in the code.