### PR TITLE
Update bash completions to use ones for Bash 4.2+

### DIFF
--- a/project/ReleaseUtils.scala
+++ b/project/ReleaseUtils.scala
@@ -119,7 +119,7 @@ object ReleaseUtils {
        |  sha256 "${artifacts.bloopCoursier.sha}"
        |  bottle :unneeded
        |
-       |  depends_on "bash-completion"
+       |  depends_on "bash-completion@2"
        |  depends_on "coursier/formulas/coursier"
        |  depends_on "openjdk"
        |


### PR DESCRIPTION
Requested here https://github.com/scalacenter/homebrew-bloop/commit/9318321fb041dbc8f1b708b0ed49572267550cd0#r55311550