### PR TITLE
fix: remove benchmark step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,12 +117,6 @@ jobs:
           which gu && gu install native-image
           ./bin/sbt-ci.sh "install" "launcherTest/test"
         shell: bash
-      - name: Benchmark
-        if: matrix.jdk == 'graalvm-ce-java11@21.1.0' && matrix.os != 'windows-latest'
-        run: |
-          ./bin/sbt-ci.sh \
-              "benchmarks/jmh:run .*HotBloopBenchmark.* -wi 0 -i 1 -f1 -t1 -p project=with-tests -p projectName=with-tests"
-        shell: bash
 
   publish-binaries:
     name: Publish binaries for ${{ matrix.os }}


### PR DESCRIPTION
Benchmark step was failing at least for 2 months - https://github.com/scalacenter/bloop/runs/4675462587?check_suite_focus=true

We can investigate what's going on there but until it's fixed this step can be removed - this action will unblock https://github.com/scalacenter/bloop/pull/1679