### PR TITLE
Fix flag bash/zsh/fish completions

### DIFF
--- a/frontend/src/main/scala/bloop/cli/completion/BashFormat.scala
+++ b/frontend/src/main/scala/bloop/cli/completion/BashFormat.scala
@@ -16,7 +16,8 @@ object BashFormat extends Format {
 
   override def showArg(commandName: String, arg: Arg): Option[String] = {
     def completionFn = completionFunction(commandName, arg.name.name).map(" " + _).getOrElse("")
-    arg.extraNames.headOption.filter(_ => !arg.noHelp).map { longName =>
+    val longName = arg.name
+    arg.helpMessage map { _ =>
       s"--${longName.name}${completionFn}"
     }
   }

--- a/frontend/src/main/scala/bloop/cli/completion/FishFormat.scala
+++ b/frontend/src/main/scala/bloop/cli/completion/FishFormat.scala
@@ -18,10 +18,11 @@ object FishFormat extends Format {
 
   override def showArg(commandName: String, arg: Arg): Option[String] = {
     val completionFn = completionFunction(commandName, arg.name.name)
-    arg.extraNames.headOption.filter(_ => !arg.noHelp).map { name =>
-      val help0 = arg.helpMessage.fold("")("'" + _.message + "'")
+    val name = arg.name
+    arg.helpMessage.map { help0 =>
+      val help = arg.helpMessage.fold("")("'" + _.message + "'")
       val argDesc = if (arg.isFlag) "(_boolean)" else completionFn
-      s"${name.name}#$help0#$argDesc"
+      s"${name.name}#$help#$argDesc"
     }
   }
 

--- a/frontend/src/main/scala/bloop/cli/completion/ZshFormat.scala
+++ b/frontend/src/main/scala/bloop/cli/completion/ZshFormat.scala
@@ -18,11 +18,12 @@ object ZshFormat extends Format {
 
   override def showArg(commandName: String, arg: Arg): Option[String] = {
     val completionFn = completionFunction(commandName, arg.name.name)
-    arg.extraNames.headOption.filter(_ => !arg.noHelp).map { name =>
-      val help0 = arg.helpMessage.fold("")("[" + _.message + "]")
+    val name = arg.name.name
+    arg.helpMessage.map { help0 =>
+      val help = ("[" + help0.message + "]")
       val sep = if (arg.isFlag) "=-" else ""
       val argDesc = if (arg.isFlag) "(true false)" else completionFn
-      s"--${name.name}$sep$help0:${name.name}:$argDesc"
+      s"--${name}$sep$help:${name}:$argDesc"
     }
   }
 


### PR DESCRIPTION
Due to the recent change in case app version, the main argument is no longer the short version, but the long one. Because of that we need to switch what we use for completions.

Fixes https://github.com/scalacenter/bloop/issues/1593

I also added tests for all kinds of completions.