### PR TITLE
Add release notes for Bloop 1.4.12

### DIFF
--- a/notes/v1.4.12.md
+++ b/notes/v1.4.12.md
@@ -1,0 +1,66 @@
+# bloop `v1.4.12`
+
+Bloop v1.4.12 is a bugfix release.
+
+## Installing Bloop
+
+For more details about installing Bloop, please see [Bloop's Installation Guide](https://scalacenter.github.io/bloop/setup))
+
+## Merged pull requests
+
+Here's a list of pull requests that were merged:
+
+- CompierCache - fix patmat [#1653]
+- Add tests for Scala version 2.13.8 [#1629]
+- Fork JavaCompiler in case if there are `-J` flags [#1652]
+- Launcher 213 [#1646]
+- Fix gradle211 compilation errors [#1645]
+- [Java] Don't pass `--add-export` semanticdb flags to jdk8 [#1647]
+- Bump actions/download-artifact from 2.0.10 to 2.1.0 [#1640]
+- Bump actions/setup-node from 2.5.0 to 2.5.1 [#1639]
+- Fix JS compilation errors [#1638]
+- [Maven] Make sure correct classifier is used when downloading artifacts. [#1634]
+- Fix fish completions error [#1633]
+- Fix typo in discord URL [#1628]
+- Update sbt to 1.4.9 and remove offloading [#1623]
+- Handle gradle project-sourceset name clashes [#1625]
+- Add exports for Semanticdb plugin on Java 17 [#1622]
+- Send TestResult to Debugee Listener [#1607]
+- Ignore hydra tests [#1619]
+- Fix regex used for HydraCompileSpec [#1618]
+- Ignore Hydra license output in tests [#1617]
+- Bump actions/checkout from 2.3.5 to 2.4.0 [#1616]
+- Bump actions/setup-node from 2.4.1 to 2.5.0 [#1615]
+- Clean-up [#1610]
+- Use coursier-interface rather than coursier [#1612]
+
+
+[#1653]: https://github.com/scalacenter/bloop/pull/1653
+[#1629]: https://github.com/scalacenter/bloop/pull/1629
+[#1652]: https://github.com/scalacenter/bloop/pull/1652
+[#1646]: https://github.com/scalacenter/bloop/pull/1646
+[#1645]: https://github.com/scalacenter/bloop/pull/1645
+[#1647]: https://github.com/scalacenter/bloop/pull/1647
+[#1640]: https://github.com/scalacenter/bloop/pull/1640
+[#1639]: https://github.com/scalacenter/bloop/pull/1639
+[#1638]: https://github.com/scalacenter/bloop/pull/1638
+[#1634]: https://github.com/scalacenter/bloop/pull/1634
+[#1633]: https://github.com/scalacenter/bloop/pull/1633
+[#1628]: https://github.com/scalacenter/bloop/pull/1628
+[#1623]: https://github.com/scalacenter/bloop/pull/1623
+[#1625]: https://github.com/scalacenter/bloop/pull/1625
+[#1622]: https://github.com/scalacenter/bloop/pull/1622
+[#1607]: https://github.com/scalacenter/bloop/pull/1607
+[#1619]: https://github.com/scalacenter/bloop/pull/1619
+[#1618]: https://github.com/scalacenter/bloop/pull/1618
+[#1617]: https://github.com/scalacenter/bloop/pull/1617
+[#1616]: https://github.com/scalacenter/bloop/pull/1616
+[#1615]: https://github.com/scalacenter/bloop/pull/1615
+[#1610]: https://github.com/scalacenter/bloop/pull/1610
+[#1612]: https://github.com/scalacenter/bloop/pull/1612
+
+
+## Contributors
+
+According to `git shortlog -sn --no-merges v1.4.11..v1.4.12`, the following people have contributed to
+this `v1.4.12` release: Kamil Podsiadlo, Tomasz Godzik, dependabot[bot], Vadim Chelyshov, Alexander Anohin, Alexandre Archambault, Arthur McGibbon.


### PR DESCRIPTION
The release is need for Java support in Metals.