### PR TITLE
Bump scala-debug-adapter to 2.0.6

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,7 +55,7 @@ object Dependencies {
   val asmVersion = "7.0"
   val snailgunVersion = "0.4.0"
   val ztExecVersion = "1.11"
-  val debugAdapterVersion = "2.0.5"
+  val debugAdapterVersion = "2.0.6"
 
   import sbt.librarymanagement.syntax.stringToOrganization
   val zinc = "ch.epfl.scala" %% "zinc" % zincVersion


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/3201#event-5468423384

Also brings many bug fixes in the expression evaluator:
https://github.com/scalacenter/scala-debug-adapter/compare/v2.0.5...v2.0.6
