### PR TITLE
support sbt Optional scope in bloopInstall

### DIFF
--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/optional-dependency/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/optional-dependency/build.sbt
@@ -1,0 +1,52 @@
+import bloop.integrations.sbt.BloopDefaults
+
+val foo = project
+val bar = project.dependsOn(foo % Optional)
+val baz = project.dependsOn(bar)
+
+val allBloopConfigFiles = settingKey[List[File]]("All config files to test")
+allBloopConfigFiles in ThisBuild := {
+  val bloopDir = Keys.baseDirectory.value./(".bloop")
+  val fooConfig = bloopDir./("foo.json")
+  val fooTestConfig = bloopDir./("foo-test.json")
+  val barConfig = bloopDir./("bar.json")
+  val barTestConfig = bloopDir./("bar-test.json")
+  val bazConfig = bloopDir./("baz.json")
+  val bazTestConfig = bloopDir./("baz-test.json")
+  List(fooConfig, fooTestConfig, barConfig, barTestConfig, bazConfig, bazTestConfig)
+}
+
+def readConfigFor(projectName: String, allConfigs: Seq[File]): bloop.config.Config.File = {
+  val configFile = allConfigs
+    .find(_.toString.endsWith(s"$projectName.json"))
+    .getOrElse(sys.error(s"Missing $projectName.json"))
+  BloopDefaults.unsafeParseConfig(configFile.toPath)
+}
+
+val checkBloopFiles = taskKey[Unit]("Check bloop file contents")
+checkBloopFiles in ThisBuild := {
+  val allConfigs = allBloopConfigFiles.value
+  val barConfigContents = readConfigFor("bar", allConfigs)
+  assert(
+    barConfigContents.project.classpath.exists(_.toString.contains("/foo")),
+    barConfigContents.project.classpath.mkString("\n")
+  )
+  assert(
+    barConfigContents.project.dependencies == List("foo"),
+    barConfigContents.project.dependencies
+  )
+
+  val bazConfigContents = readConfigFor("baz", allConfigs)
+  assert(
+    bazConfigContents.project.classpath.exists(_.toString.contains("/bar")),
+    bazConfigContents.project.classpath.mkString("\n")
+  )
+  assert(
+    !bazConfigContents.project.classpath.exists(_.toString.contains("/foo")),
+    bazConfigContents.project.classpath.mkString("\n")
+  )
+  assert(
+    bazConfigContents.project.dependencies.sorted == List("bar"),
+    bazConfigContents.project.dependencies.sorted
+  )
+}

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/optional-dependency/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/optional-dependency/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/optional-dependency/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/optional-dependency/test
@@ -1,0 +1,7 @@
+> foo/bloopGenerate
+> foo/test:bloopGenerate
+> bar/bloopGenerate
+> bar/test:bloopGenerate
+> baz/bloopGenerate
+> baz/test:bloopGenerate
+> checkBloopFiles


### PR DESCRIPTION
I don't use SBT much so I may be misinterpreting its dependency scopes but I think `Optional` isn't currently handled properly

Consider project `A` depends on `B` which depends on `C`
Project `B` uses `Optional` scope to depend on `C`

So `C` should feature in the compile classpath of `B` but **not** in the compile classpath of 'A' (as it shouldn't be included transitively)

This was already happening but before this PR there was no **project** dependency from `B` to `C` which Bloop needs to work out that it should compile `C` before `B`.

If I'm wrong on that then don't merge this PR but I think `Optional` should behave exactly like `Provided` because the runtime classpaths aren't currently exported and that's where `Optional` and `Provided` differ.

Relevant [link](https://github.com/scalacenter/bloop/discussions/1437)