### PR TITLE
Fix timeouts on Windows tests

### DIFF
--- a/frontend/src/test/scala/bloop/BaseCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/BaseCompileSpec.scala
@@ -1284,7 +1284,7 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
 
       val compiledUserState = {
         // There are two macro calls in two different sources, cancellation must avoid one
-        try Await.result(backgroundCompiledUserState, Duration(2950, "ms"))
+        try Await.result(backgroundCompiledUserState, Duration(8000, "ms"))
         catch {
           case NonFatal(t) => backgroundCompiledUserState.cancel(); throw t
           case i: InterruptedException => backgroundCompiledUserState.cancel(); compiledMacrosState

--- a/frontend/src/test/scala/bloop/DeduplicationSpec.scala
+++ b/frontend/src/test/scala/bloop/DeduplicationSpec.scala
@@ -143,7 +143,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
         )
 
         import java.util.concurrent.TimeoutException
-        val (firstNoopState, secondNoopState) = TestUtil.blockOnTask(noopCompiles, 2)
+        val (firstNoopState, secondNoopState) = TestUtil.blockOnTask(noopCompiles, 5)
 
         assert(firstNoopState.status == ExitStatus.Ok)
         assert(secondNoopState.status == ExitStatus.Ok)
@@ -523,7 +523,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
           waitUntilStartAndCompile(compiledState, `B`, startedFirstCompilation, cliLogger2)
 
         val firstCompiledState =
-          Await.result(firstCompilation, FiniteDuration(5, TimeUnit.SECONDS))
+          Await.result(firstCompilation, FiniteDuration(15, TimeUnit.SECONDS))
         val (secondCompiledState, thirdCompiledState) =
           TestUtil.blockOnTask(mapBoth(secondCompilation, thirdCompilation), 3)
 
@@ -729,9 +729,9 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
         val eighthCompilation =
           waitUntilStartAndCompile(newCliCompiledState, `B`, startedThirdCompilation, cliLogger7)
 
-        val thirdBspState = Await.result(seventhCompilation, FiniteDuration(3, TimeUnit.SECONDS))
+        val thirdBspState = Await.result(seventhCompilation, FiniteDuration(10, TimeUnit.SECONDS))
         val seventhCompiledState =
-          Await.result(eighthCompilation, FiniteDuration(1, TimeUnit.SECONDS))
+          Await.result(eighthCompilation, FiniteDuration(5, TimeUnit.SECONDS))
 
         checkDeduplication(bspLogger, isDeduplicated = false)
         checkDeduplication(cliLogger7, isDeduplicated = true)

--- a/frontend/src/test/scala/bloop/FileWatchingSpec.scala
+++ b/frontend/src/test/scala/bloop/FileWatchingSpec.scala
@@ -23,7 +23,7 @@ import bloop.data.SourcesGlobs
 
 object FileWatchingSpec extends BaseSuite {
   System.setProperty("file-watcher-batch-window-ms", "100")
-  flakyTest("simulate an incremental compiler session with file watching enabled", 3) {
+  test("simulate an incremental compiler session with file watching enabled") {
     TestUtil.withinWorkspace { workspace =>
       import ExecutionContext.ioScheduler
       object Sources {
@@ -134,7 +134,7 @@ object FileWatchingSpec extends BaseSuite {
         state
       }
 
-      TestUtil.await(FiniteDuration(20, TimeUnit.SECONDS), ExecutionContext.ioScheduler) {
+      TestUtil.await(FiniteDuration(60, TimeUnit.SECONDS), ExecutionContext.ioScheduler) {
         for {
           _ <- waitUntilIteration(1)
           initialWatchedState <- Task(testValidLatestState)
@@ -414,7 +414,7 @@ object FileWatchingSpec extends BaseSuite {
       def waitUntilIteration(totalIterations: Int): Task[Unit] =
         waitUntilWatchIteration(logsObservable, totalIterations, HasIterationStoppedMsg, None)
 
-      TestUtil.await(FiniteDuration(5, TimeUnit.SECONDS)) {
+      TestUtil.await(FiniteDuration(15, TimeUnit.SECONDS)) {
         for {
           _ <- waitUntilIteration(1)
           initialWatchedState <- Task(compiledState.getLatestSavedStateGlobally())

--- a/frontend/src/test/scala/bloop/TracerSpec.scala
+++ b/frontend/src/test/scala/bloop/TracerSpec.scala
@@ -101,7 +101,7 @@ object TracerSpec extends BaseSuite {
 
     import bloop.engine.ExecutionContext
     import bloop.util.TestUtil
-    TestUtil.await(FiniteDuration(10, "s"), ExecutionContext.ioScheduler) {
+    TestUtil.await(FiniteDuration(20, "s"), ExecutionContext.ioScheduler) {
       Task.gatherUnordered(tasks).map(_ => ())
     }
   }


### PR DESCRIPTION
It seems a number of tests have a very low tolerance, especially some test which actually have in-built delays and usually have 1-2 second tolerance. This seems to be a bigger issue on Windows.