### PR TITLE
Do not log debug output on info level

### DIFF
--- a/frontend/src/main/scala/bloop/dap/DebuggeeLogger.scala
+++ b/frontend/src/main/scala/bloop/dap/DebuggeeLogger.scala
@@ -36,7 +36,8 @@ class DebuggeeLogger(listener: DebuggeeListener, underlying: Logger) extends Log
   }
 
   override def info(msg: String): Unit = {
-    underlying.info(msg)
+    // don't log program output by default, since it can be long
+    underlying.debug(msg)(debugFilter)
     // Expect the first log to be JDI notification since debuggee runs with `quiet=n` JDI option
     if (msg.startsWith(JDINotificationPrefix)) {
       if (initialized.compareAndSet(false, true)) {


### PR DESCRIPTION
This causes any client to log all output messages twice, one in the official output for example in the editor and the second time in the logs, which can just grow the logs without purpose.

We should still be able to print it under debug flag.

Connected to https://github.com/scalameta/metals/issues/2311

Tested it locally and it works correctly. There is no need for logging all output since everything goes through DAP anyway.