### PR TITLE
ci, build: fix release command

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -956,5 +956,5 @@ addCommandAlias(
     .mkString(";", ";", "")
 )
 
-val allReleaseActions = List("releaseEarlyAllModules", "releaseLauncher", "sonatypeBundleRelease")
+val allReleaseActions = List("releaseEarlyAllModules", "sonatypeBundleRelease")
 addCommandAlias("releaseBloop", allReleaseActions.mkString(";", ";", ""))


### PR DESCRIPTION
ok, https://github.com/scalacenter/bloop/runs/5159830970?check_suite_focus=true failed because of `releaseLauncher` command which I forgot to delete.