### PR TITLE
Fork JavaCompiler in case if there are `-J` flags

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -336,7 +336,11 @@ object Compiler {
     val start = System.nanoTime()
     val scalaInstance = compileInputs.scalaInstance
     val classpathOptions = compileInputs.classpathOptions
-    val compilers = compileInputs.compilerCache.get(scalaInstance, compileInputs.javacBin)
+    val compilers = compileInputs.compilerCache.get(
+      scalaInstance,
+      compileInputs.javacBin,
+      compileInputs.javacOptions.toList
+    )
     val inputs = tracer.traceVerbose("creating zinc inputs")(_ => getInputs(compilers))
 
     // We don't need nanosecond granularity, we're happy with milliseconds

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -64,7 +64,10 @@ object Tasks {
         val javacBin = project.runtimeJdkConfig.flatMap(_.javacBin)
         val loader = ClasspathUtilities.makeLoader(entries, instance)
         val compiler =
-          state.compilerCache.get(instance, javacBin).scalac.asInstanceOf[AnalyzingCompiler]
+          state.compilerCache
+            .get(instance, javacBin, project.javacOptions)
+            .scalac
+            .asInstanceOf[AnalyzingCompiler]
         val opts = ClasspathOptionsUtil.repl
         val options = project.scalacOptions :+ "-Xnojline"
         // We should by all means add better error handling here!


### PR DESCRIPTION
It's required to correctly support java-semanticdb plugin on jdk17.
Fixes #1651