### PR TITLE
build, fix: bump mdoc plugin because of `java.lang.NoClassDefFoundError: scala/tools/nsc/reporters/AbstractReporter`

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -26,7 +26,7 @@ val `bloop-build` = project
     addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.1.1+4-9d76569a"),
     addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.1"),
     addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2"),
-    addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.0.2"),
+    addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.0"),
     addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools" % "1.1.1"),
     addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.2"),
     // We need to add libdeps for the maven integration plugin to work


### PR DESCRIPTION
CI ended with exactly the same error as described in https://github.com/scalameta/mdoc/pull/445