### PR TITLE
Force newest log4j version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,7 @@ lazy val bloopShared = (project in file("shared"))
     libraryDependencies ++= Seq(
       Dependencies.bsp4s,
       Dependencies.zinc,
+      Dependencies.log4j,
       Dependencies.xxHashLibrary,
       Dependencies.configDirectories,
       Dependencies.sbtTestInterface,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -66,6 +66,7 @@ object Dependencies {
 
   val configDirectories = "io.github.soc" % "directories" % configDirsVersion
   val libraryManagement = "org.scala-sbt" %% "librarymanagement-ivy" % lmVersion
+  val log4j = "org.apache.logging.log4j" % "log4j-core" % "2.17.1"
   val scalazCore = "org.scalaz" %% "scalaz-core" % scalazVersion
   val scalazConcurrent = "org.scalaz" %% "scalaz-concurrent" % scalazVersion
   val coursierInterface = "io.get-coursier" % "interface" % "1.0.4"


### PR DESCRIPTION
Turns out Zinc brings in log4j, and despite it all working locally (so no actual way to exploit it), it might cause issues if a company proxy blocks log4j older versions.