### PR TITLE
avoid warning about unneeded bottle with latest homebrew

### DIFF
--- a/project/ReleaseUtils.scala
+++ b/project/ReleaseUtils.scala
@@ -117,7 +117,6 @@ object ReleaseUtils {
        |  version "$version"
        |  url "${artifacts.bloopCoursier.url}"
        |  sha256 "${artifacts.bloopCoursier.sha}"
-       |  bottle :unneeded
        |
        |  depends_on "bash-completion"
        |  depends_on "coursier/formulas/coursier"


### PR DESCRIPTION
From homebrew version 3.3+ the "bottle :unneeded" instruction is deprecated and generates a verbose warning message. This fix removes the deprecated statement to reduce noise when running brew commands that touch the bloop tap.