### PR TITLE
Fix fish completions error

### DIFF
--- a/etc/fish-completions
+++ b/etc/fish-completions
@@ -102,13 +102,13 @@ for cmd in (_commands)
     set -l flags (_flags_for_command $cmd)
     for flag in $flags
         set -l parsed (string split '#' $flag)
-        if test -n $parsed[1] -a -n $parsed[2] -a -n $parsed[3]
+        if test -n "$parsed[1]" -a -n "$parsed[2]" -a -n "$parsed[3]"
             _bloop_cmpl_ $minTokens $cmd -l $parsed[1] -d $parsed[2] -xa $parsed[3]
-        else if test -n $parsed[1] -a -z $parsed[2] -a -n $parsed[3]
+        else if test -n "$parsed[1]" -a -z "$parsed[2]" -a -n "$parsed[3]"
             _bloop_cmpl_ $minTokens $cmd -l $parsed[1] -xa $parsed[3]
-        else if test -n $parsed[1] -a -n $parsed[2] -a -z $parsed[3]
+        else if test -n "$parsed[1]" -a -n "$parsed[2]" -a -z "$parsed[3]"
             _bloop_cmpl_ $minTokens $cmd -l $parsed[1] -d $parsed[2]
-        else if test -n $parsed[1] -a -z $parsed[2] -a -z $parsed[3]
+        else if test -n "$parsed[1]" -a -z "$parsed[2]" -a -z "$parsed[3]"
             _bloop_cmpl_ $minTokens $cmd -l $parsed[1]
         end
     end

--- a/etc/fish-completions
+++ b/etc/fish-completions
@@ -26,7 +26,9 @@ function _testsfqcn
     set -l cmd (commandline -poc)
     set -e cmd[1]
     set -l project $cmd[2]
-    bloop autocomplete --format fish --mode testsfqcn --project $project
+    if test -n "$project"
+        bloop autocomplete --format fish --mode testsfqcn --project $project
+    end
 end
 
 function _mainsfqcn


### PR DESCRIPTION
Mainly its fix for #1479 issue.

The problem is that when we don't have all 3 parameters in parsed
`if test -n $parsed[1] -a -n $parsed[2] -a -n $parsed[3]`
after read all vars script will look like this (for example we have only $parsed[1] = fizz)
`if test -n fizz -a -n -a -n` which is not proper syntax

Another small fix (in _testsfqcn) is for redundant `Argument --project: argument missing` in autocomplete list.
Its cause sometimes we call _testsfqcn without --project arg

<img width="1680" alt="Screenshot 2021-12-22 at 10 03 47" src="https://user-images.githubusercontent.com/1228014/147057634-808f9ff5-b9a3-43a1-8129-b0d386496690.png">
