### PR TITLE
WIP: Monix 3.x.x

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -330,7 +330,7 @@ object Compiler {
       Task
         .gatherUnordered(tasks)
         .map(_ => ())
-        .runAsync(compileInputs.ioScheduler)
+        .runToFuture(compileInputs.ioScheduler)
     }
 
     val start = System.nanoTime()

--- a/backend/src/main/scala/bloop/io/ClasspathHasher.scala
+++ b/backend/src/main/scala/bloop/io/ClasspathHasher.scala
@@ -280,6 +280,6 @@ object ClasspathHasher {
       }
     }
 
-    Task.gatherUnordered(classpath.map(readJar(_)))
+    Task.parSequenceUnordered(classpath.map(readJar(_)))
   }
 }

--- a/backend/src/main/scala/bloop/io/ParallelOps.scala
+++ b/backend/src/main/scala/bloop/io/ParallelOps.scala
@@ -156,7 +156,7 @@ object ParallelOps {
       Cancelable.cancelAll(completeSubscribers :: tasksToCancel)
     }
 
-    val copyFileSequentially = Consumer.foreachAsync[((Path, BasicFileAttributes), Path)] {
+    val copyFileSequentially = Consumer.foreachTask[((Path, BasicFileAttributes), Path)] {
       case ((originFile, originAttrs), targetFile) =>
         def copy(replaceExisting: Boolean): Unit = {
           if (replaceExisting) {

--- a/backend/src/main/scala/bloop/tracing/BraveTracer.scala
+++ b/backend/src/main/scala/bloop/tracing/BraveTracer.scala
@@ -6,7 +6,7 @@ import brave.propagation.TraceContextOrSamplingFlags
 import brave.Span
 import brave.Tracer
 import monix.eval.Task
-import monix.execution.misc.NonFatal
+import scala.util.control.NonFatal
 import scala.util.Properties
 import zipkin2.codec.SpanBytesEncoder.JSON_V1
 import zipkin2.codec.SpanBytesEncoder.JSON_V2

--- a/backend/src/main/scala/bloop/util/Java8Compat.scala
+++ b/backend/src/main/scala/bloop/util/Java8Compat.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.{CancellationException, CompletableFuture, Completio
 import java.util.function.BiFunction
 
 import monix.execution.cancelables.SingleAssignmentCancelable
-import monix.execution.misc.NonFatal
+import scala.util.control.NonFatal
 import monix.execution.schedulers.TrampolinedRunnable
 import monix.execution.{Cancelable, CancelableFuture}
 

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopHighLevelCompiler.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopHighLevelCompiler.scala
@@ -201,7 +201,7 @@ final class BloopHighLevelCompiler(
         if (javaSources.isEmpty) compileScala
         else {
           if (setup.order == CompileOrder.JavaThenScala) {
-            Task.gatherUnordered(List(compileJavaSynchronized, compileScala)).map(_ => ())
+            Task.parSequenceUnordered(List(compileJavaSynchronized, compileScala)).map(_ => ())
           } else {
             compileScala.flatMap(_ => compileJavaSynchronized)
           }

--- a/benchmarks/src/main/scala/bloop/ProjectBenchmark.scala
+++ b/benchmarks/src/main/scala/bloop/ProjectBenchmark.scala
@@ -30,7 +30,8 @@ class ProjectBenchmark {
     val client = ClientInfo.CliClientInfo(useStableCliDirs = true, () => true)
     val t = State.loadActiveStateFor(configDir, client, NoPool, CommonOptions.default, NoopLogger)
     val duration = FiniteDuration(10, TimeUnit.SECONDS)
-    val handle = t.runAsync(ExecutionContext.scheduler)
+    val handle =
+      t.executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(ExecutionContext.scheduler)
     try Await.result(handle, duration)
     catch {
       case NonFatal(t) => handle.cancel(); throw t

--- a/benchmarks/src/main/scala/bloop/ProjectBenchmark.scala
+++ b/benchmarks/src/main/scala/bloop/ProjectBenchmark.scala
@@ -15,7 +15,7 @@ import bloop.engine.NoPool
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Await
-import monix.execution.misc.NonFatal
+import scala.util.control.NonFatal
 import bloop.engine.ExecutionContext
 
 @State(Scope.Benchmark)

--- a/bridges/scalajs-1/src/main/scala/bloop/scalajs/jsenv/NodeJsEnv.scala
+++ b/bridges/scalajs-1/src/main/scala/bloop/scalajs/jsenv/NodeJsEnv.scala
@@ -286,6 +286,7 @@ object NodeJSEnv {
           debugLog = msg => logger.debug(msg),
           freshEnv = true
         )
+        .executeWithOptions(_.disableAutoCancelableRunLoops)
         .runAsync(ExecutionContext.ioScheduler)
 
     new JSRun {

--- a/frontend/src/it/scala/bloop/CommunityBuild.scala
+++ b/frontend/src/it/scala/bloop/CommunityBuild.scala
@@ -25,7 +25,7 @@ import bloop.engine.caches.ResultsCache
 import bloop.io.AbsolutePath
 import bloop.logging.{BloopLogger, Logger, NoopLogger}
 import monix.eval.Task
-import monix.execution.misc.NonFatal
+import scala.util.control.NonFatal
 import sbt.internal.inc.bloop.ZincInternals
 import bloop.engine.tasks.compilation.CompileGatekeeper
 import sbt.internal.inc.BloopComponentCompiler

--- a/frontend/src/it/scala/bloop/CommunityBuild.scala
+++ b/frontend/src/it/scala/bloop/CommunityBuild.scala
@@ -207,7 +207,8 @@ abstract class CommunityBuild(val buildpressHomeDir: AbsolutePath) {
 
   private def execute(a: Action, state: State, duration: Duration = Duration.Inf): State = {
     val task = Interpreter.execute(a, Task.now(state))
-    val handle = task.runAsync(ExecutionContext.scheduler)
+    val handle =
+      task.executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(ExecutionContext.scheduler)
     try Await.result(handle, duration)
     catch {
       case NonFatal(t) => handle.cancel(); throw t

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -471,7 +471,7 @@ object Cli {
         .map(group => Task.parSequenceUnordered(group).map(_ => ()))
 
       Task
-        .sequence(groups)
+        .sequence(groups.toIndexedSeq)
         .map(_ => ())
         .executeOn(ExecutionContext.ioScheduler)
     }

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -468,7 +468,7 @@ object Cli {
 
       val groups = deleteTasks
         .grouped(4)
-        .map(group => Task.gatherUnordered(group).map(_ => ()))
+        .map(group => Task.parSequenceUnordered(group).map(_ => ()))
 
       Task
         .sequence(groups)

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -500,6 +500,7 @@ object Cli {
         .flatMap(start => task.materialize.map(s => (s, start)))
         .map { case (state, start) => logElapsed(start); state }
         .dematerialize
+        .executeWithOptions(_.disableAutoCancelableRunLoops)
         .runAsync(ExecutionContext.scheduler)
 
     if (!cancel.isDone) {
@@ -515,6 +516,7 @@ object Cli {
             handle.cancel()
           }
         }
+        .executeWithOptions(_.disableAutoCancelableRunLoops)
         .runAsync(ExecutionContext.ioScheduler)
     }
 

--- a/frontend/src/main/scala/bloop/bsp/BloopBspDefinitions.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspDefinitions.scala
@@ -1,10 +1,12 @@
 package bloop.bsp
 
 import ch.epfl.scala.bsp.Uri
-import io.circe.derivation._
-import io.circe.{Decoder, RootEncoder}
-
-import scala.meta.jsonrpc.Endpoint
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+import com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonReader
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter
+import jsonrpc4s.Endpoint
 
 object BloopBspDefinitions {
   final case class BloopExtraBuildParams(
@@ -22,21 +24,17 @@ object BloopBspDefinitions {
       supportedScalaVersions = None
     )
 
-    val encoder: RootEncoder[BloopExtraBuildParams] = deriveEncoder
-    val decoder: Decoder[BloopExtraBuildParams] = deriveDecoder
+    implicit val codec: JsonValueCodec[BloopExtraBuildParams] = JsonCodecMaker.makeWithRequiredCollectionFields
   }
 
   final case class StopClientCachingParams(originId: String)
   object StopClientCachingParams {
-    val encoder: RootEncoder[StopClientCachingParams] = deriveEncoder
-    val decoder: Decoder[StopClientCachingParams] = deriveDecoder
+    implicit val codec: JsonValueCodec[StopClientCachingParams] = JsonCodecMaker.makeWithRequiredCollectionFields
   }
 
   object stopClientCaching
       extends Endpoint[StopClientCachingParams, Unit]("bloop/stopClientCaching") (
-        StopClientCachingParams.decoder,
-        StopClientCachingParams.encoder,
-        implicitly[Decoder[Unit]],
-        implicitly[RootEncoder[Unit]]
+        StopClientCachingParams.codec,
+        Endpoint.unitCodec
       )
 }

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -24,9 +24,9 @@ import bloop.io.{AbsolutePath, RelativePath}
 import bloop.logging.{BspServerLogger, DebugFilter, Logger}
 import bloop.reporter.{BspProjectReporter, ProblemPerPhase, ReporterConfig, ReporterInputs}
 import bloop.testing.{BspLoggingEventHandler, TestInternals}
+import ch.epfl.scala.bsp.ScalaBuildTarget
+import ch.epfl.scala.bsp.SbtBuildTarget
 import ch.epfl.scala.bsp
-import ch.epfl.scala.bsp.ScalaBuildTarget.encodeScalaBuildTarget
-import ch.epfl.scala.bsp.SbtBuildTarget.encodeSbtBuildTarget
 import ch.epfl.scala.bsp.{
   BuildTargetIdentifier,
   JvmEnvironmentItem,
@@ -35,7 +35,10 @@ import ch.epfl.scala.bsp.{
   Uri,
   endpoints
 }
-import scala.meta.jsonrpc.{JsonRpcClient, Response => JsonRpcResponse, Services => JsonRpcServices}
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+import jsonrpc4s.{RpcClient => JsonRpcClient, Response => JsonRpcResponse, Services}
+import jsonrpc4s.RawJson
 import monix.eval.Task
 import monix.reactive.Observer
 import monix.execution.Scheduler
@@ -48,7 +51,6 @@ import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success, Try}
 import monix.execution.Cancelable
-import io.circe.{Decoder, Json}
 import bloop.engine.Feedback
 import monix.reactive.subjects.BehaviorSubject
 import bloop.engine.tasks.compilation.CompileClientStore
@@ -60,8 +62,8 @@ import ch.epfl.scala.debugadapter.{DebugServer, DebuggeeRunner}
 
 final class BloopBspServices(
     callSiteState: State,
-    client: JsonRpcClient,
     relativeConfigPath: RelativePath,
+    rpcClient: JsonRpcClient,
     stopBspServer: Cancelable,
     observer: Option[BehaviorSubject[State]],
     isClientConnected: AtomicBoolean,
@@ -70,15 +72,10 @@ final class BloopBspServices(
     ioScheduler: Scheduler
 ) {
   private implicit val debugFilter: DebugFilter = DebugFilter.Bsp
-  private type ProtocolError = JsonRpcResponse.Error
-  private type BspResponse[T] = Either[ProtocolError, T]
 
-  /** The return type of every endpoint implementation */
-  private type BspEndpointResponse[T] = Task[BspResponse[T]]
-
+  private type BspResponse[T] = Either[JsonRpcResponse.Error, T]
   /** The return type of intermediate BSP computations */
   private type BspResult[T] = Task[(State, BspResponse[T])]
-
   /** The return type of a bsp computation wrapped by `ifInitialized` */
   private type BspComputation[T] = (State, BspServerLogger) => BspResult[T]
 
@@ -87,17 +84,17 @@ final class BloopBspServices(
    * thread pool and leave the serialization/deserialization work (bsp4s
    * library work) to the IO thread pool. This is critical for performance.
    */
-  def schedule[T](t: BspEndpointResponse[T]): BspEndpointResponse[T] = {
-    Task.fork(t, computationScheduler).asyncBoundary(ioScheduler)
+  def schedule[T](t: Task[T]): Task[T] = {
+    t.executeOn(computationScheduler).asyncBoundary(ioScheduler)
   }
 
   private val backgroundDebugServers = TrieMap.empty[URI, Cancelable]
 
   // Disable ansi codes for now so that the BSP clients don't get unescaped color codes
   private val taskIdCounter: AtomicInt = AtomicInt(0)
-  private val baseBspLogger = BspServerLogger(callSiteState, client, taskIdCounter, false)
+  private val baseBspLogger = BspServerLogger(callSiteState, rpcClient, taskIdCounter, false)
 
-  final val services = JsonRpcServices
+  final val services = Services
     .empty(baseBspLogger)
     .requestAsync(endpoints.Build.initialize)(p => schedule(initialize(p)))
     .notification(endpoints.Build.initialized)(initialized(_))
@@ -208,7 +205,7 @@ final class BloopBspServices(
    */
   def initialize(
       params: bsp.InitializeBuildParams
-  ): BspEndpointResponse[bsp.InitializeBuildResult] = {
+  ): Task[bsp.InitializeBuildResult] = {
     val bspLogger = baseBspLogger
     val uri = new URI(params.rootUri.value)
     val configDir = AbsolutePath(uri).resolve(relativeConfigPath)
@@ -267,7 +264,6 @@ final class BloopBspServices(
       clientInfo.success(client)
       connectedBspClients.put(client, configDir)
       publishStateInObserver(state.copy(client = client)).map { _ =>
-        Right(
           bsp.InitializeBuildResult(
             BuildInfo.bloopName,
             BuildInfo.version,
@@ -276,8 +272,10 @@ final class BloopBspServices(
               compileProvider = Some(BloopBspServices.DefaultCompileProvider),
               testProvider = Some(BloopBspServices.DefaultTestProvider),
               runProvider = Some(BloopBspServices.DefaultRunProvider),
+              debugProvider = None, // todo kpodsiad
               inverseSourcesProvider = Some(true),
               dependencySourcesProvider = Some(true),
+              dependencyModulesProvider = None, // todo kpodsiad
               resourcesProvider = Some(true),
               buildTargetChangedProvider = Some(false),
               jvmTestEnvironmentProvider = Some(true),
@@ -286,7 +284,6 @@ final class BloopBspServices(
             ),
             None
           )
-        )
       }
     }
   }
@@ -298,36 +295,34 @@ final class BloopBspServices(
     }
   }
 
-  private def parseBloopExtraParams(data: Option[Json]): Option[BloopExtraBuildParams] = {
+  private def parseBloopExtraParams(data: Option[RawJson]): Option[BloopExtraBuildParams] = {
     data.flatMap { json =>
-      BloopExtraBuildParams.decoder.decodeJson(json) match {
-        case Right(bloopParams) =>
-          Some(bloopParams)
-        case Left(failure) =>
-          callSiteState.logger.warn(
-            s"Unexpected error decoding bloop-specific initialize params: ${failure.message}"
+      try Some(readFromArray[BloopExtraBuildParams](json.value)) catch {
+        case e: Exception =>
+            callSiteState.logger.warn(
+            s"Unexpected error decoding bloop-specific initialize params: ${e.getMessage()}"
           )
           None
       }
     }
   }
 
-  val isInitialized = scala.concurrent.Promise[BspResponse[Unit]]()
+  val isInitialized = scala.concurrent.Promise[Unit]()
   val isInitializedTask = Task.fromFuture(isInitialized.future).memoize
   def initialized(
       initializedBuildParams: bsp.InitializedBuildParams
   ): Unit = {
-    isInitialized.success(Right(()))
+    isInitialized.success(())
     callSiteState.logger.info("BSP initialization handshake complete.")
   }
 
   def ifInitialized[T](
       originId: Option[String]
-  )(compute: BspComputation[T]): BspEndpointResponse[T] = {
+  )(compute: BspComputation[T]): Task[BspResponse[T]] = {
     val bspLogger = baseBspLogger.withOriginId(originId)
     // Give a time window for `isInitialized` to complete, otherwise assume it didn't happen
     isInitializedTask
-      .flatMap(response => clientInfoTask.map(clientInfo => response.map(_ => clientInfo)))
+      .flatMap(_ => clientInfoTask.map(Right(_)))
       .timeoutTo(
         FiniteDuration(1, TimeUnit.SECONDS),
         Task.now(Left(JsonRpcResponse.invalidRequest("The session has not been initialized.")))
@@ -341,6 +336,15 @@ final class BloopBspServices(
             }
           }
       }
+  }
+
+  private def ifInitializedAsTask[T](
+      originId: Option[String]
+  )(compute: BspComputation[T]): Task[T] = 
+    ifInitialized(originId)(compute).flatMap { _ match {
+      case Left(error) => Task.raiseError(error)
+      case Right(result) => Task.now(result)
+    }
   }
 
   def mapToProject(
@@ -486,7 +490,7 @@ final class BloopBspServices(
           }
       }
 
-      val response: Either[ProtocolError, bsp.CompileResult] = {
+      val response: Either[JsonRpcResponse.Error, bsp.CompileResult] = {
         if (cancelCompilation.isCompleted)
           Right(bsp.CompileResult(originId, bsp.StatusCode.Cancelled, None, None))
         else {
@@ -501,8 +505,8 @@ final class BloopBspServices(
     }
   }
 
-  def compile(params: bsp.CompileParams): BspEndpointResponse[bsp.CompileResult] = {
-    ifInitialized(params.originId) { (state: State, logger0: BspServerLogger) =>
+  def compile(params: bsp.CompileParams): Task[bsp.CompileResult] = {
+    ifInitializedAsTask(params.originId) { (state: State, logger0: BspServerLogger) =>
       mapToProjects(params.targets, state) match {
         case Left(error) =>
           // Log the mapping error to the user via a log event + an error status code
@@ -517,8 +521,8 @@ final class BloopBspServices(
     }
   }
 
-  def clean(params: bsp.CleanCacheParams): BspEndpointResponse[bsp.CleanCacheResult] = {
-    ifInitialized(None) { (state: State, logger: BspServerLogger) =>
+  def clean(params: bsp.CleanCacheParams): Task[bsp.CleanCacheResult] = {
+    ifInitializedAsTask(None) { (state: State, logger: BspServerLogger) =>
       mapToProjects(params.targets, state) match {
         case Left(error) =>
           // Log the mapping error to the user via a log event + an error status code
@@ -540,8 +544,8 @@ final class BloopBspServices(
 
   def scalaTestClasses(
       params: bsp.ScalaTestClassesParams
-  ): BspEndpointResponse[bsp.ScalaTestClassesResult] = {
-    ifInitialized(params.originId) { (state: State, logger: BspServerLogger) =>
+  ): Task[bsp.ScalaTestClassesResult] = {
+    ifInitializedAsTask(params.originId) { (state: State, logger: BspServerLogger) =>
       mapToProjects(params.targets, state) match {
         case Left(error) =>
           logger.error(error)
@@ -564,24 +568,23 @@ final class BloopBspServices(
 
   def startDebugSession(
       params: bsp.DebugSessionParams
-  ): BspEndpointResponse[bsp.DebugSessionAddress] = {
+  ): Task[bsp.DebugSessionAddress] = {
     def inferDebuggeeRunner(
         projects: Seq[Project],
         state: State
     ): BspResponse[DebuggeeRunner] = {
-      def convert[A: Decoder](
+
+      def convert[A: JsonValueCodec](
           f: A => Either[String, DebuggeeRunner]
-      ): Either[ProtocolError, DebuggeeRunner] = {
-        params.data.as[A] match {
-          case Left(error) =>
-            Left(JsonRpcResponse.invalidRequest(error.getMessage()))
-          case Right(params) =>
+      ): Either[JsonRpcResponse.Error, DebuggeeRunner] = Try(readFromArray[A](params.data.value)) match {
+          case Failure(throwable) => 
+            Left(JsonRpcResponse.invalidRequest(throwable.getMessage()))
+          case Success(params) =>
             f(params) match {
-              case Right(adapter) => Right(adapter)
               case Left(error) => Left(JsonRpcResponse.invalidRequest(error))
+              case Right(adapter) => Right(adapter)
             }
         }
-      }
 
       params.dataKind match {
         case bsp.DebugSessionParamsDataKind.ScalaMainClass =>
@@ -589,6 +592,7 @@ final class BloopBspServices(
             main => BloopDebuggeeRunner.forMainClass(projects, main, state, ioScheduler)
           )
         case bsp.DebugSessionParamsDataKind.ScalaTestSuites =>
+          implicit val codec: JsonValueCodec[List[String]] = JsonCodecMaker.makeWithRequiredCollectionFields
           convert[List[String]](
             filters => BloopDebuggeeRunner.forTestSuite(projects, filters, state, ioScheduler)
           )
@@ -598,7 +602,7 @@ final class BloopBspServices(
       }
     }
 
-    ifInitialized(None) { (state, logger) =>
+    ifInitializedAsTask(None) { (state, logger) =>
       JavaRuntime.loadJavaDebugInterface match {
         case Failure(exception) =>
           val message = JavaRuntime.current match {
@@ -644,19 +648,19 @@ final class BloopBspServices(
     }
   }
 
-  def test(params: bsp.TestParams): BspEndpointResponse[bsp.TestResult] = {
+  def test(params: bsp.TestParams): Task[bsp.TestResult] = {
     def test(
         id: BuildTargetIdentifier,
         project: Project,
         state: State
     ): Task[State] = {
       val testFilter = TestInternals.parseFilters(Nil) // Don't support test only for now
-      val handler = new BspLoggingEventHandler(id, state.logger, client)
+      val handler = new BspLoggingEventHandler(id, state.logger, rpcClient)
       Tasks.test(state, List(project), Nil, testFilter, handler, mode = RunMode.Normal)
     }
 
     val originId = params.originId
-    ifInitialized(originId) { (state: State, logger0: BspServerLogger) =>
+    ifInitializedAsTask(originId) { (state: State, logger0: BspServerLogger) =>
       mapToProjects(params.targets, state) match {
         case Left(error) =>
           // Log the mapping error to the user via a log event + an error status code
@@ -693,18 +697,18 @@ final class BloopBspServices(
 
   def jvmRunEnvironment(
       params: bsp.JvmRunEnvironmentParams
-  ): BspEndpointResponse[bsp.JvmRunEnvironmentResult] =
-    jvmEnvironment(params.targets).map(_.map(new bsp.JvmRunEnvironmentResult(_)))
+  ): Task[bsp.JvmRunEnvironmentResult] = 
+    jvmEnvironment(params.targets).map(new bsp.JvmRunEnvironmentResult(_))
 
   def jvmTestEnvironment(
       params: bsp.JvmTestEnvironmentParams
-  ): BspEndpointResponse[bsp.JvmTestEnvironmentResult] =
-    jvmEnvironment(params.targets).map(_.map(new bsp.JvmTestEnvironmentResult(_)))
+  ): Task[bsp.JvmTestEnvironmentResult] =
+    jvmEnvironment(params.targets).map(new bsp.JvmTestEnvironmentResult(_))
 
   def jvmEnvironment(
       targets: Seq[BuildTargetIdentifier]
-  ): BspEndpointResponse[List[bsp.JvmEnvironmentItem]] = {
-    ifInitialized(None) { (state: State, logger: BspServerLogger) =>
+  ): Task[List[bsp.JvmEnvironmentItem]] = {
+    ifInitializedAsTask(None) { (state: State, logger: BspServerLogger) =>
       mapToProjects(targets, state) match {
         case Left(error) =>
           logger.error(error)
@@ -734,13 +738,13 @@ final class BloopBspServices(
 
   def scalaMainClasses(
       params: bsp.ScalaMainClassesParams
-  ): BspEndpointResponse[bsp.ScalaMainClassesResult] = {
+  ): Task[bsp.ScalaMainClassesResult] = {
     def findMainClasses(state: State, project: Project): List[bsp.ScalaMainClass] =
       for {
         className <- Tasks.findMainClasses(state, project)
       } yield bsp.ScalaMainClass(className, Nil, Nil, Nil)
 
-    ifInitialized(params.originId) { (state: State, logger: BspServerLogger) =>
+    ifInitializedAsTask(params.originId) { (state: State, logger: BspServerLogger) =>
       mapToProjects(params.targets, state) match {
         case Left(error) =>
           logger.error(error)
@@ -758,15 +762,17 @@ final class BloopBspServices(
     }
   }
 
-  def run(params: bsp.RunParams): BspEndpointResponse[bsp.RunResult] = {
+  def run(params: bsp.RunParams): Task[bsp.RunResult] = {
     def parseMainClass(project: Project, state: State): Either[Exception, bsp.ScalaMainClass] = {
       params.dataKind match {
         case Some(bsp.RunParamsDataKind.ScalaMainClass) =>
           params.data match {
             case None =>
               Left(new IllegalStateException(s"Missing data for $params"))
-            case Some(json) =>
-              json.as[bsp.ScalaMainClass]
+            case Some(rawJson) =>
+              try Right(readFromArray[bsp.ScalaMainClass](rawJson.value)) catch {
+                case e: Exception => Left(e)
+              }
           }
         case Some(kind) =>
           Left(new IllegalArgumentException(s"Unsupported data kind: $kind"))
@@ -833,7 +839,7 @@ final class BloopBspServices(
     }
 
     val originId = params.originId
-    ifInitialized(originId) { (state: State, logger0: BspServerLogger) =>
+    ifInitializedAsTask(originId) { (state: State, logger0: BspServerLogger) =>
       mapToProject(params.target, state) match {
         case Left(error) =>
           // Log the mapping error to the user via a log event + an error status code
@@ -919,9 +925,9 @@ final class BloopBspServices(
 
   def buildTargets(
       request: bsp.WorkspaceBuildTargetsRequest
-  ): BspEndpointResponse[bsp.WorkspaceBuildTargetsResult] = {
+  ): Task[bsp.WorkspaceBuildTargetsResult] = {
     // need a separate block so so that state is refreshed after regenerating project data
-    val refreshTask = ifInitialized(None) { (state: State, logger: BspServerLogger) =>
+    val refreshTask = ifInitializedAsTask(None) { (state: State, logger: BspServerLogger) =>
       state.client.refreshProjectsCommand
         .map { command =>
           val cwd = state.build.origin
@@ -940,11 +946,10 @@ final class BloopBspServices(
         .getOrElse(Task.now((state, Right(()))))
     }
 
-    val buildTargetsTask = ifInitialized(None) { (state: State, _: BspServerLogger) =>
+    val buildTargetsTask = ifInitializedAsTask(None) { (state: State, _: BspServerLogger) =>
       def reportBuildError(msg: String): Unit = {
-        endpoints.Build.showMessage.notify(
-          ShowMessageParams(MessageType.Error, None, None, msg)
-        )(client)
+        implicit val client = rpcClient
+        endpoints.Build.showMessage.notify(ShowMessageParams(MessageType.Error, None, None, msg))
         ()
       }
 
@@ -961,15 +966,16 @@ final class BloopBspServices(
 
               val (extra, dataKind) = (p.scalaInstance, p.sbt) match {
                 case (Some(i), None) =>
-                  Some(encodeScalaBuildTarget(toScalaBuildTarget(p, i))) -> Some(
-                    bsp.BuildTargetDataKind.Scala
-                  )
+                  val buildTarget = toScalaBuildTarget(p, i)
+                  val encoded = writeToArray(buildTarget)
+                  (Some(RawJson(encoded)), Some(bsp.BuildTargetDataKind.Scala))
                 case (Some(i), Some(sbt)) =>
                   val scalaTarget = toScalaBuildTarget(p, i)
                   val sbtTarget = toSbtBuildTarget(sbt, scalaTarget)
-                  Some(encodeSbtBuildTarget(sbtTarget)) -> Some(bsp.BuildTargetDataKind.Sbt)
+                  val encoded = writeToArray(sbtTarget)
+                  (Some(RawJson(encoded)), Some(bsp.BuildTargetDataKind.Sbt))
                 case _ =>
-                  None -> None
+                  (None, None)
               }
 
               val capabilities = bsp.BuildTargetCapabilities(
@@ -1000,15 +1006,12 @@ final class BloopBspServices(
       }
     }
 
-    refreshTask.flatMap {
-      case Left(error) => Task.now(Left(error))
-      case Right(_) => buildTargetsTask
-    }
+    refreshTask.flatMap(_ => buildTargetsTask)
   }
 
   def sources(
       request: bsp.SourcesParams
-  ): BspEndpointResponse[bsp.SourcesResult] = {
+  ): Task[bsp.SourcesResult] = {
     def sources(
         projects: Seq[ProjectMapping],
         state: State
@@ -1040,7 +1043,7 @@ final class BloopBspServices(
       }
     }
 
-    ifInitialized(None) { (state: State, logger: BspServerLogger) =>
+    ifInitializedAsTask(None) { (state: State, logger: BspServerLogger) =>
       mapToProjects(request.targets, state) match {
         case Left(error) =>
           // Log the mapping error to the user via a log event + an error status code
@@ -1053,7 +1056,7 @@ final class BloopBspServices(
 
   def resources(
       request: bsp.ResourcesParams
-  ): BspEndpointResponse[bsp.ResourcesResult] = {
+  ): Task[bsp.ResourcesResult] = {
     def resources(
         projects: Seq[ProjectMapping],
         state: State
@@ -1072,7 +1075,7 @@ final class BloopBspServices(
       Task.now((state, Right(response)))
     }
 
-    ifInitialized(None) { (state: State, logger: BspServerLogger) =>
+    ifInitializedAsTask(None) { (state: State, logger: BspServerLogger) =>
       mapToProjects(request.targets, state) match {
         case Left(error) =>
           // Log the mapping error to the user via a log event + an error status code
@@ -1085,7 +1088,7 @@ final class BloopBspServices(
 
   def dependencySources(
       request: bsp.DependencySourcesParams
-  ): BspEndpointResponse[bsp.DependencySourcesResult] = {
+  ): Task[bsp.DependencySourcesResult] = {
     def sources(
         projects: Seq[ProjectMapping],
         state: State
@@ -1108,7 +1111,7 @@ final class BloopBspServices(
       Task.now((state, Right(response)))
     }
 
-    ifInitialized(None) { (state: State, logger: BspServerLogger) =>
+    ifInitializedAsTask(None) { (state: State, logger: BspServerLogger) =>
       mapToProjects(request.targets, state) match {
         case Left(error) =>
           // Log the mapping error to the user via a log event + an error status code
@@ -1134,7 +1137,7 @@ final class BloopBspServices(
 
   def scalacOptions(
       request: bsp.ScalacOptionsParams
-  ): BspEndpointResponse[bsp.ScalacOptionsResult] = {
+  ): Task[bsp.ScalacOptionsResult] = {
     def scalacOptions(
         projects: Seq[ProjectMapping],
         state: State
@@ -1155,7 +1158,7 @@ final class BloopBspServices(
       Task.now((state, Right(response)))
     }
 
-    ifInitialized(None) { (state: State, logger: BspServerLogger) =>
+    ifInitializedAsTask(None) { (state: State, logger: BspServerLogger) =>
       mapToProjects(request.targets, state) match {
         case Left(error) =>
           // Log the mapping error to the user via a log event + an error status code
@@ -1168,7 +1171,7 @@ final class BloopBspServices(
 
   def javacOptions(
       request: bsp.JavacOptionsParams
-  ): BspEndpointResponse[bsp.JavacOptionsResult] = {
+  ): Task[bsp.JavacOptionsResult] = {
     def javacOptions(
         projects: Seq[ProjectMapping],
         state: State
@@ -1189,7 +1192,7 @@ final class BloopBspServices(
       Task.now((state, Right(response)))
     }
 
-    ifInitialized(None) { (state: State, logger: BspServerLogger) =>
+    ifInitializedAsTask(None) { (state: State, logger: BspServerLogger) =>
       mapToProjects(request.targets, state) match {
         case Left(error) =>
           // Log the mapping error to the user via a log event + an error status code
@@ -1200,10 +1203,10 @@ final class BloopBspServices(
     }
   }
 
-  val isShutdown = scala.concurrent.Promise[BspResponse[Unit]]()
+  val isShutdown = scala.concurrent.Promise[Unit]()
   val isShutdownTask = Task.fromFuture(isShutdown.future).memoize
   def shutdown(shutdown: bsp.Shutdown): Unit = {
-    isShutdown.success(Right(()))
+    isShutdown.success(())
     callSiteState.logger.info("shutdown request received: build/shutdown")
     ()
   }
@@ -1220,12 +1223,9 @@ final class BloopBspServices(
     isShutdownTask
       .timeoutTo(
         FiniteDuration(100, TimeUnit.MILLISECONDS),
-        Task.now(Left(()))
+        Task.now(())
       )
-      .map {
-        case Left(_) => closeServices
-        case Right(_) => closeServices
-      }
+      .map(_ => closeServices)
   }
 }
 

--- a/frontend/src/main/scala/bloop/bsp/BloopLanguageClient.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopLanguageClient.scala
@@ -14,7 +14,7 @@ import java.nio.ByteBuffer
 import java.nio.channels.Channels
 
 import monix.eval.Task
-import monix.eval.Callback
+import monix.execution.Callback
 import monix.execution.Ack
 import monix.reactive.Observer
 import monix.execution.Cancelable
@@ -40,7 +40,7 @@ final class BloopLanguageClient(out: Observer[ByteBuffer], logger: LoggerSupport
   private val writer = new MessageWriter(out, logger)
   private val counter: AtomicInt = Atomic(1)
   private val activeServerRequests =
-    TrieMap.empty[RequestId, Callback[Response]]
+    TrieMap.empty[RequestId, Callback[Throwable, Response]]
 
   def notify[A: Encoder](method: String, notification: A): Future[Ack] =
     writer.write(Notification(method, Some(notification.asJson)))

--- a/frontend/src/main/scala/bloop/bsp/BloopLanguageClient.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopLanguageClient.scala
@@ -1,122 +1,13 @@
 package bloop.bsp
 
-import scala.meta.jsonrpc.Response
-import scala.meta.jsonrpc.RequestId
-import scala.meta.jsonrpc.CancelParams
-import scala.meta.jsonrpc.Notification
-import scala.meta.jsonrpc.JsonRpcClient
-import scala.meta.jsonrpc.MessageWriter
-import io.circe.Decoder
-import io.circe.Encoder
-import io.circe.syntax._
+
 import java.io.OutputStream
 import java.nio.ByteBuffer
 import java.nio.channels.Channels
 
-import monix.eval.Task
-import monix.execution.Callback
 import monix.execution.Ack
 import monix.reactive.Observer
-import monix.execution.Cancelable
-import monix.execution.atomic.Atomic
-import monix.execution.atomic.AtomicInt
-
-import scala.concurrent.Future
-import scala.collection.concurrent.TrieMap
-import scala.concurrent.duration.FiniteDuration
 import scribe.LoggerSupport
-
-/**
- * A copy of `LanguageClient` defined in `lsp4s` with a few critical fixes.
- */
-final class BloopLanguageClient(out: Observer[ByteBuffer], logger: LoggerSupport)
-    extends JsonRpcClient {
-
-  // ++ bloop
-  def this(out: OutputStream, logger: LoggerSupport) =
-    this(BloopLanguageClient.fromOutputStream(out, logger), logger)
-  // -- bloop
-
-  private val writer = new MessageWriter(out, logger)
-  private val counter: AtomicInt = Atomic(1)
-  private val activeServerRequests =
-    TrieMap.empty[RequestId, Callback[Throwable, Response]]
-
-  def notify[A: Encoder](method: String, notification: A): Future[Ack] =
-    writer.write(Notification(method, Some(notification.asJson)))
-
-  def serverRespond(response: Response): Future[Ack] = response match {
-    case Response.Empty => Ack.Continue
-    case x: Response.Success => writer.write(x)
-    case x: Response.Error =>
-      logger.error(s"Response error: $x")
-      writer.write(x)
-  }
-
-  def clientRespond(response: Response): Unit = {
-    for {
-      id <- response match {
-        case Response.Empty => None
-        case Response.Success(_, requestId) => Some(requestId)
-        case Response.Error(_, requestId) => Some(requestId)
-      }
-      callback <- activeServerRequests.get(id).orElse {
-        logger.error(s"Response to unknown request: $response")
-        None
-      }
-    } {
-      activeServerRequests.remove(id)
-      callback.onSuccess(response)
-    }
-  }
-
-  def request[A: Encoder, B: Decoder](
-      method: String,
-      request: A
-  ): Task[Either[Response.Error, B]] = {
-    val nextId = RequestId(counter.incrementAndGet())
-    val response = Task.create[Response] { (out, cb) =>
-      import java.util.concurrent.TimeUnit
-      val scheduled = out.scheduleOnce(FiniteDuration(0, TimeUnit.MILLISECONDS)) {
-        import scala.meta.jsonrpc.Request
-        val json = Request(method, Some(request.asJson), nextId)
-        activeServerRequests.put(nextId, cb)
-        writer.write(json)
-        ()
-      }
-      Cancelable { () =>
-        scheduled.cancel()
-        this.notify("$/cancelRequest", CancelParams(nextId.value))
-        ()
-      }
-    }
-
-    response.map {
-      case Response.Empty =>
-        Left(Response.invalidParams(s"Got empty response for request $request", nextId))
-      case err: Response.Error => Left(err)
-      case Response.Success(result, _) =>
-        import cats.syntax.either._
-        result.as[B].leftMap { err =>
-          Response.invalidParams(err.toString, nextId)
-        }
-    }
-  }
-
-  // Addition compared to lsp4s so that our tests can request something but forget about its result
-  def requestAndForget[A: Encoder](
-      method: String,
-      request: A
-  ): Task[Unit] = {
-    Task {
-      val nextId = RequestId(counter.incrementAndGet())
-      import scala.meta.jsonrpc.Request
-      val json = Request(method, Some(request.asJson), nextId)
-      writer.write(json)
-      ()
-    }
-  }
-}
 
 object BloopLanguageClient {
 

--- a/frontend/src/main/scala/bloop/bsp/BloopLanguageServer.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopLanguageServer.scala
@@ -128,7 +128,7 @@ final class BloopLanguageServer(
                 Response.internalError(e.getMessage, request.id)
             }
 
-          val runningResponse = response.runAsync(requestScheduler)
+          val runningResponse = response.executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(requestScheduler)
           activeClientRequests.put(jsonId, runningResponse)
           Task.fromFuture(runningResponse)
       }
@@ -150,7 +150,7 @@ final class BloopLanguageServer(
       handleMessage(msg)
         .map(client.serverRespond)
         .onErrorRecover { case NonFatal(e) => logger.error("Unhandled error", e) }
-        .runAsync(requestScheduler)
+        .executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(requestScheduler)
       ()
     }
   }

--- a/frontend/src/main/scala/bloop/bsp/BloopLanguageServer.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopLanguageServer.scala
@@ -71,7 +71,7 @@ final class BloopLanguageServer(
   def awaitRunningTasks: Task[Unit] = {
     val futures = activeClientRequests.values.map(fut => Task.fromFuture(fut))
     // Await until completion and ignore task results
-    Task.gatherUnordered(futures).materialize.map(_ => ())
+    Task.parSequenceUnordered(futures).materialize.map(_ => ())
   }
 
   def handleValidMessage(message: Message): Task[Response] = message match {

--- a/frontend/src/main/scala/bloop/bsp/BloopLanguageServer.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopLanguageServer.scala
@@ -1,9 +1,5 @@
 package bloop.bsp
 
-import io.circe.Json
-import io.circe.jawn.parseByteBuffer
-import io.circe.syntax._
-
 import java.nio.ByteBuffer
 
 import monix.eval.Task
@@ -18,27 +14,19 @@ import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 import scribe.LoggerSupport
 
-import scala.meta.jsonrpc.Message
-import scala.meta.jsonrpc.Request
-import scala.meta.jsonrpc.Response
-import scala.meta.jsonrpc.Service
-import scala.meta.jsonrpc.Services
-import scala.meta.jsonrpc.CancelParams
-import scala.meta.jsonrpc.Notification
-import scala.meta.jsonrpc.NamedJsonRpcService
-import scala.meta.jsonrpc.BaseProtocolMessage
 import bloop.util.monix.FoldLeftAsyncConsumer
+import jsonrpc4s._
 
 final class BloopLanguageServer(
-    in: Observable[BaseProtocolMessage],
-    client: BloopLanguageClient,
+    in: Observable[Message],
+    client: RpcClient,
     services: Services,
     requestScheduler: Scheduler,
     logger: LoggerSupport
 ) {
-  private val activeClientRequests: TrieMap[Json, CancelableFuture[_]] = TrieMap.empty
+  private val activeClientRequests: TrieMap[RequestId, CancelableFuture[Response]] = TrieMap.empty
   private val cancelNotification =
-    Service.notification[CancelParams]("$/cancelRequest", logger) {
+    Service.notification(RpcActions.cancelRequest, logger) {
       new Service[CancelParams, Unit] {
         def handle(params: CancelParams): Task[Unit] = {
           val id = params.id
@@ -74,80 +62,66 @@ final class BloopLanguageServer(
     Task.parSequenceUnordered(futures).materialize.map(_ => ())
   }
 
-  def handleValidMessage(message: Message): Task[Response] = message match {
-    case response: Response =>
-      Task {
-        client.clientRespond(response)
-        Response.empty
-      }
-    case Notification(method, _) =>
-      handlersByMethodName.get(method) match {
-        case None =>
-          Task {
-            // Can't respond to invalid notifications
-            logger.error(s"Unknown method '$method'")
-            Response.empty
-          }
-
-        case Some(handler) =>
-          handler
-            .handle(message)
-            .map {
-              case Response.Empty => Response.empty
-              case nonEmpty =>
-                logger.error(
-                  s"Obtained non-empty response $nonEmpty for notification $message. " +
-                    s"Expected Response.empty"
-                )
-                Response.empty
-            }
-            .onErrorRecover {
-              case NonFatal(e) =>
-                logger.error(s"Error handling notification $message", e)
-                Response.empty
-            }
-      }
-
-    case request @ Request(method, _, id) =>
-      handlersByMethodName.get(method) match {
-        case None =>
-          Task {
-            logger.info(s"Method not found '$method'")
-            Response.methodNotFound(method, id)
-          }
-
-        case Some(handler) =>
-          val jsonId = request.id.asJson
-          val unregisterUponCompletion = Task { activeClientRequests.remove(jsonId); () }
-          val response = handler
-            .handle(request)
-            .doOnFinish(_ => unregisterUponCompletion)
-            .onErrorRecover {
-              case NonFatal(e) =>
-                logger.error(s"Unhandled error handling request $request", e)
-                Response.internalError(e.getMessage, request.id)
-            }
-
-          val runningResponse = response.executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(requestScheduler)
-          activeClientRequests.put(jsonId, runningResponse)
-          Task.fromFuture(runningResponse)
-      }
-
+  def handleResponse(response: Response): Task[Response] = Task {
+      client.clientRespond(response)
+      Response.None
   }
 
-  def handleMessage(message: BaseProtocolMessage): Task[Response] =
-    parseByteBuffer(ByteBuffer.wrap(message.content)) match {
-      case Left(err) => Task.now(Response.parseError(err.toString))
-      case Right(json) =>
-        json.as[Message] match {
-          case Left(err) => Task.now(Response.invalidRequest(err.toString))
-          case Right(msg) => handleValidMessage(msg)
+  def handleNotification(notification: Notification): Task[Response] = {
+    handlersByMethodName.get(notification.method) match {
+      case None =>
+        Task.eval {
+          // Can't respond to invalid notifications
+          logger.error(s"Unknown method '${notification.method}'")
+          Response.None
+        }
+      case Some(handler) =>
+        handler
+          .handle(notification)
+          .onErrorRecover {
+            case NonFatal(e) =>
+              logger.error(s"Error handling notification $notification", e)
+              Response.None
+          }
+          .map {
+          case Response.None => Response.None
+          case nonEmpty =>
+            logger.error(s"Obtained non-empty response $nonEmpty for notification $notification!")
+            Response.None
         }
     }
+  }
+
+def handleRequest(request: Request): Task[Response] = {
+    import request.{method, id}
+    handlersByMethodName.get(method) match {
+      case None =>
+        Task.eval {
+          logger.info(s"Method not found '$method'")
+          Response.methodNotFound(method, id)
+        }
+
+      case Some(handler) =>
+        val response = handler.handle(request).onErrorRecover {
+          case NonFatal(e) =>
+            logger.error(s"Unhandled JSON-RPC error handling request $request", e)
+            Response.internalError(e.getMessage, request.id)
+        }
+        val runningResponse = response.runToFuture(requestScheduler)
+        activeClientRequests.put(request.id, runningResponse)
+        Task.fromFuture(runningResponse)
+    }
+  }
+
+  def handleValidMessage(message: Message): Task[Response] = message match {
+    case response: Response => handleResponse(response)
+    case notification: Notification => handleNotification(notification)
+    case request: Request => handleRequest(request)
+  }
 
   def startTask: Task[Unit] = {
     in.foreachL { msg =>
-      handleMessage(msg)
+      handleValidMessage(msg)
         .map(client.serverRespond)
         .onErrorRecover { case NonFatal(e) => logger.error("Unhandled error", e) }
         .executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(requestScheduler)
@@ -156,9 +130,9 @@ final class BloopLanguageServer(
   }
 
   def processMessagesSequentiallyTask: Task[Unit] = {
-    in.consumeWith(FoldLeftAsyncConsumer.consume[Unit, BaseProtocolMessage](()) {
+    in.consumeWith(FoldLeftAsyncConsumer.consume[Unit, Message](()) {
       case (_, msg) =>
-        handleMessage(msg)
+        handleValidMessage(msg)
           .map(client.serverRespond)
           .onErrorRecover { case NonFatal(e) => logger.error("Unhandled error", e) }
           .map(_ => ())

--- a/frontend/src/main/scala/bloop/bsp/BspServer.scala
+++ b/frontend/src/main/scala/bloop/bsp/BspServer.scala
@@ -294,7 +294,7 @@ object BspServer {
         }
       }
 
-      val groups = deleteExternalDirsTasks.grouped(4).map(group => Task.gatherUnordered(group))
+      val groups = deleteExternalDirsTasks.grouped(4).map(group => Task.parSequenceUnordered(group))
       Task
         .sequence(groups)
         .map(_.flatten)

--- a/frontend/src/main/scala/bloop/bsp/BspServer.scala
+++ b/frontend/src/main/scala/bloop/bsp/BspServer.scala
@@ -16,7 +16,7 @@ import monix.execution.Ack
 import monix.execution.Scheduler
 import monix.execution.Cancelable
 import monix.execution.atomic.Atomic
-import monix.execution.misc.NonFatal
+import scala.util.control.NonFatal
 import monix.reactive.OverflowStrategy
 import monix.reactive.observers.Subscriber
 import monix.reactive.{Observable, Observer}
@@ -158,7 +158,7 @@ object BspServer {
       }
 
       import monix.reactive.Consumer
-      val singleMessageConsumer = Consumer.foreachAsync[BaseProtocolMessage] { msg =>
+      val singleMessageConsumer = Consumer.foreachTask[BaseProtocolMessage] { msg =>
         import scala.meta.jsonrpc.Response.Empty
         import scala.meta.jsonrpc.Response.Success
         val taskToRun = {

--- a/frontend/src/main/scala/bloop/bsp/BspServer.scala
+++ b/frontend/src/main/scala/bloop/bsp/BspServer.scala
@@ -20,7 +20,6 @@ import scala.util.control.NonFatal
 import monix.reactive.OverflowStrategy
 import monix.reactive.observers.Subscriber
 import monix.reactive.{Observable, Observer}
-import monix.reactive.observables.ObservableLike
 import monix.execution.cancelables.CompositeCancelable
 
 import scala.concurrent.Future
@@ -296,7 +295,7 @@ object BspServer {
 
       val groups = deleteExternalDirsTasks.grouped(4).map(group => Task.parSequenceUnordered(group))
       Task
-        .sequence(groups)
+        .sequence(groups.toIndexedSeq)
         .map(_.flatten)
         .map(_ => ())
         .runAsync(ExecutionContext.ioScheduler)
@@ -306,7 +305,7 @@ object BspServer {
   }
 
   final class PumpOperator[A](pumpTarget: Observer.Sync[A], runningFuture: Cancelable)
-      extends ObservableLike.Operator[A, A] {
+      extends Observable.Operator[A, A] {
     def apply(out: Subscriber[A]): Subscriber[A] =
       new Subscriber[A] { self =>
         implicit val scheduler = out.scheduler

--- a/frontend/src/main/scala/bloop/bsp/BspServer.scala
+++ b/frontend/src/main/scala/bloop/bsp/BspServer.scala
@@ -167,7 +167,7 @@ object BspServer {
             .onErrorRecover { case NonFatal(e) => bspLogger.error("Unhandled error", e); () }
         }
 
-        val cancelable = taskToRun.runAsync(ioScheduler)
+        val cancelable = taskToRun.executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(ioScheduler)
         cancelables.synchronized { cancelables.+=(cancelable) }
         Task
           .fromFuture(cancelable)
@@ -203,7 +203,7 @@ object BspServer {
         .flatMap(_ => server.awaitRunningTasks.map(_ => provider.stateAfterExecution))
 
       // Start consumer in the background and assign cancelable
-      val consumerFuture = consumingTask.runAsync(ioScheduler)
+      val consumerFuture = consumingTask.executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(ioScheduler)
       stopBspConnection.:=(Cancelable(() => consumerFuture.cancel()))
 
       /*
@@ -298,7 +298,7 @@ object BspServer {
         .sequence(groups.toIndexedSeq)
         .map(_.flatten)
         .map(_ => ())
-        .runAsync(ExecutionContext.ioScheduler)
+        .executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(ExecutionContext.ioScheduler)
 
       ()
     }

--- a/frontend/src/main/scala/bloop/dap/BloopDebuggeeRunner.scala
+++ b/frontend/src/main/scala/bloop/dap/BloopDebuggeeRunner.scala
@@ -24,7 +24,8 @@ abstract class BloopDebuggeeRunner(initialState: State, ioScheduler: Scheduler)
       .map { status =>
         if (!status.isOk) throw new Exception(s"debugee failed with ${status.name}")
       }
-    DapCancellableFuture.runAsync(task, ioScheduler)
+    DapCancellableFuture
+      .runAsync(task, ioScheduler)
   }
 
   protected def start(state: State): Task[ExitStatus]

--- a/frontend/src/main/scala/bloop/dap/DapCancellableFuture.scala
+++ b/frontend/src/main/scala/bloop/dap/DapCancellableFuture.scala
@@ -23,6 +23,7 @@ object DapCancellableFuture {
         case Some(t) => Task(promise.failure(t))
       }
       .doOnCancel(Task(promise.success(())))
+      .executeWithOptions(_.disableAutoCancelableRunLoops)
       .runAsync(ioScheduler)
     new DapCancellableFuture(promise.future, cancelable)
   }

--- a/frontend/src/main/scala/bloop/data/ClientInfo.scala
+++ b/frontend/src/main/scala/bloop/data/ClientInfo.scala
@@ -12,7 +12,7 @@ import scala.collection.mutable
 import java.nio.file.Path
 import bloop.io.Paths
 import java.io.IOException
-import monix.execution.misc.NonFatal
+import scala.util.control.NonFatal
 import bloop.logging.Logger
 import bloop.tracing.BraveTracer
 import bloop.logging.DebugFilter

--- a/frontend/src/main/scala/bloop/engine/Build.scala
+++ b/frontend/src/main/scala/bloop/engine/Build.scala
@@ -139,7 +139,7 @@ final case class Build private (
       }
     }
 
-    Task.gatherUnordered(detectedChanges).map(_.flatten).map { changes =>
+    Task.parSequenceUnordered(detectedChanges).map(_.flatten).map { changes =>
       val deleted = oldFilesMap.values.collect {
         case f if !newToAttributed.contains(f.path) => f.path
       }

--- a/frontend/src/main/scala/bloop/engine/BuildLoader.scala
+++ b/frontend/src/main/scala/bloop/engine/BuildLoader.scala
@@ -55,7 +55,7 @@ object BuildLoader {
       val loadMsg = s"Loading ${configs.length} projects from '${configDir.syntax}'..."
       logger.debug(loadMsg)(DebugFilter.All)
       val rawProjects = configs.map(f => Task(loadProject(f.bytes, f.origin, logger)))
-      val groupTasks = rawProjects.grouped(10).map(group => Task.gatherUnordered(group)).toList
+      val groupTasks = rawProjects.grouped(10).map(group => Task.parSequenceUnordered(group)).toList
       val newOrModifiedRawProjects = Task.sequence(groupTasks).map(fp => fp.flatten)
 
       newOrModifiedRawProjects.flatMap { projects =>
@@ -136,7 +136,7 @@ object BuildLoader {
         coeval.task
     }
 
-    Task.gatherUnordered(enableMetalsInProjectsTask).map { pps =>
+    Task.parSequenceUnordered(enableMetalsInProjectsTask).map { pps =>
       // Add projects with Metals settings enabled + projects with no scala config at all
       pps.flatten ++ projectsWithNoScalaConfig.toList.map(_ -> None)
     }

--- a/frontend/src/main/scala/bloop/engine/BuildLoader.scala
+++ b/frontend/src/main/scala/bloop/engine/BuildLoader.scala
@@ -193,7 +193,7 @@ object BuildLoader {
               }
 
               // Run coeval, we rethrow but note that `tryEnablingSemanticDB` handles errors
-              coeval.run match {
+              coeval.run.toEither match {
                 case Left(value) => throw value
                 case Right(value) => value
               }

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -83,7 +83,7 @@ object Interpreter {
       }
     }
 
-    execute(action, stateTask)
+    execute(action, stateTask).executeWithOptions(_.disableAutoCancelableRunLoops)
   }
 
   private def notHandled(command: String, cliOptions: CliOptions, state: State): Task[State] = {

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -112,7 +112,7 @@ object Interpreter {
     val reachable = Dag.dfs(getProjectsDag(projects, state))
     val projectsSourcesAndDirs = reachable.map(_.allSourceFilesAndDirectories)
     val groupTasks =
-      projectsSourcesAndDirs.grouped(8).map(group => Task.gatherUnordered(group)).toList
+      projectsSourcesAndDirs.grouped(8).map(group => Task.parSequenceUnordered(group)).toList
     Task
       .sequence(groupTasks)
       .map(fp => fp.flatten.flatten.map(_.underlying))

--- a/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
@@ -31,7 +31,7 @@ import scala.collection.mutable
 import java.nio.file.Path
 import bloop.io.Paths
 import java.nio.file.NoSuchFileException
-import monix.execution.misc.NonFatal
+import scala.util.control.NonFatal
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.ConcurrentHashMap
 import sbt.internal.inc.Analysis

--- a/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
@@ -141,7 +141,12 @@ object ResultsCache {
       logger: Logger
   ): ResultsCache = {
     val handle = loadAsync(build, cwd, cleanOrphanedInternalDirs, logger)
-    Await.result(handle.runAsync(ExecutionContext.ioScheduler), Duration.Inf)
+    Await.result(
+      handle
+        .executeWithOptions(_.disableAutoCancelableRunLoops)
+        .runAsync(ExecutionContext.ioScheduler),
+      Duration.Inf
+    )
   }
 
   def loadAsync(
@@ -291,7 +296,11 @@ object ResultsCache {
       }
 
       // Spawn the cleanup tasks sequentially in the background and forget about it
-      Task.sequence(cleanupTasks).materialize.runAsync(ExecutionContext.ioScheduler)
+      Task
+        .sequence(cleanupTasks)
+        .materialize
+        .executeWithOptions(_.disableAutoCancelableRunLoops)
+        .runAsync(ExecutionContext.ioScheduler)
 
       // Return the collected results per project
       results

--- a/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
@@ -281,7 +281,7 @@ object ResultsCache {
 
     val projects = build.loadedProjects.map(_.project)
     val all = projects.map(p => fetchPreviousResult(p).map(r => p -> r))
-    Task.gatherUnordered(all).executeOn(ExecutionContext.ioScheduler).map { projectResults =>
+    Task.parSequenceUnordered(all).executeOn(ExecutionContext.ioScheduler).map { projectResults =>
       val newCache = new ResultsCache(Map.empty, Map.empty)
       val cleanupTasks = new mutable.ListBuffer[Task[Unit]]()
       val results = projectResults.foldLeft(newCache) {

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -443,7 +443,10 @@ object CompileTask {
       parallelUnits: Int = Runtime.getRuntime().availableProcessors()
   ): Unit = {
     val aggregatedTask = Task.sequence(
-      tasks.toList.grouped(parallelUnits).map(group => Task.parSequenceUnordered(group))
+      tasks.toList
+        .grouped(parallelUnits)
+        .map(group => Task.parSequenceUnordered(group))
+        .toIndexedSeq
     )
     aggregatedTask.map(_ => ()).runAsync(ExecutionContext.ioScheduler)
     ()

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -182,7 +182,9 @@ object CompileTask {
                       logger
                     )
                     .doOnFinish(_ => Task(compileProjectTracer.terminate()))
-                postCompilationTasks.runAsync(ExecutionContext.ioScheduler)
+                postCompilationTasks
+                  .executeWithOptions(_.disableAutoCancelableRunLoops)
+                  .runAsync(ExecutionContext.ioScheduler)
               }
 
               // Populate the last successful result if result was success
@@ -448,7 +450,10 @@ object CompileTask {
         .map(group => Task.parSequenceUnordered(group))
         .toIndexedSeq
     )
-    aggregatedTask.map(_ => ()).runAsync(ExecutionContext.ioScheduler)
+    aggregatedTask
+      .map(_ => ())
+      .executeWithOptions(_.disableAutoCancelableRunLoops)
+      .runAsync(ExecutionContext.ioScheduler)
     ()
   }
 

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileResult.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileResult.scala
@@ -70,7 +70,7 @@ object PartialCompileResult {
       case f @ PartialFailure(project, _, bundle) =>
         bundle.map(b => FinalNormalCompileResult(project, b) :: Nil)
       case PartialFailures(failures, _) =>
-        Task.gatherUnordered(failures.map(toFinalResult(_))).map(_.flatten)
+        Task.parSequenceUnordered(failures.map(toFinalResult(_))).map(_.flatten)
       case PartialSuccess(bundle, _, result) =>
         result.map(res => FinalNormalCompileResult(bundle.project, res) :: Nil)
     }

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginWhitelist.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginWhitelist.scala
@@ -140,7 +140,7 @@ object CompilerPluginWhitelist {
                     .map(group => Task.parSequenceUnordered(group))
                 }
 
-                Task.sequence(blockingBatches).map(_.flatten).map { _ =>
+                Task.sequence(blockingBatches.toIndexedSeq).map(_.flatten).map { _ =>
                   val enableCacheFlag = cachePluginResults.forall(_ == true)
                   if (!enableCacheFlag) scalacOptions
                   else "-Ycache-plugin-class-loader:last-modified" :: scalacOptions

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginWhitelist.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginWhitelist.scala
@@ -100,7 +100,7 @@ object CompilerPluginWhitelist {
           tracer.traceTaskVerbose("enabling plugin caching") { tracer =>
             // Consumers are processed with `foreachParallel`, so we side-effect on `cachePluginResults`
             val parallelConsumer = {
-              Consumer.foreachParallelAsync[WorkItem](parallelUnits) {
+              Consumer.foreachParallelTask[WorkItem](parallelUnits) {
                 case WorkItem(pluginCompilerFlag, idx, p) =>
                   shouldCachePlugin(pluginCompilerFlag, tracer, logger).materialize.map {
                     case scala.util.Success(cache) =>

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginWhitelist.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginWhitelist.scala
@@ -137,7 +137,7 @@ object CompilerPluginWhitelist {
                 val blockingBatches = {
                   acquiredByOtherTasks.toList
                     .grouped(parallelUnits)
-                    .map(group => Task.gatherUnordered(group))
+                    .map(group => Task.parSequenceUnordered(group))
                 }
 
                 Task.sequence(blockingBatches).map(_.flatten).map { _ =>

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/PipeliningOracle.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/PipeliningOracle.scala
@@ -18,7 +18,7 @@ import xsbti.compile.Signature
 import monix.execution.atomic.AtomicBoolean
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import monix.execution.misc.NonFatal
+import scala.util.control.NonFatal
 
 /** @inheritdoc */
 final class PipeliningOracle(

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/PipeliningOracle.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/PipeliningOracle.scala
@@ -80,6 +80,7 @@ final class PipeliningOracle(
           Task
             .sequence(dependentProjectPromises)
             .map(_ => ())
+            .executeWithOptions(_.disableAutoCancelableRunLoops)
             .runAsync(ExecutionContext.ioScheduler)
         }
 
@@ -144,7 +145,9 @@ object PipeliningOracle {
     }
 
     // Think strategies to get a hold of this future or cancel it if compilation is cancelled
-    persistPicklesInParallel.runAsync(ExecutionContext.ioScheduler)
+    persistPicklesInParallel
+      .executeWithOptions(_.disableAutoCancelableRunLoops)
+      .runAsync(ExecutionContext.ioScheduler)
     ()
   }
 }

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/PipeliningOracle.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/PipeliningOracle.scala
@@ -133,7 +133,7 @@ object PipeliningOracle {
       logger: Logger
   ): Unit = {
     val writePickles = signatures.map(ScalaSig.write(picklesDir, _, logger))
-    val groupTasks = writePickles.grouped(4).map(group => Task.gatherUnordered(group)).toList
+    val groupTasks = writePickles.grouped(4).map(group => Task.parSequenceUnordered(group)).toList
     val persistPicklesInParallel = {
       tracer.traceTask("writing pickles") { _ =>
         Task.sequence(groupTasks).doOnFinish {

--- a/frontend/src/main/scala/bloop/io/SourceWatcher.scala
+++ b/frontend/src/main/scala/bloop/io/SourceWatcher.scala
@@ -17,7 +17,7 @@ import monix.eval.Task
 import monix.reactive.Consumer
 import monix.execution.Cancelable
 import monix.reactive.{MulticastStrategy, Observable}
-import monix.execution.misc.NonFatal
+import scala.util.control.NonFatal
 import monix.execution.atomic.AtomicBoolean
 import monix.reactive.OverflowStrategy
 import java.util.concurrent.ConcurrentHashMap

--- a/frontend/src/main/scala/bloop/io/SourceWatcher.scala
+++ b/frontend/src/main/scala/bloop/io/SourceWatcher.scala
@@ -196,8 +196,7 @@ final class SourceWatcher private (
       else FiniteDuration(userMs.toLong, "ms")
     }
 
-    observable
-      .transform(self => new BloopBufferTimedObservable(self, timespan, 0))
+    new BloopBufferTimedObservable(observable, timespan, 0)
       .liftByOperator(
         new BloopWhileBusyDropEventsAndSignalOperator((es: Seq[Seq[DirectoryChangeEvent]]) =>
           es.flatten

--- a/frontend/src/main/scala/bloop/logging/ScribeAdapter.scala
+++ b/frontend/src/main/scala/bloop/logging/ScribeAdapter.scala
@@ -1,11 +1,11 @@
 package bloop.logging
 
 import scribe.LogRecord
+import scribe.Level
 
 trait ScribeAdapter extends scribe.LoggerSupport { self: Logger =>
   override def log[M](record: LogRecord[M]): Unit = {
-    import scribe.Level
-    val msg = record.message
+    val msg = record.logOutput.plainText
     record.level match {
       case Level.Info => info(msg)
       case Level.Error => error(msg)
@@ -14,8 +14,10 @@ trait ScribeAdapter extends scribe.LoggerSupport { self: Logger =>
       case Level.Trace =>
         record.throwable match {
           case Some(t) => trace(t)
-          case None => debug(record.message)(DebugFilter.Bsp)
+          case None => debug(msg)(DebugFilter.Bsp)
         }
+      case Level.Fatal => error(msg)
+      case _ => ()
     }
   }
 }

--- a/frontend/src/main/scala/bloop/testing/TestInternals.scala
+++ b/frontend/src/main/scala/bloop/testing/TestInternals.scala
@@ -152,7 +152,9 @@ object TestInternals {
       runTask.map(exitCode => Forker.exitStatus(exitCode).code)
     }
 
-    val listenerHandle = listener.reporter.runAsync(ExecutionContext.ioScheduler)
+    val listenerHandle = listener.reporter
+      .executeWithOptions(_.disableAutoCancelableRunLoops)
+      .runAsync(ExecutionContext.ioScheduler)
 
     def cancel(): Unit = {
       if (!cancelled.getAndSet(true)) {

--- a/frontend/src/main/scala/bloop/testing/TestServer.scala
+++ b/frontend/src/main/scala/bloop/testing/TestServer.scala
@@ -9,7 +9,7 @@ import bloop.config.Config
 import scala.util.Try
 import bloop.logging.{DebugFilter, Logger}
 import monix.eval.Task
-import monix.execution.misc.NonFatal
+import scala.util.control.NonFatal
 import sbt.{ForkConfiguration, ForkTags}
 import sbt.testing.{Event, Framework, TaskDef}
 

--- a/frontend/src/main/scala/bloop/testing/TestSuiteEvent.scala
+++ b/frontend/src/main/scala/bloop/testing/TestSuiteEvent.scala
@@ -8,8 +8,9 @@ import ch.epfl.scala.bsp.endpoints.{Build, BuildTarget}
 import sbt.testing.{Event, Selector, Status}
 
 import scala.collection.mutable
-import scala.meta.jsonrpc.JsonRpcClient
 import scala.util.Try
+
+import jsonrpc4s.RpcClient
 
 sealed trait TestSuiteEvent
 object TestSuiteEvent {
@@ -148,9 +149,9 @@ class LoggingEventHandler(logger: Logger) extends TestSuiteEventHandler {
   }
 }
 
-final class BspLoggingEventHandler(id: BuildTargetIdentifier, logger: Logger, client: JsonRpcClient)
+final class BspLoggingEventHandler(id: BuildTargetIdentifier, logger: Logger, client: RpcClient)
     extends LoggingEventHandler(logger) {
-  implicit val client0: JsonRpcClient = client
+  implicit val client0: RpcClient = client
   override def report(): Unit = {
     /*    val failed = suitesFailed.length
     val r = bsp.TestReport(id, None, suitesPassed, failed, 0, 0, 0, 0, Some(suitesDuration))

--- a/frontend/src/main/scala/bloop/util/monix/FoldLeftAsyncConsumer.scala
+++ b/frontend/src/main/scala/bloop/util/monix/FoldLeftAsyncConsumer.scala
@@ -19,7 +19,10 @@ final class FoldLeftAsyncConsumer[A, R](
     f: (R, A) => Task[R]
 ) extends Consumer[A, R] {
 
-  def createSubscriber(cb: Callback[Throwable, R], s: Scheduler): (Subscriber[A], AssignableCancelable) = {
+  def createSubscriber(
+      cb: Callback[Throwable, R],
+      s: Scheduler
+  ): (Subscriber[A], AssignableCancelable) = {
     val cancelables = new ListBuffer[Cancelable]()
     val out = new Subscriber[A] {
       implicit val scheduler = s
@@ -89,14 +92,6 @@ final class FoldLeftAsyncConsumer[A, R](
     }
 
     (out, cancelable)
-  }
-
-  override def apply(source: Observable[A]): Task[R] = {
-    Task.create[R] { (scheduler, cb) =>
-      val (out, consumerSubscription) = createSubscriber(cb, scheduler)
-      val sourceSubscription = source.subscribe(out)
-      CompositeCancelable(sourceSubscription, consumerSubscription)
-    }
   }
 
 }

--- a/frontend/src/main/scala/bloop/util/monix/WhileBusyDropEventsAndSignalOperator.scala
+++ b/frontend/src/main/scala/bloop/util/monix/WhileBusyDropEventsAndSignalOperator.scala
@@ -3,7 +3,7 @@ package bloop.util.monix
 import monix.execution.Ack
 import monix.execution.Ack.{Continue, Stop}
 import scala.util.control.NonFatal
-import monix.reactive.observables.ObservableLike.Operator
+import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 import monix.execution.atomic.AtomicBoolean
 

--- a/frontend/src/main/scala/bloop/util/monix/WhileBusyDropEventsAndSignalOperator.scala
+++ b/frontend/src/main/scala/bloop/util/monix/WhileBusyDropEventsAndSignalOperator.scala
@@ -2,7 +2,7 @@ package bloop.util.monix
 
 import monix.execution.Ack
 import monix.execution.Ack.{Continue, Stop}
-import monix.execution.misc.NonFatal
+import scala.util.control.NonFatal
 import monix.reactive.observables.ObservableLike.Operator
 import monix.reactive.observers.Subscriber
 import monix.execution.atomic.AtomicBoolean

--- a/frontend/src/test/resources/compiler-plugin-whitelist/whitelist/shared/src/main/scala/hello/App.scala
+++ b/frontend/src/test/resources/compiler-plugin-whitelist/whitelist/shared/src/main/scala/hello/App.scala
@@ -5,3 +5,4 @@ object App {
     println("Whitelist application was compiled successfully v3.0")
   }
 }
+        

--- a/frontend/src/test/scala/bloop/BaseCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/BaseCompileSpec.scala
@@ -17,7 +17,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 
 import monix.eval.Task
-import monix.execution.misc.NonFatal
+import scala.util.control.NonFatal
 import monix.execution.CancelableFuture
 import bloop.cli.CommonOptions
 import bloop.engine.NoPool

--- a/frontend/src/test/scala/bloop/BaseCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/BaseCompileSpec.scala
@@ -1480,7 +1480,12 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
       def runCompileAsync = Task.fork(Task.eval(Cli.run(compileAction, NoPool)))
       val runCompile =
         Task.parSequenceUnordered(List(runCompileAsync, runCompileAsync)).map(_ => ())
-      Await.result(runCompile.runAsync(ExecutionContext.ioScheduler), FiniteDuration(10, "s"))
+      Await.result(
+        runCompile
+          .executeWithOptions(_.disableAutoCancelableRunLoops)
+          .runAsync(ExecutionContext.ioScheduler),
+        FiniteDuration(10, "s")
+      )
 
       val actionsOutput = new String(testOut.toByteArray(), StandardCharsets.UTF_8)
       def removeAsciiColorCodes(line: String): String = line.replaceAll("\u001B\\[[;\\d]*m", "")

--- a/frontend/src/test/scala/bloop/BaseCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/BaseCompileSpec.scala
@@ -1478,7 +1478,8 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
       val compileArgs = Array("compile", "a", "--config-dir", configDir.syntax)
       val compileAction = Cli.parse(compileArgs, options)
       def runCompileAsync = Task.fork(Task.eval(Cli.run(compileAction, NoPool)))
-      val runCompile = Task.gatherUnordered(List(runCompileAsync, runCompileAsync)).map(_ => ())
+      val runCompile =
+        Task.parSequenceUnordered(List(runCompileAsync, runCompileAsync)).map(_ => ())
       Await.result(runCompile.runAsync(ExecutionContext.ioScheduler), FiniteDuration(10, "s"))
 
       val actionsOutput = new String(testOut.toByteArray(), StandardCharsets.UTF_8)

--- a/frontend/src/test/scala/bloop/BuildLoaderSpec.scala
+++ b/frontend/src/test/scala/bloop/BuildLoaderSpec.scala
@@ -192,7 +192,7 @@ object BuildLoaderSpec extends BaseSuite {
     }
 
     Task
-      .gatherUnordered(changes)
+      .parSequenceUnordered(changes)
       .flatMap { _ =>
         testBuild.state.build.checkForChange(None, logger).map {
           case action: Build.UpdateState =>

--- a/frontend/src/test/scala/bloop/DeduplicationSpec.scala
+++ b/frontend/src/test/scala/bloop/DeduplicationSpec.scala
@@ -865,6 +865,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
         val _ = Task
           .fromFuture(startedFirstCompilation.future)
           .map(_ => { firstCompilation.cancel() })
+          .executeWithOptions(_.disableAutoCancelableRunLoops)
           .runAsync(ExecutionContext.ioScheduler)
 
         val (firstCompiledState, secondCompiledState) =
@@ -1080,6 +1081,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
         val secondCompilation = Task
           .fromFuture(startedProjectCompilation.future)
           .flatMap(_ => compiledMacrosState.withLogger(logger2).runTask(build.userProject))
+          .executeWithOptions(_.disableAutoCancelableRunLoops)
           .runAsync(ExecutionContext.ioScheduler)
 
         val firstRunState = waitInSeconds(firstRunExecution, 10)(logger1.writeToFile("1"))

--- a/frontend/src/test/scala/bloop/FileWatchingSpec.scala
+++ b/frontend/src/test/scala/bloop/FileWatchingSpec.scala
@@ -18,7 +18,7 @@ import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration.FiniteDuration
-import monix.execution.misc.NonFatal
+import scala.util.control.NonFatal
 import bloop.data.SourcesGlobs
 
 object FileWatchingSpec extends BaseSuite {

--- a/frontend/src/test/scala/bloop/FileWatchingSpec.scala
+++ b/frontend/src/test/scala/bloop/FileWatchingSpec.scala
@@ -492,7 +492,7 @@ object FileWatchingSpec extends BaseSuite {
       ()
     }
 
-    val f = Task.mapBoth(consumingTask, createEvents)((_: Unit, _: Unit) => ()).runAsync
+    val f = Task.mapBoth(consumingTask, createEvents)((_: Unit, _: Unit) => ()).runToFuture
     scala.concurrent.Await.result(f, 2.second)
     println(received.toString)
   }

--- a/frontend/src/test/scala/bloop/RunSpec.scala
+++ b/frontend/src/test/scala/bloop/RunSpec.scala
@@ -314,7 +314,9 @@ class RunSpec extends BloopHelpers {
       val cancelTime = Duration.apply(7, TimeUnit.SECONDS)
       def msgs = logger.getMessages
       val runTask = TestUtil.interpreterTask(action, state)
-      val handle = runTask.runAsync(ExecutionContext.ioScheduler)
+      val handle = runTask
+        .executeWithOptions(_.disableAutoCancelableRunLoops)
+        .runAsync(ExecutionContext.ioScheduler)
       val driver = ExecutionContext.ioScheduler.scheduleOnce(cancelTime) { handle.cancel() }
 
       val runState = {

--- a/frontend/src/test/scala/bloop/ScalaVersionsSpec.scala
+++ b/frontend/src/test/scala/bloop/ScalaVersionsSpec.scala
@@ -78,7 +78,7 @@ object ScalaVersionsSpec extends bloop.testing.BaseSuite {
     try {
       TestUtil.await(FiniteDuration(120, "s"), ExecutionContext.ioScheduler) {
         Task
-          .sequence(all.grouped(2).map(group => Task.parSequenceUnordered(group)))
+          .sequence(all.grouped(2).map(group => Task.parSequenceUnordered(group)).toIndexedSeq)
           .map(_ => ())
       }
     } catch {

--- a/frontend/src/test/scala/bloop/ScalaVersionsSpec.scala
+++ b/frontend/src/test/scala/bloop/ScalaVersionsSpec.scala
@@ -78,7 +78,7 @@ object ScalaVersionsSpec extends bloop.testing.BaseSuite {
     try {
       TestUtil.await(FiniteDuration(120, "s"), ExecutionContext.ioScheduler) {
         Task
-          .sequence(all.grouped(2).map(group => Task.gatherUnordered(group)))
+          .sequence(all.grouped(2).map(group => Task.parSequenceUnordered(group)))
           .map(_ => ())
       }
     } catch {

--- a/frontend/src/test/scala/bloop/ScalaVersionsSpec.scala
+++ b/frontend/src/test/scala/bloop/ScalaVersionsSpec.scala
@@ -9,7 +9,7 @@ import bloop.cli.ExitStatus
 import scala.concurrent.duration.FiniteDuration
 import bloop.engine.State
 import java.util.concurrent.TimeoutException
-import monix.execution.misc.NonFatal
+import scala.util.control.NonFatal
 import java.lang.management.ManagementFactory
 
 object ScalaVersionsSpec extends bloop.testing.BaseSuite {

--- a/frontend/src/test/scala/bloop/TracerSpec.scala
+++ b/frontend/src/test/scala/bloop/TracerSpec.scala
@@ -102,7 +102,7 @@ object TracerSpec extends BaseSuite {
     import bloop.engine.ExecutionContext
     import bloop.util.TestUtil
     TestUtil.await(FiniteDuration(10, "s"), ExecutionContext.ioScheduler) {
-      Task.gatherUnordered(tasks).map(_ => ())
+      Task.parSequenceUnordered(tasks).map(_ => ())
     }
   }
 }

--- a/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
@@ -126,7 +126,7 @@ trait BspClientTest {
     val configPath = RelativePath(configDirectory.underlying.getFileName)
     val bspServer = BspServer
       .run(cmd, state, configPath, None, None, ExecutionContext.scheduler, ioScheduler)
-      .runAsync(ioScheduler)
+      .executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(ioScheduler)
     val bspClientExecution = establishClientConnection(cmd).flatMap { socket =>
       val in = socket.getInputStream
       val out = socket.getOutputStream
@@ -136,7 +136,7 @@ trait BspClientTest {
       val services =
         customServices(TestUtil.createTestServices(addDiagnosticsHandler, logger))
       val lsServer = new LanguageServer(messages, lsClient, services, ioScheduler, logger)
-      val runningClientServer = lsServer.startTask.runAsync(ioScheduler)
+      val runningClientServer = lsServer.startTask.executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(ioScheduler)
 
       val cwd = configDirectory.underlying.getParent
       val initializeServer = endpoints.Build.initialize.request(
@@ -169,7 +169,7 @@ trait BspClientTest {
 
     import scala.concurrent.Await
     import scala.concurrent.duration.FiniteDuration
-    val bspClient = bspClientExecution.runAsync(ioScheduler)
+    val bspClient = bspClientExecution.executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(ioScheduler)
 
     try {
       // The timeout for all our bsp tests, no matter what operation they run, is 60s

--- a/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
@@ -53,7 +53,7 @@ class BspConnectionSpec(
           // Wait 500ms to let the rest of clients to connect to server and then simulate dropout
           Thread.sleep(500)
           bspState.simulateClientDroppingOut()
-        }
+        }.executeWithOptions(_.disableAutoCancelableRunLoops)
       }
 
       val client1 = createClient

--- a/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
@@ -250,8 +250,8 @@ class BspConnectionSpec(
 
             import BuildTarget.compile._
             bspState.client0
-              .requestAndForget(
-                BuildTarget.compile.method,
+              .request(
+                BuildTarget.compile,
                 bsp.CompileParams(List(target), None, None)
               )
               .flatMap { _ =>

--- a/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
@@ -66,7 +66,7 @@ class BspConnectionSpec(
       // A pool of 20 threads can only support 6 clients concurrently (more will make it fail)
       val firstBatchOfClients = List(client1, client2, client3, client4, client5, client6)
       TestUtil.await(FiniteDuration(5, "s"), poolFor6Clients) {
-        Task.gatherUnordered(firstBatchOfClients).map(_ => ())
+        Task.parSequenceUnordered(firstBatchOfClients).map(_ => ())
       }
 
       val client7 = createClient
@@ -79,7 +79,7 @@ class BspConnectionSpec(
       // If we can connect six more clients, it means resources were correctly cleaned up
       val secondBatchOfClients = List(client7, client8, client9, client10, client11, client12)
       TestUtil.await(FiniteDuration(5, "s"), poolFor6Clients) {
-        Task.gatherUnordered(secondBatchOfClients).map(_ => ())
+        Task.parSequenceUnordered(secondBatchOfClients).map(_ => ())
       }
     }
   }

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -285,7 +285,7 @@ class BspMetalsClientSpec(
 
       val allClients = Random.shuffle(List(client1, client2, metalsClient))
       TestUtil.await(FiniteDuration(20, "s"), ExecutionContext.ioScheduler) {
-        Task.gatherUnordered(allClients).map(_ => ())
+        Task.parSequenceUnordered(allClients).map(_ => ())
       }
 
       assert(configDir.resolve(WorkspaceSettings.settingsFileName).exists)

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -14,9 +14,6 @@ import bloop.bsp.BloopBspDefinitions.BloopExtraBuildParams
 
 import java.nio.file.{Files, Paths}
 
-import io.circe.JsonObject
-import io.circe.Json
-
 import monix.execution.Scheduler
 import monix.execution.ExecutionModel
 import monix.eval.Task

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -20,8 +20,8 @@ import io.circe.Json
 import bloop.testing.DiffAssertions.TestFailedException
 import bloop.data.SourcesGlobs
 
-object TcpBspProtocolSpec extends BspProtocolSpec(BspProtocol.Tcp)
-object LocalBspProtocolSpec extends BspProtocolSpec(BspProtocol.Local)
+ object TcpBspProtocolSpec extends BspProtocolSpec(BspProtocol.Tcp)
+ object LocalBspProtocolSpec extends BspProtocolSpec(BspProtocol.Local)
 
 class BspProtocolSpec(
     override val protocol: BspProtocol

--- a/frontend/src/test/scala/bloop/bsp/BspSbtClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspSbtClientSpec.scala
@@ -328,7 +328,7 @@ class BspSbtClientSpec(
     )
 
     val duration = new FiniteDuration(20, TimeUnit.SECONDS)
-    val allCompiledStatesTask = Task.gatherUnordered(random.shuffle(allCompilationTasks))
+    val allCompiledStatesTask = Task.parSequenceUnordered(random.shuffle(allCompilationTasks))
     val compiledStates =
       TestUtil.await(duration, ExecutionContext.ioScheduler, Some(logger))(allCompiledStatesTask)
 

--- a/frontend/src/test/scala/bloop/dap/DebugAdapterProxy.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugAdapterProxy.scala
@@ -14,7 +14,7 @@ import monix.reactive.{Observable, Observer}
 
 import scala.collection.mutable
 import scala.concurrent.{Future, Promise}
-import scala.meta.jsonrpc.{BaseProtocolMessage, MessageWriter}
+import jsonrpc4s._
 import monix.reactive.MulticastStrategy
 import bloop.engine.ExecutionContext
 import com.microsoft.java.debug.core.protocol.Events.DebugEvent
@@ -116,8 +116,9 @@ private[dap] final class DebugAdapterProxy(
 
 private[dap] object DebugAdapterProxy {
   def apply(socket: Socket): DebugAdapterProxy = {
-    val in = BaseProtocolMessage
-      .fromInputStream(socket.getInputStream, null)
+    val in = LowLevelMessage
+      .fromInputStream(socket.getInputStream(), null)
+      .map(msg => LowLevelMessage.toMsg(msg))
       .liftByOperator(Parser)
 
     val out = new Writer(BloopLanguageClient.fromOutputStream(socket.getOutputStream, null))
@@ -125,13 +126,13 @@ private[dap] object DebugAdapterProxy {
     new DebugAdapterProxy(in, out)
   }
 
-  private object Parser extends Operator[BaseProtocolMessage, Messages.ProtocolMessage] {
+  private object Parser extends Operator[Message, Messages.ProtocolMessage] {
     override def apply(
         upstream: Subscriber[Messages.ProtocolMessage]
-    ): Subscriber[BaseProtocolMessage] =
-      new Subscriber[BaseProtocolMessage] {
-        override def onNext(elem: BaseProtocolMessage): Future[Ack] = {
-          val content = new String(elem.content)
+    ): Subscriber[Message] =
+      new Subscriber[Message] {
+        override def onNext(elem: Message): Future[Ack] = {
+          val content = new String(elem.jsonrpc)
           val messageKind = JsonUtils.fromJson(content, classOf[ProtocolMessage]).`type`
           val targetType = messageKind match {
             case "request" => classOf[Messages.Request]
@@ -157,8 +158,7 @@ private[dap] object DebugAdapterProxy {
       extends Observer[Messages.ProtocolMessage] {
     override def onNext(elem: ProtocolMessage): Future[Ack] = {
       val bytes = JsonUtils.toJson(elem).getBytes
-      val message = BaseProtocolMessage.fromBytes(bytes)
-      val serialized = MessageWriter.write(message)
+      val serialized = ByteBuffer.wrap(bytes);
       underlying.onNext(serialized)
     }
     override def onError(ex: Throwable): Unit = underlying.onError(ex)

--- a/frontend/src/test/scala/bloop/dap/DebugAdapterProxy.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugAdapterProxy.scala
@@ -8,7 +8,7 @@ import com.microsoft.java.debug.core.protocol.Messages.ProtocolMessage
 import com.microsoft.java.debug.core.protocol.{JsonUtils, Messages}
 import monix.eval.Task
 import monix.execution.{Ack, Scheduler}
-import monix.reactive.observables.ObservableLike.Operator
+import monix.reactive.Observable.Operator
 import monix.reactive.observers.Subscriber
 import monix.reactive.{Observable, Observer}
 

--- a/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
@@ -620,7 +620,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
           RunMode.Debug
         )
 
-        remoteProcess.runAsync(defaultScheduler)
+        remoteProcess.executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(defaultScheduler)
 
         val attachRemoteProcessRunner =
           BloopDebuggeeRunner.forAttachRemote(
@@ -726,7 +726,8 @@ object DebugServerSpec extends DebugBspBaseSuite {
     val runner = new DebuggeeRunner {
       def name: String = "MockRunner"
       def run(listener: DebuggeeListener): CancelableFuture[Unit] = {
-        DapCancellableFuture.runAsync(task.map(_ => ()), defaultScheduler)
+        DapCancellableFuture
+          .runAsync(task.map(_ => ()), defaultScheduler)
       }
 
       def classFilesMappedTo(
@@ -756,7 +757,10 @@ object DebugServerSpec extends DebugBspBaseSuite {
       autoCloseSession = true,
       gracePeriod
     )(defaultScheduler)
-    Task.fromFuture(server.start()).runAsync(defaultScheduler)
+    Task
+      .fromFuture(server.start())
+      .executeWithOptions(_.disableAutoCancelableRunLoops)
+      .runAsync(defaultScheduler)
 
     val testServer = new TestServer(server)
     val test = Task(f(testServer))

--- a/frontend/src/test/scala/bloop/io/ClasspathHasherSpec.scala
+++ b/frontend/src/test/scala/bloop/io/ClasspathHasherSpec.scala
@@ -36,10 +36,13 @@ object ClasspathHasherSpec extends bloop.testing.BaseSuite {
       ClasspathHasher.hash(jars, 2, cancelPromise, ioScheduler, logger, tracer, System.out)
     val competingHashClasspathTask =
       ClasspathHasher.hash(jars, 2, cancelPromise2, ioScheduler, logger, tracer, System.out)
-    val running = hashClasspathTask.runAsync(ioScheduler)
+    val running =
+      hashClasspathTask.executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(ioScheduler)
 
     Thread.sleep(10)
-    val running2 = competingHashClasspathTask.runAsync(ioScheduler)
+    val running2 = competingHashClasspathTask
+      .executeWithOptions(_.disableAutoCancelableRunLoops)
+      .runAsync(ioScheduler)
 
     Thread.sleep(5)
     running.cancel()

--- a/frontend/src/test/scala/bloop/io/SourceHasherSpec.scala
+++ b/frontend/src/test/scala/bloop/io/SourceHasherSpec.scala
@@ -40,7 +40,8 @@ object SourceHasherSpec extends bloop.testing.BaseSuite {
 
       val sourceHashesTask =
         SourceHasher.findAndHashSourcesInProject(projectA, 2, cancelPromise, ioScheduler)
-      val running = sourceHashesTask.runAsync(ioScheduler)
+      val running =
+        sourceHashesTask.executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(ioScheduler)
 
       Thread.sleep(2)
       running.cancel()
@@ -51,7 +52,8 @@ object SourceHasherSpec extends bloop.testing.BaseSuite {
 
       val sourceHashesTask2 =
         SourceHasher.findAndHashSourcesInProject(projectA, 2, cancelPromise2, ioScheduler)
-      val running2 = sourceHashesTask2.runAsync(ioScheduler)
+      val running2 =
+        sourceHashesTask2.executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(ioScheduler)
       val uncancelledResult = Await.result(running2, FiniteDuration(20, "s"))
       assert(uncancelledResult.isRight)
       assert(uncancelledResult.forall(_.nonEmpty))

--- a/frontend/src/test/scala/bloop/nailgun/NailgunTestUtils.scala
+++ b/frontend/src/test/scala/bloop/nailgun/NailgunTestUtils.scala
@@ -14,7 +14,7 @@ import bloop.util.{TestUtil, CrossPlatform}
 import com.martiansoftware.nailgun.{BloopThreadLocalInputStream, NGServer, ThreadLocalPrintStream}
 
 import monix.eval.Task
-import monix.execution.misc.NonFatal
+import scala.util.control.NonFatal
 import monix.execution.Scheduler
 
 import org.apache.commons.io.IOUtils
@@ -72,7 +72,6 @@ trait NailgunTestUtils {
       // Trick nailgun into thinking these are the real streams
       import java.net.InetAddress
       val addr = InetAddress.getLoopbackAddress
-      import monix.execution.misc.NonFatal
       try {
         val server = Server.launchServer(localIn, localOut, localErr, addr, TEST_PORT, log)
         serverIsStarted.success(())

--- a/frontend/src/test/scala/bloop/nailgun/NailgunTestUtils.scala
+++ b/frontend/src/test/scala/bloop/nailgun/NailgunTestUtils.scala
@@ -144,7 +144,7 @@ trait NailgunTestUtils {
       op: (RecordingLogger, Client) => T
   ): T = {
     // These tests can be flaky on Windows, so if they fail we restart them up to 3 times
-    val f = withServerTask(log, config, noExit)(op).runAsync(nailgunPool)
+    val f = withServerTask(log, config, noExit)(op).executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(nailgunPool)
     // Note we cannot use restart because our task uses promises that cannot be completed twice
     try Await.result(f, FiniteDuration(35, TimeUnit.SECONDS))
     catch {

--- a/frontend/src/test/scala/bloop/testing/BaseSuite.scala
+++ b/frontend/src/test/scala/bloop/testing/BaseSuite.scala
@@ -30,7 +30,7 @@ import utest.ufansi.Color
 
 import monix.eval.Task
 import bloop.io.Paths
-import monix.execution.misc.NonFatal
+import scala.util.control.NonFatal
 import bloop.logging.RecordingLogger
 import bloop.logging.BspServerLogger
 

--- a/frontend/src/test/scala/bloop/testing/BaseSuite.scala
+++ b/frontend/src/test/scala/bloop/testing/BaseSuite.scala
@@ -571,7 +571,12 @@ abstract class BaseSuite extends TestSuite with BloopHelpers {
       run: => Unit
   ): Unit = {
     test(name) {
-      Await.result(Task { run }.runAsync(ExecutionContext.scheduler), maxDuration)
+      Await.result(
+        Task { run }
+          .executeWithOptions(_.disableAutoCancelableRunLoops)
+          .runAsync(ExecutionContext.scheduler),
+        maxDuration
+      )
     }
   }
 

--- a/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
+++ b/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
@@ -97,7 +97,7 @@ trait BloopHelpers {
         }
       }
 
-      val loaders = all.grouped(5).map(group => Task.gatherUnordered(group)).toList
+      val loaders = all.grouped(5).map(group => Task.parSequenceUnordered(group)).toList
       Task.sequence(loaders).executeOn(ExecutionContext.ioScheduler).map { projects =>
         val state = new TestState(TestUtil.loadTestProject(configDir, logger, false))
         TestBuild(state, projects.flatten)
@@ -309,7 +309,7 @@ trait BloopHelpers {
       }
 
       TestUtil.await(scala.concurrent.duration.FiniteDuration(5, "s")) {
-        Task.gatherUnordered(newSuccessfulTasks).map {
+        Task.parSequenceUnordered(newSuccessfulTasks).map {
           case newSuccessful =>
             val newResults = state.results.copy(successful = newSuccessful.toMap)
             new TestState(state.copy(results = newResults))

--- a/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
+++ b/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
@@ -115,7 +115,6 @@ trait BloopHelpers {
       newBaseDir: String,
       logger: Logger
   ): TestProject = {
-    import _root_.io.circe.parser
     val bytes = Files.readAllBytes(configFile)
     val contents = new String(bytes, StandardCharsets.UTF_8)
     val newContents = contents.replace(previousBaseDir, newBaseDir)

--- a/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
+++ b/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
@@ -189,7 +189,9 @@ trait BloopHelpers {
         }
       }
 
-      interpretedTask.runAsync(ExecutionContext.scheduler)
+      interpretedTask
+        .executeWithOptions(_.disableAutoCancelableRunLoops)
+        .runAsync(ExecutionContext.scheduler)
     }
 
     def cascadeCompile(projects: TestProject*): TestState = {
@@ -232,7 +234,9 @@ trait BloopHelpers {
         }
       }
 
-      interpretedTask.runAsync(userScheduler.getOrElse(ExecutionContext.scheduler))
+      interpretedTask
+        .executeWithOptions(_.disableAutoCancelableRunLoops)
+        .runAsync(userScheduler.getOrElse(ExecutionContext.scheduler))
     }
 
     def getProjectFor(project: TestProject): Project =

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -34,7 +34,7 @@ import sbt.internal.inc.bloop.ZincInternals
 
 import scala.concurrent.duration.{Duration, FiniteDuration, TimeUnit}
 import scala.concurrent.{Await, ExecutionException}
-import scala.meta.jsonrpc.Services
+import jsonrpc4s.Services
 import scala.tools.nsc.Properties
 import scala.util.control.NonFatal
 import bloop.data.WorkspaceSettings

--- a/launcher/src/test/scala/bloop/launcher/LauncherBaseSuite.scala
+++ b/launcher/src/test/scala/bloop/launcher/LauncherBaseSuite.scala
@@ -200,7 +200,7 @@ abstract class LauncherBaseSuite(
     )
     val run = new LauncherRun(launcher, baos)
 
-    import monix.execution.misc.NonFatal
+    import scala.util.control.NonFatal
     try launcherLogic(run)
     catch {
       case NonFatal(t) =>

--- a/launcher/src/test/scala/bloop/launcher/LauncherBaseSuite.scala
+++ b/launcher/src/test/scala/bloop/launcher/LauncherBaseSuite.scala
@@ -239,7 +239,8 @@ abstract class LauncherBaseSuite(
     val messages = BaseProtocolMessage.fromInputStream(in, logger)
     val services = TestUtil.createTestServices(false, logger)
     val lsServer = new BloopLanguageServer(messages, lsClient, services, bspScheduler, logger)
-    val runningClientServer = lsServer.startTask.runAsync(bspScheduler)
+    val runningClientServer =
+      lsServer.startTask.executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(bspScheduler)
 
     val initializeServer = endpoints.Build.initialize.request(
       bsp.InitializeBuildParams(
@@ -311,7 +312,8 @@ abstract class LauncherBaseSuite(
       }
     }
 
-    val runServer = startServer.runAsync(bspScheduler)
+    val runServer =
+      startServer.executeWithOptions(_.disableAutoCancelableRunLoops).runAsync(bspScheduler)
 
     val logger = new RecordingLogger()
     val connectToServer = Task.fromFuture(startedServer.future).flatMap { _ =>

--- a/launcher/src/test/scala/bloop/launcher/LauncherSpec.scala
+++ b/launcher/src/test/scala/bloop/launcher/LauncherSpec.scala
@@ -14,7 +14,6 @@ import sbt.internal.util.MessageOnlyException
 
 import scala.concurrent.{Await, Promise}
 import scala.concurrent.duration.FiniteDuration
-import scala.meta.jsonrpc._
 import scala.util.control.NonFatal
 import bloop.bloopgun.ServerConfig
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   // Keep in sync in BloopComponentCompiler
   val zincVersion = "1.3.0-M4+46-edbe573e"
 
-  val bspVersion = "2.0.0-M13"
+  val bspVersion = "2.0.0-M15"
   val javaDebugVersion = "0.21.0+1-7f1080f1"
 
   val scalazVersion = "7.2.20"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,7 +37,7 @@ object Dependencies {
   val groovyVersion = "2.5.4"
   val gradleAndroidPluginVersion = "4.2.0"
   val ipcsocketVersion = "1.0.1"
-  val monixVersion = "3.3.0"
+  val monixVersion = "3.2.0"
   val circeVersion = "0.9.3"
   val jsoniterVersion = "2.4.0"
   val circeVersion213 = "0.12.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,7 +37,7 @@ object Dependencies {
   val groovyVersion = "2.5.4"
   val gradleAndroidPluginVersion = "4.2.0"
   val ipcsocketVersion = "1.0.1"
-  val monixVersion = "2.3.3"
+  val monixVersion = "3.3.0"
   val circeVersion = "0.9.3"
   val jsoniterVersion = "2.4.0"
   val circeVersion213 = "0.12.2"


### PR DESCRIPTION
I accidentally closed https://github.com/scalacenter/bloop/pull/1537 :(
The aim of this PR is to close #1510

I managed to bump the Monix version to 3.3.0, but then I encountered various problems:
- some tests were failing. After investigation, I found that this is because of https://github.com/monix/monix/pull/724. Using find & replace I added an option that restores the previous behavior. For that moment, such a quick & dirty solution was ok, but before the merge, a better one should be found and applied.
- after that, some other tests were failing, but this time it was due to the incompatibility of Monix versions. JSONRPC framework from [scalameta lsp4s](https://github.com/scalameta/lsp4s) which was used in the Bloop depended on 2.x series so I have to bump [bsp](https://github.com/build-server-protocol ) version to the newest M15. This involves further changes, mentioned earlier JSON RPC framework was replaced by [one used in Bloop](https://github.com/jvican/jsonrpc4s)
- ~~now, there is a deadlock in `bloop.bsp.TcpBspConnectionSpec` which causes `Await's` to fail, but moreover, tests also hang after this failure. I checked and this deadlock also was happening before I bumped the BSP version so it's very probable that it's connected with Monix.~~ It's gone 🥳

Unfortunately, I failed to resolve the last problem and I would appreciate any help with it. 

Test Summary (13 August):
Failed: Total 322, Failed 31, Errors 0, Passed 291
Failed tests:
- [ ] bloop.bsp.TcpBspConnectionSpec
- [ ] bloop.bsp.LocalBspProtocolSpec
- [ ] bloop.bsp.TcpBspCompileSpec
- These three above works but the assertion which is checking no diff on strings is failling :(
- [ ] bloop.dap.DebugProtocolSpec
- [ ] bloop.CompileSpec
- [ ] bloop.FileWatchingSpec
- [ ] bloop.dap.DebugServerSpec
- [ ] bloop.bsp.LocalBspConnectionSpec
- [ ] bloop.JsTestSpec
- [ ] bloop.bsp.LocalBspCompileSpec
- [ ] bloop.JvmTestSpec
- [x] bloop.io.SourceHasherSpec
- [ ] bloop.DeduplicationSpec