### PR TITLE
Fix JS compilation errors

### DIFF
--- a/config/.js/src/main/scala/bloop/config/PlatformFiles.scala
+++ b/config/.js/src/main/scala/bloop/config/PlatformFiles.scala
@@ -4,6 +4,7 @@ object PlatformFiles {
   type Path = String
   val emptyPath: Path = getPath("")
   def getPath(path: String): Path = path
+  def getFileName(path: Path): Path = path.split('/').last
 
   def userDir: Path = NodePath.resolve(".")
 

--- a/config/.jvm/src/main/scala/bloop/config/PlatformFiles.scala
+++ b/config/.jvm/src/main/scala/bloop/config/PlatformFiles.scala
@@ -6,6 +6,7 @@ object PlatformFiles {
   type Path = java.nio.file.Path
   val emptyPath: Path = Paths.get("")
   def getPath(path: String): Path = Paths.get(path)
+  def getFileName(path: Path): Path = path.getFileName()
 
   def userDir: Path = getPath(System.getProperty("user.dir"))
 

--- a/config/src/test/scala/bloop/config/utils/BaseConfigSuite.scala
+++ b/config/src/test/scala/bloop/config/utils/BaseConfigSuite.scala
@@ -1,8 +1,9 @@
 package bloop.config.utils
 
 import bloop.config.Config
+import bloop.config.PlatformFiles.Path
+import bloop.config.PlatformFiles
 import java.io.File
-import java.nio.file.Path
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
@@ -172,7 +173,9 @@ trait BaseConfigSuite {
             s"${config.project.name} $jarName",
             config.project.resolution.exists(
               _.modules.exists(
-                _.artifacts.exists(a => matchMethod(a.path.getFileName.toString, jarName))
+                _.artifacts.exists(a =>
+                  matchMethod(PlatformFiles.getFileName(a.path).toString, jarName)
+                )
               )
             )
           )


### PR DESCRIPTION
Config module is cross published for JVM and JS, which means that config-test is also compiled with both. This is causing compilation errors for `BasicConfigSuite`, although it is never actually used in tests for js, which is why it wasn't failing on CI. This PR is just to get rid of that annoying error.