### PR TITLE
Add release notes for 1.4.11 release

### DIFF
--- a/notes/v1.4.11.md
+++ b/notes/v1.4.11.md
@@ -1,0 +1,41 @@
+# bloop `v1.4.11`
+
+Bloop v1.4.11 is a bugfix release.
+
+## Installing Bloop
+
+For more details about installing Bloop, please see [Bloop's Installation
+Guide](https://scalacenter.github.io/bloop/setup)
+
+## Merged pull requests
+
+Here's a list of pull requests that were merged:
+
+- Bump scala-debug-adapter to 2.0.11 [#1601]
+- Update zinc fork with the newest fixes [#1600]
+- Bump actions/checkout from 2.3.4 to 2.3.5 [#1597]
+- Fix flag bash/zsh/fish completions [#1596]
+- Avoid warning about unneeded bottle with latest homebrew [#1595]
+- Update bash completions to use ones for Bash 4.2+ [#1594]
+- Bump debug adapter to 2.0.8 [#1592]
+- Use current version for specifying the tag to use [#1591]
+- Forker: fix env processing [#1590]
+- Update release notes' link to install guide and remove blog part of website
+  [#1589]
+
+[#1601]: https://github.com/scalacenter/bloop/pull/1601
+[#1600]: https://github.com/scalacenter/bloop/pull/1600
+[#1597]: https://github.com/scalacenter/bloop/pull/1597
+[#1596]: https://github.com/scalacenter/bloop/pull/1596
+[#1595]: https://github.com/scalacenter/bloop/pull/1595
+[#1594]: https://github.com/scalacenter/bloop/pull/1594
+[#1592]: https://github.com/scalacenter/bloop/pull/1592
+[#1591]: https://github.com/scalacenter/bloop/pull/1591
+[#1590]: https://github.com/scalacenter/bloop/pull/1590
+[#1589]: https://github.com/scalacenter/bloop/pull/1589
+
+## Contributors
+
+According to `git shortlog -sn --no-merges v1.4.10..v1.4.11`, the following
+people have contributed to this `v1.4.11` release: Tomasz Godzik, Adrien
+Piquerez, Jurjen Vorhauer, Vadim Chelyshov, dependabot[bot].


### PR DESCRIPTION
This includes the fix for 2.13.7, so it's important to have it easily available for users.