### PR TITLE
Try to make frontend tests less flaky

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -288,6 +288,10 @@ lazy val frontend: Project = project
     buildInfoKeys := bloopInfoKeys(nativeBridge04, jsBridge06, jsBridge1),
     javaOptions in run ++= jvmOptions,
     javaOptions in Test ++= jvmOptions,
+    javaOptions in Test += {
+      val tmpDir = (baseDirectory in ThisBuild).value / "target" / "tests-tmp"
+      s"-Dbloop.tests.tmp-dir=$tmpDir"
+    },
     javaOptions in IntegrationTest ++= jvmOptions,
     libraryDependencies += Dependencies.graphviz % Test,
     fork in run := true,

--- a/frontend/src/test/scala/bloop/DeduplicationSpec.scala
+++ b/frontend/src/test/scala/bloop/DeduplicationSpec.scala
@@ -38,7 +38,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
     if (isDeduplicated) assert(deduplicated) else assert(!deduplicated)
   }
 
-  test("three concurrent clients deduplicate compilation") {
+  def deduplicationTest(): Unit = {
     val logger = new RecordingLogger(ansiCodesSupported = false)
     val logger1 = new RecordingLogger(ansiCodesSupported = false)
     val logger2 = new RecordingLogger(ansiCodesSupported = false)
@@ -172,6 +172,11 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
          """.stripMargin
         )
       }
+    }
+  }
+  test("three concurrent clients deduplicate compilation") {
+    TestUtil.retry() {
+      deduplicationTest()
     }
   }
 

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -632,4 +632,28 @@ object TestUtil {
     try new String(Stream.continually(inputStream.read).takeWhile(_ != -1).map(_.toByte).toArray)
     finally inputStream.close()
   }
+
+  def retry[T](
+      attempts: Int = if (System.getenv("CI") == null) 1 else 3
+  )(
+      f: => T
+  ): T = {
+    def helper(count: Int): T = {
+      val resOpt =
+        try Some(f)
+        catch {
+          case NonFatal(e) =>
+            if (count < attempts) {
+              System.err.println(s"Caught $e, trying again")
+              None
+            } else
+              throw new Exception(e)
+        }
+      resOpt match {
+        case Some(res) => res
+        case None => helper(count + 1)
+      }
+    }
+    helper(1)
+  }
 }


### PR DESCRIPTION
By writing temporary data somewhere under the current directory, rather than via Files.createTempDirectory. (In the Scala CLI repo, this got rid of many transient failures in tests involving domain sockets, https://github.com/VirtusLab/scala-cli/commit/cc5052eeeb3b729649027ce0f428097fae5d0a36).