### PR TITLE
[Java] Don't pass `--add-export` semanticdb flags to jdk8

### DIFF
--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -218,6 +218,7 @@ final case class Project(
     }
     def getJavaVersionFromJavaHome(javaHome: AbsolutePath): String = {
       val releaseFile = javaHome.resolve("release")
+      def rtJar = javaHome.resolve("lib").resolve("rt.jar")
       if (releaseFile.exists) {
         val properties = ConfigFactory.parseFile(
           releaseFile.toFile,
@@ -231,6 +232,9 @@ final case class Project(
             )
             Properties.javaVersion
         }
+      } else if (rtJar.exists) {
+        // jdk 8 doesn't have `release` file
+        "1.8.0"
       } else {
         logger.error(
           s"No `release` file found in $javaHome - using Bloop's JVM version ${Properties.javaVersion}"


### PR DESCRIPTION
Fixes the following:
- project was exported and has `platform.jdk.home=${jdk8-home}`
- bloop was started using jdk17
- bloop tries to check if there is a need to pass jdk17 flags for
semanticdb-java
- ${jdk8-home} doesn't have `/release` and we incorrectly mark jdk8
as jdk17
- compile fails with:
  ```
  [W] Unexpected javac output: Unrecognized option: --add-exports
  [W] Error: Could not create the Java Virtual Machine.
  ```