### PR TITLE
Add expression evaluation for Scala 2.12 and 2.13

### DIFF
--- a/backend/src/main/scala/bloop/BloopComponentsLock.scala
+++ b/backend/src/main/scala/bloop/BloopComponentsLock.scala
@@ -14,3 +14,5 @@ sealed trait ComponentLock extends GlobalLock {
 object BloopComponentsLock extends ComponentLock
 
 object SemanticDBCacheLock extends ComponentLock
+
+object ExpressionCompilerCacheLock extends ComponentLock

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -594,7 +594,7 @@ final class BloopBspServices(
             filters => BloopDebuggeeRunner.forTestSuite(projects, filters, state, ioScheduler)
           )
         case bsp.DebugSessionParamsDataKind.ScalaAttachRemote =>
-          Right(BloopDebuggeeRunner.forAttachRemote(state, ioScheduler))
+          Right(BloopDebuggeeRunner.forAttachRemote(state, ioScheduler, projects))
         case dataKind => Left(JsonRpcResponse.invalidRequest(s"Unsupported data kind: $dataKind"))
       }
     }
@@ -1102,7 +1102,7 @@ final class BloopBspServices(
             val sourceJars = project.resolution.toList.flatMap { res =>
               res.modules.flatMap { m =>
                 m.artifacts.iterator
-                  .filter(a => a.classifier.toList.contains("sources"))
+                  .filter(a => a.classifier.contains("sources"))
                   .map(a => bsp.Uri(AbsolutePath(a.path).toBspUri))
                   .toList
               }

--- a/frontend/src/main/scala/bloop/dap/BloopDebuggeeRunner.scala
+++ b/frontend/src/main/scala/bloop/dap/BloopDebuggeeRunner.scala
@@ -1,21 +1,23 @@
 package bloop.dap
 
+import bloop.ScalaInstance
 import bloop.cli.ExitStatus
 import bloop.data.{JdkConfig, Platform, Project}
-import bloop.engine.State
+import bloop.engine.{Build, State}
 import bloop.engine.tasks.{RunMode, Tasks}
+import bloop.logging.Logger
 import bloop.testing.{LoggingEventHandler, TestInternals}
 import ch.epfl.scala.bsp.ScalaMainClass
-import ch.epfl.scala.debugadapter.{CancelableFuture, DebuggeeRunner, DebuggeeListener}
+import ch.epfl.scala.debugadapter._
 import monix.eval.Task
 import monix.execution.Scheduler
-import xsbti.compile.analysis.SourceInfo
 
-import java.nio.file.Path
+import java.net.URLClassLoader
+import scala.collection.mutable
+import scala.annotation.tailrec
 
 abstract class BloopDebuggeeRunner(initialState: State, ioScheduler: Scheduler)
     extends DebuggeeRunner {
-  private lazy val allAnalysis = initialState.results.allAnalysis
 
   override def run(listener: DebuggeeListener): CancelableFuture[Unit] = {
     val debugSessionLogger = new DebuggeeLogger(listener, initialState.logger)
@@ -28,31 +30,18 @@ abstract class BloopDebuggeeRunner(initialState: State, ioScheduler: Scheduler)
   }
 
   protected def start(state: State): Task[ExitStatus]
-
-  override def classFilesMappedTo(
-      origin: Path,
-      lines: Array[Int],
-      columns: Array[Int]
-  ): List[Path] = {
-    def isInfoEmpty(info: SourceInfo) = info == sbt.internal.inc.SourceInfos.emptyInfo
-
-    val originFile = origin.toFile
-    val foundClassFiles = allAnalysis.collectFirst {
-      case analysis if !isInfoEmpty(analysis.infos.get(originFile)) =>
-        analysis.relations.products(originFile).iterator.map(_.toPath).toList
-    }
-
-    foundClassFiles.toList.flatten
-  }
 }
 
 private final class MainClassDebugAdapter(
     project: Project,
     mainClass: ScalaMainClass,
+    val classPathEntries: Seq[ClassPathEntry],
+    val evaluationClassLoader: Option[ClassLoader],
     env: JdkConfig,
     initialState: State,
     ioScheduler: Scheduler
 ) extends BloopDebuggeeRunner(initialState, ioScheduler) {
+  val javaRuntime = JavaRuntime(env.javaHome.underlying)
   def name: String = s"${getClass.getSimpleName}(${project.name}, ${mainClass.`class`})"
   def start(state: State): Task[ExitStatus] = {
     val workingDir = state.commonOptions.workingPath
@@ -78,6 +67,9 @@ private final class MainClassDebugAdapter(
 private final class TestSuiteDebugAdapter(
     projects: Seq[Project],
     filters: List[String],
+    val classPathEntries: Seq[ClassPathEntry],
+    val javaRuntime: Option[JavaRuntime],
+    val evaluationClassLoader: Option[ClassLoader],
     initialState: State,
     ioScheduler: Scheduler
 ) extends BloopDebuggeeRunner(initialState, ioScheduler) {
@@ -103,8 +95,13 @@ private final class TestSuiteDebugAdapter(
   }
 }
 
-private final class AttachRemoteDebugAdapter(initialState: State, ioScheduler: Scheduler)
-    extends BloopDebuggeeRunner(initialState, ioScheduler) {
+private final class AttachRemoteDebugAdapter(
+    val classPathEntries: Seq[ClassPathEntry],
+    val javaRuntime: Option[JavaRuntime],
+    val evaluationClassLoader: Option[ClassLoader],
+    initialState: State,
+    ioScheduler: Scheduler
+) extends BloopDebuggeeRunner(initialState, ioScheduler) {
   override def name: String = s"${getClass.getSimpleName}(${initialState.build.origin})"
   override def start(state: State): Task[ExitStatus] = Task(ExitStatus.Ok)
 }
@@ -121,11 +118,22 @@ object BloopDebuggeeRunner {
       case Seq(project) =>
         project.platform match {
           case jvm: Platform.Jvm =>
-            Right(new MainClassDebugAdapter(project, mainClass, jvm.config, state, ioScheduler))
+            val classPathEntries = getClassPathEntries(state.build, project)
+            val evaluationClassLoader = getEvaluationClassLoader(project, state, ioScheduler)
+            Right(
+              new MainClassDebugAdapter(
+                project,
+                mainClass,
+                classPathEntries,
+                evaluationClassLoader,
+                jvm.config,
+                state,
+                ioScheduler
+              )
+            )
           case platform =>
             Left(s"Unsupported platform: ${platform.getClass.getSimpleName}")
         }
-
       case projects => Left(s"Multiple projects specified for main class [$mainClass]: $projects")
     }
   }
@@ -138,10 +146,157 @@ object BloopDebuggeeRunner {
   ): Either[String, DebuggeeRunner] = {
     projects match {
       case Seq() => Left(s"No projects specified for the test suites: [${filters.sorted}]")
-      case projects => Right(new TestSuiteDebugAdapter(projects, filters, state, ioScheduler))
+      case Seq(project) if project.platform.isInstanceOf[Platform.Jvm] =>
+        val Platform.Jvm(config, _, _, _, _, _) = project.platform
+        val classPathEntries = getClassPathEntries(state.build, project)
+        val javaRuntime = JavaRuntime(config.javaHome.underlying)
+        val evaluationClassLoader = getEvaluationClassLoader(project, state, ioScheduler)
+        Right(
+          new TestSuiteDebugAdapter(
+            projects,
+            filters,
+            classPathEntries,
+            javaRuntime,
+            evaluationClassLoader,
+            state,
+            ioScheduler
+          )
+        )
+      case _ =>
+        Right(
+          new TestSuiteDebugAdapter(projects, filters, Seq.empty, None, None, state, ioScheduler)
+        )
     }
   }
 
-  def forAttachRemote(state: State, ioScheduler: Scheduler): DebuggeeRunner =
-    new AttachRemoteDebugAdapter(state, ioScheduler)
+  def forAttachRemote(
+      state: State,
+      ioScheduler: Scheduler,
+      projects: Seq[Project]
+  ): DebuggeeRunner = {
+    projects match {
+      case Seq(project) if project.platform.isInstanceOf[Platform.Jvm] =>
+        val Platform.Jvm(config, _, _, _, _, _) = project.platform
+        val classPathEntries = getClassPathEntries(state.build, project)
+        val javaRuntime = JavaRuntime(config.javaHome.underlying)
+        val evaluationClassLoader = getEvaluationClassLoader(project, state, ioScheduler)
+        new AttachRemoteDebugAdapter(
+          classPathEntries,
+          javaRuntime,
+          evaluationClassLoader,
+          state,
+          ioScheduler
+        )
+      case _ => new AttachRemoteDebugAdapter(Seq.empty, None, None, state, ioScheduler)
+    }
+  }
+
+  private def getClassPathEntries(build: Build, project: Project): Seq[ClassPathEntry] = {
+    val allProjects = getAllDepsRecursively(build, project)
+    getLibraries(allProjects) ++ getClassDirectories(allProjects)
+  }
+
+  private def getEvaluationClassLoader(
+      project: Project,
+      state: State,
+      ioScheduler: Scheduler
+  ): Option[ClassLoader] = {
+    project.scalaInstance
+      .flatMap(getEvaluationClassLoader(_, state.logger, ioScheduler))
+  }
+
+  private def getEvaluationClassLoader(
+      scalaInstance: ScalaInstance,
+      logger: Logger,
+      ioScheduler: Scheduler
+  ): Option[ClassLoader] = {
+    import ch.epfl.scala.debugadapter.BuildInfo._
+    import coursier._
+    val scalaVersion = scalaInstance.version
+    val module = s"${expressionCompilerName}_$scalaVersion"
+    val expressionCompilerDep = Dependency(
+      Module(
+        Organization(expressionCompilerOrganization),
+        ModuleName(module)
+      ),
+      expressionCompilerVersion
+    )
+    val resolution = Fetch()
+      .addDependencies(expressionCompilerDep)
+      .either()(ioScheduler)
+
+    resolution match {
+      case Left(error) =>
+        logger.warn(
+          s"Failed fetching $expressionCompilerOrganization:$module:$expressionCompilerVersion"
+        )
+        logger.warn(error.getMessage)
+        logger.warn(s"Expression evaluation will not work.")
+        None
+      case Right(files) =>
+        val expressionCompilerJar = files
+          .find(_.getName.startsWith(expressionCompilerName))
+          .map(_.toURI.toURL)
+        val evaluationClassLoader =
+          new URLClassLoader(expressionCompilerJar.toArray, scalaInstance.loader)
+        Some(evaluationClassLoader)
+    }
+  }
+
+  private def getAllDepsRecursively(build: Build, project: Project): Seq[Project] = {
+    @tailrec def tailApply(projects: Seq[Project], acc: Set[Project]): Seq[Project] = {
+      if (projects.isEmpty) acc.toSeq
+      else {
+        val dependencies = projects
+          .flatMap(_.dependencies)
+          .flatMap(build.getProjectFor)
+          .distinct
+          .filterNot(acc.contains)
+        tailApply(dependencies, acc ++ dependencies)
+      }
+    }
+    tailApply(Seq(project), Set(project))
+  }
+
+  private def getLibraries(allProjects: Seq[Project]): Seq[ClassPathEntry] = {
+    allProjects
+      .flatMap(_.resolution)
+      .flatMap(_.modules)
+      .distinct
+      .flatMap { module =>
+        for {
+          classJar <- module.artifacts.find(_.classifier.isEmpty)
+          sourceJar <- module.artifacts.find(_.classifier.contains("sources"))
+        } yield {
+          val sourceEntry = SourceJar(sourceJar.path)
+          ClassPathEntry(classJar.path, Seq(sourceEntry))
+        }
+      }
+      .distinct
+  }
+
+  private def getClassDirectories(allProjects: Seq[Project]): Seq[ClassPathEntry] = {
+    allProjects.map { project =>
+      val sourceBuffer = mutable.Buffer.empty[SourceEntry]
+      for (sourcePath <- project.sources) {
+        if (sourcePath.isDirectory) {
+          sourceBuffer += SourceDirectory(sourcePath.underlying)
+        } else {
+          sourceBuffer += StandaloneSourceFile(
+            sourcePath.underlying,
+            sourcePath.underlying.getFileName.toString
+          )
+        }
+      }
+      for (glob <- project.sourcesGlobs) {
+        glob.walkThrough { file =>
+          sourceBuffer += StandaloneSourceFile(
+            file.underlying,
+            file.toRelative(glob.directory).toString
+          )
+        }
+      }
+      ClassPathEntry(project.out.underlying, sourceBuffer.toSeq)
+    }
+  }
 }

--- a/frontend/src/main/scala/bloop/engine/caches/ExpressionCompilerCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ExpressionCompilerCache.scala
@@ -1,0 +1,56 @@
+package bloop.engine.caches
+
+import bloop.DependencyResolution
+import bloop.ExpressionCompilerCacheLock
+import bloop.io.AbsolutePath
+import bloop.io.Paths
+import bloop.logging.Logger
+import ch.epfl.scala.debugadapter.BuildInfo
+import sbt.internal.inc.BloopComponentCompiler
+import sbt.internal.inc.BloopComponentManager
+import sbt.internal.inc.IfMissing
+
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+object ExpressionCompilerCache {
+  import ch.epfl.scala.debugadapter.BuildInfo._
+
+  private val cacheDirectory = Paths.getCacheDirectory(expressionCompilerName)
+  private val provider = BloopComponentCompiler.getComponentProvider(cacheDirectory)
+  private val manager =
+    new BloopComponentManager(ExpressionCompilerCacheLock, provider, secondaryCacheDir = None)
+
+  def fetch(
+      scalaVersion: String,
+      logger: Logger
+  ): Either[String, AbsolutePath] = {
+    val module = s"${expressionCompilerName}_$scalaVersion"
+    val expressionCompilerId = s"$expressionCompilerOrganization.$module.$expressionCompilerVersion"
+
+    def attemptResolution(): Either[String, AbsolutePath] = {
+      import bloop.engine.ExecutionContext.ioScheduler
+      val artifact = DependencyResolution.Artifact(
+        expressionCompilerOrganization,
+        module,
+        expressionCompilerVersion
+      )
+      DependencyResolution.resolveWithErrors(List(artifact), logger)(ioScheduler) match {
+        case Left(error) => Left(error.getMessage())
+        case Right(paths) =>
+          paths
+            .find(_.syntax.contains(module))
+            .toRight(s"Missing $module in resolved jars ${paths.map(_.syntax).mkString(",")}")
+      }
+    }
+
+    Try(manager.file(expressionCompilerId)(IfMissing.Fail)) match {
+      case Success(pluginPath) => Right(AbsolutePath(pluginPath))
+      case Failure(exception) =>
+        val resolution = attemptResolution()
+        resolution.foreach(jar => manager.define(expressionCompilerId, Seq(jar.toFile)))
+        resolution
+    }
+  }
+}

--- a/frontend/src/test/scala/bloop/dap/DebugAdapterConnection.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugAdapterConnection.scala
@@ -18,6 +18,7 @@ import com.microsoft.java.debug.core.protocol.Responses.ContinueResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.ScopesResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.StackTraceResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.VariablesResponseBody
+import com.microsoft.java.debug.core.protocol.Responses.EvaluateResponseBody
 
 /**
  * Manages a connection with a debug adapter.
@@ -78,6 +79,13 @@ private[dap] final class DebugAdapterConnection(
     val arguments = new VariablesArguments
     arguments.variablesReference = variablesReference
     adapter.request(Variables, arguments)
+  }
+
+  def evaluate(frameId: Int, expression: String): Task[EvaluateResponseBody] = {
+    val arguments = new EvaluateArguments
+    arguments.frameId = frameId
+    arguments.expression = expression
+    adapter.request(Evaluate, arguments)
   }
 
   def stopped: Task[Events.StoppedEvent] = {

--- a/frontend/src/test/scala/bloop/dap/DebugTestEndpoints.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugTestEndpoints.scala
@@ -8,6 +8,7 @@ import com.microsoft.java.debug.core.protocol.Responses.ContinueResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.ScopesResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.StackTraceResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.VariablesResponseBody
+import com.microsoft.java.debug.core.protocol.Responses.EvaluateResponseBody
 
 private[dap] object DebugTestEndpoints {
   val Initialize = new Request[InitializeArguments, Types.Capabilities]("initialize")
@@ -19,6 +20,7 @@ private[dap] object DebugTestEndpoints {
   val StackTrace = new Request[StackTraceArguments, StackTraceResponseBody]("stackTrace")
   val Scopes = new Request[ScopesArguments, ScopesResponseBody]("scopes")
   val Variables = new Request[VariablesArguments, VariablesResponseBody]("variables")
+  val Evaluate = new Request[EvaluateArguments, EvaluateResponseBody]("evaluate")
   val Continue = new Request[ContinueArguments, ContinueResponseBody]("continue")
   val ConfigurationDone = new Request[Unit, Unit]("configurationDone")
 

--- a/launcher/src/test/scala/bloop/launcher/LauncherBaseSuite.scala
+++ b/launcher/src/test/scala/bloop/launcher/LauncherBaseSuite.scala
@@ -2,7 +2,7 @@ package bloop.launcher
 
 import bloop.io.Paths
 import bloop.io.AbsolutePath
-import bloop.io.Environment.{lineSeparator, LineSplitter}
+import bloop.io.Environment.LineSplitter
 import bloop.testing.BaseSuite
 import bloop.bloopgun.core.Shell
 import bloop.bloopgun.util.Environment

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,7 +55,7 @@ object Dependencies {
   val asmVersion = "7.0"
   val snailgunVersion = "0.4.0"
   val ztExecVersion = "1.11"
-  val debugAdapterVersion = "1.1.3"
+  val debugAdapterVersion = "2.0.2"
 
   import sbt.librarymanagement.syntax.stringToOrganization
   val zinc = "ch.epfl.scala" %% "zinc" % zincVersion


### PR DESCRIPTION
Upgrade to scala 2.12.13 to be able to test expression evaluation. The tests were running with Scala 2.12.8 but expression evaluation is only available on Scala 2.12.10 or greater.

Upgrade scala-debug-adapter to 2.0.2, the debug server now needs:
- a set of all the class path entries to be able to map the source files to the class files
- the jvm runtime
- the expression compiler class loader containing the expression-compiler jar and the compiler jars

Add a simple test on expression evaluation.

Warning: After merging this PR, Bloop debug session will no longer be compatible with the current version of Metals. https://github.com/scalameta/metals/pull/2959 in Metals intends to fix this.