### PR TITLE
Recognize the community contributions

### DIFF
--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -140,7 +140,7 @@ object Cli {
        |Using Scala v$scalaVersion and Zinc v$zincVersion
        |Running on Java ${JavaRuntime.current} v$javaVersion ($javaHome)
        |  -> $jdiStatus
-       |Maintained by the Scala Center ($developers)
+       |Maintained by the Scala Center and the community.
        |""".stripMargin
   }
 

--- a/frontend/src/test/scala/bloop/nailgun/NailgunSpec.scala
+++ b/frontend/src/test/scala/bloop/nailgun/NailgunSpec.scala
@@ -93,7 +93,7 @@ object NailgunSpec extends BaseSuite with NailgunTestUtils {
             |Using Scala v${BuildInfo.scalaVersion} and Zinc v${BuildInfo.zincVersion}
             |$jvmLine
             |  -> Supports debugging user code, Java Debug Interface (JDI) is available.
-            |Maintained by the Scala Center (Jorge Vicente Cantero, Martin Duhem)
+            |Maintained by the Scala Center and the community.
             |""".stripMargin
       )
     }
@@ -151,7 +151,7 @@ object NailgunSpec extends BaseSuite with NailgunTestUtils {
             |Using Scala v${BuildInfo.scalaVersion} and Zinc v${BuildInfo.zincVersion}
             |$jvmLine
             |  -> Supports debugging user code, Java Debug Interface (JDI) is available.
-            |Maintained by the Scala Center (Jorge Vicente Cantero, Martin Duhem)
+            |Maintained by the Scala Center and the community.
             |""".stripMargin
       )
 

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -71,9 +71,6 @@ class Footer extends React.Component {
             <a href="https://gitter.im/scalacenter/bloop" target="_blank">
               <img src="https://img.shields.io/gitter/room/scalacenter/bloop.svg?logo=gitter&style=social" />
             </a>
-            <a href="https://twitter.com/jvican" target="_blank">
-              <img src="https://img.shields.io/twitter/follow/jvican.svg?logo=twitter&style=social" />
-            </a>
           </div>
         </section>
         <section className="copyright">{copyright}</section>


### PR DESCRIPTION
Previously the about message would be:
```
bloop v1.4.8-90-77e59d70-20210802-1858

Using Scala v2.12.8 and Zinc v1.3.0-M4+46-edbe573e
Running on Java JDK v1.8.0_292 (/usr/lib/jvm/java-8-openjdk-amd64/jre)
  -> Supports debugging user code, Java Debug Interface (JDI) is available.
Maintained by the Scala Center (Jorge Vicente Cantero, Martin Duhem)
```

now:

```
bloop v1.4.8-90-77e59d70-20210802-1858

Using Scala v2.12.8 and Zinc v1.3.0-M4+46-edbe573e
Running on Java JDK v1.8.0_292 (/usr/lib/jvm/java-8-openjdk-amd64/jre)
  -> Supports debugging user code, Java Debug Interface (JDI) is available.
Maintained by the Scala Center and the community.
```

Since the developers list is not actively updated and there has been a lot of community contributions I think it's a good idea to recognize it in the about message.

I also remove the twitter handle as we currently don't have an official twitter account.