### PR TITLE
Accept connections on domain socket / named pipe too

### DIFF
--- a/.github/nailgun-publish-local.sh
+++ b/.github/nailgun-publish-local.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+cd nailgun
+sbt nailgun-server/publishLocal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           key: ${{ hashFiles('project/GradleIntegration.scala') }}
       - name: Tests
         run: |
+          .github/nailgun-publish-local.sh &&\
           ./bin/sbt-ci.sh \
               "mavenBloop/publishM2" \
               "mavenBloop/test" \
@@ -90,6 +91,7 @@ jobs:
         shell: bash
       - name: Compile and test main projects
         run: |
+          .github/nailgun-publish-local.sh &&\
           ./bin/sbt-ci.sh \
               "frontend/test:compile" \
               "sbtBloop013/compile" \
@@ -154,6 +156,7 @@ jobs:
           java-version: ${{ matrix.jdk }}
       - name: Publish GraalVM Native artifacts
         run: |
+          .github/nailgun-publish-local.sh
           echo $JAVA_HOME
           which gu
           gu install native-image
@@ -208,7 +211,7 @@ jobs:
         # cmd.
         # Keep the sbt version in sync with `sbt-ci-release.bat`.
         run: |
-          sbt -sbt-version 1.3.3 version
+          .github/nailgun-publish-local.sh && sbt -sbt-version 1.3.3 version
         shell: bash
       - name: Publish GraalVM Native artifacts
         run: >-

--- a/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
@@ -45,6 +45,10 @@ import java.io.BufferedReader
 import java.io.IOException
 import snailgun.Client
 import libdaemonjvm.LockFiles
+import scala.util.Properties
+import libdaemonjvm.internal.SocketMaker
+import libdaemonjvm.internal.SocketHandler
+import java.io.File
 
 /**
  * The main library entrypoint for bloopgun, the Bloop binary CLI.
@@ -129,9 +133,27 @@ class BloopgunCli(
       val daemonDirOpt = builder
         .opt[String]("daemon-dir")
         .action((dir, params) => {
+          val pipeNameOpt = params.serverConfig.listenOn match {
+            case Left(_) => None
+            case Right((_, opt)) => opt
+          }
           params.copy(
             serverConfig = params.serverConfig.copy(
-              listenOn = Right(Some(Paths.get(dir)))
+              listenOn = Right((Some(Paths.get(dir)), pipeNameOpt))
+            )
+          )
+        })
+        .text("Specify the daemon directory of the target Bloop server")
+      val pipeNameOpt = builder
+        .opt[String]("pipe-name")
+        .action((pipeName, params) => {
+          val daemonDirOpt = params.serverConfig.listenOn match {
+            case Left(_) => None
+            case Right((opt, _)) => opt
+          }
+          params.copy(
+            serverConfig = params.serverConfig.copy(
+              listenOn = Right((daemonDirOpt, Some(pipeName)))
             )
           )
         })
@@ -169,8 +191,13 @@ class BloopgunCli(
             .action {
               case (arg, params) =>
                 if (arg.startsWith("daemon:")) {
-                  val path = Paths.get(arg.stripPrefix("daemon:"))
-                  params.copy(serverConfig = params.serverConfig.copy(listenOn = Right(Some(path))))
+                  val arg0 = arg.stripPrefix("daemon:")
+                  val (dir, pipeNameOpt) = arg0.split(File.pathSeparator, 2) match {
+                    case Array(dir) => (dir, None)
+                    case Array(dir, pipeName) => (dir, Some(pipeName))
+                  }
+                  val listenOn = (Some(Paths.get(dir)), pipeNameOpt)
+                  params.copy(serverConfig = params.serverConfig.copy(listenOn = Right(listenOn)))
                 } else {
                   val port = arg.toInt // FIXME Catch exceptions?
                   val hostOpt = params.serverConfig.listenOn match {
@@ -218,6 +245,7 @@ class BloopgunCli(
           nailgunServerOpt,
           nailgunPortOpt,
           daemonDirOpt,
+          pipeNameOpt,
           nailgunHelpOpt,
           nailgunShowVersionOpt,
           nailgunVerboseOpt,
@@ -332,7 +360,7 @@ class BloopgunCli(
 
     try executeCmd(client)
     catch {
-      case _: ConnectException | _: libdaemonjvm.errors.ConnectExceptionLike =>
+      case _: ConnectException | _: libdaemonjvm.errors.ConnectExceptionLike | _: libdaemonjvm.errors.SocketExceptionLike =>
         noServer()
       case e: IOException if e.getCause.isInstanceOf[org.scalasbt.ipcsocket.NativeErrorException] =>
         noServer()
@@ -464,9 +492,11 @@ class BloopgunCli(
           case Left((Some(host), None)) =>
             logger.warn(Feedback.unexpectedServerArgsSyntax(host))
             Nil
-          case Right(Some(path)) =>
-            List(s"daemon:$path")
-          case Right(None) =>
+          case Right((pathOpt, pipeOpt)) =>
+            val path = pathOpt.getOrElse(Defaults.daemonDir)
+            val pipe = pipeOpt.getOrElse(Defaults.daemonPipeName)
+            List(s"daemon:$path${File.pathSeparator}$pipe")
+          case Right(_) =>
             Nil
         }
       }

--- a/bloopgun/src/main/scala/bloop/bloopgun/BloopgunParams.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/BloopgunParams.scala
@@ -1,9 +1,9 @@
 package bloop.bloopgun
 
+import java.nio.file.Path
+
 final case class BloopgunParams(
     bloopVersion: String,
-    nailgunServer: String = Defaults.Host,
-    nailgunPort: Int = Defaults.Port,
     nailgunHelp: Boolean = false,
     verbose: Boolean = false,
     nailgunShowVersion: Boolean = false,

--- a/bloopgun/src/main/scala/bloop/bloopgun/Defaults.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/Defaults.scala
@@ -1,6 +1,8 @@
 package bloop.bloopgun
 
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
+import scala.util.Properties
+import dev.dirs.ProjectDirectories
 
 object Defaults {
   val Version = "0.9.3"
@@ -15,5 +17,17 @@ object Defaults {
   object Time {
     val DefaultHeartbeatIntervalMillis = 500.toLong
     val SendThreadWaitTerminationMillis = 5000.toLong
+  }
+
+  // also more or less in bloop.io.Paths…
+  private val projectDirectories = ProjectDirectories.from("", "", "bloop")
+  private final val bloopCacheDir: Path = Paths.get(projectDirectories.cacheDir)
+  private final val bloopDataDir: Path = Paths.get(projectDirectories.dataDir)
+
+  final val daemonDir: Path = {
+    val baseDir =
+      if (Properties.isMac) bloopCacheDir
+      else bloopDataDir
+    baseDir.resolve("daemon")
   }
 }

--- a/bloopgun/src/main/scala/bloop/bloopgun/Defaults.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/Defaults.scala
@@ -30,4 +30,5 @@ object Defaults {
       else bloopDataDir
     baseDir.resolve("daemon")
   }
+  final val daemonPipeName: String = "scala_bloop_server"
 }

--- a/bloopgun/src/main/scala/bloop/bloopgun/ServerConfig.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/ServerConfig.scala
@@ -3,7 +3,7 @@ import java.nio.file.Path
 import libdaemonjvm.LockFiles
 
 final case class ServerConfig(
-    listenOn: Either[(Option[String], Option[Int]), Option[Path]] = Right(None),
+    listenOn: Either[(Option[String], Option[Int]), (Option[Path], Option[String])] = Right((None, None)),
     serverArgs: List[String] = Nil,
     serverLocation: Option[Path] = None,
     startTimeout: Option[Int] = None,
@@ -15,9 +15,10 @@ final case class ServerConfig(
         val host = hostOpt.getOrElse(Defaults.Host)
         val port = portOpt.getOrElse(Defaults.Port)
         Left((host, port))
-      case Right(daemonDirOpt) =>
+      case Right((daemonDirOpt, pipeNameOpt)) =>
         val daemonDir = daemonDirOpt.getOrElse(Defaults.daemonDir)
-        Right(LockFiles.under(daemonDir, "scala_bloop_server"))
+        val pipeName = pipeNameOpt.getOrElse(Defaults.daemonPipeName)
+        Right(LockFiles.under(daemonDir, pipeName))
     }
   override def toString(): String = listenOnWithDefaults match {
     case Left((host, port)) => s"$host:$port"

--- a/bloopgun/src/main/scala/bloop/bloopgun/ServerConfig.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/ServerConfig.scala
@@ -1,15 +1,26 @@
 package bloop.bloopgun
 import java.nio.file.Path
+import libdaemonjvm.LockFiles
 
 final case class ServerConfig(
-    host: Option[String] = None,
-    port: Option[Int] = None,
+    listenOn: Either[(Option[String], Option[Int]), Option[Path]] = Right(None),
     serverArgs: List[String] = Nil,
     serverLocation: Option[Path] = None,
     startTimeout: Option[Int] = None,
     fireAndForget: Boolean = false
 ) {
-  def userOrDefaultHost: String = host.getOrElse(Defaults.Host)
-  def userOrDefaultPort: Int = port.getOrElse(Defaults.Port)
-  override def toString(): String = userOrDefaultHost + ":" + userOrDefaultPort
+  def listenOnWithDefaults: Either[(String, Int), LockFiles] =
+    listenOn match {
+      case Left((hostOpt, portOpt)) =>
+        val host = hostOpt.getOrElse(Defaults.Host)
+        val port = portOpt.getOrElse(Defaults.Port)
+        Left((host, port))
+      case Right(daemonDirOpt) =>
+        val daemonDir = daemonDirOpt.getOrElse(Defaults.daemonDir)
+        Right(LockFiles.under(daemonDir, "scala_bloop_server"))
+    }
+  override def toString(): String = listenOnWithDefaults match {
+    case Left((host, port)) => s"$host:$port"
+    case Right(daemonDir) => daemonDir.toString
+  }
 }

--- a/bloopgun/src/main/scala/bloop/bloopgun/core/Shell.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/core/Shell.scala
@@ -67,9 +67,6 @@ final class Shell(runWithInterpreter: Boolean, detectPython: Boolean) {
   ): StatusCommand = {
     import scala.collection.JavaConverters._
     val builder = new ProcessBuilder()
-    val newEnv = builder.environment()
-    newEnv.putAll(System.getenv())
-    addAdditionalEnvironmentVariables(newEnv)
 
     val cmd = deriveCommandForPlatform(cmd0, attachTerminal)
     val code = builder.command(cmd.asJava).directory(cwd.toFile).inheritIO().start().waitFor()
@@ -90,10 +87,6 @@ final class Shell(runWithInterpreter: Boolean, detectPython: Boolean) {
     val outBuilder = StringBuilder.newBuilder
     val cmd = deriveCommandForPlatform(cmd0, attachTerminal)
     val executor = new ProcessExecutor(cmd: _*)
-
-    val newEnv = executor.getEnvironment()
-    newEnv.putAll(System.getenv())
-    addAdditionalEnvironmentVariables(newEnv)
 
     executor
       .directory(cwd.toFile)
@@ -129,21 +122,6 @@ final class Shell(runWithInterpreter: Boolean, detectPython: Boolean) {
         val cmd = if (attachTerminal) s"(${cmd0.mkString(" ")}) </dev/tty" else cmd0.mkString(" ")
         List("sh", "-c", cmd)
       }
-    }
-  }
-
-  // Add coursier cache and ivy home system properties if set and not available in env
-  protected def addAdditionalEnvironmentVariables(env: java.util.Map[String, String]): Unit = {
-    Option(System.getProperty("coursier.cache")).foreach { cache =>
-      val coursierKey = "COURSIER_CACHE"
-      if (env.containsKey(coursierKey)) ()
-      else env.put(coursierKey, cache)
-    }
-
-    Option(System.getProperty("ivy.home")).foreach { ivyHome =>
-      val ivyHomeKey = "IVY_HOME"
-      if (env.containsKey(ivyHomeKey)) ()
-      else env.put(ivyHomeKey, ivyHome)
     }
   }
 

--- a/bloopgun/src/main/scala/bloop/bloopgun/core/Shell.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/core/Shell.scala
@@ -18,6 +18,12 @@ import org.zeroturnaround.exec.stream.ExecuteStreamHandler
 import org.zeroturnaround.exec.stream.LogOutputStream
 import snailgun.logging.Logger
 import bloop.bloopgun.ServerConfig
+import libdaemonjvm.client.Connect
+import libdaemonjvm.client.ConnectError
+import java.net.Socket
+import java.nio.channels.SocketChannel
+import java.io.InputStream
+import java.io.ByteArrayOutputStream
 
 /**
  * Defines shell utilities to run programs via system process.
@@ -176,30 +182,60 @@ final class Shell(runWithInterpreter: Boolean, detectPython: Boolean) {
       config: ServerConfig,
       logger: Logger
   ): Boolean = {
-    import java.net.Socket
-    var socket: Socket = null
     import scala.util.control.NonFatal
-    try {
-      socket = new Socket()
-      socket.setReuseAddress(true)
-      socket.setTcpNoDelay(true)
-      import java.net.InetAddress
-      import java.net.InetSocketAddress
-      logger.info("Attempting a connection to the server...")
-      socket.connect(new InetSocketAddress(config.userOrDefaultHost, config.userOrDefaultPort))
-      socket.isConnected()
-    } catch {
-      case NonFatal(t) =>
-        logger.debug(s"Connection to port $config failed with '${t.getMessage()}'")
-        false
-    } finally {
-      if (socket != null) {
+
+    config.listenOnWithDefaults match {
+      case Left((host, port)) =>
+        import java.net.Socket
+        var socket: Socket = null
         try {
-          socket.shutdownInput()
-          socket.shutdownOutput()
-          socket.close()
-        } catch { case NonFatal(_) => }
-      }
+          socket = new Socket()
+          socket.setReuseAddress(true)
+          socket.setTcpNoDelay(true)
+          import java.net.InetAddress
+          import java.net.InetSocketAddress
+          logger.info("Attempting a connection to the server...")
+          socket.connect(new InetSocketAddress(host, port))
+          socket.isConnected()
+        } catch {
+          case NonFatal(t) =>
+            logger.debug(s"Connection to port $config failed with '${t.getMessage()}'")
+            false
+        } finally {
+          if (socket != null) {
+            try {
+              socket.shutdownInput()
+              socket.shutdownOutput()
+              socket.close()
+            } catch { case NonFatal(_) => }
+          }
+        }
+      case Right(daemonFiles) =>
+        var res = Option.empty[Either[ConnectError, Either[Socket, SocketChannel]]]
+        try {
+          logger.info("Attempting a connection to the server...")
+          res = Connect.tryConnect(daemonFiles)
+          res.exists(_.isRight)
+        } catch {
+          case NonFatal(t) =>
+            logger.debug(s"Connection to $daemonFiles failed with '${t.getMessage()}'")
+            false
+        } finally {
+          res.foreach(_.foreach {
+            case Left(socket) =>
+              try {
+                socket.shutdownInput()
+                socket.shutdownOutput()
+                socket.close()
+              } catch { case NonFatal(_) => }
+            case Right(channel) =>
+              try {
+                channel.shutdownInput()
+                channel.shutdownOutput()
+                channel.close()
+              } catch { case NonFatal(_) => }
+          })
+        }
     }
   }
 

--- a/bloopgun/src/main/scala/bloop/bloopgun/util/DomainSocketClient.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/util/DomainSocketClient.scala
@@ -1,0 +1,69 @@
+package bloop.bloopgun.util
+
+import snailgun.logging.Logger
+import snailgun.logging.SnailgunLogger
+import snailgun.protocol.Defaults
+import snailgun.protocol.Protocol
+import snailgun.protocol.Streams
+
+import java.net.Socket
+import java.nio.file.Paths
+import java.nio.file.Path
+import java.io.PrintStream
+import java.io.InputStream
+import java.net.InetAddress
+import java.util.concurrent.atomic.AtomicBoolean
+import java.net.SocketException
+import snailgun.Client
+import libdaemonjvm.SocketPaths
+import libdaemonjvm.client.Connect
+import libdaemonjvm.internal.SocketHandler
+import java.io.IOException
+import java.nio.channels.Channels
+import java.io.OutputStream
+import java.nio.channels.ReadableByteChannel
+import java.nio.ByteBuffer
+
+final case class DomainSocketClient(socketPaths: SocketPaths) extends Client {
+  def run(
+      cmd: String,
+      args: Array[String],
+      cwd: Path,
+      env: Map[String, String],
+      streams: Streams,
+      logger: Logger,
+      stop: AtomicBoolean,
+      interactiveSession: Boolean
+  ): Int = {
+    val socket = SocketHandler.client(socketPaths) match {
+      case Left(socket0) => socket0
+      case Right(channel) => libdaemonjvm.Util.socketFromChannel(channel)
+    }
+    try {
+      val in = socket.getInputStream()
+      val out = socket.getOutputStream()
+      val protocol = new Protocol(streams, cwd, env, logger, stop, interactiveSession)
+      protocol.sendCommand(cmd, args, out, in)
+    } finally {
+      try {
+        if (socket.isClosed()) ()
+        else {
+          try socket.shutdownInput()
+          finally {
+            try socket.shutdownOutput()
+            finally socket.close()
+          }
+        }
+      } catch {
+        case t: IOException =>
+          logger.debug("Tracing an ignored socket exception...")
+          // logger.trace(t)
+          ()
+        case t: SocketException =>
+          logger.debug("Tracing an ignored socket exception...")
+          logger.trace(t)
+          ()
+      }
+    }
+  }
+}

--- a/bloopgun/src/main/scala/bloop/bloopgun/util/Feedback.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/util/Feedback.scala
@@ -9,7 +9,7 @@ object Feedback {
     s"""Unexpected server args syntax, got: '$obtained', expected: <port> | <host> <port>"""
 
   def serverCouldNotBeStarted(config: ServerConfig): String = {
-    s"Server could not be started at ${config.host}:${config.port}! Giving up..."
+    s"Server could not be started at $config! Giving up..."
   }
 
   def startingBloopServer(config: ServerConfig): String = {

--- a/build.sbt
+++ b/build.sbt
@@ -529,7 +529,7 @@ def shadeSbtSettingsForModule(
       "coursier.jniutils"
     ),
     libraryDependencies ++= List(
-      "io.github.alexarchambault.libdaemon" %% "libdaemon" % "0.0.2",
+      Dependencies.libdaemonjvm,
       "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.4.0"
     ),
     toShadeJars := {

--- a/build.sbt
+++ b/build.sbt
@@ -952,3 +952,16 @@ addCommandAlias(
 
 val allReleaseActions = List("releaseEarlyAllModules", "sonatypeBundleRelease")
 addCommandAlias("releaseBloop", allReleaseActions.mkString(";", ";", ""))
+
+lazy val stuff = project
+  .aggregate(
+    sockets,
+    frontend,
+    backend,
+    launcher,
+    bloopgun,
+    launcherShaded,
+    bloopShared,
+    jsonConfig212.jvm,
+    jsBridge1
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -236,6 +236,13 @@ lazy val sockets: Project = project
     sources in (Compile, doc) := Nil
   )
 
+lazy val tmpDirSettings = Def.settings(
+  javaOptions in Test += {
+    val tmpDir = (baseDirectory in ThisBuild).value / "target" / "tests-tmp"
+    s"-Dbloop.tests.tmp-dir=$tmpDir"
+  }
+)
+
 import build.BuildImplementation.jvmOptions
 // For the moment, the dependency is fixed
 lazy val frontend: Project = project
@@ -287,6 +294,7 @@ lazy val frontend: Project = project
     buildInfoKeys := bloopInfoKeys(nativeBridge04, jsBridge06, jsBridge1),
     javaOptions in run ++= jvmOptions,
     javaOptions in Test ++= jvmOptions,
+    tmpDirSettings,
     javaOptions in IntegrationTest ++= jvmOptions,
     libraryDependencies += Dependencies.graphviz % Test,
     fork in run := true,
@@ -443,7 +451,8 @@ lazy val launcher: Project = project
     parallelExecution in Test := false,
     libraryDependencies ++= List(
       Dependencies.coursierInterface
-    )
+    ),
+    tmpDirSettings
   )
 
 lazy val launcherShaded = project

--- a/frontend/src/main/scala/bloop/Server.scala
+++ b/frontend/src/main/scala/bloop/Server.scala
@@ -60,11 +60,9 @@ object Server {
       case Left(hostPort) =>
         startServer(Left(hostPort))
       case Right(lockFiles) =>
-        Lock.tryAcquire(
-          lockFiles,
-          LockProcess.default,
+        Lock.tryAcquire(lockFiles, LockProcess.default) {
           startServer(Right(lockFiles.socketPaths))
-        ) match {
+        } match {
           case Left(err) => throw new Exception(err)
           case Right(()) =>
         }

--- a/frontend/src/test/scala/bloop/DeduplicationSpec.scala
+++ b/frontend/src/test/scala/bloop/DeduplicationSpec.scala
@@ -38,7 +38,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
     if (isDeduplicated) assert(deduplicated) else assert(!deduplicated)
   }
 
-  test("three concurrent clients deduplicate compilation") {
+  def deduplicationTest(): Unit = {
     val logger = new RecordingLogger(ansiCodesSupported = false)
     val logger1 = new RecordingLogger(ansiCodesSupported = false)
     val logger2 = new RecordingLogger(ansiCodesSupported = false)
@@ -172,6 +172,11 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
          """.stripMargin
         )
       }
+    }
+  }
+  test("three concurrent clients deduplicate compilation") {
+    TestUtil.retry() {
+      deduplicationTest()
     }
   }
 

--- a/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
@@ -32,6 +32,11 @@ object DebugServerSpec extends DebugBspBaseSuite {
   private val ServerNotListening = new IllegalStateException("Server is not accepting connections")
   private val Success: ExitStatus = ExitStatus.Ok
 
+  override def test(name: String)(fun: => Any): Unit =
+    super.test(name) {
+      TestUtil.retry()(fun)
+    }
+
   test("cancelling server closes server connection") {
     startDebugServer(Task.now(Success)) { server =>
       val test = for {

--- a/frontend/src/test/scala/bloop/nailgun/NailgunTestUtils.scala
+++ b/frontend/src/test/scala/bloop/nailgun/NailgunTestUtils.scala
@@ -11,7 +11,7 @@ import bloop.testing.BaseSuite
 import bloop.logging.{DebugFilter, ProcessLogger, RecordingLogger}
 import bloop.util.{TestUtil, CrossPlatform}
 
-import com.martiansoftware.nailgun.{BloopThreadLocalInputStream, NGServer, ThreadLocalPrintStream}
+import com.martiansoftware.nailgun.{BloopThreadLocalInputStream, NGListeningAddress, NGServer, ThreadLocalPrintStream}
 
 import monix.eval.Task
 import monix.execution.misc.NonFatal
@@ -74,7 +74,7 @@ trait NailgunTestUtils {
       val addr = InetAddress.getLoopbackAddress
       import monix.execution.misc.NonFatal
       try {
-        val server = Server.launchServer(localIn, localOut, localErr, addr, TEST_PORT, log)
+        val server = Server.launchServer(localIn, localOut, localErr, new NGListeningAddress(addr, TEST_PORT), log, None)
         serverIsStarted.success(())
         server.run()
         serverIsFinished.success(())

--- a/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
+++ b/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
@@ -330,6 +330,8 @@ trait BloopHelpers {
     import java.nio.file.StandardOpenOption
     val body = Try(TestUtil.parseFile(contents)).map(_.contents).getOrElse(contents)
 
+    Files.createDirectories(path.underlying.getParent)
+
     // Running this piece in Windows can produce spurious `AccessDeniedException`s
     if (!bloop.util.CrossPlatform.isWindows) {
       // Delete the file, there are weird issues when creating new files and

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -463,6 +463,12 @@ object TestUtil {
 
   private val tmpDirCount = new AtomicInteger
 
+  def tmpDir(): Path = {
+    val dir = baseTmpDir.resolve(s"tmp-dir-${tmpDirCount.incrementAndGet()}")
+    Files.createDirectories(dir)
+    dir
+  }
+
   /** Creates an empty workspace where operations can happen. */
   def withinWorkspace[T](op: AbsolutePath => T): T = {
     val temp = baseTmpDir.resolve(s"test-${tmpDirCount.incrementAndGet()}")

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -43,6 +43,7 @@ import sbt.internal.inc.BloopComponentCompiler
 import java.util.concurrent.TimeoutException
 import java.security.SecureRandom
 import java.util.concurrent.atomic.AtomicInteger
+import java.nio.file.attribute.PosixFilePermissions
 
 object TestUtil {
   def projectDir(base: Path, name: String) = base.resolve(name)
@@ -463,9 +464,15 @@ object TestUtil {
 
   private val tmpDirCount = new AtomicInteger
 
-  def tmpDir(): Path = {
+  def tmpDir(strictPermissions: Boolean = false): Path = {
     val dir = baseTmpDir.resolve(s"tmp-dir-${tmpDirCount.incrementAndGet()}")
     Files.createDirectories(dir)
+    if (strictPermissions && !scala.util.Properties.isWin) {
+      Files.setPosixFilePermissions(
+        dir,
+        PosixFilePermissions.fromString("rwx------")
+      )
+    }
     dir
   }
 

--- a/integrations/sbt-bloop/src/main/scala-sbt-1.0/bloop/integrations/sbt/BloopGateway.scala
+++ b/integrations/sbt-bloop/src/main/scala-sbt-1.0/bloop/integrations/sbt/BloopGateway.scala
@@ -93,7 +93,7 @@ object BloopGateway {
     val shell = Shell.default
     val started = Promise[Unit]()
     val launcher =
-      new LauncherMain(launcherIn, launcherOut, logOut, charset, shell, None, None, started)
+      new LauncherMain(launcherIn, launcherOut, logOut, charset, shell, Right(None), started)
 
     val exitStatus = new AtomicReference[Option[LauncherStatus]](None)
     val launcherThread = new Thread {

--- a/integrations/sbt-bloop/src/main/scala-sbt-1.0/bloop/integrations/sbt/BloopGateway.scala
+++ b/integrations/sbt-bloop/src/main/scala-sbt-1.0/bloop/integrations/sbt/BloopGateway.scala
@@ -93,7 +93,7 @@ object BloopGateway {
     val shell = Shell.default
     val started = Promise[Unit]()
     val launcher =
-      new LauncherMain(launcherIn, launcherOut, logOut, charset, shell, Right(None), started)
+      new LauncherMain(launcherIn, launcherOut, logOut, charset, shell, Right((None, None)), started)
 
     val exitStatus = new AtomicReference[Option[LauncherStatus]](None)
     val launcherThread = new Thread {

--- a/launcher/src/main/scala/bloop/launcher/Launcher.scala
+++ b/launcher/src/main/scala/bloop/launcher/Launcher.scala
@@ -31,8 +31,7 @@ object Launcher
       System.err,
       StandardCharsets.UTF_8,
       Shell.default,
-      userNailgunHost = None,
-      userNailgunPort = None,
+      Right(None),
       Promise[Unit]()
     )
 
@@ -42,17 +41,25 @@ class LauncherMain(
     val out: PrintStream,
     charset: Charset,
     val shell: Shell,
-    val userNailgunHost: Option[String],
-    val userNailgunPort: Option[Int],
+    val userListenOn: Either[(Option[String], Option[Int]), Option[Path]],
     startedServer: Promise[Unit]
 ) {
   private final val launcherTmpDir = Files.createTempDirectory(s"bsp-launcher")
-  private final val nailgunHost = userNailgunHost.getOrElse(Defaults.Host)
-  private final val nailgunPort = userNailgunPort.getOrElse(Defaults.Port).toString
-  private final val bloopAdditionalCliArgs: List[String] = {
-    val hostArg = if (nailgunHost == Defaults.Host) Nil else List("--nailgun-host", nailgunHost)
-    val portArg = if (nailgunPort == Defaults.Port) Nil else List("--nailgun-port", nailgunPort)
-    portArg ++ hostArg
+  private final val listenOn = userListenOn match {
+    case Left((hostOpt, portOpt)) =>
+      val host = hostOpt.getOrElse(Defaults.Host)
+      val port = portOpt.getOrElse(Defaults.Port).toString
+      Left((host, port))
+    case Right(pathOpt) =>
+      Right(pathOpt.getOrElse(Defaults.daemonDir))
+  }
+  private final val bloopAdditionalCliArgs: List[String] = userListenOn match {
+    case Left((hostOpt, portOpt)) =>
+      val hostArg = hostOpt.toList.flatMap(host => List("--nailgun-host", host))
+      val portArg = portOpt.toList.flatMap(port => List("--nailgun-port", port.toString))
+      portArg ++ hostArg
+    case Right(pathOpt) =>
+      pathOpt.toList.flatMap(dir => List("--daemon-dir", dir.toString))
   }
 
   def main(args: Array[String]): Unit = {
@@ -154,7 +161,11 @@ class LauncherMain(
     }
 
     if (skipBspConnection) {
-      val bloopgunArgs = List("server", "--fire-and-forget", nailgunPort) ++ serverJvmOptions
+      val extraArg = listenOn match {
+        case Left((_, port)) => port.toString
+        case Right(path) => s"daemon:$path"
+      }
+      val bloopgunArgs = List("server", "--fire-and-forget", extraArg) ++ serverJvmOptions
       val bloopgun = newBloopgunCli(bloopVersion, out)
       Try(bloopgun.run(bloopgunArgs.toArray)).toEither match {
         case Right(code) if code == 0 => Right(Left(()))

--- a/launcher/src/main/scala/bloop/launcher/Launcher.scala
+++ b/launcher/src/main/scala/bloop/launcher/Launcher.scala
@@ -31,7 +31,7 @@ object Launcher
       System.err,
       StandardCharsets.UTF_8,
       Shell.default,
-      Right(None),
+      Right((None, None)),
       Promise[Unit]()
     )
 
@@ -41,7 +41,7 @@ class LauncherMain(
     val out: PrintStream,
     charset: Charset,
     val shell: Shell,
-    val userListenOn: Either[(Option[String], Option[Int]), Option[Path]],
+    val userListenOn: Either[(Option[String], Option[Int]), (Option[Path], Option[String])],
     startedServer: Promise[Unit]
 ) {
   private final val launcherTmpDir = Files.createTempDirectory(s"bsp-launcher")
@@ -50,16 +50,17 @@ class LauncherMain(
       val host = hostOpt.getOrElse(Defaults.Host)
       val port = portOpt.getOrElse(Defaults.Port).toString
       Left((host, port))
-    case Right(pathOpt) =>
-      Right(pathOpt.getOrElse(Defaults.daemonDir))
+    case Right((pathOpt, pipeNameOpt)) =>
+      Right((pathOpt.getOrElse(Defaults.daemonDir), pipeNameOpt.getOrElse(Defaults.daemonPipeName)))
   }
   private final val bloopAdditionalCliArgs: List[String] = userListenOn match {
     case Left((hostOpt, portOpt)) =>
       val hostArg = hostOpt.toList.flatMap(host => List("--nailgun-host", host))
       val portArg = portOpt.toList.flatMap(port => List("--nailgun-port", port.toString))
       portArg ++ hostArg
-    case Right(pathOpt) =>
-      pathOpt.toList.flatMap(dir => List("--daemon-dir", dir.toString))
+    case Right((pathOpt, pipeNameOpt)) =>
+      pathOpt.toList.flatMap(dir => List("--daemon-dir", dir.toString)) :::
+        pipeNameOpt.toList.flatMap(pipeName => List("--pipe-name", pipeName))
   }
 
   def main(args: Array[String]): Unit = {
@@ -161,11 +162,11 @@ class LauncherMain(
     }
 
     if (skipBspConnection) {
-      val extraArg = listenOn match {
-        case Left((_, port)) => port.toString
-        case Right(path) => s"daemon:$path"
+      val extraArgs = listenOn match {
+        case Left((_, port)) => List(port.toString)
+        case Right((path, pipe)) => List(s"daemon:$path${File.pathSeparator}$pipe")
       }
-      val bloopgunArgs = List("server", "--fire-and-forget", extraArg) ++ serverJvmOptions
+      val bloopgunArgs = List("server", "--fire-and-forget") ++ extraArgs ++ serverJvmOptions
       val bloopgun = newBloopgunCli(bloopVersion, out)
       Try(bloopgun.run(bloopgunArgs.toArray)).toEither match {
         case Right(code) if code == 0 => Right(Left(()))

--- a/launcher/src/test/scala/bloop/launcher/GlobalSettingsSpec.scala
+++ b/launcher/src/test/scala/bloop/launcher/GlobalSettingsSpec.scala
@@ -5,7 +5,8 @@ import scala.concurrent.Promise
 import bloop.bloopgun.util.Environment
 import bloop.internal.build.BuildInfo
 
-object GlobalSettingsSpec extends LauncherBaseSuite(BuildInfo.version, BuildInfo.bspVersion, 9014) {
+object GlobalSettingsSpec
+    extends LauncherBaseSuite(BuildInfo.version, BuildInfo.bspVersion, Left(9014)) {
   val launcherArguments = Array(bloopVersion, "--skip-bsp-connection")
 
   def writeJsonSettings(json: String): Unit = {

--- a/launcher/src/test/scala/bloop/launcher/LauncherBaseSuite.scala
+++ b/launcher/src/test/scala/bloop/launcher/LauncherBaseSuite.scala
@@ -44,12 +44,12 @@ abstract class LauncherBaseSuite(
   protected val shellWithPython = new Shell(true, true)
 
   // Init code acting as beforeAll()
-  stopServer(complainIfError = false)
+  stopServer(complainIfError = true)
 
   override def test(name: String)(fun: => Any): Unit = {
     val newFun = () => {
       try {
-        stopServer(complainIfError = false)
+        stopServer(complainIfError = true)
         fun
       } finally {
         stopServer(complainIfError = true)

--- a/launcher/src/test/scala/bloop/launcher/LauncherBaseSuite.scala
+++ b/launcher/src/test/scala/bloop/launcher/LauncherBaseSuite.scala
@@ -34,11 +34,14 @@ import snailgun.logging.SnailgunLogger
 abstract class LauncherBaseSuite(
     val bloopVersion: String,
     val bspVersion: String,
-    val bloopServerPortOrDaemonDir: Either[Int, Path]
+    val bloopServerPortOrDaemonDir: Either[Int, (Path, String)]
 ) extends BaseSuite {
   private val listenOn = bloopServerPortOrDaemonDir.left
     .map(port => (None, Some(port)))
-    .map(path => Some(path))
+    .map {
+      case (path, pipeName) =>
+        (Some(path), Some(pipeName))
+    }
   val defaultConfig = ServerConfig(listenOn = listenOn)
 
   protected val shellWithPython = new Shell(true, true)
@@ -72,8 +75,8 @@ abstract class LauncherBaseSuite(
       val ngArgs = bloopServerPortOrDaemonDir match {
         case Left(port) =>
           List("--nailgun-port", port.toString)
-        case Right(path) =>
-          List("--daemon-dir", path.toString)
+        case Right((path, pipeName)) =>
+          List("--daemon-dir", path.toString, "--pipe-name", pipeName)
       }
       ngArgs ::: List("exit")
     }

--- a/launcher/src/test/scala/bloop/launcher/LauncherBaseSuite.scala
+++ b/launcher/src/test/scala/bloop/launcher/LauncherBaseSuite.scala
@@ -41,51 +41,18 @@ abstract class LauncherBaseSuite(
     .map(path => Some(path))
   val defaultConfig = ServerConfig(listenOn = listenOn)
 
-  val oldEnv = System.getenv()
-  val oldCwd = AbsolutePath(System.getProperty("user.dir"))
-  val oldHomeDir = AbsolutePath(System.getProperty("user.home"))
-  val oldIvyHome = Option(System.getProperty("ivy.home"))
-  val oldCoursierCacheDir = Option(System.getProperty("coursier.cache"))
-  val ivyHome = oldHomeDir.resolve(".ivy2")
-  val coursierCacheDir = AbsolutePath(coursierapi.Cache.create().getLocation)
-  val bloopBinDirectory = AbsolutePath(Files.createTempDirectory("bsp-bin"))
-
   protected val shellWithPython = new Shell(true, true)
 
   // Init code acting as beforeAll()
   stopServer(complainIfError = false)
-  prependToPath(bloopBinDirectory.syntax)
-  System.setProperty("ivy.home", ivyHome.syntax)
-  System.setProperty("bloop.home", AbsolutePath(BuildTestInfo.baseDirectory).syntax)
-  System.setProperty("coursier.cache", coursierCacheDir.syntax)
-
-  // Hijack so that lookup for bloop in PATH fails even if this machine has bloop installed
-  val hijackedBloop = bloopBinDirectory.resolve("bloop")
-  val hijackedBloopServer = bloopBinDirectory.resolve("blp-server")
-  writeFile(hijackedBloop, "I am not a script and I must fail to be executed")
-  // Add empty contents to blp-server so that `ServerStatus.findServerToRun` doesn't find a valid server
-  writeFile(hijackedBloopServer, "")
-  hijackedBloop.toFile.setExecutable(true)
-  hijackedBloopServer.toFile.setExecutable(true)
-  assertIsFile(hijackedBloop)
-  assertIsFile(hijackedBloopServer)
 
   override def test(name: String)(fun: => Any): Unit = {
-    val newCwd = AbsolutePath(Files.createTempDirectory("cwd-test"))
-    val newHome = AbsolutePath(Files.createTempDirectory("home-test"))
-
     val newFun = () => {
       try {
         stopServer(complainIfError = false)
-        System.setProperty("user.dir", newCwd.syntax)
-        System.setProperty("user.home", newHome.syntax)
         fun
       } finally {
         stopServer(complainIfError = true)
-        System.setProperty("user.dir", oldCwd.syntax)
-        System.setProperty("user.home", oldHomeDir.syntax)
-        Paths.delete(newCwd)
-        Paths.delete(newHome)
         ()
       }
     }
@@ -119,28 +86,7 @@ abstract class LauncherBaseSuite(
     }
   }
 
-  override def afterAll(): Unit = {
-    super.afterAll()
-    oldIvyHome.foreach(h => System.setProperty("ivy.home", h))
-    oldCoursierCacheDir.foreach(c => System.setProperty("coursier.cache", c))
-    val newOldMap = oldEnv.asScala.toMap.asJava
-    changeEnvironment(newOldMap)
-    Paths.delete(bloopBinDirectory)
-  }
-
   import java.{util => ju}
-  private def prependToPath(newEntry: String): Unit = {
-    import java.io.File
-    import bloop.util.CrossPlatform
-    val pathVariableName = if (CrossPlatform.isWindows) "Path" else "PATH"
-    val ourEnv = System.getenv().asScala.toMap
-    val currentPath = ourEnv
-      .get(pathVariableName)
-      .orElse(ourEnv.get("PATH"))
-      .getOrElse(sys.error(s"No Path or PATH in env!"))
-    val newPath = newEntry + File.pathSeparator + currentPath
-    changeEnvironment((ourEnv + (pathVariableName -> newPath)).asJava)
-  }
 
   private def changeEnvironment(newEnv: ju.Map[String, String]): Unit = {
     // From https://stackoverflow.com/questions/318239/how-do-i-set-environment-variables-from-java

--- a/launcher/src/test/scala/bloop/launcher/LauncherSpec.scala
+++ b/launcher/src/test/scala/bloop/launcher/LauncherSpec.scala
@@ -26,7 +26,7 @@ object LatestStableLauncherSpec extends LauncherSpec("1.3.2")
 object LatestMasterLauncherSpec extends LauncherSpec(BuildInfo.version)
 
 class LauncherSpec(bloopVersion: String)
-    extends LauncherBaseSuite(bloopVersion, BuildInfo.bspVersion, 9014) {
+    extends LauncherBaseSuite(bloopVersion, BuildInfo.bspVersion, Left(9014)) {
   private final val bloopDependency = s"ch.epfl.scala:bloop-frontend_2.12:${bloopVersion}"
   test("fail if arguments are empty") {
     setUpLauncher(shellWithPython) { run =>

--- a/launcher/src/test/scala/bloop/launcher/LauncherSpec.scala
+++ b/launcher/src/test/scala/bloop/launcher/LauncherSpec.scala
@@ -26,9 +26,9 @@ import bloop.bloopgun.core.AvailableAtPath
 object LatestStableLauncherSpec extends LauncherSpec("1.3.2", Left(9014))
 object LatestMasterLauncherSpec extends LauncherSpec(BuildInfo.version, Left(9014))
 object LatestMasterLauncherDomainSocketSpec
-    extends LauncherSpec(BuildInfo.version, Right(TestUtil.tmpDir(strictPermissions = true)))
+    extends LauncherSpec(BuildInfo.version, Right((TestUtil.tmpDir(strictPermissions = true), "bloop_tests\\daemon")))
 
-class LauncherSpec(bloopVersion: String, bloopServerPortOrDaemonDir: Either[Int, Path])
+class LauncherSpec(bloopVersion: String, bloopServerPortOrDaemonDir: Either[Int, (Path, String)])
     extends LauncherBaseSuite(bloopVersion, BuildInfo.bspVersion, bloopServerPortOrDaemonDir) {
   private final val bloopDependency = s"ch.epfl.scala:bloop-frontend_2.12:${bloopVersion}"
   test("fail if arguments are empty") {

--- a/launcher/src/test/scala/bloop/launcher/LauncherSpec.scala
+++ b/launcher/src/test/scala/bloop/launcher/LauncherSpec.scala
@@ -39,12 +39,6 @@ class LauncherSpec(bloopVersion: String, bloopServerPortOrDaemonDir: Either[Int,
     }
   }
 
-  test("check that environment is correctly mocked") {
-    val parentDir = this.bloopBinDirectory.getParent
-    assert(parentDir.underlying == Environment.cwd.getParent)
-    assert(parentDir.underlying == Environment.homeDirectory.getParent)
-  }
-
   test("check that python is in the classpath") {
     // Python must always be in the classpath in order to run these tests, if this fails install it
     assert(shellWithPython.isPythonInClasspath)

--- a/launcher/src/test/scala/bloop/launcher/LauncherSpec.scala
+++ b/launcher/src/test/scala/bloop/launcher/LauncherSpec.scala
@@ -26,7 +26,7 @@ import bloop.bloopgun.core.AvailableAtPath
 object LatestStableLauncherSpec extends LauncherSpec("1.3.2", Left(9014))
 object LatestMasterLauncherSpec extends LauncherSpec(BuildInfo.version, Left(9014))
 object LatestMasterLauncherDomainSocketSpec
-    extends LauncherSpec(BuildInfo.version, Right(TestUtil.tmpDir()))
+    extends LauncherSpec(BuildInfo.version, Right(TestUtil.tmpDir(strictPermissions = true)))
 
 class LauncherSpec(bloopVersion: String, bloopServerPortOrDaemonDir: Either[Int, Path])
     extends LauncherBaseSuite(bloopVersion, BuildInfo.bspVersion, bloopServerPortOrDaemonDir) {

--- a/launcher/src/test/scala/bloop/launcher/LauncherSpec.scala
+++ b/launcher/src/test/scala/bloop/launcher/LauncherSpec.scala
@@ -3,6 +3,7 @@ package bloop.launcher
 import java.io._
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.nio.file.Path
 
 import bloop.internal.build.BuildInfo
 import bloop.bloopgun.util.Environment
@@ -22,11 +23,13 @@ import bloop.launcher.core.{Feedback => LauncherFeedback}
 import bloop.bloopgun.util.{Feedback => BloopgunFeedback}
 import bloop.bloopgun.core.AvailableAtPath
 
-object LatestStableLauncherSpec extends LauncherSpec("1.3.2")
-object LatestMasterLauncherSpec extends LauncherSpec(BuildInfo.version)
+object LatestStableLauncherSpec extends LauncherSpec("1.3.2", Left(9014))
+object LatestMasterLauncherSpec extends LauncherSpec(BuildInfo.version, Left(9014))
+object LatestMasterLauncherDomainSocketSpec
+    extends LauncherSpec(BuildInfo.version, Right(TestUtil.tmpDir()))
 
-class LauncherSpec(bloopVersion: String)
-    extends LauncherBaseSuite(bloopVersion, BuildInfo.bspVersion, Left(9014)) {
+class LauncherSpec(bloopVersion: String, bloopServerPortOrDaemonDir: Either[Int, Path])
+    extends LauncherBaseSuite(bloopVersion, BuildInfo.bspVersion, bloopServerPortOrDaemonDir) {
   private final val bloopDependency = s"ch.epfl.scala:bloop-frontend_2.12:${bloopVersion}"
   test("fail if arguments are empty") {
     setUpLauncher(shellWithPython) { run =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -142,5 +142,5 @@ object Dependencies {
   val asm = "org.ow2.asm" % "asm" % asmVersion
   val asmUtil = "org.ow2.asm" % "asm-util" % asmVersion
 
-  val libdaemonjvm = "io.github.alexarchambault.libdaemon" %% "libdaemon" % "0.0.2"
+  val libdaemonjvm = "io.github.alexarchambault.libdaemon" %% "libdaemon" % "0.0.4"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,9 +8,9 @@ object Dependencies {
   val Sbt013Version = "0.13.18"
   val Sbt1Version = "1.3.3"
 
-  val nailgunVersion = "ee3c4343"
+  val nailgunVersion = "057f7de3"
   // Used to download the python client instead of resolving
-  val nailgunCommit = "a2520c1e"
+  val nailgunCommit = "057f7de3"
 
   // Keep in sync in BloopComponentCompiler
   val zincVersion = "1.3.0-M4+47-d881fa2f"
@@ -141,4 +141,6 @@ object Dependencies {
   val jnaPlatform = "net.java.dev.jna" % "jna-platform" % jnaVersion
   val asm = "org.ow2.asm" % "asm" % asmVersion
   val asmUtil = "org.ow2.asm" % "asm-util" % asmVersion
+
+  val libdaemonjvm = "io.github.alexarchambault.libdaemon" %% "libdaemon" % "0.0.2"
 }

--- a/project/project/build.sbt
+++ b/project/project/build.sbt
@@ -36,7 +36,9 @@ val sbtBloopBuildShadedJar = project
       "org.zeroturnaround" % "zt-exec" % "1.11",
       "me.vican.jorge" %% "snailgun-cli" % "0.3.1",
       "io.get-coursier" % "interface" % "1.0.4",
-      "ch.epfl.scala" % "bsp4j" % "2.0.0-M4+10-61e61e87"
+      "ch.epfl.scala" % "bsp4j" % "2.0.0-M4+10-61e61e87",
+      "io.github.alexarchambault.libdaemon" %% "libdaemon" % "0.0.2",
+      "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.4.0"
     ),
     toShadeClasses := {
       build.Shading.toShadeClasses(
@@ -63,7 +65,10 @@ val sbtBloopBuildShadedJar = project
 
         // Copy over jar and remove signed entries
         if (!path.exists || !path.isFile) Nil
-        else if (ppath.contains("gson") || ppath.contains("jsr") || ppath.contains("jna")) Nil
+        else if (
+          ppath.contains("gson") || ppath.contains("jsr") || ppath.contains("jna") || ppath
+            .contains("ipcsocket") || ppath.contains("coursier-jniutils")
+        ) Nil
         else if (!ppath.contains("eclipse")) List(path)
         else {
           val targetJar = eclipseJarsUnsignedDir.resolve(path.getName)
@@ -74,7 +79,16 @@ val sbtBloopBuildShadedJar = project
 
     },
     shadingNamespace := "shaded.build",
-    shadeIgnoredNamespaces := Set("com.google.gson", "org.slf4j", "scala"),
+    shadeIgnoredNamespaces := Set(
+      "com.google.gson",
+      "org.slf4j",
+      "scala",
+      "org.scalasbt.ipcsocket",
+      "libdaemonjvm",
+      "dev.dirs",
+      "META-INF.versions.16.libdaemonjvm",
+      "coursier.jniutils"
+    ),
     shadeNamespaces := Set(
       "com.github.plokhotnyuk.jsoniter_scala",
       "machinist",

--- a/project/project/build.sbt
+++ b/project/project/build.sbt
@@ -37,7 +37,7 @@ val sbtBloopBuildShadedJar = project
       "me.vican.jorge" %% "snailgun-cli" % "0.3.1",
       "io.get-coursier" % "interface" % "1.0.4",
       "ch.epfl.scala" % "bsp4j" % "2.0.0-M4+10-61e61e87",
-      "io.github.alexarchambault.libdaemon" %% "libdaemon" % "0.0.2",
+      "io.github.alexarchambault.libdaemon" %% "libdaemon" % "0.0.4",
       "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.4.0"
     ),
     toShadeClasses := {

--- a/shared/src/main/scala/bloop/io/Paths.scala
+++ b/shared/src/main/scala/bloop/io/Paths.scala
@@ -1,7 +1,7 @@
 package bloop.io
 
 import java.io.IOException
-import java.nio.file.attribute.{BasicFileAttributes, FileTime}
+import java.nio.file.attribute.{BasicFileAttributes, FileTime, PosixFilePermissions}
 import java.nio.file.{
   DirectoryNotEmptyException,
   FileSystems,
@@ -33,7 +33,17 @@ object Paths {
     val baseDir =
       if (Properties.isMac) bloopCacheDir
       else bloopDataDir
-    baseDir.resolve("daemon")
+    val dir = baseDir.resolve("daemon")
+    if (!Files.exists(dir.underlying)) {
+      Files.createDirectories(dir.underlying)
+      if (!Properties.isWin) {
+        Files.setPosixFilePermissions(
+          dir.underlying,
+          PosixFilePermissions.fromString("rwx------")
+        )
+      }
+    }
+    dir
   }
 
   def getCacheDirectory(dirName: String): AbsolutePath = {

--- a/shared/src/main/scala/bloop/io/Paths.scala
+++ b/shared/src/main/scala/bloop/io/Paths.scala
@@ -17,6 +17,7 @@ import java.util
 import io.github.soc.directories.ProjectDirectories
 import scala.collection.mutable
 import java.nio.file.NoSuchFileException
+import scala.util.Properties
 
 object Paths {
   private val projectDirectories = ProjectDirectories.from("", "", "bloop")
@@ -27,6 +28,13 @@ object Paths {
   final val bloopDataDir: AbsolutePath = createDirFor(projectDirectories.dataDir)
   final val bloopLogsDir: AbsolutePath = createDirFor(bloopDataDir.resolve("logs").syntax)
   final val bloopConfigDir: AbsolutePath = createDirFor(projectDirectories.configDir)
+
+  final val daemonDir: AbsolutePath = {
+    val baseDir =
+      if (Properties.isMac) bloopCacheDir
+      else bloopDataDir
+    baseDir.resolve("daemon")
+  }
 
   def getCacheDirectory(dirName: String): AbsolutePath = {
     val dir = bloopCacheDir.resolve(dirName)

--- a/shared/src/main/scala/bloop/io/Paths.scala
+++ b/shared/src/main/scala/bloop/io/Paths.scala
@@ -46,6 +46,8 @@ object Paths {
     dir
   }
 
+  final val pipeName: String = "scala_bloop_server"
+
   def getCacheDirectory(dirName: String): AbsolutePath = {
     val dir = bloopCacheDir.resolve(dirName)
     val dirPath = dir.underlying


### PR DESCRIPTION
Opening this to know if everybody's fine with the idea. Currently, this PR makes Bloop listen on both a TCP port (as Bloop does currently) and on a unix domain socket in the "data directory" (`~/.local/share/bloop/socket` on Linux, `~/Library/Application Support/Bloop/socket` on macOS) or a named pipe on Windows. So both a TCP port and a socket at the same time.

This would allow Bloop clients to more easily give a try to named sockets, and maybe progressively phase out the default opening of a TCP port.

Phasing out the TCP port would also to close a security loophole. (AFAIU, anyone that can access the Bloop port can compile code with macros, so can basically run arbitrary code with the Bloop process privileges.)

Fixes https://github.com/scalacenter/bloop/issues/1240.

(Things added in this PR need to be made configurable prior to merging.)