### PR TITLE
Update coursier-interface to 1.0.6

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,8 +69,8 @@ object Dependencies {
   val log4j = "org.apache.logging.log4j" % "log4j-core" % "2.17.1"
   val scalazCore = "org.scalaz" %% "scalaz-core" % scalazVersion
   val scalazConcurrent = "org.scalaz" %% "scalaz-concurrent" % scalazVersion
-  val coursierInterface = "io.get-coursier" % "interface" % "1.0.4"
-  val coursierInterfaceSubs = "io.get-coursier" % "interface-svm-subs" % "1.0.4"
+  val coursierInterface = "io.get-coursier" % "interface" % "1.0.6"
+  val coursierInterfaceSubs = "io.get-coursier" % "interface-svm-subs" % "1.0.6"
   val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.2"
   val shapeless = "com.chuusai" %% "shapeless" % shapelessVersion
   val caseApp = "com.github.alexarchambault" %% "case-app" % caseAppVersion


### PR DESCRIPTION
I'm [currently seeing](https://github.com/coursier/setup-action/runs/5028748027?check_suite_focus=true#step:15:40) issues with the native Bloop `1.4.2` launcher on Windows (complaining that it can't find the `sun.misc.BASE64Encoder` class, via directories, shaded in coursier-interface).

Updating coursier-interface might fix it (directories should ship with the right config since https://github.com/dirs-dev/directories-jvm/pull/33, I suspect it might be missing in coursier-interface `1.0.4`).