### PR TITLE
Fix issues with last tag not being detected properly

### DIFF
--- a/project/GitUtils.scala
+++ b/project/GitUtils.scala
@@ -9,6 +9,8 @@ import _root_.org.eclipse.jgit.api.{Git, TransportCommand, PushCommand, CloneCom
 import _root_.org.eclipse.jgit.lib.ObjectId
 import _root_.org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
 
+import scala.collection.JavaConverters._
+
 /** Utility functions that help manipulate git repos */
 object GitUtils {
 
@@ -42,7 +44,8 @@ object GitUtils {
   }
 
   /** The latest tag in this repository. */
-  def latestTagIn(git: Git): Option[String] = Option(git.describe().call())
+  def latestTagIn(git: Git): Option[String] =
+    git.tagList.call().asScala.lastOption.map(_.getName().stripPrefix("refs/tags/"))
 
   /** Function that takes a TransportCommand and applies some authentication method on it. */
   type GitAuth = TransportCommand[_, _] => Unit


### PR DESCRIPTION
Previously, describe would return a wrong tag, which wasn't the lastest published tag. Now we lsit tags explicitely and get the last one.

Fixes https://github.com/scalacenter/homebrew-bloop/issues/17