### PR TITLE
Set correct Scala version when multiple scala libraries are on Gradle classpath

### DIFF
--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -943,9 +943,8 @@ class BloopConverter(parameters: BloopParameters, info: String => Unit) {
     val artifactIds = artifacts
       .map(_.getId)
       .collect({ case mcai: ModuleComponentArtifactIdentifier => mcai })
-    val stdLibIds = stdLibNames.flatMap(stdLibName =>
-      artifactIds.find(_.getComponentIdentifier.getModule == stdLibName)
-    )
+    val stdLibIds =
+      artifactIds.filter(f => stdLibNames.contains(f.getComponentIdentifier.getModule))
     stdLibIds.headOption match {
       case Some(stdLibArtifact) =>
         val scalaCompileTaskName = sourceSet.getCompileTaskName("scala")


### PR DESCRIPTION
The plugin wasn't respecting the order of the scala libraries on the classpath so Scala 3 version never got taken

When Gradle 7.3 is out I'll uncomment the tests but they work locally with the snapshot distribution