### PR TITLE
Continue if `bloopGenerate` fails for a project

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -16,6 +16,7 @@ import sbt.{
   Def,
   File,
   Global,
+  Inc,
   Keys,
   LocalRootProject,
   Logger,
@@ -27,7 +28,8 @@ import sbt.{
   ThisProject,
   KeyRanks,
   Optional,
-  Provided
+  Provided,
+  Value
 }
 import xsbti.compile.CompileOrder
 
@@ -1051,6 +1053,12 @@ object BloopDefaults {
           logger.success(s"Generated $userFriendlyConfigPath")
           Some(outFile)
         }
+    }.result.map {
+      case Inc(_) =>
+        logger.error(s"Couldn't run bloopGenerate for $projectName")
+        None
+      case Value(maybeFile) =>
+        maybeFile
     }
   }
 


### PR DESCRIPTION
I'm in a situation where I want to generate bloop files for all projects for all scala versions.

Unfortunately, if we have the following project graph

```scala
lazy val a = project.settings(crossScalaVersions := List("2.13.0", "3.0.0"))
lazy val b = project.settings(crossScalaVersions := List("2.13.0")).dependsOn(a)
```

and then `+bloopInstall` may fail for `b` when generating for scala `3.0.0`, because it'll then use the `3.0.0` version of `a` and `2.13.0` of `b`.

I have seen errors like this:
```
[error] Modules were resolved with conflicting cross-version suffixes in ProjectRef...:
[error]    org.scala-lang.modules:scala-collection-compat _3, _2.13
[error]    com.lihaoyi:sourcecode _2.13, _3
[error]    org.typelevel:simulacrum-scalafix-annotations _2.13, _3
[error]    org.typelevel:cats-kernel _2.13, _3
[error]    com.lihaoyi:fansi _3, _2.13
[error]    org.typelevel:cats-core _2.13, _3
```

--- 

I should also comment that I tried to do this in a "cleaner" way. Ideally we'd pick out the "active" scala version, and only try to generate for those if some flag was set. However, I was unable to find that anywhere. 

Suggestions in that directions welcome