### PR TITLE
Bump debug-adapter to 2.0.10

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,7 +55,7 @@ object Dependencies {
   val asmVersion = "7.0"
   val snailgunVersion = "0.4.0"
   val ztExecVersion = "1.11"
-  val debugAdapterVersion = "2.0.8"
+  val debugAdapterVersion = "2.0.10"
 
   import sbt.librarymanagement.syntax.stringToOrganization
   val zinc = "ch.epfl.scala" %% "zinc" % zincVersion


### PR DESCRIPTION
-  Fix https://github.com/scalacenter/scala-debug-adapter/issues/148
- Add support for Scala 2.13.7