### PR TITLE
Download only external dependencies in multi module Maven projects

### DIFF
--- a/integrations/maven-bloop/src/main/java/bloop/integrations/maven/BloopMojo.java
+++ b/integrations/maven-bloop/src/main/java/bloop/integrations/maven/BloopMojo.java
@@ -4,23 +4,41 @@ import bloop.config.Config;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.maven.plugin.MavenPluginManager;
 import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.project.MavenProject;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.*;
 import scala.util.Either;
 import scala_maven.AppLauncher;
 import scala_maven.ExtendedScalaContinuousCompileMojo;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.repository.RemoteRepository;
 
 import java.io.File;
 import java.util.List;
 
-@Mojo(name = "bloopInstall", threadSafe = true, requiresProject = true, defaultPhase = LifecyclePhase.GENERATE_RESOURCES, requiresDependencyResolution = ResolutionScope.TEST)
+@Mojo(
+    name = "bloopInstall", 
+    threadSafe = true, 
+    requiresProject = true, 
+    defaultPhase = LifecyclePhase.GENERATE_RESOURCES,
+    requiresDependencyCollection = ResolutionScope.TEST
+)
 public class BloopMojo extends ExtendedScalaContinuousCompileMojo {
     @Parameter(defaultValue = "${mojoExecution}", readonly = true, required = true)
     private MojoExecution mojoExecution;
 
     @Component
+    private RepositorySystem repoSystem;
+
+    @Component
     private MavenPluginManager mavenPluginManager;
+
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true)
+    private List<RemoteRepository> remoteRepos;
+
+    @Parameter(property = "reactorProjects", required = true, readonly = true)
+    private List<MavenProject> reactorProjects;
 
     @Parameter(property = "bloop.configDirectory", defaultValue = "${session.executionRootDirectory}/.bloop")
     private File bloopConfigDir;
@@ -94,6 +112,10 @@ public class BloopMojo extends ExtendedScalaContinuousCompileMojo {
         return downloadSources;
     }
 
+    public List<MavenProject> getReactorProjects(){
+        return reactorProjects;
+    }
+
     private Config.CompileOrder getCompileOrder() {
         if ( this.moduleType == ModuleType.JAVA ) {
             return Config.JavaThenScala$.MODULE$;
@@ -116,6 +138,13 @@ public class BloopMojo extends ExtendedScalaContinuousCompileMojo {
                                        classpathOptionsExtra,
                                        classpathOptionsAutoBoot,
                                        classpathOptionsFilterLibrary);
+    }
+
+    public RepositorySystem getRepoSystem() {
+        return repoSystem;
+    }
+    public List<RemoteRepository> getRemoteRepositories() {
+        return remoteRepos;
     }
 
     public String getScalaArtifactID() {

--- a/integrations/maven-bloop/src/test/resources/multi_dependency/module1/pom.xml
+++ b/integrations/maven-bloop/src/test/resources/multi_dependency/module1/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>module1</artifactId>
+  <version>0.1</version>
+  <name>module1</name>
+  <description>A minimal Scala project using the Maven build tool.</description>
+  <parent>
+      <groupId>com.example</groupId>
+      <artifactId>multi_dependency</artifactId>
+      <version>0.1</version>
+  </parent> 
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <encoding>UTF-8</encoding>
+    <scala.version>2.13.6</scala.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>2.13.6</version>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>org.scalameta</groupId>
+      <artifactId>munit_2.13</artifactId>
+      <version>0.7.26</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/integrations/maven-bloop/src/test/resources/multi_dependency/module2/pom.xml
+++ b/integrations/maven-bloop/src/test/resources/multi_dependency/module2/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>module2</artifactId>
+  <version>0.1</version>
+  <name>module2</name>
+  <description>A minimal Scala project using the Maven build tool.</description>
+  <parent>
+      <groupId>com.example</groupId>
+      <artifactId>multi_dependency</artifactId>
+      <version>0.1</version>
+  </parent> 
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <encoding>UTF-8</encoding>
+    <scala.version>2.13.6</scala.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>2.13.6</version>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>org.scalameta</groupId>
+      <artifactId>munit_2.13</artifactId>
+      <version>0.7.26</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>module1</artifactId>
+      <version>0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.lihaoyi</groupId>
+      <artifactId>scalatags_2.13</artifactId>
+      <version>0.8.2</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/integrations/maven-bloop/src/test/resources/multi_dependency/pom.xml
+++ b/integrations/maven-bloop/src/test/resources/multi_dependency/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>multi_dependency</artifactId>
+  <version>0.1</version>
+  <packaging>pom</packaging>
+  <name>multi_dependency</name>
+  <description>A minimal Scala project using the Maven build tool.</description>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <encoding>UTF-8</encoding>
+  </properties>
+
+    <modules>
+        <module>module1</module>       
+        <module>module2</module>      
+    </modules>
+
+</project>

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -521,7 +521,6 @@ object BuildImplementation {
         Dependencies.mavenCore,
         Dependencies.mavenPluginApi,
         Dependencies.mavenPluginAnnotations,
-        Dependencies.mavenInvoker,
         // We add an explicit dependency to the maven-plugin artifact in the dependent plugin
         Dependencies.mavenScalaPlugin
           .withExplicitArtifacts(Vector(Artifact("scala-maven-plugin", "maven-plugin", "jar")))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -92,7 +92,6 @@ object Dependencies {
   import sbt.Provided
   val mavenCore = "org.apache.maven" % "maven-core" % mavenApiVersion % Provided
   val mavenPluginApi = "org.apache.maven" % "maven-plugin-api" % mavenApiVersion
-  val mavenInvoker = "org.apache.maven.shared" % "maven-invoker" % "3.0.1"
   val mavenPluginAnnotations =
     "org.apache.maven.plugin-tools" % "maven-plugin-annotations" % mavenAnnotationsVersion % Provided
   val mavenScalaPlugin = "net.alchim31.maven" % "scala-maven-plugin" % mavenScalaPluginVersion


### PR DESCRIPTION
Previously, we the Bloop Maven plugin would try to download all jars including ones that come from uncompiled subprojects. Now, we will only download external dependencies.

This was done via several steps:
- `requiresDependencyResolution` was replaced by `requiresDependencyCollection` which doesn't try to resolve the jar, but resolves information about all the tranisitive dependencies using pom
- to download the jars we use aether component `RepositorySystem`
- we will resolve both file and source files, if they exist we will write the correct config for Module, but also update file reference in the Artifact, which is null without resolution (caused by the first point). Thanks to the last step we will be able to get the correct classpath of the project

Additionally, since we no longer invoke maven tasks the plugin should be considerably faster.

Fixes https://github.com/scalacenter/bloop/issues/1022