### PR TITLE
Gradle: handle --release and multi-threaded dir create

### DIFF
--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -1106,12 +1106,21 @@ class BloopConverter(parameters: BloopParameters, info: String => Unit) {
 
     var args = builder.build().asScala.toList
 
-    if (!args.contains("-source")) {
-      if (specs.getSourceCompatibility != null) {
+    if (!args.contains("--release")) {
+      if (
+        !args.contains("-source") &&
+        !args.contains("--source") &&
+        specs.getSourceCompatibility != null
+      ) {
         args = "-source" :: specs.getSourceCompatibility :: args
-      } else {
-        Option(DefaultInstalledJdk.current())
-          .foreach(jvm => args = "-source" :: jvm.getJavaVersion.toString :: args)
+      }
+
+      if (
+        !args.contains("-target") &&
+        !args.contains("--target") &&
+        specs.getTargetCompatibility != null
+      ) {
+        args = "-target" :: specs.getTargetCompatibility :: args
       }
     }
 
@@ -1120,15 +1129,6 @@ class BloopConverter(parameters: BloopParameters, info: String => Unit) {
       args = args.takeWhile(_ != "-s") ++ args.dropWhile(_ != "-s").drop(2)
     } else if (args.contains("-s")) {
       Files.createDirectories(Paths.get(args(args.indexOf("-s") + 1)))
-    }
-
-    if (!args.contains("-target")) {
-      if (specs.getTargetCompatibility != null) {
-        args = "-target" :: specs.getTargetCompatibility :: args
-      } else {
-        Option(DefaultInstalledJdk.current())
-          .foreach(jvm => args = "-target" :: jvm.getJavaVersion.toString :: args)
-      }
     }
 
     // Always return a java configuration (this cannot hurt us)

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/BloopInstallTask.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/BloopInstallTask.scala
@@ -14,6 +14,7 @@ import com.android.build.gradle.api.BaseVariant
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success}
+import java.nio.file.FileAlreadyExistsException
 
 /**
  * Define a Gradle task that generates bloop configuration files from a Gradle project.
@@ -46,7 +47,11 @@ class BloopInstallTask extends DefaultTask with PluginUtils with TaskLogging {
 
     if (!targetDir.exists()) {
       debug(s"Creating target directory ${targetDir}")
-      Files.createDirectory(targetDir.toPath)
+      try {
+        Files.createDirectory(targetDir.toPath)
+      } catch {
+        case _: FileAlreadyExistsException => // do nothing - parallel exports cause this
+      }
     }
 
     if (hasJavaScalaPlugin)


### PR DESCRIPTION
Don't add `-source` or `-target` javac options if `--release` is present
Don't set `-source` or `-target` from default jvm if not set by Gradle build

Ignore `FileAlreadyExistsException` exceptions on `.bloop` dir creation.  It's a function of parallel export of multiple projects.