### PR TITLE
chore: add scalafix

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,18 @@
+rules = [ 
+  DisableSyntax,
+  OrganizeImports,
+  NoValInForComprehension,
+]
+
+OrganizeImports {
+  removeUnused = true
+  expandRelative = true
+  groupedImports = Explode
+  groups = [
+  "re:javax?\\."
+  "scala."
+  "ch.epfl"
+  "bloop"
+  "*"
+]
+}

--- a/backend/src/main/scala/bloop/BloopClassFileManager.scala
+++ b/backend/src/main/scala/bloop/BloopClassFileManager.scala
@@ -1,26 +1,26 @@
 package bloop
 
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+
+import scala.collection.mutable
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
 import bloop.io.AbsolutePath
 import bloop.io.ParallelOps
 import bloop.io.ParallelOps.CopyMode
 import bloop.io.{Paths => BloopPaths}
 import bloop.reporter.Reporter
 import bloop.tracing.BraveTracer
+
 import monix.eval.Task
 import xsbti.compile.ClassFileManager
-import xsbti.compile.PreviousResult
-
-import java.io.File
-import java.io.IOException
-import java.nio.file.CopyOption
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
-import java.nio.file.StandardCopyOption
-import scala.collection.mutable
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
 
 final class BloopClassFileManager(
     backupDir0: Path,

--- a/backend/src/main/scala/bloop/BloopClasspathEntryLookup.scala
+++ b/backend/src/main/scala/bloop/BloopClasspathEntryLookup.scala
@@ -1,11 +1,15 @@
 package bloop
 
-import bloop.util.AnalysisUtils
+import java.io.File
+import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+import java.util.zip.ZipException
+import java.util.zip.ZipFile
+import java.{util => ju}
+
 import sbt.internal.inc.PlainVirtualFileConverter
-import sbt.internal.inc.bloop.internal.BloopNameHashing
 import sbt.internal.inc.bloop.internal.BloopStamps
 import sbt.internal.inc.classpath.ClasspathUtil
-import sbt.internal.inc.classpath.ClasspathUtilities
 import sbt.util.InterfaceUtil
 import xsbti.FileConverter
 import xsbti.VirtualFile
@@ -14,13 +18,6 @@ import xsbti.compile.DefinesClass
 import xsbti.compile.FileHash
 import xsbti.compile.PerClasspathEntryLookup
 import xsbti.compile.PreviousResult
-
-import java.io.File
-import java.nio.file.Path
-import java.util.concurrent.ConcurrentHashMap
-import java.util.zip.ZipException
-import java.util.zip.ZipFile
-import java.{util => ju}
 
 final class BloopClasspathEntryLookup(
     results: Map[File, PreviousResult],

--- a/backend/src/main/scala/bloop/CompileBackgroundTasks.scala
+++ b/backend/src/main/scala/bloop/CompileBackgroundTasks.scala
@@ -1,11 +1,11 @@
 package bloop
 
-import monix.eval.Task
-
 import bloop.io.AbsolutePath
-import bloop.tracing.BraveTracer
-import bloop.reporter.Reporter
 import bloop.logging.Logger
+import bloop.reporter.Reporter
+import bloop.tracing.BraveTracer
+
+import monix.eval.Task
 
 abstract class CompileBackgroundTasks {
   def trigger(

--- a/backend/src/main/scala/bloop/CompilerCache.scala
+++ b/backend/src/main/scala/bloop/CompilerCache.scala
@@ -1,29 +1,5 @@
 package bloop
 
-import bloop.io.AbsolutePath
-import bloop.io.Paths
-import bloop.logging.Logger
-import bloop.util.JavaRuntime
-import sbt.internal.inc.AnalyzingCompiler
-import sbt.internal.inc.BloopComponentCompiler
-import sbt.internal.inc.BloopZincLibraryManagement
-import sbt.internal.inc.ZincUtil
-import sbt.internal.inc.bloop.ZincInternals
-import sbt.internal.inc.javac.DiagnosticsReporter
-import sbt.internal.inc.javac.JavaTools
-import sbt.internal.inc.javac.Javadoc
-import sbt.internal.inc.javac.WriteReportingJavaFileObject
-import sbt.internal.util.LoggerWriter
-import sbt.librarymanagement.Resolver
-import xsbti.ComponentProvider
-import xsbti.compile.ClassFileManager
-import xsbti.compile.Compilers
-import xsbti.compile.JavaCompiler
-import xsbti.compile.ScalaCompiler
-import xsbti.compile.{JavaTool => XJavaTool}
-import xsbti.{Logger => XLogger}
-import xsbti.{Reporter => XReporter}
-
 import java.io.File
 import java.io.IOException
 import java.io.PrintWriter
@@ -36,13 +12,36 @@ import javax.tools.JavaFileManager.Location
 import javax.tools.JavaFileObject
 import javax.tools.JavaFileObject.Kind
 import javax.tools.{JavaCompiler => JavaxCompiler}
+
 import scala.collection.mutable.HashSet
 import scala.concurrent.ExecutionContext
-import xsbti.VirtualFile
-import bloop.util.AnalysisUtils
-import xsbti.compile.{IncToolOptions, Output}
+
+import bloop.io.AbsolutePath
+import bloop.io.Paths
+import bloop.logging.Logger
+import bloop.util.JavaRuntime
+
+import sbt.internal.inc.AnalyzingCompiler
+import sbt.internal.inc.BloopComponentCompiler
+import sbt.internal.inc.BloopZincLibraryManagement
 import sbt.internal.inc.CompilerArguments
 import sbt.internal.inc.PlainVirtualFileConverter
+import sbt.internal.inc.ZincUtil
+import sbt.internal.inc.javac.DiagnosticsReporter
+import sbt.internal.inc.javac.JavaTools
+import sbt.internal.inc.javac.Javadoc
+import sbt.internal.inc.javac.WriteReportingJavaFileObject
+import sbt.internal.util.LoggerWriter
+import sbt.librarymanagement.Resolver
+import xsbti.ComponentProvider
+import xsbti.VirtualFile
+import xsbti.compile.ClassFileManager
+import xsbti.compile.Compilers
+import xsbti.compile.JavaCompiler
+import xsbti.compile.Output
+import xsbti.compile.ScalaCompiler
+import xsbti.{Logger => XLogger}
+import xsbti.{Reporter => XReporter}
 
 final class CompilerCache(
     componentProvider: ComponentProvider,
@@ -271,7 +270,6 @@ final class CompilerCache(
       }
 
       var compileSuccess = false
-      import sbt.internal.inc.javac.WriteReportingFileManager
       val zincFileManager = incToolOptions.classFileManager().get()
       val fileManager = new BloopInvalidatingFileManager(fileManager0, zincFileManager)
       val sourceFiles: Array[File] = sources.map(converter.toPath(_).toFile())

--- a/backend/src/main/scala/bloop/DependencyResolution.scala
+++ b/backend/src/main/scala/bloop/DependencyResolution.scala
@@ -1,14 +1,13 @@
 package bloop
 
-import bloop.logging.{DebugFilter, Logger}
-import bloop.io.AbsolutePath
+import scala.collection.JavaConverters._
 
-import sbt.librarymanagement._
-import sbt.librarymanagement.ivy._
+import bloop.io.AbsolutePath
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+
 import coursierapi.Repository
 import coursierapi.error.CoursierError
-
-import scala.collection.JavaConverters._
 
 object DependencyResolution {
 

--- a/backend/src/main/scala/bloop/ScalaInstance.scala
+++ b/backend/src/main/scala/bloop/ScalaInstance.scala
@@ -1,18 +1,21 @@
 package bloop
 
 import java.io.File
-import java.net.URLClassLoader
-import java.nio.file.{Files, Path, Paths, StandardCopyOption}
-import java.nio.file.attribute.{BasicFileAttributes, FileTime}
-import java.util.Properties
 import java.lang.invoke.MethodHandles
 import java.lang.invoke.MethodType
-
-import bloop.internal.build.BloopScalaInfo
-import bloop.logging.{DebugFilter, Logger}
+import java.net.URLClassLoader
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.FileTime
+import java.util.Properties
 
 import scala.util.control.NonFatal
-import sbt.internal.inc.BloopComponentCompiler
+
+import bloop.internal.build.BloopScalaInfo
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
 
 final class ScalaInstance private (
     val organization: String,

--- a/backend/src/main/scala/bloop/UniqueCompileInputs.scala
+++ b/backend/src/main/scala/bloop/UniqueCompileInputs.scala
@@ -1,9 +1,9 @@
 package bloop
 
-import bloop.io.AbsolutePath
 import bloop.util.CacheHashCode
-import xsbti.compile.FileHash
+
 import xsbti.VirtualFileRef
+import xsbti.compile.FileHash
 
 case class UniqueCompileInputs(
     sources: Vector[UniqueCompileInputs.HashedSource],

--- a/backend/src/main/scala/bloop/io/ClasspathHasher.scala
+++ b/backend/src/main/scala/bloop/io/ClasspathHasher.scala
@@ -1,33 +1,31 @@
 package bloop.io
 
-import bloop.logging.Logger
-import bloop.logging.DebugFilter
-import bloop.tracing.BraveTracer
+import java.io.File
+import java.io.InputStream
+import java.io.PrintStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.FileTime
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import java.util.zip.ZipEntry
 
 import scala.collection.mutable
 import scala.concurrent.Promise
 
-import java.io.{File, InputStream}
-import java.nio.file.{Files, NoSuchFileException, Path}
-import java.util.concurrent.ConcurrentHashMap
-import java.nio.file.attribute.{BasicFileAttributes, FileTime}
-import java.util.zip.ZipEntry
+import bloop.logging.Logger
+import bloop.tracing.BraveTracer
 
 import monix.eval.Task
-import monix.eval.Callback
-import monix.execution.Scheduler
 import monix.execution.Cancelable
+import monix.execution.Scheduler
 import monix.execution.atomic.AtomicBoolean
-import monix.execution.cancelables.CompositeCancelable
-import monix.reactive.{Observable, MulticastStrategy, Consumer}
-
-import xsbti.compile.FileHash
-import sbt.internal.inc.{EmptyStamp, Stamper}
+import monix.reactive.Consumer
+import monix.reactive.Observable
 import sbt.internal.inc.bloop.internal.BloopStamps
 import sbt.io.IO
-import java.util.concurrent.TimeUnit
-import java.io.PrintStream
-import xsbti.VirtualFile
+import xsbti.compile.FileHash
 
 object ClasspathHasher {
 

--- a/backend/src/main/scala/bloop/io/ParallelOps.scala
+++ b/backend/src/main/scala/bloop/io/ParallelOps.scala
@@ -1,32 +1,27 @@
 package bloop.io
 
+import java.io.IOException
+import java.nio.file.FileVisitResult
+import java.nio.file.FileVisitor
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.concurrent.Promise
+
 import bloop.logging.Logger
 
-import java.io.{IOException, File}
-import java.util.concurrent.Executor
-import java.util.concurrent.ConcurrentHashMap
-import java.nio.file.attribute.BasicFileAttributes
-import java.nio.file.{
-  FileVisitOption,
-  FileVisitResult,
-  FileVisitor,
-  Files,
-  Path,
-  SimpleFileVisitor,
-  StandardCopyOption
-}
-
-import scala.util.control.NonFatal
-import scala.concurrent.Promise
-import scala.collection.JavaConverters._
-
 import monix.eval.Task
-import monix.execution.{Scheduler, Cancelable}
-import monix.reactive.{Observable, Consumer, Observer}
-import monix.reactive.MulticastStrategy
+import monix.execution.Cancelable
+import monix.execution.Scheduler
 import monix.execution.atomic.AtomicBoolean
-import monix.execution.cancelables.CompositeCancelable
 import monix.execution.cancelables.AssignableCancelable
+import monix.execution.cancelables.CompositeCancelable
+import monix.reactive.Consumer
+import monix.reactive.MulticastStrategy
+import monix.reactive.Observable
 
 object ParallelOps {
 

--- a/backend/src/main/scala/bloop/io/Timer.scala
+++ b/backend/src/main/scala/bloop/io/Timer.scala
@@ -1,6 +1,7 @@
 package bloop.io
 
-import bloop.logging.{DebugFilter, Logger}
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
 
 object Timer {
   @inline def timed[T](logger: Logger, prefix: Option[String] = None)(op: => T): T = {

--- a/backend/src/main/scala/bloop/logging/BloopLogger.scala
+++ b/backend/src/main/scala/bloop/logging/BloopLogger.scala
@@ -2,9 +2,14 @@ package bloop.logging
 
 import java.io.PrintStream
 
-import scala.Console.{CYAN, GREEN, RED, RESET, YELLOW}
-import scala.util.matching.Regex
-import bloop.io.Environment.{lineSeparator, LineSplitter}
+import scala.Console.CYAN
+import scala.Console.GREEN
+import scala.Console.RED
+import scala.Console.RESET
+import scala.Console.YELLOW
+
+import bloop.io.Environment.LineSplitter
+import bloop.io.Environment.lineSeparator
 
 /**
  * Creates a logger that writes to the given streams.

--- a/backend/src/main/scala/bloop/logging/ObservedLogger.scala
+++ b/backend/src/main/scala/bloop/logging/ObservedLogger.scala
@@ -1,6 +1,7 @@
 package bloop.logging
 
 import bloop.reporter.ReporterAction
+
 import monix.reactive.Observer
 
 /**

--- a/backend/src/main/scala/bloop/logging/ProcessLogger.scala
+++ b/backend/src/main/scala/bloop/logging/ProcessLogger.scala
@@ -1,13 +1,12 @@
 package bloop.logging
 
-import java.io.{
-  BufferedReader,
-  ByteArrayOutputStream,
-  InputStream,
-  InputStreamReader,
-  OutputStream,
-  PrintStream
-}
+import java.io.BufferedReader
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.OutputStream
+import java.io.PrintStream
+
 import scala.annotation.tailrec
 
 /**

--- a/backend/src/main/scala/bloop/logging/Slf4jAdapter.scala
+++ b/backend/src/main/scala/bloop/logging/Slf4jAdapter.scala
@@ -1,6 +1,7 @@
 package bloop.logging
 
-import org.slf4j.{Marker, Logger => Slf4jLogger}
+import org.slf4j.Marker
+import org.slf4j.{Logger => Slf4jLogger}
 
 /**
  * Defines a slf4j-compliant logger wrapping Bloop logging utils.

--- a/backend/src/main/scala/bloop/reporter/ConfigurableReporter.scala
+++ b/backend/src/main/scala/bloop/reporter/ConfigurableReporter.scala
@@ -1,7 +1,6 @@
 package bloop.reporter
 
 import bloop.io.AbsolutePath
-import bloop.logging.{ObservedLogger, Logger}
 
 /**
  * Interface for a reporter that has a configuration.

--- a/backend/src/main/scala/bloop/reporter/ObservedReporter.scala
+++ b/backend/src/main/scala/bloop/reporter/ObservedReporter.scala
@@ -1,13 +1,15 @@
 package bloop.reporter
 
 import java.io.File
+
 import scala.util.Try
-import scala.collection.mutable
-import bloop.io.AbsolutePath
+
 import ch.epfl.scala.bsp
-import bloop.logging.{ObservedLogger, Logger}
-import scala.concurrent.Promise
-import bloop.logging.CompilationEvent
+
+import bloop.io.AbsolutePath
+import bloop.logging.Logger
+import bloop.logging.ObservedLogger
+
 import xsbti.VirtualFile
 
 final class ObservedReporter(

--- a/backend/src/main/scala/bloop/reporter/Reporter.scala
+++ b/backend/src/main/scala/bloop/reporter/Reporter.scala
@@ -2,21 +2,21 @@ package bloop.reporter
 
 import java.io.File
 
-import bloop.io.AbsolutePath
-import bloop.logging.{Logger, ObservedLogger}
-import xsbti.{Position, Severity}
-import ch.epfl.scala.bsp
-import sbt.util.InterfaceUtil
-import xsbti.compile.CompileAnalysis
-
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 import scala.util.Try
-import bloop.logging.CompilationEvent
-import scala.concurrent.Promise
+
+import ch.epfl.scala.bsp
+
+import bloop.io.AbsolutePath
+import bloop.logging.Logger
+
 import monix.execution.atomic.AtomicInt
-import xsbti.VirtualFile
 import sbt.internal.inc.PlainVirtualFileConverter
+import sbt.util.InterfaceUtil
+import xsbti.Position
+import xsbti.Severity
+import xsbti.VirtualFile
 
 /**
  * A flexible reporter whose configuration is provided by a `ReporterConfig`.
@@ -98,8 +98,8 @@ abstract class Reporter(
     }
   }
 
-  protected val phasesAtFile = TrieMap.empty[File, String]
-  protected val filesToPhaseStack = TrieMap.empty[File, List[String]]
+  protected val phasesAtFile: TrieMap[File, String] = TrieMap.empty[File, String]
+  protected val filesToPhaseStack: TrieMap[File, List[String]] = TrieMap.empty[File, List[String]]
 
   // Adapted from https://github.com/scala/scala/blob/2.12.x/src/compiler/scala/tools/nsc/reporters/AbstractReporter.scala#L68-L88
   private def deduplicate(problem: xsbti.Problem): Boolean = {

--- a/backend/src/main/scala/bloop/reporter/ReporterAction.scala
+++ b/backend/src/main/scala/bloop/reporter/ReporterAction.scala
@@ -1,8 +1,11 @@
 package bloop.reporter
 
 import java.io.File
+
 import scala.util.Try
+
 import ch.epfl.scala.bsp
+
 import xsbti.VirtualFile
 
 sealed trait ReporterAction

--- a/backend/src/main/scala/bloop/reporter/ReporterConfig.scala
+++ b/backend/src/main/scala/bloop/reporter/ReporterConfig.scala
@@ -33,7 +33,7 @@ final case class ReporterConfig(
 )
 
 object ReporterConfig {
-  final val defaultFormat = {
+  final val defaultFormat: ReporterConfig = {
     new ReporterConfig(
       true,
       true,
@@ -50,7 +50,7 @@ object ReporterConfig {
     )
   }
 
-  final val scalacFormat = {
+  final val scalacFormat: ReporterConfig = {
     new ReporterConfig(
       true,
       true,

--- a/backend/src/main/scala/bloop/reporter/ReporterFormat.scala
+++ b/backend/src/main/scala/bloop/reporter/ReporterFormat.scala
@@ -1,13 +1,15 @@
 package bloop.reporter
 
-import xsbti.{Position, Severity}
-import scala.Console.RESET
-import scala.compat.Platform.EOL
-
 import java.io.File
 import java.util.Optional
 
+import scala.Console.RESET
+import scala.compat.Platform.EOL
+
 import bloop.io.AbsolutePath
+
+import xsbti.Position
+import xsbti.Severity
 
 /**
  * Describes how messages should be formatted by a `ConfigurableReporter`.

--- a/backend/src/main/scala/bloop/reporter/ScalacFormat.scala
+++ b/backend/src/main/scala/bloop/reporter/ScalacFormat.scala
@@ -1,9 +1,11 @@
 package bloop.reporter
 
-import xsbti.{Position, Severity}
+import java.util.Optional
+
 import scala.compat.Platform.EOL
 
-import java.util.Optional
+import xsbti.Position
+import xsbti.Severity
 
 object ScalacFormat extends (Reporter => ReporterFormat) {
   override def apply(reporter: Reporter): ReporterFormat =

--- a/backend/src/main/scala/bloop/tracing/BraveTracer.scala
+++ b/backend/src/main/scala/bloop/tracing/BraveTracer.scala
@@ -1,16 +1,16 @@
 package bloop.tracing
 
+import java.util.concurrent.ConcurrentHashMap
+
+import brave.Span
+import brave.Tracer
 import brave.propagation.SamplingFlags
 import brave.propagation.TraceContext
 import brave.propagation.TraceContextOrSamplingFlags
-import brave.Span
-import brave.Tracer
 import monix.eval.Task
 import monix.execution.misc.NonFatal
-import scala.util.Properties
 import zipkin2.codec.SpanBytesEncoder.JSON_V1
 import zipkin2.codec.SpanBytesEncoder.JSON_V2
-import java.util.concurrent.ConcurrentHashMap
 
 final class BraveTracer private (
     tracer: Tracer,

--- a/backend/src/main/scala/bloop/util/AnalysisUtils.scala
+++ b/backend/src/main/scala/bloop/util/AnalysisUtils.scala
@@ -1,11 +1,10 @@
 package bloop.util
 
 import bloop.reporter.ProblemPerPhase
+
 import xsbti.VirtualFileRef
 import xsbti.compile.CompileAnalysis
 import xsbti.compile.analysis.SourceInfo
-
-import java.io.File
 
 object AnalysisUtils {
   import scala.collection.JavaConverters._

--- a/backend/src/main/scala/bloop/util/Java8Compat.scala
+++ b/backend/src/main/scala/bloop/util/Java8Compat.scala
@@ -1,15 +1,22 @@
 package bloop.util
 
-import java.util.concurrent.{CancellationException, CompletableFuture, CompletionException}
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.function.BiFunction
 
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import monix.execution.Cancelable
+import monix.execution.CancelableFuture
 import monix.execution.cancelables.SingleAssignmentCancelable
 import monix.execution.misc.NonFatal
 import monix.execution.schedulers.TrampolinedRunnable
-import monix.execution.{Cancelable, CancelableFuture}
-
-import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.util.{Failure, Success, Try}
 
 /**
  * Utilities for integration with Java 8 classes

--- a/backend/src/main/scala/bloop/util/JavaRuntime.scala
+++ b/backend/src/main/scala/bloop/util/JavaRuntime.scala
@@ -1,10 +1,12 @@
 package bloop.util
 
-import javax.tools.ToolProvider
-import scala.util.Try
-import scala.util.Failure
-import bloop.io.AbsolutePath
 import javax.tools.JavaCompiler
+import javax.tools.ToolProvider
+
+import scala.util.Failure
+import scala.util.Try
+
+import bloop.io.AbsolutePath
 
 sealed trait JavaRuntime
 object JavaRuntime {

--- a/backend/src/main/scala/bloop/util/UUIDUtil.scala
+++ b/backend/src/main/scala/bloop/util/UUIDUtil.scala
@@ -1,6 +1,7 @@
 package bloop.util
 import java.nio.ByteBuffer
-import java.util.{Base64, UUID}
+import java.util.Base64
+import java.util.UUID
 
 object UUIDUtil {
 

--- a/backend/src/main/scala/sbt/internal/inc/BloopComponentCompiler.scala
+++ b/backend/src/main/scala/sbt/internal/inc/BloopComponentCompiler.scala
@@ -10,35 +10,31 @@ package internal
 package inc
 
 import java.io.File
-import java.util.concurrent.Callable
-
-import sbt.internal.inc.classpath.ClasspathUtilities
-import sbt.io.IO
-import sbt.internal.librarymanagement._
-import sbt.internal.util.{BufferedLogger, FullLogger}
-import sbt.librarymanagement._
-import sbt.librarymanagement.syntax._
-import sbt.util.InterfaceUtil.{toSupplier => f0}
-import xsbti.ArtifactInfo._
-import xsbti.{ComponentProvider, GlobalLock, Logger}
-import xsbti.compile.{ClasspathOptionsUtil, CompilerBridgeProvider}
-import _root_.bloop.io.AbsolutePath
-import _root_.bloop.{ScalaInstance => BloopScalaInstance}
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
 
+import scala.concurrent.ExecutionContext
+
+import _root_.bloop.io.AbsolutePath
+import _root_.bloop.logging.DebugFilter
 import _root_.bloop.logging.{Logger => BloopLogger}
 import _root_.bloop.{DependencyResolution => BloopDependencyResolution}
-import _root_.bloop.logging.DebugFilter
-import scala.concurrent.ExecutionContext
-import java.nio.file.Path
+import _root_.bloop.{ScalaInstance => BloopScalaInstance}
 import sbt.internal.inc.classpath.ClasspathUtil
+import sbt.io.IO
+import sbt.librarymanagement._
+import xsbti.ArtifactInfo._
+import xsbti.ComponentProvider
+import xsbti.Logger
+import xsbti.compile.ClasspathOptionsUtil
+import xsbti.compile.CompilerBridgeProvider
 
 object BloopComponentCompiler {
   import xsbti.compile.ScalaInstance
 
   final val binSeparator = "-bin_"
-  final val javaClassVersion = System.getProperty("java.class.version")
+  final val javaClassVersion: String = System.getProperty("java.class.version")
 
   final lazy val latestVersion: String = BloopComponentManager.version
 
@@ -232,7 +228,7 @@ private[inc] class BloopComponentCompiler(
     logger: BloopLogger,
     scheduler: ExecutionContext
 ) {
-  implicit val debugFilter = DebugFilter.Compilation
+  implicit val debugFilter: DebugFilter.Compilation.type = DebugFilter.Compilation
   def compiledBridgeJar: File = {
     val jarBinaryName = {
       val instance = compiler.scalaInstance
@@ -312,7 +308,6 @@ private[inc] class BloopComponentCompiler(
     }
   }
 
-  import xsbti.compile.ScalaInstance
   private def mergeBloopAndHydraBridges(
       bloopBridgeSourceJars: Vector[Path],
       hydraBridgeModule: ModuleID
@@ -336,7 +331,7 @@ private[inc] class BloopComponentCompiler(
         Left(new InvalidComponent(msg, t))
     }
 
-    import sbt.io.IO.{zip, unzip, withTemporaryDirectory, listFiles, relativize}
+    import sbt.io.IO.{zip, unzip, withTemporaryDirectory, relativize}
     hydraSourcesJars match {
       case Right(sourceJar +: otherJars) =>
         if (otherJars.nonEmpty) {

--- a/backend/src/main/scala/sbt/internal/inc/BloopComponentManager.scala
+++ b/backend/src/main/scala/sbt/internal/inc/BloopComponentManager.scala
@@ -12,10 +12,8 @@ package inc
 import java.io.File
 import java.util.concurrent.Callable
 
-import sbt.internal.util.FullLogger
 import sbt.io.IO
 import xsbti._
-import xsbti.ArtifactInfo.SbtOrganization
 
 /**
  * A component manager provides access to the pieces of zinc that are distributed as components.
@@ -120,5 +118,5 @@ object BloopComponentManager {
     val properties = ResourceLoader.getPropertiesFor("/incrementalcompiler.version.properties")
     (properties.getProperty("version"), properties.getProperty("timestamp"))
   }
-  lazy val stampedVersion = s"${version}_$timestamp"
+  lazy val stampedVersion: String = s"${version}_$timestamp"
 }

--- a/backend/src/main/scala/sbt/internal/inc/BloopZincLibraryManagement.scala
+++ b/backend/src/main/scala/sbt/internal/inc/BloopZincLibraryManagement.scala
@@ -10,11 +10,12 @@ package sbt.internal.inc
 import java.io.File
 import java.net.URLClassLoader
 
-import sbt.librarymanagement.{DependencyResolution, ModuleID}
+import scala.concurrent.ExecutionContext
+
 import sbt.internal.inc.classpath.ClassLoaderCache
+import sbt.librarymanagement.ModuleID
 import xsbti._
 import xsbti.compile._
-import scala.concurrent.ExecutionContext
 
 object BloopZincLibraryManagement {
   import xsbti.compile.ScalaInstance

--- a/backend/src/main/scala/sbt/internal/inc/HydraSupport.scala
+++ b/backend/src/main/scala/sbt/internal/inc/HydraSupport.scala
@@ -1,19 +1,19 @@
 package sbt.internal.inc
 
 import _root_.bloop.{ScalaInstance => BloopScalaInstance}
-
-import sbt.librarymanagement.ModuleID
+import coursierapi.MavenRepository
 import sbt.librarymanagement.Configurations
+import sbt.librarymanagement.ModuleID
 
 object HydraSupport {
   import xsbti.compile.ScalaInstance
 
-  val bridgeVersion = sys.props.get("bloop.hydra.bridgeVersion").getOrElse("0.2.0")
-  val bridgeNamePrefix =
+  val bridgeVersion: String = sys.props.get("bloop.hydra.bridgeVersion").getOrElse("0.2.0")
+  val bridgeNamePrefix: String =
     sys.props.get("bloop.hydra.bridgeNamePrefix").getOrElse("bloop-hydra-bridge")
 
   // The Hydra resolver is used to fetch both the bloop-hydra-bridge and the Hydra jars
-  val resolver = {
+  val resolver: MavenRepository = {
     coursierapi.MavenRepository.of(
       sys.props
         .get("bloop.hydra.resolver")
@@ -22,7 +22,7 @@ object HydraSupport {
   }
 
   /* Hydra is considered enabled if the Scala instance contains the hydra scala-compiler jar. */
-  def isEnabled(instance: ScalaInstance) = {
+  def isEnabled(instance: ScalaInstance): Boolean = {
     instance match {
       case instance: BloopScalaInstance => instance.supportsHydra
       case _ => false
@@ -36,7 +36,7 @@ object HydraSupport {
       .sources()
   }
 
-  def getCompilerBridgeId(instance: ScalaInstance) = {
+  def getCompilerBridgeId(instance: ScalaInstance): String = {
     val suffix = instance.version match {
       case sc if (sc startsWith "2.11.") => "2.11"
       case sc if (sc startsWith "2.12.") => "2.12"

--- a/backend/src/main/scala/sbt/internal/inc/bloop/BloopZincCompiler.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/BloopZincCompiler.scala
@@ -1,30 +1,36 @@
 // scalafmt: { maxColumn = 250 }
 package sbt.internal.inc.bloop
 
-import java.io.File
-import java.util.concurrent.CompletableFuture
-
-import bloop.reporter.ZincReporter
-import bloop.logging.ObservedLogger
-import bloop.tracing.BraveTracer
-import sbt.internal.inc.bloop.internal.{BloopLookup, BloopStamps}
-import monix.eval.Task
-import sbt.internal.inc.{Analysis, CompileConfiguration, CompileOutput, HydraSupport, Incremental, JarUtils, MiniSetupUtil, MixedAnalyzingCompiler}
-import xsbti.{AnalysisCallback, Logger}
-import sbt.internal.inc.JavaInterfaceUtil.{EnrichOptional, EnrichSbtTuple}
-import sbt.internal.inc.bloop.internal.{BloopHighLevelCompiler, BloopIncremental}
-import sbt.util.InterfaceUtil
-import xsbti.compile._
-import bloop.UniqueCompileInputs
-
 import scala.concurrent.Promise
+
+import bloop.UniqueCompileInputs
+import bloop.logging.ObservedLogger
+import bloop.reporter.ZincReporter
+import bloop.tracing.BraveTracer
+
+import monix.eval.Task
+import sbt.internal.inc.Analysis
+import sbt.internal.inc.CompileConfiguration
+import sbt.internal.inc.CompileOutput
+import sbt.internal.inc.HydraSupport
+import sbt.internal.inc.JarUtils
+import sbt.internal.inc.JavaInterfaceUtil.EnrichOptional
+import sbt.internal.inc.JavaInterfaceUtil.EnrichSbtTuple
+import sbt.internal.inc.MiniSetupUtil
+import sbt.internal.inc.MixedAnalyzingCompiler
 import sbt.internal.inc.PlainVirtualFileConverter
-import bloop.util.AnalysisUtils
+import sbt.internal.inc.bloop.internal.BloopHighLevelCompiler
+import sbt.internal.inc.bloop.internal.BloopIncremental
+import sbt.internal.inc.bloop.internal.BloopLookup
+import sbt.internal.inc.bloop.internal.BloopStamps
+import sbt.util.InterfaceUtil
+import xsbti.AnalysisCallback
 import xsbti.VirtualFile
+import xsbti.compile._
 
 object BloopZincCompiler {
   import bloop.logging.DebugFilter
-  private implicit val filter = DebugFilter.Compilation
+  private implicit val filter: DebugFilter.Compilation.type = DebugFilter.Compilation
 
   /**
    * Performs an incremental compilation based on [[xsbti.compile.Inputs]].
@@ -191,7 +197,6 @@ object BloopZincCompiler {
     import MiniSetupUtil._
 
     /* Define first because `Equiv[CompileOrder.value]` dominates `Equiv[MiniSetup]`. */
-    import xsbti.compile.Output
     val equiv: Equiv[MiniSetup] = {
       new Equiv[MiniSetup] {
         def equiv(a: MiniSetup, b: MiniSetup) = {

--- a/backend/src/main/scala/sbt/internal/inc/bloop/ZincInternals.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/ZincInternals.scala
@@ -1,19 +1,13 @@
 package sbt.internal.inc.bloop
 
-import java.io.File
 import java.{util => ju}
-import java.nio.file.Files
 
-import bloop.ScalaInstance
-import bloop.io.AbsolutePath
-import sbt.internal.inc.BloopComponentCompiler
 import sbt.internal.inc.javac.AnalyzingJavaCompiler
-import sbt.librarymanagement.{Configurations, ModuleID}
-import xsbti.compile.{ClasspathOptions, JavaCompiler}
-import xsbti.{ComponentProvider, Position}
+import xsbti.Position
 import xsbti.VirtualFile
-import bloop.util.AnalysisUtils
 import xsbti.VirtualFileRef
+import xsbti.compile.ClasspathOptions
+import xsbti.compile.JavaCompiler
 
 object ZincInternals {
   import sbt.internal.inc.JavaInterfaceUtil.EnrichOptional

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopAnalysisCallback.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopAnalysisCallback.scala
@@ -1,44 +1,40 @@
 package sbt.internal.inc.bloop.internal
 
 import java.io.File
+import java.nio.file.Path
 import java.{util => ju}
 
-import xsbti.api.AnalyzedClass
-import xsbti.compile.analysis.ReadStamps
-import xsbti.compile.Output
-import xsbti.compile.IncOptions
-import xsbti.api.SafeLazyProxy
-import xsbt.api.HashAPI
-import xsbti.api.ClassLike
-import xsbti.api.NameHash
-import xsbti.Problem
-import xsbti.api.InternalDependency
-import xsbti.api.ExternalDependency
-import xsbti.api.DependencyContext
-import xsbti.Position
-import xsbti.Severity
-import xsbti.api.DefinitionType
-import xsbti.UseScope
-import xsbti.api.Companions
-import xsbt.api.APIUtil
-import xsbt.api.NameHashing
-import xsbti.compile.ClassFileManager
-
-import sbt.internal.inc.Incremental
-import sbt.util.InterfaceUtil
-import sbt.internal.inc.UsedName
 import sbt.internal.inc.Analysis
 import sbt.internal.inc.Compilation
-import sbt.internal.inc.SourceInfos
-import sbt.internal.inc.UsedNames
-import xsbti.VirtualFile
-import bloop.util.AnalysisUtils
-import java.nio.file.Path
-import xsbti.VirtualFileRef
-import xsbti.VirtualFileRef
-import java.nio.file.Path
-import xsbti.T2
+import sbt.internal.inc.Incremental
 import sbt.internal.inc.PlainVirtualFileConverter
+import sbt.internal.inc.SourceInfos
+import sbt.internal.inc.UsedName
+import sbt.internal.inc.UsedNames
+import sbt.util.InterfaceUtil
+import xsbt.api.APIUtil
+import xsbt.api.HashAPI
+import xsbt.api.NameHashing
+import xsbti.Position
+import xsbti.Problem
+import xsbti.Severity
+import xsbti.T2
+import xsbti.UseScope
+import xsbti.VirtualFile
+import xsbti.VirtualFileRef
+import xsbti.api.AnalyzedClass
+import xsbti.api.ClassLike
+import xsbti.api.Companions
+import xsbti.api.DefinitionType
+import xsbti.api.DependencyContext
+import xsbti.api.ExternalDependency
+import xsbti.api.InternalDependency
+import xsbti.api.NameHash
+import xsbti.api.SafeLazyProxy
+import xsbti.compile.ClassFileManager
+import xsbti.compile.IncOptions
+import xsbti.compile.Output
+import xsbti.compile.analysis.ReadStamps
 
 trait IBloopAnalysisCallback extends xsbti.AnalysisCallback {
   def get: Analysis
@@ -56,7 +52,7 @@ final class BloopAnalysisCallback(
 
   private[this] val compilation: Compilation = Compilation(System.currentTimeMillis(), output)
 
-  override def toString =
+  override def toString: String =
     (List("Class APIs", "Object APIs", "Binary deps", "Products", "Source deps") zip
       List(classApis, objectApis, binaryDeps, nonLocalClasses, intSrcDeps))
       .map { case (label, map) => label + "\n\t" + map.mkString("\n\t") }
@@ -135,7 +131,11 @@ final class BloopAnalysisCallback(
     }
   }
 
-  def classDependency(onClassName: String, sourceClassName: String, context: DependencyContext) = {
+  def classDependency(
+      onClassName: String,
+      sourceClassName: String,
+      context: DependencyContext
+  ): Unit = {
     if (onClassName != sourceClassName)
       add(intSrcDeps, sourceClassName, InternalDependency.of(sourceClassName, onClassName, context))
   }
@@ -189,7 +189,7 @@ final class BloopAnalysisCallback(
       fromClassName: String,
       fromSourceFile: File,
       context: DependencyContext
-  ) = {
+  ): Unit = {
     binaryDependency(
       classFile.toPath(),
       onBinaryClassName,
@@ -291,7 +291,7 @@ final class BloopAnalysisCallback(
     mainClass(converter.toVirtualFile(sourceFile.toPath()), className)
   }
 
-  def usedName(className: String, name: String, useScopes: ju.EnumSet[UseScope]) =
+  def usedName(className: String, name: String, useScopes: ju.EnumSet[UseScope]): Unit =
     add(usedNames, className, UsedName(name, useScopes))
 
   override def enabled(): Boolean = options.enabled

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopHighLevelCompiler.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopHighLevelCompiler.scala
@@ -1,32 +1,30 @@
 // scalafmt: { maxColumn = 250 }
 package sbt.internal.inc.bloop.internal
 
-import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.Optional
-import java.util.concurrent.CompletableFuture
 
-import bloop.reporter.ZincReporter
+import scala.concurrent.Promise
+import scala.util.control.NonFatal
+
 import bloop.logging.ObservedLogger
-import bloop.JavaSignal
+import bloop.reporter.ZincReporter
 import bloop.tracing.BraveTracer
 
 import monix.eval.Task
+import sbt.internal.inc.AnalyzingCompiler
+import sbt.internal.inc.CompileConfiguration
+import sbt.internal.inc.CompilerArguments
 import sbt.internal.inc.JavaInterfaceUtil.EnrichOption
-import sbt.internal.inc.javac.AnalyzingJavaCompiler
-import sbt.internal.inc.{AnalyzingCompiler, CompileConfiguration, CompilerArguments, MixedAnalyzingCompiler, ScalaInstance, Stamper, Stamps}
-import sbt.util.Logger
-import xsbti.{AnalysisCallback, CompileFailed}
-import xsbti.compile._
-
-import scala.util.control.NonFatal
-import sbt.internal.inc.JarUtils
-import scala.concurrent.Promise
-import xsbt.InterfaceCompileCancelled
-import bloop.util.AnalysisUtils
+import sbt.internal.inc.MixedAnalyzingCompiler
 import sbt.internal.inc.PlainVirtualFileConverter
-import java.nio.file.Path
+import sbt.internal.inc.javac.AnalyzingJavaCompiler
+import xsbt.InterfaceCompileCancelled
+import xsbti.AnalysisCallback
+import xsbti.CompileFailed
 import xsbti.VirtualFile
-import java.nio.file.Files
+import xsbti.compile._
 
 /**
  * Defines a high-level compiler after [[sbt.internal.inc.MixedAnalyzingCompiler]], with the

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopIncremental.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopIncremental.scala
@@ -2,27 +2,24 @@
 package sbt.internal.inc.bloop.internal
 
 import java.io.File
-import java.util.concurrent.CompletableFuture
+import java.nio.file.Path
 
 import bloop.UniqueCompileInputs
 import bloop.reporter.ZincReporter
 import bloop.tracing.BraveTracer
 
 import monix.eval.Task
-import sbt.internal.inc.{Analysis, InvalidationProfiler, Lookup, Stamper, Stamps}
+import sbt.internal.inc.Analysis
+import sbt.internal.inc.InvalidationProfiler
+import sbt.internal.inc.Lookup
+import sbt.internal.inc.PlainVirtualFileConverter
 import sbt.util.Logger
 import xsbti.AnalysisCallback
-import xsbti.api.AnalyzedClass
-import xsbti.compile.analysis.{ReadStamps, Stamp}
-import xsbti.compile._
 import xsbti.VirtualFile
-import xsbti.VirtualFileRef
-import bloop.util.AnalysisUtils
-import sbt.internal.inc.PlainVirtualFileConverter
-import java.nio.file.Path
-import xsbti.PathBasedFile
-import sbt.internal.inc.MappedFileConverter
-import scala.tools.nsc.Properties
+import xsbti.api.AnalyzedClass
+import xsbti.compile._
+import xsbti.compile.analysis.ReadStamps
+import xsbti.compile.analysis.Stamp
 
 object BloopIncremental {
   type CompileFunction =
@@ -118,7 +115,6 @@ object BloopIncremental {
       }
     }
 
-    import sbt.internal.inc.{ClassFileManager => ClassFileManagerImpl}
     val analysisTask = {
       val doCompile = (srcs: Set[VirtualFile], changes: DependencyChanges) => {
         for {

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopLookup.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopLookup.scala
@@ -1,12 +1,15 @@
 package sbt.internal.inc.bloop.internal
 
-import bloop.util.Diff
 import bloop.CompileOutPaths
 import bloop.io.AbsolutePath
-import bloop.logging.{DebugFilter, Logger}
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+import bloop.util.Diff
 
-import xsbti.compile.{Changes, CompileAnalysis, FileHash, MiniSetup}
-import sbt.internal.inc.{CompileConfiguration, LookupImpl}
+import sbt.internal.inc.CompileConfiguration
+import sbt.internal.inc.LookupImpl
+import xsbti.compile.FileHash
+import xsbti.compile.MiniSetup
 
 final class BloopLookup(
     compileConfiguration: CompileConfiguration,

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopNameHashing.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopNameHashing.scala
@@ -1,20 +1,18 @@
 package sbt.internal.inc.bloop.internal
 
-import java.io.File
-
 import _root_.bloop.UniqueCompileInputs
 import _root_.bloop.reporter.ZincReporter
 import _root_.bloop.tracing.BraveTracer
-
 import monix.eval.Task
-import sbt.util.Logger
 import sbt.internal.inc._
-import xsbti.compile.{ClassFileManager, DependencyChanges, IncOptions}
-import xsbti.compile.Output
-import xsbti.VirtualFile
+import sbt.util.Logger
+import xsbti.FileConverter
 import xsbti.VirtualFile
 import xsbti.VirtualFileRef
-import xsbti.FileConverter
+import xsbti.compile.ClassFileManager
+import xsbti.compile.DependencyChanges
+import xsbti.compile.IncOptions
+import xsbti.compile.Output
 
 /**
  * Defines Bloop's version of `IncrementalNameHashing` that extends Zinc's original
@@ -169,7 +167,6 @@ private final class BloopNameHashing(
             val removed = previousSources -- inBoth
             val added = sourceRefs -- inBoth
             val (changed, unmodified) = inBoth.partition { f =>
-              import sbt.internal.inc.Hash
               // We compute hashes via xxHash in Bloop, so we adapt them to the zinc hex format
               val newStamp = hashesMap
                 .get(f)

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopStamps.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopStamps.scala
@@ -1,19 +1,17 @@
 package sbt.internal.inc.bloop.internal
 
-import java.io.File
+import java.nio.file.Path
 
 import _root_.bloop.io.ByteHasher
-
-import xsbti.compile.FileHash
-import sbt.internal.inc.Hash
-import sbt.internal.inc.Stamps
-import sbt.internal.inc.Stamper
 import sbt.internal.inc.EmptyStamp
-import xsbti.compile.analysis.{ReadStamps, Stamp}
-import xsbti.VirtualFileRef
-import bloop.util.AnalysisUtils
-import java.nio.file.Path
+import sbt.internal.inc.Hash
 import sbt.internal.inc.PlainVirtualFileConverter
+import sbt.internal.inc.Stamper
+import sbt.internal.inc.Stamps
+import xsbti.VirtualFileRef
+import xsbti.compile.FileHash
+import xsbti.compile.analysis.ReadStamps
+import xsbti.compile.analysis.Stamp
 
 object BloopStamps {
   private val converter = PlainVirtualFileConverter.converter

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/ConcurrentAnalysisCallback.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/ConcurrentAnalysisCallback.scala
@@ -1,42 +1,40 @@
 package sbt.internal.inc.bloop.internal
 
 import java.io.File
+import java.nio.file.Path
 import java.{util => ju}
 
-import xsbti.api.AnalyzedClass
-import xsbti.compile.analysis.ReadStamps
-import xsbti.compile.Output
-import xsbti.compile.IncOptions
-import xsbti.api.SafeLazyProxy
-import xsbt.api.HashAPI
-import xsbti.api.ClassLike
-import xsbti.api.NameHash
-import xsbti.Problem
-import xsbti.api.InternalDependency
-import xsbti.api.ExternalDependency
-import xsbti.api.DependencyContext
-import xsbti.Position
-import xsbti.Severity
-import xsbti.api.DefinitionType
-import xsbti.UseScope
-import xsbti.api.Companions
-import xsbt.api.APIUtil
-import xsbt.api.NameHashing
-import xsbti.compile.ClassFileManager
-
-import sbt.internal.inc.Incremental
-import sbt.util.InterfaceUtil
-import sbt.internal.inc.UsedName
 import sbt.internal.inc.Analysis
 import sbt.internal.inc.Compilation
-import sbt.internal.inc.SourceInfos
-import xsbti.VirtualFile
-import sbt.internal.inc.UsedNames
-import java.nio.file.Path
-import xsbti.VirtualFileRef
-import xsbti.T2
-import bloop.util.AnalysisUtils
+import sbt.internal.inc.Incremental
 import sbt.internal.inc.PlainVirtualFileConverter
+import sbt.internal.inc.SourceInfos
+import sbt.internal.inc.UsedName
+import sbt.internal.inc.UsedNames
+import sbt.util.InterfaceUtil
+import xsbt.api.APIUtil
+import xsbt.api.HashAPI
+import xsbt.api.NameHashing
+import xsbti.Position
+import xsbti.Problem
+import xsbti.Severity
+import xsbti.T2
+import xsbti.UseScope
+import xsbti.VirtualFile
+import xsbti.VirtualFileRef
+import xsbti.api.AnalyzedClass
+import xsbti.api.ClassLike
+import xsbti.api.Companions
+import xsbti.api.DefinitionType
+import xsbti.api.DependencyContext
+import xsbti.api.ExternalDependency
+import xsbti.api.InternalDependency
+import xsbti.api.NameHash
+import xsbti.api.SafeLazyProxy
+import xsbti.compile.ClassFileManager
+import xsbti.compile.IncOptions
+import xsbti.compile.Output
+import xsbti.compile.analysis.ReadStamps
 
 /**
  * This class provides a thread-safe implementation of `xsbti.AnalysisCallback` which is required to compile with the
@@ -60,7 +58,7 @@ final class ConcurrentAnalysisCallback(
 
   private[this] val compilation: Compilation = Compilation(System.currentTimeMillis(), output)
 
-  override def toString =
+  override def toString: String =
     (List("Class APIs", "Object APIs", "Binary deps", "Products", "Source deps") zip
       List(classApis, objectApis, binaryDeps, nonLocalClasses, intSrcDeps))
       .map { case (label, map) => label + "\n\t" + map.mkString("\n\t") }
@@ -141,7 +139,11 @@ final class ConcurrentAnalysisCallback(
     }
   }
 
-  def classDependency(onClassName: String, sourceClassName: String, context: DependencyContext) = {
+  def classDependency(
+      onClassName: String,
+      sourceClassName: String,
+      context: DependencyContext
+  ): Unit = {
     if (onClassName != sourceClassName)
       add(intSrcDeps, sourceClassName, InternalDependency.of(sourceClassName, onClassName, context))
   }
@@ -173,7 +175,7 @@ final class ConcurrentAnalysisCallback(
       fromClassName: String,
       fromSourceFile: VirtualFileRef,
       context: DependencyContext
-  ) = {
+  ): Unit = {
     internalBinaryToSourceClassName(onBinaryClassName) match {
       case Some(dependsOn) => // dependsOn is a source class name
         // dependency is a product of a source not included in this compilation
@@ -196,7 +198,7 @@ final class ConcurrentAnalysisCallback(
       fromClassName: String,
       fromSourceFile: File,
       context: DependencyContext
-  ) = {
+  ): Unit = {
     binaryDependency(
       classFile.toPath(),
       onBinaryClassName,
@@ -300,7 +302,7 @@ final class ConcurrentAnalysisCallback(
     mainClass(converter.toVirtualFile(sourceFile.toPath()), className)
   }
 
-  def usedName(className: String, name: String, useScopes: ju.EnumSet[UseScope]) =
+  def usedName(className: String, name: String, useScopes: ju.EnumSet[UseScope]): Unit =
     add(usedNames, className, UsedName(name, useScopes))
 
   override def enabled(): Boolean = options.enabled

--- a/backend/src/main/scala/sbt/internal/inc/javac/BloopForkedJavaUtils.scala
+++ b/backend/src/main/scala/sbt/internal/inc/javac/BloopForkedJavaUtils.scala
@@ -1,9 +1,10 @@
 package sbt.internal.inc.javac
 
 import java.io.File
+import java.nio.file.Path
+
 import xsbti.Logger
 import xsbti.Reporter
-import java.nio.file.Path
 
 object BloopForkedJavaUtils {
   def launch(

--- a/backend/src/test/scala/bloop/CompilerCacheSpec.scala
+++ b/backend/src/test/scala/bloop/CompilerCacheSpec.scala
@@ -1,19 +1,24 @@
 package bloop
 
 import java.nio.charset.Charset
+import java.nio.file.Files
 import java.util.Locale
+import javax.tools.Diagnostic
+import javax.tools.DiagnosticListener
+import javax.tools.JavaFileObject
+import javax.tools.StandardLocation
+
+import scala.concurrent.ExecutionContext
 
 import bloop.io.AbsolutePath
-import javax.tools.{Diagnostic, DiagnosticListener, JavaFileObject, StandardLocation}
+import bloop.io.Paths
+
 import org.junit.Assert._
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import sbt.internal.inc.javac.WriteReportingJavaFileObject
 import sbt.io.syntax.File
 import xsbti.compile.ClassFileManager
-import java.nio.file.Files
-import bloop.io.Paths
-import scala.concurrent.ExecutionContext
 
 @Category(Array(classOf[FastTests]))
 class CompilerCacheSpec {

--- a/backend/src/test/scala/bloop/ScalaInstanceCachingSpec.scala
+++ b/backend/src/test/scala/bloop/ScalaInstanceCachingSpec.scala
@@ -1,22 +1,25 @@
 package bloop
 
-import java.util.{Arrays, Collection}
+import java.util.Arrays
+import java.util.Collection
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import bloop.logging.BloopLogger
-import org.junit.Assert.{assertSame, assertTrue}
+
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 object ScalaInstanceCachingSpec {
-  val sameVersionPairs = Array("2.10.6", "2.10.1", "2.11.11", "2.12.0", "2.12.4")
-  val unsharedVersionPairs =
+  val sameVersionPairs: Array[String] = Array("2.10.6", "2.10.1", "2.11.11", "2.12.0", "2.12.4")
+  val unsharedVersionPairs: Array[(String, String)] =
     Array("2.10.6" -> "2.10.4", "2.11.11" -> "2.11.6", "2.12.4" -> "2.12.1")
-  val logger = BloopLogger.default("test-logger")
+  val logger: BloopLogger = BloopLogger.default("test-logger")
 
   def getForVersion(version: String): ScalaInstance = {
     ScalaInstance.resolve("org.scala-lang", "scala-compiler", version, logger)
@@ -27,7 +30,7 @@ object ScalaInstanceCachingSpec {
 @RunWith(classOf[Parameterized])
 class SameScalaVersions(version: String) {
   @Test
-  def sameScalaVersionsShareClassLoaders = {
+  def sameScalaVersionsShareClassLoaders: Unit = {
     val instance1 = ScalaInstanceCachingSpec.getForVersion(version)
     val instance2 = ScalaInstanceCachingSpec.getForVersion(version)
     assertSame(s"Failed with version = $version", instance1.loader, instance2.loader)
@@ -43,7 +46,7 @@ object SameScalaVersions {
 @RunWith(classOf[Parameterized])
 class DifferentScalaVersions(v1: String, v2: String) {
   @Test
-  def differentVersionSameMajorNumberDontShareClassLoaders = {
+  def differentVersionSameMajorNumberDontShareClassLoaders: Unit = {
     val instance1 = ScalaInstanceCachingSpec.getForVersion(v1)
     val instance2 = ScalaInstanceCachingSpec.getForVersion(v2)
     assertTrue(s"Failed with v1 = $v1, v2 = $v2", instance1.loader != instance2.loader)

--- a/backend/src/test/scala/bloop/ScalaInstanceSpec.scala
+++ b/backend/src/test/scala/bloop/ScalaInstanceSpec.scala
@@ -1,7 +1,9 @@
 package bloop
 
 import bloop.logging.RecordingLogger
-import org.junit.{Assert, Test}
+
+import org.junit.Assert
+import org.junit.Test
 import org.junit.experimental.categories.Category
 
 @Category(Array(classOf[FastTests]))

--- a/backend/src/test/scala/bloop/logging/RecordingLogger.scala
+++ b/backend/src/test/scala/bloop/logging/RecordingLogger.scala
@@ -2,9 +2,10 @@ package bloop.logging
 
 import java.io.PrintStream
 import java.util.concurrent.ConcurrentLinkedQueue
-import bloop.io.Environment.lineSeparator
 
 import scala.collection.JavaConverters.asScalaIteratorConverter
+
+import bloop.io.Environment.lineSeparator
 
 class RecordingLogger(
     debug: Boolean = false,
@@ -125,7 +126,6 @@ class RecordingLogger(
       .mkString(lineSeparator)
   }
 
-  import java.nio.file.Path
   import java.nio.file.Files
   import java.nio.charset.StandardCharsets
   def writeToFile(id: String): Unit = {

--- a/benchmarks/src/main/scala/bloop/HotBloopBenchmark.scala
+++ b/benchmarks/src/main/scala/bloop/HotBloopBenchmark.scala
@@ -92,7 +92,7 @@ abstract class HotBloopBenchmarkBase {
     awaitPrompt()
   }
 
-  def issue(str: String) = {
+  def issue(str: String): Unit = {
     processInputReader.write(str + "\n")
     processInputReader.flush()
   }

--- a/benchmarks/src/main/scala/bloop/ProjectBenchmark.scala
+++ b/benchmarks/src/main/scala/bloop/ProjectBenchmark.scala
@@ -1,22 +1,22 @@
 package bloop
 
 import java.nio.file.Files
-
-import bloop.data.ClientInfo
-import bloop.io.AbsolutePath
-import bloop.logging.NoopLogger
-import org.openjdk.jmh.annotations.Benchmark
 import java.util.concurrent.TimeUnit
 
+import scala.concurrent.Await
+import scala.concurrent.duration.FiniteDuration
+
 import bloop.cli.CommonOptions
+import bloop.data.ClientInfo
+import bloop.engine.ExecutionContext
+import bloop.engine.NoPool
+import bloop.io.AbsolutePath
+import bloop.logging.NoopLogger
+
+import monix.execution.misc.NonFatal
+import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.Mode.SampleTime
 import org.openjdk.jmh.annotations._
-import bloop.engine.NoPool
-
-import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.Await
-import monix.execution.misc.NonFatal
-import bloop.engine.ExecutionContext
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(SampleTime))

--- a/benchmarks/src/main/scala/bloop/logging/BloopLoggerBenchmark.scala
+++ b/benchmarks/src/main/scala/bloop/logging/BloopLoggerBenchmark.scala
@@ -6,7 +6,7 @@ import org.openjdk.jmh.annotations.Benchmark
 
 object BloopLoggerBenchmark {
   private val devnull = new PrintStream(_ => ())
-  val logger = BloopLogger.at("benchmark", devnull, devnull, false, DebugFilter.All)
+  val logger: BloopLogger = BloopLogger.at("benchmark", devnull, devnull, false, DebugFilter.All)
 }
 
 class BloopLoggerBenchmark {

--- a/benchmarks/src/main/scala/sbt/HotSbtBenchmark.scala
+++ b/benchmarks/src/main/scala/sbt/HotSbtBenchmark.scala
@@ -101,7 +101,7 @@ class HotSbtBenchmark {
     awaitPrompt()
   }
 
-  def issue(str: String) = {
+  def issue(str: String): Unit = {
     processInputReader.write(str + "\n")
     processInputReader.flush()
   }

--- a/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
@@ -1,47 +1,34 @@
 package bloop.bloopgun
 
+import java.io.IOException
+import java.io.InputStream
+import java.io.PrintStream
+import java.net.ConnectException
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.concurrent.Promise
+
+import bloop.bloopgun.core.AvailableAtPath
+import bloop.bloopgun.core.AvailableWithCommand
+import bloop.bloopgun.core.LocatedServer
+import bloop.bloopgun.core.ResolvedAt
+import bloop.bloopgun.core.ServerStatus
 import bloop.bloopgun.core.Shell
-import bloop.bloopgun.core.DependencyResolution
+import bloop.bloopgun.core.Shell.StatusCommand
 import bloop.bloopgun.util.Environment
 import bloop.bloopgun.util.Feedback
 import bloop.bloopgun.util.GlobalSettings
-import bloop.bloopgun.core.AvailableAtPath
-import bloop.bloopgun.core.AvailableWithCommand
-import bloop.bloopgun.core.ListeningAndAvailableAt
-import bloop.bloopgun.core.ServerStatus
-import bloop.bloopgun.core.ResolvedAt
 import bloopgun.internal.build.BloopgunInfo
 
-import java.io.PrintStream
-import java.io.InputStream
-import java.util.concurrent.atomic.AtomicBoolean
-import java.net.ConnectException
-import java.nio.file.Files
-import java.nio.file.Paths
-import java.nio.file.Path
-import java.nio.charset.StandardCharsets
-
-import snailgun.TcpClient
-import snailgun.protocol.Streams
-import snailgun.logging.SnailgunLogger
-
-import scala.collection.mutable
-
 import scopt.OParser
-
-import scala.sys.process.ProcessIO
-import java.lang.ProcessBuilder.Redirect
-import scala.util.Try
-import java.net.URLDecoder
-import java.net.URLClassLoader
-import bloop.bloopgun.core.Shell.StatusCommand
-import java.util.concurrent.atomic.AtomicReference
-import scala.concurrent.Promise
+import snailgun.TcpClient
 import snailgun.logging.Logger
-import bloop.bloopgun.core.LocatedServer
-import java.io.InputStreamReader
-import java.io.BufferedReader
-import java.io.IOException
+import snailgun.logging.SnailgunLogger
+import snailgun.protocol.Streams
 
 /**
  * The main library entrypoint for bloopgun, the Bloop binary CLI.

--- a/bloopgun/src/main/scala/bloop/bloopgun/Defaults.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/Defaults.scala
@@ -1,7 +1,5 @@
 package bloop.bloopgun
 
-import java.nio.file.Paths
-
 object Defaults {
   val Version = "0.9.3"
   val Host = "127.0.0.1"
@@ -13,7 +11,7 @@ object Defaults {
   }
 
   object Time {
-    val DefaultHeartbeatIntervalMillis = 500.toLong
-    val SendThreadWaitTerminationMillis = 5000.toLong
+    val DefaultHeartbeatIntervalMillis: Long = 500.toLong
+    val SendThreadWaitTerminationMillis: Long = 5000.toLong
   }
 }

--- a/bloopgun/src/main/scala/bloop/bloopgun/core/DependencyResolution.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/core/DependencyResolution.scala
@@ -1,14 +1,14 @@
 package bloop.bloopgun.core
 
+import java.nio.file.Path
+
+import scala.collection.JavaConverters._
+
 import bloop.bloopgun.util.Feedback
 
 import coursierapi.Repository
 import coursierapi.error.CoursierError
-
-import java.nio.file.Path
 import snailgun.logging.Logger
-
-import scala.collection.JavaConverters._
 
 object DependencyResolution {
 

--- a/bloopgun/src/main/scala/bloop/bloopgun/core/ServerStatus.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/core/ServerStatus.scala
@@ -1,14 +1,8 @@
 package bloop.bloopgun.core
 
 import java.nio.file.Path
-import java.nio.file.Files
 
-import bloop.bloopgun.util.Environment
-import bloop.bloopgun.core.Shell.StatusCommand
 import snailgun.logging.Logger
-import bloop.bloopgun.ServerConfig
-import java.nio.file.Paths
-import bloop.bloopgun.util.Feedback
 
 sealed trait ServerStatus
 sealed trait LocatedServer extends ServerStatus
@@ -18,7 +12,7 @@ case class ResolvedAt(files: Seq[Path]) extends LocatedServer
 case class ListeningAndAvailableAt(binary: List[String]) extends ServerStatus
 
 object ServerStatus {
-  def resolveServer(bloopVersion: String, logger: Logger) = {
+  def resolveServer(bloopVersion: String, logger: Logger): Option[ResolvedAt] = {
     import scala.concurrent.ExecutionContext.Implicits.global
     DependencyResolution.resolveWithErrors(
       "ch.epfl.scala",

--- a/bloopgun/src/main/scala/bloop/bloopgun/core/Shell.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/core/Shell.scala
@@ -1,23 +1,19 @@
 package bloop.bloopgun.core
 
 import java.io.PrintStream
-import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path}
+import java.nio.file.Path
 import java.util.concurrent.TimeUnit
-
-import bloop.bloopgun.util.Environment
-import bloop.bloopgun.core.Shell.StatusCommand
 
 import scala.collection.mutable.ListBuffer
 import scala.util.Try
 
+import bloop.bloopgun.ServerConfig
+import bloop.bloopgun.core.Shell.StatusCommand
+import bloop.bloopgun.util.Environment
+
 import org.zeroturnaround.exec.ProcessExecutor
-import org.zeroturnaround.exec.listener.ProcessListener
-import org.zeroturnaround.exec.stream.ExecuteStreamHandler
 import org.zeroturnaround.exec.stream.LogOutputStream
 import snailgun.logging.Logger
-import bloop.bloopgun.ServerConfig
 
 /**
  * Defines shell utilities to run programs via system process.
@@ -183,7 +179,6 @@ final class Shell(runWithInterpreter: Boolean, detectPython: Boolean) {
       socket = new Socket()
       socket.setReuseAddress(true)
       socket.setTcpNoDelay(true)
-      import java.net.InetAddress
       import java.net.InetSocketAddress
       logger.info("Attempting a connection to the server...")
       socket.connect(new InetSocketAddress(config.userOrDefaultHost, config.userOrDefaultPort))

--- a/bloopgun/src/main/scala/bloop/bloopgun/util/Environment.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/util/Environment.scala
@@ -1,13 +1,15 @@
 package bloop.bloopgun.util
 
-import java.{util => ju}
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path, Paths}
-
-import bloop.bloopgun.core.LocatedServer
-import bloop.bloopgun.core.AvailableAtPath
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.{util => ju}
 
 import scala.util.control.NonFatal
+
+import bloop.bloopgun.core.AvailableAtPath
+import bloop.bloopgun.core.LocatedServer
 
 import snailgun.logging.Logger
 
@@ -86,7 +88,7 @@ object Environment {
   }
 
   // TODO: Add more options to better tweak GC based on benchmarks
-  val PerformanceSensitiveOptsForBloop = List(
+  val PerformanceSensitiveOptsForBloop: List[String] = List(
     "-Xss4m",
     "-XX:MaxInlineLevel=20", // Specific option for faster C2, ignored by GraalVM
     "-XX:+UseParallelGC" // Full parallel GC is the best choice for Scala compilation

--- a/bloopgun/src/main/scala/bloop/bloopgun/util/GlobalSettings.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/util/GlobalSettings.scala
@@ -1,18 +1,18 @@
 package bloop.bloopgun.util
 
-import com.github.plokhotnyuk.jsoniter_scala.{core => jsoniter}
-import com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException
-import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
-import com.github.plokhotnyuk.jsoniter_scala.core.WriterConfig
-import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
-import com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import snailgun.logging.Logger
+
 import scala.util.Failure
 import scala.util.Success
-import java.nio.file.Files
 import scala.util.Try
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+import com.github.plokhotnyuk.jsoniter_scala.{core => jsoniter}
+import snailgun.logging.Logger
 
 case class GlobalSettings(
     javaHome: Option[String] = None,

--- a/bridges/scala-native-0.4/src/main/scala/bloop/scalanative/NativeBridge.scala
+++ b/bridges/scala-native-0.4/src/main/scala/bloop/scalanative/NativeBridge.scala
@@ -1,13 +1,16 @@
 package bloop.scalanative
-import bloop.config.Config.{LinkerMode, NativeConfig}
-import bloop.io.Paths
-import bloop.logging.{DebugFilter, Logger}
-import java.nio.file.{Files, Path}
-
-import bloop.data.Project
+import java.nio.file.Files
+import java.nio.file.Path
 
 import scala.scalanative.build
 import scala.scalanative.util.Scope
+
+import bloop.config.Config.LinkerMode
+import bloop.config.Config.NativeConfig
+import bloop.data.Project
+import bloop.io.Paths
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
 
 object NativeBridge {
   private implicit val ctx: DebugFilter = DebugFilter.Link

--- a/bridges/scala-native-0.4/src/test/scala/bloop/scalanative/ScalaNativeToolchainSpec.scala
+++ b/bridges/scala-native-0.4/src/test/scala/bloop/scalanative/ScalaNativeToolchainSpec.scala
@@ -1,15 +1,18 @@
 package bloop.scalanative
 
-import bloop.cli.{Commands, OptimizerConfig}
-import bloop.engine.Run
-import bloop.logging.RecordingLogger
-
-import scala.concurrent.duration.Duration
 import java.util.concurrent.TimeUnit
 
-import bloop.data.{Platform, Project}
-import bloop.engine.tasks.toolchains.{ScalaJsToolchain, ScalaNativeToolchain}
+import scala.concurrent.duration.Duration
+
+import bloop.cli.Commands
+import bloop.cli.OptimizerConfig
+import bloop.data.Platform
+import bloop.data.Project
+import bloop.engine.Run
+import bloop.engine.tasks.toolchains.ScalaNativeToolchain
+import bloop.logging.RecordingLogger
 import bloop.util.TestUtil
+
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.experimental.categories.Category

--- a/bridges/scalajs-0.6/src/main/scala/bloop/scalajs/JsBridge.scala
+++ b/bridges/scalajs-0.6/src/main/scala/bloop/scalajs/JsBridge.scala
@@ -1,30 +1,36 @@
 package bloop.scalajs
 
-import scala.collection.JavaConverters._
-import java.nio.file.{Files, Path}
+import java.nio.file.Files
+import java.nio.file.Path
 
-import org.scalajs.core.tools.io.IRFileCache.IRContainer
-import org.scalajs.core.tools.io.{
-  AtomicWritableFileVirtualJSFile,
-  FileVirtualBinaryFile,
-  FileVirtualJSFile,
-  FileVirtualScalaJSIRFile,
-  MemVirtualJSFile,
-  VirtualJSFile,
-  VirtualJarFile
-}
-import org.scalajs.core.tools.linker.{ModuleInitializer, StandardLinker}
-import org.scalajs.core.tools.logging.{Level, Logger => JsLogger}
-import bloop.config.Config.{JsConfig, LinkerMode, ModuleKindJS}
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+
+import bloop.config.Config.JsConfig
+import bloop.config.Config.LinkerMode
+import bloop.config.Config.ModuleKindJS
 import bloop.data.Project
-import bloop.logging.{DebugFilter, Logger => BloopLogger}
+import bloop.logging.DebugFilter
+import bloop.logging.{Logger => BloopLogger}
+
+import org.scalajs.core.tools.io.AtomicWritableFileVirtualJSFile
+import org.scalajs.core.tools.io.FileVirtualBinaryFile
+import org.scalajs.core.tools.io.FileVirtualJSFile
+import org.scalajs.core.tools.io.FileVirtualScalaJSIRFile
+import org.scalajs.core.tools.io.IRFileCache.IRContainer
+import org.scalajs.core.tools.io.MemVirtualJSFile
+import org.scalajs.core.tools.io.VirtualJSFile
+import org.scalajs.core.tools.io.VirtualJarFile
 import org.scalajs.core.tools.jsdep.ResolvedJSDependency
+import org.scalajs.core.tools.linker.ModuleInitializer
+import org.scalajs.core.tools.linker.StandardLinker
 import org.scalajs.core.tools.linker.backend.ModuleKind
+import org.scalajs.core.tools.logging.Level
+import org.scalajs.core.tools.logging.{Logger => JsLogger}
 import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
 import org.scalajs.jsenv.nodejs.NodeJSEnv
 import org.scalajs.testadapter.TestAdapter
-import scala.concurrent.ExecutionContext
 
 object JsBridge {
   private class Logger(logger: BloopLogger) extends JsLogger {

--- a/bridges/scalajs-0.6/src/test/scala/bloop/scalajs/ScalaJsToolchainSpec.scala
+++ b/bridges/scalajs-0.6/src/test/scala/bloop/scalajs/ScalaJsToolchainSpec.scala
@@ -1,15 +1,19 @@
 package bloop.scalajs
 
-import bloop.cli.{Commands, OptimizerConfig}
-import bloop.engine.{Run, State}
-import bloop.logging.RecordingLogger
-
-import scala.concurrent.duration.Duration
 import java.util.concurrent.TimeUnit
 
-import bloop.data.{Platform, Project}
+import scala.concurrent.duration.Duration
+
+import bloop.cli.Commands
+import bloop.cli.OptimizerConfig
+import bloop.data.Platform
+import bloop.data.Project
+import bloop.engine.Run
+import bloop.engine.State
 import bloop.engine.tasks.toolchains.ScalaJsToolchain
+import bloop.logging.RecordingLogger
 import bloop.util.TestUtil
+
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.experimental.categories.Category

--- a/bridges/scalajs-1/src/main/scala/bloop/scalajs/JsBridge.scala
+++ b/bridges/scalajs-1/src/main/scala/bloop/scalajs/JsBridge.scala
@@ -2,19 +2,29 @@ package bloop.scalajs
 
 import java.nio.file.Path
 
-import bloop.config.Config.{JsConfig, LinkerMode, ModuleKindJS}
-import bloop.data.Project
-import bloop.logging.{DebugFilter, Logger => BloopLogger}
-import bloop.scalajs.jsenv.{JsDomNodeJsEnv, NodeJSConfig, NodeJSEnv}
-import org.scalajs.logging.{Level, Logger => JsLogger}
-import org.scalajs.linker.{PathIRContainer, PathOutputFile, StandardImpl}
-import org.scalajs.linker.interface.{ModuleKind => ScalaJSModuleKind, _}
-import org.scalajs.jsenv.Input
-import org.scalajs.testing.adapter.{TestAdapter, TestAdapterInitializer}
-
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.Duration
+
+import bloop.config.Config.JsConfig
+import bloop.config.Config.LinkerMode
+import bloop.config.Config.ModuleKindJS
+import bloop.data.Project
+import bloop.logging.DebugFilter
+import bloop.logging.{Logger => BloopLogger}
+import bloop.scalajs.jsenv.JsDomNodeJsEnv
+import bloop.scalajs.jsenv.NodeJSConfig
+import bloop.scalajs.jsenv.NodeJSEnv
+
+import org.scalajs.jsenv.Input
+import org.scalajs.linker.PathIRContainer
+import org.scalajs.linker.PathOutputFile
+import org.scalajs.linker.StandardImpl
+import org.scalajs.linker.interface.{ModuleKind => ScalaJSModuleKind, _}
+import org.scalajs.logging.Level
+import org.scalajs.logging.{Logger => JsLogger}
+import org.scalajs.testing.adapter.TestAdapter
+import org.scalajs.testing.adapter.TestAdapterInitializer
 
 /**
  * Defines operations provided by the Scala.JS 1.x toolchain.

--- a/bridges/scalajs-1/src/main/scala/bloop/scalajs/jsenv/JsDomNodeJsEnv.scala
+++ b/bridges/scalajs-1/src/main/scala/bloop/scalajs/jsenv/JsDomNodeJsEnv.scala
@@ -1,25 +1,27 @@
 package bloop.scalajs.jsenv
 
-import java.io.{File, InputStream}
+import java.io.File
+import java.io.InputStream
 import java.net.URI
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path, StandardCopyOption}
-
-import bloop.logging.Logger
-import com.google.common.jimfs.Jimfs
-import org.scalajs.jsenv.nodejs.BloopComRun
-import org.scalajs.jsenv.{
-  ExternalJSRun,
-  Input,
-  JSComRun,
-  JSEnv,
-  JSRun,
-  RunConfig,
-  UnsupportedInputException
-}
-import org.scalajs.jsenv.JSUtils.escapeJS
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 
 import scala.util.control.NonFatal
+
+import bloop.logging.Logger
+
+import com.google.common.jimfs.Jimfs
+import org.scalajs.jsenv.ExternalJSRun
+import org.scalajs.jsenv.Input
+import org.scalajs.jsenv.JSComRun
+import org.scalajs.jsenv.JSEnv
+import org.scalajs.jsenv.JSRun
+import org.scalajs.jsenv.JSUtils.escapeJS
+import org.scalajs.jsenv.RunConfig
+import org.scalajs.jsenv.UnsupportedInputException
+import org.scalajs.jsenv.nodejs.BloopComRun
 
 /**
  * See comments in [[bloop.scalajs.JsBridge]].

--- a/bridges/scalajs-1/src/main/scala/bloop/scalajs/jsenv/NodeJsEnv.scala
+++ b/bridges/scalajs-1/src/main/scala/bloop/scalajs/jsenv/NodeJsEnv.scala
@@ -1,33 +1,32 @@
 package bloop.scalajs.jsenv
 
 import java.io.File
-import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path, StandardCopyOption}
-
-import bloop.logging.{DebugFilter, Logger}
-import bloop.scalajs.jsenv
-import com.google.common.jimfs.Jimfs
-import monix.execution.atomic.AtomicBoolean
-import org.scalajs.jsenv.nodejs.NodeJSEnv.SourceMap
-import org.scalajs.jsenv.nodejs.BloopComRun
-import org.scalajs.jsenv.{
-  ExternalJSRun,
-  Input,
-  JSComRun,
-  JSEnv,
-  JSRun,
-  RunConfig,
-  UnsupportedInputException
-}
-import org.scalajs.jsenv.JSUtils.escapeJS
-
-import scala.collection.JavaConverters._
-import scala.concurrent.{Future, Promise}
 import java.io.OutputStream
-import bloop.exec.Forker
-import monix.execution.Cancelable
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+import scala.concurrent.Future
+
 import bloop.engine.ExecutionContext
+import bloop.exec.Forker
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+
+import com.google.common.jimfs.Jimfs
+import monix.execution.Cancelable
+import monix.execution.atomic.AtomicBoolean
+import org.scalajs.jsenv.ExternalJSRun
+import org.scalajs.jsenv.Input
+import org.scalajs.jsenv.JSComRun
+import org.scalajs.jsenv.JSEnv
+import org.scalajs.jsenv.JSRun
+import org.scalajs.jsenv.JSUtils.escapeJS
+import org.scalajs.jsenv.RunConfig
+import org.scalajs.jsenv.UnsupportedInputException
+import org.scalajs.jsenv.nodejs.BloopComRun
+import org.scalajs.jsenv.nodejs.NodeJSEnv.SourceMap
 
 // Copy pasted verbatim from Scala.js source code, added withCwd()
 // Original file: scala-js/nodejs-env/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala

--- a/bridges/scalajs-1/src/main/scala/org/scalajs/jsenv/nodejs/BloopComRun.scala
+++ b/bridges/scalajs-1/src/main/scala/org/scalajs/jsenv/nodejs/BloopComRun.scala
@@ -11,17 +11,17 @@ package org.scalajs.jsenv.nodejs
 import java.io._
 import java.net._
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path}
+import java.nio.file.Files
+import java.nio.file.Path
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent._
+import scala.util.Failure
+import scala.util.Success
+import scala.util.control.NonFatal
 
 import com.google.common.jimfs.Jimfs
 import org.scalajs.jsenv._
-
-import scala.concurrent._
-import scala.util.{Failure, Success}
-import scala.util.control.NonFatal
-
-// TODO Replace this by a better execution context on the RunConfig.
-import scala.concurrent.ExecutionContext.Implicits.global
 
 /**
  * A copy of the `ComRun` in the scala-js codebase to handles

--- a/bridges/scalajs-1/src/test/scala/bloop/scalajs/ScalaJsToolchainSpec.scala
+++ b/bridges/scalajs-1/src/test/scala/bloop/scalajs/ScalaJsToolchainSpec.scala
@@ -1,15 +1,19 @@
 package bloop.scalajs
 
-import bloop.cli.{Commands, OptimizerConfig}
-import bloop.engine.{Run, State}
-import bloop.logging.RecordingLogger
-
-import scala.concurrent.duration.Duration
 import java.util.concurrent.TimeUnit
 
-import bloop.data.{Platform, Project}
+import scala.concurrent.duration.Duration
+
+import bloop.cli.Commands
+import bloop.cli.OptimizerConfig
+import bloop.data.Platform
+import bloop.data.Project
+import bloop.engine.Run
+import bloop.engine.State
 import bloop.engine.tasks.toolchains.ScalaJsToolchain
+import bloop.logging.RecordingLogger
 import bloop.util.TestUtil
+
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.experimental.categories.Category

--- a/config/.jvm/src/main/scala/bloop/config/PlatformFiles.scala
+++ b/config/.jvm/src/main/scala/bloop/config/PlatformFiles.scala
@@ -1,6 +1,7 @@
 package bloop.config
 
-import java.nio.file.{Files, Paths}
+import java.nio.file.Files
+import java.nio.file.Paths
 
 object PlatformFiles {
   type Path = java.nio.file.Path

--- a/config/.jvm/src/test/scala/bloop/config/TestPlatform.scala
+++ b/config/.jvm/src/test/scala/bloop/config/TestPlatform.scala
@@ -1,7 +1,7 @@
 package bloop.config
 
-import java.io.InputStreamReader
 import java.io.BufferedReader
+import java.io.InputStreamReader
 import java.util.stream.Collectors
 
 object TestPlatform {

--- a/config/src/main/scala-2.11-13/bloop/config/ConfigCodecs.scala
+++ b/config/src/main/scala-2.11-13/bloop/config/ConfigCodecs.scala
@@ -1,18 +1,19 @@
 package bloop.config
 
-import PlatformFiles.Path
-
-import scala.util.Try
 import java.nio.charset.StandardCharsets
+
 import scala.util.Failure
 import scala.util.Success
+import scala.util.Try
 
-import com.github.plokhotnyuk.jsoniter_scala.{core => jsoniter}
+import bloop.config.PlatformFiles.Path
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonReader
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter
-import com.github.plokhotnyuk.jsoniter_scala.core.JsonReader
 import com.github.plokhotnyuk.jsoniter_scala.core.WriterConfig
 import com.github.plokhotnyuk.jsoniter_scala.macros._
+import com.github.plokhotnyuk.jsoniter_scala.{core => jsoniter}
 
 object ConfigCodecs {
 

--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -1,7 +1,7 @@
 package bloop.config
 
-import PlatformFiles.Path
-import PlatformFiles.emptyPath
+import bloop.config.PlatformFiles.Path
+import bloop.config.PlatformFiles.emptyPath
 
 object Config {
   case class Java(options: List[String])
@@ -9,28 +9,28 @@ object Config {
   case class TestFramework(names: List[String])
 
   object TestFramework {
-    val utest = Config.TestFramework(
+    val utest: TestFramework = Config.TestFramework(
       List("utest.runner.Framework")
     )
 
-    val munit = Config.TestFramework(
+    val munit: TestFramework = Config.TestFramework(
       List("munit.Framework")
     )
 
-    val ScalaCheck = Config.TestFramework(
+    val ScalaCheck: TestFramework = Config.TestFramework(
       List(
         "org.scalacheck.ScalaCheckFramework"
       )
     )
 
-    val ScalaTest = Config.TestFramework(
+    val ScalaTest: TestFramework = Config.TestFramework(
       List(
         "org.scalatest.tools.Framework",
         "org.scalatest.tools.ScalaTestFramework"
       )
     )
 
-    val Specs2 = Config.TestFramework(
+    val Specs2: TestFramework = Config.TestFramework(
       List(
         "org.specs.runner.SpecsFramework",
         "org.specs2.runner.Specs2Framework",
@@ -38,18 +38,19 @@ object Config {
       )
     )
 
-    val JUnit = Config.TestFramework(
+    val JUnit: TestFramework = Config.TestFramework(
       List(
         "com.novocode.junit.JUnitFramework"
       )
     )
 
-    val DefaultFrameworks = List(JUnit, ScalaTest, ScalaCheck, Specs2, utest, munit)
+    val DefaultFrameworks: List[TestFramework] =
+      List(JUnit, ScalaTest, ScalaCheck, Specs2, utest, munit)
   }
 
   case class TestArgument(args: List[String], framework: Option[TestFramework])
   case class TestOptions(excludes: List[String], arguments: List[TestArgument])
-  object TestOptions { val empty = TestOptions(Nil, Nil) }
+  object TestOptions { val empty: TestOptions = TestOptions(Nil, Nil) }
 
   case class Test(frameworks: List[TestFramework], options: TestOptions)
   object Test {
@@ -133,13 +134,13 @@ object Config {
 
   sealed trait PlatformConfig
   case class JvmConfig(home: Option[Path], options: List[String]) extends PlatformConfig
-  object JvmConfig { val empty = JvmConfig(None, Nil) }
+  object JvmConfig { val empty: JvmConfig = JvmConfig(None, Nil) }
 
   sealed abstract class LinkerMode(val id: String)
   object LinkerMode {
     case object Debug extends LinkerMode("debug")
     case object Release extends LinkerMode("release")
-    val All = List(Debug.id, Release.id)
+    val All: List[String] = List(Debug.id, Release.id)
   }
 
   sealed abstract class ModuleKindJS(val id: String)
@@ -147,7 +148,7 @@ object Config {
     case object NoModule extends ModuleKindJS("none")
     case object CommonJSModule extends ModuleKindJS("commonjs")
     case object ESModule extends ModuleKindJS("esmodule")
-    val All = List(NoModule.id, CommonJSModule.id, ESModule.id)
+    val All: List[String] = List(NoModule.id, CommonJSModule.id, ESModule.id)
   }
 
   case class JsConfig(
@@ -261,7 +262,7 @@ object Config {
     private[bloop] val empty: Project = Project("", emptyPath, None, List(), None, None, List(), List(),  emptyPath, emptyPath, None, None, None, None, None, None, None, None)
     // FORMAT: ON
 
-    def analysisFileName(projectName: String) = s"$projectName-analysis.bin"
+    def analysisFileName(projectName: String): String = s"$projectName-analysis.bin"
   }
 
   case class File(version: String, project: Project)

--- a/config/src/main/scala/bloop/config/util/ConfigUtil.scala
+++ b/config/src/main/scala/bloop/config/util/ConfigUtil.scala
@@ -1,6 +1,7 @@
 package bloop.config.util
 
-import java.nio.file.{Path, Files}
+import java.nio.file.Files
+import java.nio.file.Path
 
 object ConfigUtil {
   def pathsOutsideRoots(roots: Seq[Path], paths: Seq[Path]): Seq[Path] = {

--- a/config/src/test/scala/bloop/config/ConfigCodecsSpec.scala
+++ b/config/src/test/scala/bloop/config/ConfigCodecsSpec.scala
@@ -1,8 +1,12 @@
 package bloop.config
 
-import bloop.config.Config.File
-import org.junit.{AfterClass, Assert, Test}
 import java.nio.charset.StandardCharsets
+
+import bloop.config.Config.File
+
+import org.junit.AfterClass
+import org.junit.Assert
+import org.junit.Test
 
 object ConfigCodecsSpec {
   val dummyFile = File.dummyForTests
@@ -15,7 +19,6 @@ object ConfigCodecsSpec {
 }
 
 class ConfigCodecsSpec {
-  import bloop.config.ConfigCodecs._
   def parseConfig(contents: String): Config.File = {
     bloop.config.read(contents.getBytes(StandardCharsets.UTF_8)) match {
       case Right(file) => file

--- a/config/src/test/scala/bloop/config/utils/BaseConfigSuite.scala
+++ b/config/src/test/scala/bloop/config/utils/BaseConfigSuite.scala
@@ -1,11 +1,12 @@
 package bloop.config.utils
 
-import bloop.config.Config
-import bloop.config.PlatformFiles.Path
-import bloop.config.PlatformFiles
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+
+import bloop.config.Config
+import bloop.config.PlatformFiles
+import bloop.config.PlatformFiles.Path
 
 trait BaseConfigSuite {
 

--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -1,18 +1,28 @@
 package bloop
 
+import scala.annotation.tailrec
+
+import bloop.cli.CliOptions
+import bloop.cli.Commands
+import bloop.cli.ExitStatus
 import bloop.data.ClientInfo
-import bloop.cli.{CliOptions, Commands, ExitStatus}
-import bloop.cli.CliParsers.{inputStreamRead, pathParser, printStreamRead, propertiesParser}
-import bloop.engine.{Action, Build, BuildLoader, Exit, Interpreter, NoPool, Print, Run, State}
-import bloop.engine.tasks.Tasks
+import bloop.data.WorkspaceSettings
+import bloop.engine.Action
+import bloop.engine.Build
+import bloop.engine.BuildLoader
+import bloop.engine.Exit
+import bloop.engine.Interpreter
+import bloop.engine.NoPool
+import bloop.engine.Print
+import bloop.engine.Run
+import bloop.engine.State
 import bloop.io.AbsolutePath
 import bloop.logging.BloopLogger
-import caseapp.{CaseApp, RemainingArgs}
-import jline.console.ConsoleReader
+
 import _root_.monix.eval.Task
-import bloop.data.WorkspaceSettings
-import scala.annotation.tailrec
-import scala.concurrent.Promise
+import caseapp.CaseApp
+import caseapp.RemainingArgs
+import jline.console.ConsoleReader
 
 object Bloop extends CaseApp[CliOptions] {
   private val reader = consoleReader()

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -1,36 +1,37 @@
 package bloop
 
-import java.io.{InputStream, PrintStream}
+import java.io.InputStream
+import java.io.PrintStream
 import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 
-import bloop.bsp.BspServer
-import bloop.io.AbsolutePath
-import bloop.util.{CrossPlatform, JavaRuntime}
-import bloop.cli.{CliOptions, CliParsers, Commands, CommonOptions, ExitStatus, Validate}
-import bloop.engine._
-import bloop.engine.tasks.Tasks
-import bloop.logging.{BloopLogger, DebugFilter, Logger}
-import bloop.data.ClientInfo.CliClientInfo
+import scala.util.control.NonFatal
 
+import bloop.cli.CliOptions
+import bloop.cli.Commands
+import bloop.cli.CommonOptions
+import bloop.cli.ExitStatus
+import bloop.cli.Validate
+import bloop.data.ClientInfo.CliClientInfo
+import bloop.engine._
+import bloop.io.AbsolutePath
+import bloop.io.Paths
+import bloop.logging.BloopLogger
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+import bloop.util.CrossPlatform
+import bloop.util.JavaRuntime
+
+import _root_.monix.eval.Task
 import caseapp.core.help.Help
 import com.martiansoftware.nailgun.NGContext
-import _root_.monix.eval.Task
-
-import scala.concurrent.Promise
-import scala.util.control.NonFatal
-import scala.concurrent.duration.FiniteDuration
-import java.util.concurrent.TimeUnit
 import monix.execution.atomic.AtomicBoolean
-import bloop.io.Paths
-import scala.util.Success
-import scala.util.Failure
 
 class Cli
 object Cli {
 
-  implicit private val filter = DebugFilter.All
+  implicit private val filter: DebugFilter.All.type = DebugFilter.All
   def main(args: Array[String]): Unit = {
     val action = parse(args, CommonOptions.default)
     val exitStatus = run(action, NoPool)

--- a/frontend/src/main/scala/bloop/Server.scala
+++ b/frontend/src/main/scala/bloop/Server.scala
@@ -1,20 +1,21 @@
 package bloop
 
+import java.io.InputStream
+import java.io.PrintStream
 import java.net.InetAddress
+
+import scala.util.Try
 
 import bloop.logging.BloopLogger
 import bloop.logging.Logger
 import bloop.logging.Slf4jAdapter
 import bloop.util.ProxySetup
 
-import java.io.InputStream
-import java.io.PrintStream
-
-import com.martiansoftware.nailgun.NGListeningAddress
+import com.martiansoftware.nailgun.Alias
 import com.martiansoftware.nailgun.NGConstants
-import com.martiansoftware.nailgun.{Alias, NGContext, NGServer}
-
-import scala.util.Try
+import com.martiansoftware.nailgun.NGContext
+import com.martiansoftware.nailgun.NGListeningAddress
+import com.martiansoftware.nailgun.NGServer
 
 class Server
 object Server {

--- a/frontend/src/main/scala/bloop/bsp/BloopBspDefinitions.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspDefinitions.scala
@@ -1,10 +1,12 @@
 package bloop.bsp
 
-import ch.epfl.scala.bsp.Uri
-import io.circe.derivation._
-import io.circe.{Decoder, RootEncoder}
-
 import scala.meta.jsonrpc.Endpoint
+
+import ch.epfl.scala.bsp.Uri
+
+import io.circe.Decoder
+import io.circe.RootEncoder
+import io.circe.derivation._
 
 object BloopBspDefinitions {
   final case class BloopExtraBuildParams(
@@ -16,7 +18,7 @@ object BloopBspDefinitions {
   )
 
   object BloopExtraBuildParams {
-    val empty = BloopExtraBuildParams(
+    val empty: BloopExtraBuildParams = BloopExtraBuildParams(
       ownsBuildFiles = None,
       clientClassesRootDir = None,
       semanticdbVersion = None,

--- a/frontend/src/main/scala/bloop/bsp/BloopLanguageClient.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopLanguageClient.scala
@@ -1,29 +1,29 @@
 package bloop.bsp
 
-import scala.meta.jsonrpc.Response
-import scala.meta.jsonrpc.RequestId
-import scala.meta.jsonrpc.CancelParams
-import scala.meta.jsonrpc.Notification
-import scala.meta.jsonrpc.JsonRpcClient
-import scala.meta.jsonrpc.MessageWriter
-import io.circe.Decoder
-import io.circe.Encoder
-import io.circe.syntax._
 import java.io.OutputStream
 import java.nio.ByteBuffer
 import java.nio.channels.Channels
 
-import monix.eval.Task
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import scala.meta.jsonrpc.CancelParams
+import scala.meta.jsonrpc.JsonRpcClient
+import scala.meta.jsonrpc.MessageWriter
+import scala.meta.jsonrpc.Notification
+import scala.meta.jsonrpc.RequestId
+import scala.meta.jsonrpc.Response
+
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.syntax._
 import monix.eval.Callback
+import monix.eval.Task
 import monix.execution.Ack
-import monix.reactive.Observer
 import monix.execution.Cancelable
 import monix.execution.atomic.Atomic
 import monix.execution.atomic.AtomicInt
-
-import scala.concurrent.Future
-import scala.collection.concurrent.TrieMap
-import scala.concurrent.duration.FiniteDuration
+import monix.reactive.Observer
 import scribe.LoggerSupport
 
 /**

--- a/frontend/src/main/scala/bloop/bsp/BloopLanguageServer.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopLanguageServer.scala
@@ -1,33 +1,29 @@
 package bloop.bsp
 
-import io.circe.Json
-import io.circe.jawn.parseByteBuffer
-import io.circe.syntax._
-
 import java.nio.ByteBuffer
 
-import monix.eval.Task
-import monix.execution.Cancelable
-import monix.execution.Scheduler
-import monix.reactive.Observable
-import monix.execution.CancelableFuture
-
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
-import scala.util.control.NonFatal
-import scribe.LoggerSupport
-
+import scala.meta.jsonrpc.BaseProtocolMessage
+import scala.meta.jsonrpc.CancelParams
 import scala.meta.jsonrpc.Message
+import scala.meta.jsonrpc.NamedJsonRpcService
+import scala.meta.jsonrpc.Notification
 import scala.meta.jsonrpc.Request
 import scala.meta.jsonrpc.Response
 import scala.meta.jsonrpc.Service
 import scala.meta.jsonrpc.Services
-import scala.meta.jsonrpc.CancelParams
-import scala.meta.jsonrpc.Notification
-import scala.meta.jsonrpc.NamedJsonRpcService
-import scala.meta.jsonrpc.BaseProtocolMessage
+import scala.util.control.NonFatal
+
 import bloop.util.monix.FoldLeftAsyncConsumer
+
+import io.circe.Json
+import io.circe.jawn.parseByteBuffer
+import io.circe.syntax._
+import monix.eval.Task
+import monix.execution.CancelableFuture
+import monix.execution.Scheduler
+import monix.reactive.Observable
+import scribe.LoggerSupport
 
 final class BloopLanguageServer(
     in: Observable[BaseProtocolMessage],

--- a/frontend/src/main/scala/bloop/bsp/BspServer.scala
+++ b/frontend/src/main/scala/bloop/bsp/BspServer.scala
@@ -1,35 +1,36 @@
 package bloop.bsp
 
-import java.net.Socket
 import java.net.ServerSocket
-import java.util.Locale
-
-import bloop.cli.Commands
-import bloop.data.ClientInfo
-import bloop.engine.{ExecutionContext, State}
-import bloop.io.{AbsolutePath, RelativePath, ServerHandle}
-import bloop.logging.{BspClientLogger, DebugFilter}
-import bloop.sockets.UnixDomainServerSocket
-import bloop.sockets.Win32NamedPipeServerSocket
-import monix.eval.Task
-import monix.execution.Ack
-import monix.execution.Scheduler
-import monix.execution.Cancelable
-import monix.execution.atomic.Atomic
-import monix.execution.misc.NonFatal
-import monix.reactive.OverflowStrategy
-import monix.reactive.observers.Subscriber
-import monix.reactive.{Observable, Observer}
-import monix.reactive.observables.ObservableLike
-import monix.execution.cancelables.CompositeCancelable
+import java.net.Socket
+import java.nio.file.NoSuchFileException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 
 import scala.concurrent.Future
 import scala.concurrent.Promise
-import scala.meta.jsonrpc.{BaseProtocolMessage, LanguageClient, LanguageServer}
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit
+import scala.meta.jsonrpc.BaseProtocolMessage
+
+import bloop.cli.Commands
+import bloop.data.ClientInfo
+import bloop.engine.ExecutionContext
+import bloop.engine.State
+import bloop.io.AbsolutePath
+import bloop.io.RelativePath
+import bloop.io.ServerHandle
+import bloop.logging.BspClientLogger
+import bloop.logging.DebugFilter
+
+import monix.eval.Task
+import monix.execution.Ack
+import monix.execution.Cancelable
+import monix.execution.Scheduler
+import monix.execution.atomic.Atomic
 import monix.execution.cancelables.AssignableCancelable
-import java.nio.file.NoSuchFileException
+import monix.execution.cancelables.CompositeCancelable
+import monix.execution.misc.NonFatal
+import monix.reactive.Observer
+import monix.reactive.observables.ObservableLike
+import monix.reactive.observers.Subscriber
 import monix.reactive.subjects.BehaviorSubject
 
 object BspServer {
@@ -159,8 +160,6 @@ object BspServer {
 
       import monix.reactive.Consumer
       val singleMessageConsumer = Consumer.foreachAsync[BaseProtocolMessage] { msg =>
-        import scala.meta.jsonrpc.Response.Empty
-        import scala.meta.jsonrpc.Response.Success
         val taskToRun = {
           server
             .handleMessage(msg)

--- a/frontend/src/main/scala/bloop/bsp/ProjectUris.scala
+++ b/frontend/src/main/scala/bloop/bsp/ProjectUris.scala
@@ -3,12 +3,13 @@ package bloop.bsp
 import java.net.URI
 import java.nio.file.Path
 
+import scala.util.Try
+
+import ch.epfl.scala.bsp.Uri
+
 import bloop.data.Project
 import bloop.engine.State
 import bloop.io.AbsolutePath
-import ch.epfl.scala.bsp.Uri
-
-import scala.util.Try
 
 object ProjectUris {
   def getProjectDagFromUri(projectUri: String, state: State): Either[String, Option[Project]] = {

--- a/frontend/src/main/scala/bloop/bsp/ScalaTestSuites.scala
+++ b/frontend/src/main/scala/bloop/bsp/ScalaTestSuites.scala
@@ -1,10 +1,9 @@
 package bloop.bsp
 
-import io.circe.derivation.JsonCodec
-import io.circe.derivation.deriveDecoder
-import io.circe.derivation.deriveEncoder
 import io.circe.Decoder
 import io.circe.Encoder
+import io.circe.derivation.deriveDecoder
+import io.circe.derivation.deriveEncoder
 
 /**
   * Below datatypes are based on https://github.com/build-server-protocol/build-server-protocol/issues/249#issuecomment-983435766

--- a/frontend/src/main/scala/bloop/bsp/ScalaTestSuitesResult.scala
+++ b/frontend/src/main/scala/bloop/bsp/ScalaTestSuitesResult.scala
@@ -1,13 +1,14 @@
 package bloop.bsp
 
-import io.circe.derivation.JsonCodec
+import scala.meta.jsonrpc.Endpoint
+
 import ch.epfl.scala.bsp.BuildTargetIdentifier
-import io.circe.derivation.deriveDecoder
-import io.circe.derivation.deriveEncoder
+import ch.epfl.scala.bsp.ScalaTestClassesParams
+
 import io.circe.Decoder
 import io.circe.Encoder
-import scala.meta.jsonrpc.Endpoint
-import ch.epfl.scala.bsp.ScalaTestClassesParams
+import io.circe.derivation.deriveDecoder
+import io.circe.derivation.deriveEncoder
 
 object ScalaTestClasses {
   val endpoint = new Endpoint[ScalaTestClassesParams, ScalaTestClassesResult]("buildTarget/scalaTestClasses")

--- a/frontend/src/main/scala/bloop/cli/BspProtocol.scala
+++ b/frontend/src/main/scala/bloop/cli/BspProtocol.scala
@@ -1,7 +1,8 @@
 package bloop.cli
 
-import caseapp.core.argparser.{ArgParser, SimpleArgParser}
 import caseapp.core.Error
+import caseapp.core.argparser.ArgParser
+import caseapp.core.argparser.SimpleArgParser
 
 sealed abstract class BspProtocol(val name: String)
 

--- a/frontend/src/main/scala/bloop/cli/CliOptions.scala
+++ b/frontend/src/main/scala/bloop/cli/CliOptions.scala
@@ -2,12 +2,15 @@ package bloop.cli
 
 import java.nio.file.Path
 
+import bloop.cli.CliParsers._
 import bloop.logging.DebugFilter
-import caseapp.{ExtraName, HelpMessage, Recurse, ValueDescription}
-import caseapp.core.parser.Parser
-import caseapp.core.help.Help
 
-import CliParsers._
+import caseapp.ExtraName
+import caseapp.HelpMessage
+import caseapp.Recurse
+import caseapp.ValueDescription
+import caseapp.core.help.Help
+import caseapp.core.parser.Parser
 
 case class CliOptions(
     @ExtraName("c")
@@ -31,7 +34,7 @@ case class CliOptions(
 )
 
 object CliOptions {
-  val default = CliOptions()
+  val default: CliOptions = CliOptions()
 
   implicit lazy val parser: Parser[CliOptions] = Parser.derive
   implicit lazy val help: Help[CliOptions] = Help.derive

--- a/frontend/src/main/scala/bloop/cli/CliParsers.scala
+++ b/frontend/src/main/scala/bloop/cli/CliParsers.scala
@@ -1,13 +1,17 @@
 package bloop.cli
 
-import java.io.{InputStream, PrintStream}
-import java.nio.file.{Path, Paths}
-
-import bloop.logging.DebugFilter
-import caseapp.core.argparser.{ArgParser, SimpleArgParser}
-import caseapp.core.Error
+import java.io.InputStream
+import java.io.PrintStream
+import java.nio.file.Path
+import java.nio.file.Paths
 
 import scala.util.Try
+
+import bloop.logging.DebugFilter
+
+import caseapp.core.Error
+import caseapp.core.argparser.ArgParser
+import caseapp.core.argparser.SimpleArgParser
 import caseapp.core.default.Default
 
 object CliParsers {

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -3,11 +3,17 @@ package bloop.cli
 import java.net.InetAddress
 import java.nio.file.Path
 
+import bloop.cli.CliParsers._
 import bloop.io.AbsolutePath
-import caseapp.{CommandName, ExtraName, HelpMessage, Recurse}
-import caseapp.{Help => CaseAppHelp, CommandsHelp, CommandParser, Parser, core}
 
-import CliParsers._
+import caseapp.CommandName
+import caseapp.CommandParser
+import caseapp.CommandsHelp
+import caseapp.ExtraName
+import caseapp.HelpMessage
+import caseapp.Parser
+import caseapp.Recurse
+import caseapp.{Help => CaseAppHelp}
 
 object Commands {
 

--- a/frontend/src/main/scala/bloop/cli/CommonOptions.scala
+++ b/frontend/src/main/scala/bloop/cli/CommonOptions.scala
@@ -1,15 +1,15 @@
 package bloop.cli
 
-import java.io.{InputStream, PrintStream}
+import java.io.InputStream
+import java.io.PrintStream
 import java.util.Properties
 
-import bloop.engine.ExecutionContext
+import bloop.cli.CliParsers._
 import bloop.io.AbsolutePath
+
 import caseapp.Hidden
 import caseapp.core.help.Help
 import caseapp.core.parser.Parser
-
-import CliParsers._
 
 /**
  * Describes the common options for any command or CLI operation.
@@ -33,7 +33,7 @@ case class CommonOptions(
 }
 
 object CommonOptions {
-  final val default = CommonOptions()
+  final val default: CommonOptions = CommonOptions()
 
   // Our own version of properties in which we override `toString`
   final class PrettyProperties extends Properties {

--- a/frontend/src/main/scala/bloop/cli/ReplKind.scala
+++ b/frontend/src/main/scala/bloop/cli/ReplKind.scala
@@ -1,6 +1,7 @@
 package bloop.cli
-import caseapp.core.argparser.{ArgParser, SimpleArgParser}
 import caseapp.core.Error
+import caseapp.core.argparser.ArgParser
+import caseapp.core.argparser.SimpleArgParser
 
 sealed abstract class ReplKind(val name: String)
 case object ScalacRepl extends ReplKind("scalac")

--- a/frontend/src/main/scala/bloop/cli/ReporterKind.scala
+++ b/frontend/src/main/scala/bloop/cli/ReporterKind.scala
@@ -1,8 +1,10 @@
 package bloop.cli
 
 import bloop.reporter.ReporterConfig
-import caseapp.core.argparser.{ArgParser, SimpleArgParser}
+
 import caseapp.core.Error
+import caseapp.core.argparser.ArgParser
+import caseapp.core.argparser.SimpleArgParser
 
 /** Represents a reporter kind that users can pick to display compiler messages. */
 sealed abstract class ReporterKind(val name: String)

--- a/frontend/src/main/scala/bloop/cli/Validate.scala
+++ b/frontend/src/main/scala/bloop/cli/Validate.scala
@@ -3,11 +3,15 @@ package bloop.cli
 import java.nio.charset.Charset
 import java.nio.file.Files
 
-import bloop.bsp.BspServer
+import bloop.engine.Action
+import bloop.engine.Exit
+import bloop.engine.Feedback
+import bloop.engine.Print
+import bloop.engine.Run
+import bloop.engine.State
 import bloop.io.AbsolutePath
 import bloop.util.CrossPlatform
 import bloop.util.Environment
-import bloop.engine.{Action, Exit, Feedback, Print, Run, State}
 
 import monix.eval.Task
 

--- a/frontend/src/main/scala/bloop/cli/completion/BashFormat.scala
+++ b/frontend/src/main/scala/bloop/cli/completion/BashFormat.scala
@@ -1,8 +1,10 @@
 package bloop.cli.completion
 
-import caseapp.core.Arg
-import bloop.cli.{BspProtocol, ReporterKind}
+import bloop.cli.BspProtocol
+import bloop.cli.ReporterKind
 import bloop.data.Project
+
+import caseapp.core.Arg
 import caseapp.core.help.CommandHelp
 
 object BashFormat extends Format {

--- a/frontend/src/main/scala/bloop/cli/completion/Case.scala
+++ b/frontend/src/main/scala/bloop/cli/completion/Case.scala
@@ -1,7 +1,7 @@
 package bloop.cli.completion
 
-import caseapp.core.Arg
 import caseapp.Name
+import caseapp.core.Arg
 
 object Case {
   private val Kebab = "-([a-z])".r

--- a/frontend/src/main/scala/bloop/cli/completion/FishFormat.scala
+++ b/frontend/src/main/scala/bloop/cli/completion/FishFormat.scala
@@ -1,9 +1,11 @@
 package bloop.cli.completion
 
+import bloop.cli.BspProtocol
+import bloop.cli.ReporterKind
+import bloop.data.Project
+
 import caseapp.core.Arg
 import caseapp.core.help.CommandHelp
-import bloop.cli.{BspProtocol, ReporterKind}
-import bloop.data.Project
 
 /** Format for tab completion with fish */
 object FishFormat extends Format {

--- a/frontend/src/main/scala/bloop/cli/completion/Format.scala
+++ b/frontend/src/main/scala/bloop/cli/completion/Format.scala
@@ -1,9 +1,11 @@
 package bloop.cli.completion
 
+import bloop.cli.BspProtocol
+import bloop.cli.ReporterKind
+import bloop.data.Project
+
 import caseapp.core.Arg
 import caseapp.core.help.CommandHelp
-import bloop.cli.{BspProtocol, ReporterKind}
-import bloop.data.Project
 
 /**
  * A format for generating output that can be understood by

--- a/frontend/src/main/scala/bloop/cli/completion/Mode.scala
+++ b/frontend/src/main/scala/bloop/cli/completion/Mode.scala
@@ -1,7 +1,8 @@
 package bloop.cli.completion
 
-import caseapp.core.argparser.{ArgParser, SimpleArgParser}
 import caseapp.core.Error
+import caseapp.core.argparser.ArgParser
+import caseapp.core.argparser.SimpleArgParser
 
 sealed abstract class Mode(val name: String)
 

--- a/frontend/src/main/scala/bloop/cli/completion/ZshFormat.scala
+++ b/frontend/src/main/scala/bloop/cli/completion/ZshFormat.scala
@@ -1,9 +1,11 @@
 package bloop.cli.completion
 
+import bloop.cli.BspProtocol
+import bloop.cli.ReporterKind
+import bloop.data.Project
+
 import caseapp.core.Arg
 import caseapp.core.help.CommandHelp
-import bloop.cli.{BspProtocol, ReporterKind}
-import bloop.data.Project
 
 /** Format for autocompletion with zsh */
 object ZshFormat extends Format {

--- a/frontend/src/main/scala/bloop/dap/BloopDebuggeeRunner.scala
+++ b/frontend/src/main/scala/bloop/dap/BloopDebuggeeRunner.scala
@@ -1,22 +1,31 @@
 package bloop.dap
 
-import bloop.ScalaInstance
-import bloop.cli.ExitStatus
-import bloop.data.{ClientInfo, JdkConfig, Platform, Project}
-import bloop.engine.caches.ExpressionCompilerCache
-import bloop.engine.tasks.{RunMode, Tasks}
-import bloop.engine.{Dag, State}
-import bloop.logging.Logger
-import bloop.testing.{DebugLoggingEventHandler, LoggingEventHandler, TestInternals}
+import java.net.URLClassLoader
+import java.nio.file.Path
+
+import scala.collection.mutable
+
 import ch.epfl.scala.bsp.ScalaMainClass
 import ch.epfl.scala.debugadapter._
+
+import bloop.ScalaInstance
+import bloop.bsp.ScalaTestSuites
+import bloop.cli.ExitStatus
+import bloop.data.ClientInfo
+import bloop.data.JdkConfig
+import bloop.data.Platform
+import bloop.data.Project
+import bloop.engine.Dag
+import bloop.engine.State
+import bloop.engine.caches.ExpressionCompilerCache
+import bloop.engine.tasks.RunMode
+import bloop.engine.tasks.Tasks
+import bloop.logging.Logger
+import bloop.testing.DebugLoggingEventHandler
+import bloop.testing.TestInternals
+
 import monix.eval.Task
 import monix.execution.Scheduler
-
-import java.net.URLClassLoader
-import scala.collection.mutable
-import java.nio.file.Path
-import bloop.bsp.ScalaTestSuites
 
 abstract class BloopDebuggeeRunner(initialState: State, ioScheduler: Scheduler)
     extends DebuggeeRunner {

--- a/frontend/src/main/scala/bloop/dap/DapCancellableFuture.scala
+++ b/frontend/src/main/scala/bloop/dap/DapCancellableFuture.scala
@@ -1,9 +1,11 @@
 package bloop.dap
 
-import monix.eval.Task
-import monix.execution.{Cancelable, Scheduler}
+import scala.concurrent.Future
+import scala.concurrent.Promise
 
-import scala.concurrent.{Future, Promise}
+import monix.eval.Task
+import monix.execution.Cancelable
+import monix.execution.Scheduler
 
 private class DapCancellableFuture(future: Future[Unit], cancelable: Cancelable)
     extends ch.epfl.scala.debugadapter.CancelableFuture[Unit] {

--- a/frontend/src/main/scala/bloop/dap/DebuggeeLogger.scala
+++ b/frontend/src/main/scala/bloop/dap/DebuggeeLogger.scala
@@ -1,11 +1,14 @@
 package bloop.dap
 
 import java.net.InetSocketAddress
+
 import ch.epfl.scala.debugadapter.DebuggeeListener
-import bloop.logging.Logger
+
+import bloop.dap.DebuggeeLogger.JDINotificationPrefix
 import bloop.logging.DebugFilter
+import bloop.logging.Logger
+
 import monix.execution.atomic.Atomic
-import DebuggeeLogger.JDINotificationPrefix
 
 object DebuggeeLogger {
   final val JDINotificationPrefix = "Listening for transport dt_socket at address: "

--- a/frontend/src/main/scala/bloop/data/ClientInfo.scala
+++ b/frontend/src/main/scala/bloop/data/ClientInfo.scala
@@ -1,25 +1,21 @@
 package bloop.data
 
-import bloop.io.AbsolutePath
-import bloop.io.Filenames
-import bloop.util.UUIDUtil
-
-import java.nio.file.Files
-import java.util.concurrent.ConcurrentHashMap
 import java.io.PrintStream
-import monix.eval.Task
-import scala.collection.mutable
-import java.nio.file.Path
-import bloop.io.Paths
-import java.io.IOException
-import monix.execution.misc.NonFatal
-import bloop.logging.Logger
-import bloop.tracing.BraveTracer
-import bloop.logging.DebugFilter
+import java.nio.file.Files
 import java.nio.file.NoSuchFileException
-import bloop.cli.CommonOptions
 import java.nio.file.attribute.BasicFileAttributes
 import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.collection.mutable
+import scala.util.matching.Regex
+
+import bloop.io.AbsolutePath
+import bloop.io.Filenames
+import bloop.io.Paths
+import bloop.util.UUIDUtil
+
+import monix.execution.misc.NonFatal
 
 sealed trait ClientInfo {
 
@@ -211,7 +207,7 @@ object ClientInfo {
       s"bsp client '$name $version' (since ${activeSinceMillis(connectionTimestamp)})"
   }
 
-  val internalClassesNameFormat = "(.*)-[^-]*-[^-]*-[^-]*$".r
+  val internalClassesNameFormat: Regex = "(.*)-[^-]*-[^-]*-[^-]*$".r
 
   /**
    * Returns the path from which we derived an internal compile classes directory.
@@ -240,7 +236,7 @@ object ClientInfo {
     }
   }
 
-  def activeSinceMillis(startMs: Long) = {
+  def activeSinceMillis(startMs: Long): String = {
     import java.time.{Instant, Duration}
     val start = Instant.ofEpochMilli(startMs)
     val now = Instant.ofEpochMilli(System.currentTimeMillis())

--- a/frontend/src/main/scala/bloop/data/JdkConfig.scala
+++ b/frontend/src/main/scala/bloop/data/JdkConfig.scala
@@ -1,10 +1,8 @@
 package bloop.data
 
 import bloop.config.Config
-import bloop.util.JavaRuntime
 import bloop.io.AbsolutePath
-
-import scala.util.{Failure, Try}
+import bloop.util.JavaRuntime
 
 /**
  * The configuration of a JDK for a concrete project. It can be used for either

--- a/frontend/src/main/scala/bloop/data/Platform.scala
+++ b/frontend/src/main/scala/bloop/data/Platform.scala
@@ -1,7 +1,9 @@
 package bloop.data
 
 import bloop.config.Config
-import bloop.engine.tasks.toolchains.{JvmToolchain, ScalaJsToolchain, ScalaNativeToolchain}
+import bloop.engine.tasks.toolchains.JvmToolchain
+import bloop.engine.tasks.toolchains.ScalaJsToolchain
+import bloop.engine.tasks.toolchains.ScalaNativeToolchain
 import bloop.io.AbsolutePath
 
 sealed trait Platform {

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -1,5 +1,14 @@
 package bloop.data
 
+import java.nio.charset.StandardCharsets
+
+import scala.collection.mutable
+import scala.util.Properties
+import scala.util.Try
+import scala.util.control.NonFatal
+
+import ch.epfl.scala.{bsp => Bsp}
+
 import bloop.ScalaInstance
 import bloop.bsp.ProjectUris
 import bloop.config.Config
@@ -12,7 +21,7 @@ import bloop.io.AbsolutePath
 import bloop.io.ByteHasher
 import bloop.logging.DebugFilter
 import bloop.logging.Logger
-import ch.epfl.scala.{bsp => Bsp}
+
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigParseOptions
@@ -20,12 +29,6 @@ import com.typesafe.config.ConfigSyntax
 import monix.eval.Task
 import xsbti.compile.ClasspathOptions
 import xsbti.compile.CompileOrder
-
-import java.nio.charset.StandardCharsets
-import scala.collection.mutable
-import scala.util.Properties
-import scala.util.Try
-import scala.util.control.NonFatal
 
 final case class Project(
     name: String,
@@ -93,7 +96,7 @@ final case class Project(
     buf.result()
   }
 
-  val uniqueId = s"${origin.path.syntax}#${name}"
+  val uniqueId: String = s"${origin.path.syntax}#${name}"
   override def toString: String = s"$name"
   override val hashCode: Int =
     ByteHasher.hashBytes(uniqueId.getBytes(StandardCharsets.UTF_8))
@@ -264,7 +267,7 @@ final case class Project(
 }
 
 object Project {
-  private implicit val filter = DebugFilter.All
+  private implicit val filter: DebugFilter.All.type = DebugFilter.All
   final implicit val ps: scalaz.Show[Project] =
     new scalaz.Show[Project] { override def shows(f: Project): String = f.name }
 

--- a/frontend/src/main/scala/bloop/data/SourcesGlobs.scala
+++ b/frontend/src/main/scala/bloop/data/SourcesGlobs.scala
@@ -1,12 +1,13 @@
 package bloop.data
 
+import java.nio.file._
+import java.nio.file.attribute.BasicFileAttributes
+
+import scala.util.control.NonFatal
+
 import bloop.config.Config
 import bloop.io.AbsolutePath
 import bloop.logging.Logger
-
-import java.nio.file._
-import java.nio.file.attribute.BasicFileAttributes
-import scala.util.control.NonFatal
 
 case class SourcesGlobs(
     directory: AbsolutePath,

--- a/frontend/src/main/scala/bloop/data/WorkspaceSettings.scala
+++ b/frontend/src/main/scala/bloop/data/WorkspaceSettings.scala
@@ -1,16 +1,20 @@
 package bloop.data
 
-import bloop.logging.Logger
-import bloop.logging.DebugFilter
-import bloop.io.AbsolutePath
-import bloop.io.RelativePath
-import scala.util.Try
+import java.nio.file.Files
+
 import scala.util.Failure
 import scala.util.Success
-import java.nio.file.Files
+import scala.util.Try
+
+import bloop.io.AbsolutePath
+import bloop.io.RelativePath
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
 import bloop.tracing.TraceProperties
-import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, WriterConfig}
-import com.github.plokhotnyuk.jsoniter_scala.macros.{CodecMakerConfig, JsonCodecMaker}
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.core.WriterConfig
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 
 /**
  * Defines the settings of a given workspace. A workspace is a URI that has N

--- a/frontend/src/main/scala/bloop/engine/Action.scala
+++ b/frontend/src/main/scala/bloop/engine/Action.scala
@@ -1,6 +1,8 @@
 package bloop.engine
 
-import bloop.cli.{Commands, CommonOptions, ExitStatus}
+import bloop.cli.Commands
+import bloop.cli.CommonOptions
+import bloop.cli.ExitStatus
 
 sealed trait Action
 case class Exit(exitStatus: ExitStatus) extends Action

--- a/frontend/src/main/scala/bloop/engine/Build.scala
+++ b/frontend/src/main/scala/bloop/engine/Build.scala
@@ -1,13 +1,18 @@
 package bloop.engine
 
-import bloop.data.{LoadedProject, Origin, Project, WorkspaceSettings}
+import scala.collection.mutable
+
+import bloop.data.LoadedProject
+import bloop.data.Origin
+import bloop.data.Project
+import bloop.data.WorkspaceSettings
 import bloop.engine.Dag.DagResult
-import bloop.io.{AbsolutePath, ByteHasher}
+import bloop.io.AbsolutePath
+import bloop.io.ByteHasher
 import bloop.logging.Logger
 import bloop.util.CacheHashCode
-import monix.eval.Task
 
-import scala.collection.mutable
+import monix.eval.Task
 
 final case class Build private (
     origin: AbsolutePath,
@@ -215,7 +220,7 @@ object Build {
       settingsForReload: Option[WorkspaceSettings],
       writeSettingsToDisk: Boolean
   ) extends ReloadAction {
-    def createdOrModified = created ++ modified
+    def createdOrModified: List[ReadConfiguration] = created ++ modified
   }
 
   sealed trait UpdateSettingsAction

--- a/frontend/src/main/scala/bloop/engine/BuildLoader.scala
+++ b/frontend/src/main/scala/bloop/engine/BuildLoader.scala
@@ -1,20 +1,21 @@
 package bloop.engine
 
-import bloop.data.{Origin, Project}
-import bloop.io.Paths.AttributedPath
-import bloop.io.AbsolutePath
-import bloop.logging.{DebugFilter, Logger}
-import bloop.io.ByteHasher
 import bloop.data.JavaSemanticdbSettings
+import bloop.data.LoadedProject
+import bloop.data.Origin
+import bloop.data.Project
 import bloop.data.ScalaSemanticdbSettings
 import bloop.data.SemanticdbSettings
 import bloop.data.WorkspaceSettings
-import bloop.data.LoadedProject
 import bloop.engine.caches.SemanticDBCache
+import bloop.io.AbsolutePath
+import bloop.io.ByteHasher
+import bloop.io.Paths.AttributedPath
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
 
-import monix.eval.{Task, Coeval}
-import scala.collection.mutable
-import bloop.ScalaInstance
+import monix.eval.Coeval
+import monix.eval.Task
 
 object BuildLoader {
 

--- a/frontend/src/main/scala/bloop/engine/ClientPool.scala
+++ b/frontend/src/main/scala/bloop/engine/ClientPool.scala
@@ -1,6 +1,8 @@
 package bloop.engine
 
-import com.martiansoftware.nailgun.{NGClientDisconnectReason, NGClientListener, NGContext}
+import com.martiansoftware.nailgun.NGClientDisconnectReason
+import com.martiansoftware.nailgun.NGClientListener
+import com.martiansoftware.nailgun.NGContext
 
 sealed trait CloseEvent
 case object Heartbeat extends CloseEvent

--- a/frontend/src/main/scala/bloop/engine/Dag.scala
+++ b/frontend/src/main/scala/bloop/engine/Dag.scala
@@ -1,11 +1,13 @@
 package bloop.engine
 import java.{util => ju}
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
 import bloop.data.Project
 import bloop.util.CacheHashCode
-import scalaz.Show
 
-import scala.collection.mutable.ListBuffer
-import scala.collection.mutable
+import scalaz.Show
 
 /**
  * A [[Dag]] is a Directed Acyclic Graph where each node contains a value of T

--- a/frontend/src/main/scala/bloop/engine/ExecutionContext.scala
+++ b/frontend/src/main/scala/bloop/engine/ExecutionContext.scala
@@ -1,15 +1,13 @@
 package bloop.engine
 
 import java.lang.Thread.UncaughtExceptionHandler
-import java.util.concurrent.{
-  LinkedBlockingQueue,
-  SynchronousQueue,
-  ThreadFactory,
-  ThreadPoolExecutor,
-  TimeUnit
-}
+import java.util.concurrent.SynchronousQueue
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
 
-import monix.execution.{ExecutionModel, UncaughtExceptionReporter}
+import monix.execution.ExecutionModel
+import monix.execution.UncaughtExceptionReporter
 import monix.execution.schedulers.ExecutorScheduler
 
 object ExecutionContext {

--- a/frontend/src/main/scala/bloop/engine/Feedback.scala
+++ b/frontend/src/main/scala/bloop/engine/Feedback.scala
@@ -4,8 +4,8 @@ import java.nio.file.Path
 import bloop.data.Project
 import bloop.engine.Dag.RecursiveTrace
 import bloop.io.AbsolutePath
-import bloop.util.JavaRuntime
 import bloop.io.Environment.lineSeparator
+import bloop.util.JavaRuntime
 
 object Feedback {
   private final val eol = lineSeparator

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -1,31 +1,42 @@
 package bloop.engine
 
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import scala.collection.immutable.Nil
+import scala.concurrent.Promise
+
+import bloop.ScalaInstance
 import bloop.bsp.BspServer
-import bloop.cli._
-import bloop.cli.completion.{Case, Mode}
-import bloop.io.{AbsolutePath, RelativePath, SourceWatcher}
-import bloop.logging.{DebugFilter, Logger, NoopLogger}
-import bloop.testing.{LoggingEventHandler, TestInternals}
-import bloop.engine.tasks.{CompileTask, LinkTask, Tasks, TestTask, RunMode}
+import bloop.bsp.ScalaTestSuites
 import bloop.cli.Commands.CompilingCommand
 import bloop.cli.Validate
-import bloop.util.JavaRuntime
-import bloop.data.{ClientInfo, Platform, Project, JdkConfig}
+import bloop.cli._
+import bloop.cli.completion.Case
+import bloop.cli.completion.Mode
+import bloop.data.Platform
+import bloop.data.Project
 import bloop.engine.Feedback.XMessageString
-import bloop.engine.tasks.toolchains.{ScalaJsToolchain, ScalaNativeToolchain}
-import bloop.reporter.{LogReporter, ReporterInputs}
+import bloop.engine.tasks.CompileTask
+import bloop.engine.tasks.LinkTask
+import bloop.engine.tasks.RunMode
+import bloop.engine.tasks.Tasks
+import bloop.engine.tasks.TestTask
+import bloop.engine.tasks.toolchains.ScalaJsToolchain
+import bloop.engine.tasks.toolchains.ScalaNativeToolchain
 import bloop.io.Environment.lineSeparator
-import caseapp.core.help.CommandHelp
-import monix.eval.Task
+import bloop.io.RelativePath
+import bloop.io.SourceWatcher
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+import bloop.logging.NoopLogger
+import bloop.reporter.LogReporter
+import bloop.reporter.ReporterInputs
+import bloop.testing.LoggingEventHandler
+import bloop.testing.TestInternals
 
-import scala.concurrent.Promise
-import java.nio.file.Files
-import java.nio.charset.StandardCharsets
-import bloop.ScalaInstance
-import scala.collection.immutable.Nil
-import scala.annotation.tailrec
-import java.io.IOException
-import bloop.bsp.ScalaTestSuites
+import monix.eval.Task
 
 object Interpreter {
   // This is stack-safe because of Monix's trampolined execution

--- a/frontend/src/main/scala/bloop/engine/State.scala
+++ b/frontend/src/main/scala/bloop/engine/State.scala
@@ -1,13 +1,17 @@
 package bloop.engine
 
 import bloop.CompilerCache
-import bloop.cli.{CommonOptions, ExitStatus}
-import bloop.data.{Project, ClientInfo}
-import bloop.engine.caches.{ResultsCache, StateCache}
-import bloop.io.Paths
-import bloop.logging.{DebugFilter, Logger}
-import monix.eval.Task
+import bloop.cli.CommonOptions
+import bloop.cli.ExitStatus
+import bloop.data.ClientInfo
 import bloop.data.WorkspaceSettings
+import bloop.engine.caches.ResultsCache
+import bloop.engine.caches.StateCache
+import bloop.io.Paths
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+
+import monix.eval.Task
 import sbt.internal.inc.BloopComponentCompiler
 
 /**

--- a/frontend/src/main/scala/bloop/engine/caches/ExpressionCompilerCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ExpressionCompilerCache.scala
@@ -1,18 +1,18 @@
 package bloop.engine.caches
 
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
 import bloop.DependencyResolution
 import bloop.ExpressionCompilerCacheLock
 import bloop.io.AbsolutePath
 import bloop.io.Paths
 import bloop.logging.Logger
-import ch.epfl.scala.debugadapter.BuildInfo
+
 import sbt.internal.inc.BloopComponentCompiler
 import sbt.internal.inc.BloopComponentManager
 import sbt.internal.inc.IfMissing
-
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
 
 object ExpressionCompilerCache {
   import ch.epfl.scala.debugadapter.BuildInfo._

--- a/frontend/src/main/scala/bloop/engine/caches/LastSuccessfulResult.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/LastSuccessfulResult.scala
@@ -1,19 +1,19 @@
 package bloop.engine.caches
 
-import bloop.Compiler
+import java.util.Optional
+
+import bloop.CompileOutPaths
 import bloop.CompileProducts
+import bloop.UniqueCompileInputs
 import bloop.data.Project
 import bloop.io.AbsolutePath
 
-import java.nio.file.Files
-import java.util.Optional
-
-import xsbti.compile.{PreviousResult, CompileAnalysis, MiniSetup, FileHash}
-
 import monix.eval.Task
-import bloop.UniqueCompileInputs
-import bloop.CompileOutPaths
 import monix.execution.atomic.AtomicInt
+import xsbti.compile.CompileAnalysis
+import xsbti.compile.FileHash
+import xsbti.compile.MiniSetup
+import xsbti.compile.PreviousResult
 
 case class LastSuccessfulResult(
     sources: Vector[UniqueCompileInputs.HashedSource],

--- a/frontend/src/main/scala/bloop/engine/caches/SemanticDBCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/SemanticDBCache.scala
@@ -1,26 +1,20 @@
 package bloop.engine.caches
 
-import bloop.logging.Logger
-import coursierapi.Repository
-import bloop.io.AbsolutePath
-import bloop.io.Paths
-import bloop.DependencyResolution
-import scala.util.Try
-import java.nio.file.Files
-import xsbti.ComponentProvider
-import xsbti.GlobalLock
-import java.io.File
-import java.util.concurrent.Callable
-import sbt.internal.inc.bloop.ZincInternals
-import sbt.internal.inc.BloopComponentManager
-import sbt.internal.inc.IfMissing
+import java.nio.file.Path
+
 import scala.util.Failure
 import scala.util.Success
-import bloop.ComponentLock
+import scala.util.Try
+
+import bloop.DependencyResolution
 import bloop.SemanticDBCacheLock
-import java.nio.file.Path
-import coursierapi.error.CoursierError
+import bloop.io.AbsolutePath
+import bloop.io.Paths
+import bloop.logging.Logger
+
 import sbt.internal.inc.BloopComponentCompiler
+import sbt.internal.inc.BloopComponentManager
+import sbt.internal.inc.IfMissing
 
 object SemanticDBCache {
   private def fetchPlugin(

--- a/frontend/src/main/scala/bloop/engine/caches/StateCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/StateCache.scala
@@ -2,13 +2,16 @@ package bloop.engine.caches
 
 import java.util.concurrent.ConcurrentHashMap
 
+import bloop.cli.CommonOptions
+import bloop.cli.ExitStatus
 import bloop.data.ClientInfo
 import bloop.data.WorkspaceSettings
-import bloop.logging.Logger
-import bloop.cli.CommonOptions
-import bloop.engine.{Build, BuildLoader, State, ClientPool}
+import bloop.engine.Build
+import bloop.engine.BuildLoader
+import bloop.engine.ClientPool
+import bloop.engine.State
 import bloop.io.AbsolutePath
-import bloop.cli.ExitStatus
+import bloop.logging.Logger
 import bloop.util.Environment
 
 import monix.eval.Task

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -1,31 +1,41 @@
 package bloop.engine.tasks
 
+import scala.collection.mutable
+import scala.concurrent.Promise
+
+import bloop.CompileBackgroundTasks
+import bloop.CompileInputs
+import bloop.CompileOutPaths
+import bloop.CompileProducts
+import bloop.Compiler
 import bloop.Compiler.Result.Success
 import bloop.cli.ExitStatus
 import bloop.data.Project
+import bloop.data.WorkspaceSettings
+import bloop.engine.Dag
+import bloop.engine.ExecutionContext
+import bloop.engine.Feedback
+import bloop.engine.State
 import bloop.engine.caches.LastSuccessfulResult
-import bloop.engine.tasks.compilation.{FinalCompileResult, _}
-import bloop.engine.{Dag, ExecutionContext, Feedback, State}
+import bloop.engine.tasks.compilation.FinalCompileResult
+import bloop.engine.tasks.compilation._
+import bloop.io.ParallelOps
 import bloop.io.ParallelOps.CopyMode
-import bloop.io.{ParallelOps, Paths => BloopPaths}
-import bloop.logging.{DebugFilter, Logger, LoggerAction, ObservedLogger}
-import bloop.reporter.{ObservedReporter, Reporter, ReporterAction, ReporterInputs}
+import bloop.io.{Paths => BloopPaths}
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+import bloop.logging.LoggerAction
+import bloop.logging.ObservedLogger
+import bloop.reporter.ObservedReporter
+import bloop.reporter.Reporter
+import bloop.reporter.ReporterAction
+import bloop.reporter.ReporterInputs
 import bloop.tracing.BraveTracer
-import bloop.tracing.TraceProperties
-import bloop.{
-  CompileBackgroundTasks,
-  CompileExceptions,
-  CompileInputs,
-  CompileOutPaths,
-  CompileProducts,
-  Compiler
-}
+
 import monix.eval.Task
 import monix.execution.CancelableFuture
-import monix.reactive.{MulticastStrategy, Observable}
-import scala.collection.mutable
-import scala.concurrent.Promise
-import bloop.data.WorkspaceSettings
+import monix.reactive.MulticastStrategy
+import monix.reactive.Observable
 
 object CompileTask {
   private implicit val logContext: DebugFilter = DebugFilter.Compilation

--- a/frontend/src/main/scala/bloop/engine/tasks/LinkTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/LinkTask.scala
@@ -1,12 +1,17 @@
 package bloop.engine.tasks
 
 import bloop.cli.Commands.LinkingCommand
-import bloop.cli.{ExitStatus, OptimizerConfig}
+import bloop.cli.ExitStatus
+import bloop.cli.OptimizerConfig
 import bloop.config.Config
-import bloop.data.{Platform, Project}
-import bloop.engine.tasks.toolchains.{ScalaJsToolchain, ScalaNativeToolchain}
-import bloop.engine.{ExecutionContext, Feedback, State}
+import bloop.data.Platform
+import bloop.data.Project
+import bloop.engine.Feedback
+import bloop.engine.State
+import bloop.engine.tasks.toolchains.ScalaJsToolchain
+import bloop.engine.tasks.toolchains.ScalaNativeToolchain
 import bloop.io.AbsolutePath
+
 import monix.eval.Task
 
 object LinkTask {

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -1,25 +1,31 @@
 package bloop.engine.tasks
 
-import java.nio.file.{Files, Path}
+import java.nio.file.Files
+import java.nio.file.Path
 
-import bloop.cli.ExitStatus
-import bloop.engine.caches.ResultsCache
-import bloop.logging.DebugFilter
-import bloop.data.{Project, JdkConfig}
-import bloop.engine.{Dag, State}
-import bloop.exec.{Forker, JvmProcessForker}
-import bloop.io.AbsolutePath
-import bloop.util.JavaCompat.EnrichOptional
-import bloop.testing.{LoggingEventHandler, BloopTestSuiteEventHandler}
 import ch.epfl.scala.debugadapter.testing.TestSuiteEvent
-import monix.eval.Task
-import sbt.internal.inc.{Analysis, AnalyzingCompiler, ConcreteAnalysisContents, FileAnalysisStore}
-import sbt.internal.inc.classpath.ClasspathUtilities
-import sbt.testing._
-import xsbti.compile.{ClasspathOptionsUtil, CompileAnalysis, MiniSetup, PreviousResult}
+
 import bloop.bsp.ScalaTestSuites
+import bloop.cli.ExitStatus
+import bloop.data.JdkConfig
+import bloop.data.Project
+import bloop.engine.Dag
+import bloop.engine.State
+import bloop.exec.Forker
+import bloop.exec.JvmProcessForker
+import bloop.io.AbsolutePath
+import bloop.logging.DebugFilter
+import bloop.testing.BloopTestSuiteEventHandler
+import bloop.testing.LoggingEventHandler
+import bloop.util.JavaCompat.EnrichOptional
+
+import monix.eval.Task
+import sbt.internal.inc.Analysis
+import sbt.internal.inc.AnalyzingCompiler
 import sbt.internal.inc.PlainVirtualFileConverter
 import sbt.internal.inc.classpath.ClasspathUtil
+import sbt.testing._
+import xsbti.compile.ClasspathOptionsUtil
 
 object Tasks {
   private[bloop] val TestFailedStatus: Set[Status] =

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -1,25 +1,37 @@
 package bloop.engine.tasks
 
+import scala.util.Failure
+import scala.util.Success
+import scala.util.control.NonFatal
+
+import bloop.bsp.ScalaTestSuites
 import bloop.cli.ExitStatus
-import bloop.config.{Config, Tag}
-import bloop.data.{Platform, Project}
-import bloop.engine.{Dag, ExecutionContext, Feedback, State}
+import bloop.config.Config
+import bloop.config.Tag
+import bloop.data.Platform
+import bloop.data.Project
+import bloop.engine.Feedback
+import bloop.engine.State
 import bloop.engine.tasks.toolchains.ScalaJsToolchain
-import bloop.exec.{Forker, JvmProcessForker}
+import bloop.exec.JvmProcessForker
 import bloop.io.AbsolutePath
-import bloop.logging.{DebugFilter, Logger}
-import bloop.testing.{DiscoveredTestFrameworks, LoggingEventHandler, TestInternals, FingerprintInfo}
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+import bloop.testing.DiscoveredTestFrameworks
+import bloop.testing.FingerprintInfo
+import bloop.testing.LoggingEventHandler
+import bloop.testing.TestInternals
 import bloop.util.JavaCompat.EnrichOptional
+
 import monix.eval.Task
 import monix.execution.atomic.AtomicBoolean
 import sbt.internal.inc.Analysis
-import sbt.testing.{Framework, SuiteSelector, TaskDef, TestSelector}
+import sbt.testing.Framework
+import sbt.testing.SuiteSelector
+import sbt.testing.TaskDef
+import sbt.testing.TestSelector
 import xsbt.api.Discovery
 import xsbti.compile.CompileAnalysis
-
-import scala.util.control.NonFatal
-import scala.util.{Failure, Success}
-import bloop.bsp.ScalaTestSuites
 
 final case class TestFrameworkWithClasses(
     framework: String,

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileClientStore.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileClientStore.scala
@@ -1,8 +1,9 @@
 package bloop.engine.tasks.compilation
 
-import bloop.engine.Dag
-import bloop.data.{Project}
 import java.util.concurrent.ConcurrentHashMap
+
+import bloop.data.Project
+import bloop.engine.Dag
 import bloop.engine.tasks.compilation.CompileDefinitions.CompileTraversal
 
 sealed trait CompileClientStore {

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileDefinitions.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileDefinitions.scala
@@ -1,14 +1,11 @@
 package bloop.engine.tasks.compilation
 
-import monix.eval.Task
-import bloop.engine.Dag
-import bloop.PartialCompileProducts
 import bloop.CompileProducts
+import bloop.PartialCompileProducts
 import bloop.data.Project
-import java.io.File
-import xsbti.compile.PreviousResult
-import scala.concurrent.Promise
-import bloop.JavaSignal
+import bloop.engine.Dag
+
+import monix.eval.Task
 
 object CompileDefinitions {
   type ProjectId = String

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileDependenciesData.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileDependenciesData.scala
@@ -1,15 +1,13 @@
 package bloop.engine.tasks.compilation
 
-import bloop.data.Project
-import bloop.CompileProducts
-import bloop.io.AbsolutePath
+import java.io.File
 
 import scala.collection.mutable
 
-import java.io.File
-
-import xsbti.compile.PreviousResult
+import bloop.CompileProducts
 import bloop.PartialCompileProducts
+import bloop.data.Project
+import bloop.io.AbsolutePath
 
 case class CompileDependenciesData(
     dependencyClasspath: Array[AbsolutePath],

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGatekeeper.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGatekeeper.scala
@@ -1,25 +1,23 @@
 package bloop.engine.tasks.compilation
 
-import bloop.Compiler
-import bloop.engine.{Dag, Leaf, Parent, Aggregate}
-import bloop.data.Project
-import bloop.UniqueCompileInputs
-import bloop.engine.caches.LastSuccessfulResult
-import bloop.data.ClientInfo
-import bloop.logging.Logger
-import bloop.CompileOutPaths
-import bloop.logging.DebugFilter
-import bloop.engine.ExecutionContext
-import bloop.reporter.ReporterAction
-import bloop.logging.LoggerAction
-import bloop.io.AbsolutePath
-
-import monix.execution.atomic.AtomicBoolean
-import monix.eval.Task
-import monix.reactive.Observable
-import monix.execution.atomic.AtomicInt
-
 import java.util.concurrent.ConcurrentHashMap
+
+import bloop.Compiler
+import bloop.UniqueCompileInputs
+import bloop.data.ClientInfo
+import bloop.data.Project
+import bloop.engine.Dag
+import bloop.engine.caches.LastSuccessfulResult
+import bloop.io.AbsolutePath
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+import bloop.logging.LoggerAction
+import bloop.reporter.ReporterAction
+
+import monix.eval.Task
+import monix.execution.atomic.AtomicBoolean
+import monix.execution.atomic.AtomicInt
+import monix.reactive.Observable
 
 object CompileGatekeeper {
   private implicit val filter: DebugFilter = DebugFilter.Compilation
@@ -106,7 +104,6 @@ object CompileGatekeeper {
     import inputs.project
     import bundle.logger
     import logger.debug
-    import bundle.cancelCompilation
 
     var counterForUsedClassesDir: AtomicInt = null
 

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileResult.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileResult.scala
@@ -1,16 +1,15 @@
 package bloop.engine.tasks.compilation
 
-import bloop.{Compiler, JavaSignal, CompileProducts, CompileExceptions}
+import bloop.Compiler
 import bloop.data.Project
-import bloop.engine.{Dag, Leaf, Parent, Aggregate}
+import bloop.engine.Aggregate
+import bloop.engine.Dag
+import bloop.engine.Leaf
+import bloop.engine.Parent
 import bloop.reporter.Problem
 import bloop.util.CacheHashCode
 
 import monix.eval.Task
-import monix.execution.CancelableFuture
-
-import scala.util.Try
-import scala.concurrent.Promise
 
 sealed trait CompileResult[+R] {
   def result: R

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginAllowlist.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompilerPluginAllowlist.scala
@@ -1,21 +1,27 @@
 package bloop.engine.tasks.compilation
 
 import java.net.URI
-import java.nio.file.{FileSystems, Files, Path, Paths}
-import java.nio.file.attribute.{BasicFileAttributes, FileTime}
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.FileTime
 import java.util.concurrent.ConcurrentHashMap
 
-import bloop.tracing.BraveTracer
-import bloop.logging.{DebugFilter, Logger}
+import scala.collection.mutable
+import scala.concurrent.Promise
+import scala.util.control.NonFatal
+import scala.xml.XML
+
 import bloop.engine.ExecutionContext
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+import bloop.tracing.BraveTracer
 
 import monix.eval.Task
-import monix.reactive.{Observable, Consumer}
-
-import scala.xml.XML
-import scala.concurrent.Promise
-import scala.collection.mutable
-import scala.util.control.NonFatal
+import monix.reactive.Consumer
+import monix.reactive.Observable
 
 object CompilerPluginAllowlist {
 
@@ -46,10 +52,10 @@ object CompilerPluginAllowlist {
   )
 
   /** A sequence of versions that are known not to support compiler plugin classloading. */
-  val disallowedScalaVersions =
+  val disallowedScalaVersions: List[String] =
     List("2.10.", "2.11.", "2.12.1", "2.12.2", "2.12.3", "2.12.4", "0.", "3.")
 
-  private implicit val debug = DebugFilter.Compilation
+  private implicit val debug: DebugFilter.Compilation.type = DebugFilter.Compilation
   private val emptyMap = java.util.Collections.emptyMap[String, String]()
   private[this] val pluginPromises = new ConcurrentHashMap[String, Promise[Boolean]]()
   private[this] val cachePluginJar = new ConcurrentHashMap[Path, (FileTime, Boolean)]()

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/ResultBundle.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/ResultBundle.scala
@@ -4,7 +4,6 @@ import bloop.Compiler
 import bloop.engine.caches.LastSuccessfulResult
 
 import monix.execution.CancelableFuture
-import monix.eval.Task
 
 /**
  * Defines a result that aggregates several compilation outputs together.

--- a/frontend/src/main/scala/bloop/engine/tasks/toolchains/ScalaJsToolchain.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/toolchains/ScalaJsToolchain.scala
@@ -3,6 +3,9 @@ package bloop.engine.tasks.toolchains
 import java.lang.reflect.InvocationTargetException
 import java.nio.file.Path
 
+import scala.concurrent.ExecutionContext
+import scala.util.Try
+
 import bloop.DependencyResolution
 import bloop.config.Config
 import bloop.config.Config.JsConfig
@@ -11,10 +14,8 @@ import bloop.internal.build.BuildInfo
 import bloop.io.AbsolutePath
 import bloop.logging.Logger
 import bloop.testing.DiscoveredTestFrameworks
-import monix.eval.Task
 
-import scala.concurrent.ExecutionContext
-import scala.util.Try
+import monix.eval.Task
 import monix.execution.Scheduler
 
 /**

--- a/frontend/src/main/scala/bloop/engine/tasks/toolchains/ScalaNativeToolchain.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/toolchains/ScalaNativeToolchain.scala
@@ -3,6 +3,8 @@ package bloop.engine.tasks.toolchains
 import java.lang.reflect.InvocationTargetException
 import java.nio.file.Path
 
+import scala.util.Try
+
 import bloop.DependencyResolution
 import bloop.config.Config
 import bloop.config.Config.NativeConfig
@@ -10,9 +12,8 @@ import bloop.data.Project
 import bloop.internal.build.BuildInfo
 import bloop.io.AbsolutePath
 import bloop.logging.Logger
-import monix.eval.Task
 
-import scala.util.Try
+import monix.eval.Task
 
 final class ScalaNativeToolchain private (classLoader: ClassLoader) {
 

--- a/frontend/src/main/scala/bloop/engine/tasks/toolchains/ToolchainCompanion.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/toolchains/ToolchainCompanion.scala
@@ -6,8 +6,8 @@ import java.util.concurrent.ConcurrentHashMap
 
 import bloop.DependencyResolution
 import bloop.config.Config
-import bloop.internal.build.BuildInfo
-import bloop.logging.{DebugFilter, Logger}
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
 
 /**
  * Base class for companion objects of toolchains.

--- a/frontend/src/main/scala/bloop/exec/Forker.scala
+++ b/frontend/src/main/scala/bloop/exec/Forker.scala
@@ -1,25 +1,24 @@
 package bloop.exec
 
-import java.io.{FileNotFoundException, IOException}
-import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
-import java.util.concurrent.TimeUnit
-
-import bloop.cli.{CommonOptions, ExitStatus}
-import bloop.dap.DebuggeeLogger
-import bloop.engine.ExecutionContext
-import bloop.io.AbsolutePath
-import bloop.logging.{DebugFilter, Logger}
-import bloop.util.CrossPlatform
-import monix.eval.Task
-import monix.execution.Cancelable
-import scala.collection.JavaConverters._
-import scala.annotation.tailrec
-import scala.concurrent.duration.FiniteDuration
+import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
+import java.util.concurrent.TimeUnit
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.FiniteDuration
 import scala.sys.process.BasicIO
 import scala.util.control.NonFatal
+
+import bloop.cli.CommonOptions
+import bloop.cli.ExitStatus
+import bloop.engine.ExecutionContext
+import bloop.io.AbsolutePath
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+
+import monix.eval.Task
+import monix.execution.Cancelable
 
 object Forker {
   private implicit val logContext: DebugFilter = DebugFilter.All

--- a/frontend/src/main/scala/bloop/exec/JvmProcessForker.scala
+++ b/frontend/src/main/scala/bloop/exec/JvmProcessForker.scala
@@ -1,19 +1,27 @@
 package bloop.exec
 
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Files
+import java.util.jar.Attributes
+import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
+
+import scala.util.Failure
+import scala.util.Properties
+import scala.util.Success
+import scala.util.Try
+
 import bloop.cli.CommonOptions
 import bloop.data.JdkConfig
 import bloop.engine.tasks.RunMode
-import bloop.io.{AbsolutePath, Paths}
-import bloop.logging.{DebugFilter, Logger}
+import bloop.io.AbsolutePath
+import bloop.io.Paths
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
 import bloop.util.CrossPlatform
-import java.io.File
-import java.net.URLClassLoader
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import java.util.jar.{Attributes, JarOutputStream, Manifest}
+
 import monix.eval.Task
-import scala.util.{Failure, Properties, Success, Try}
 
 /**
  * Collects configuration to start a new program in a new process

--- a/frontend/src/main/scala/bloop/io/Filenames.scala
+++ b/frontend/src/main/scala/bloop/io/Filenames.scala
@@ -1,7 +1,8 @@
 package bloop.io
 
+import scala.util.matching.Regex
 object Filenames {
-  lazy val specialCharacters = "[^\\p{Alnum}-]".r
+  lazy val specialCharacters: Regex = "[^\\p{Alnum}-]".r
   def escapeSpecialCharacters(filename: String): String =
     specialCharacters.replaceAllIn(filename, "_")
 }

--- a/frontend/src/main/scala/bloop/io/ServerHandle.scala
+++ b/frontend/src/main/scala/bloop/io/ServerHandle.scala
@@ -1,8 +1,11 @@
 package bloop.io
 
-import java.net.{InetAddress, InetSocketAddress, ServerSocket}
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.ServerSocket
 
-import bloop.sockets.{UnixDomainServerSocket, Win32NamedPipeServerSocket}
+import bloop.sockets.UnixDomainServerSocket
+import bloop.sockets.Win32NamedPipeServerSocket
 
 sealed trait ServerHandle {
   def uri: String

--- a/frontend/src/main/scala/bloop/io/SourceHasher.scala
+++ b/frontend/src/main/scala/bloop/io/SourceHasher.scala
@@ -1,36 +1,28 @@
 package bloop.io
 
 import java.io.IOException
-import java.util.concurrent.ConcurrentLinkedDeque
+import java.nio.file.FileSystems
+import java.nio.file.FileVisitOption
+import java.nio.file.FileVisitResult
+import java.nio.file.FileVisitor
+import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.attribute.BasicFileAttributes
-import java.nio.file.{
-  FileSystems,
-  StandardCopyOption,
-  FileVisitResult,
-  FileVisitOption,
-  FileVisitor,
-  Files,
-  Path,
-  SimpleFileVisitor,
-  Paths => NioPaths
-}
 
 import scala.collection.mutable
 import scala.concurrent.Promise
 
-import bloop.data.Project
-import bloop.engine.ExecutionContext
-import bloop.util.monix.FoldLeftAsyncConsumer
 import bloop.UniqueCompileInputs.HashedSource
+import bloop.data.Project
+import bloop.util.monix.FoldLeftAsyncConsumer
 
-import monix.reactive.{MulticastStrategy, Consumer, Observable}
 import monix.eval.Task
-import monix.execution.atomic.AtomicBoolean
-import monix.execution.Scheduler
-import monix.reactive.internal.operators.MapAsyncParallelObservable
 import monix.execution.Cancelable
-import monix.execution.cancelables.CompositeCancelable
-
+import monix.execution.Scheduler
+import monix.execution.atomic.AtomicBoolean
+import monix.reactive.Consumer
+import monix.reactive.MulticastStrategy
+import monix.reactive.Observable
 import sbt.internal.inc.PlainVirtualFileConverter
 
 object SourceHasher {

--- a/frontend/src/main/scala/bloop/io/SourceWatcher.scala
+++ b/frontend/src/main/scala/bloop/io/SourceWatcher.scala
@@ -1,28 +1,31 @@
 package bloop.io
 
-import java.nio.file.{Files, Path}
-
-import bloop.bsp.BspServer
-import bloop.engine.{ExecutionContext, State}
-import bloop.logging.{DebugFilter, Logger, Slf4jAdapter}
-import bloop.util.monix.FoldLeftAsyncConsumer
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.FiniteDuration
 
-import io.methvin.watcher.DirectoryChangeEvent.EventType
-import io.methvin.watcher.{DirectoryChangeEvent, DirectoryChangeListener, DirectoryWatcher}
+import bloop.engine.ExecutionContext
+import bloop.engine.State
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+import bloop.logging.Slf4jAdapter
+import bloop.util.monix.FoldLeftAsyncConsumer
 
+import io.methvin.watcher.DirectoryChangeEvent
+import io.methvin.watcher.DirectoryChangeEvent.EventType
+import io.methvin.watcher.DirectoryChangeListener
+import io.methvin.watcher.DirectoryWatcher
 import monix.eval.Task
-import monix.reactive.Consumer
 import monix.execution.Cancelable
-import monix.reactive.{MulticastStrategy, Observable}
-import monix.execution.misc.NonFatal
 import monix.execution.atomic.AtomicBoolean
-import monix.reactive.OverflowStrategy
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit
-import java.nio.file.attribute.BasicFileAttributes
+import monix.execution.misc.NonFatal
+import monix.reactive.MulticastStrategy
+import monix.reactive.Observable
 
 final class SourceWatcher private (
     projectNames: List[String],
@@ -159,7 +162,6 @@ final class SourceWatcher private (
       ngout.println(s"$watchLogId has been successfully cancelled")
     }
 
-    import SourceWatcher.EventStream
     val fileEventConsumer = {
       FoldLeftAsyncConsumer.consume[State, Seq[DirectoryChangeEvent]](state0) {
         case (state, events) =>

--- a/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
+++ b/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
@@ -1,23 +1,20 @@
 package bloop.logging
 
-import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 
-import bloop.data.Project
-import bloop.engine.State
-import bloop.reporter.Problem
-import sbt.internal.inc.bloop.ZincInternals
-import xsbti.Severity
-
 import scala.meta.jsonrpc.JsonRpcClient
+
 import ch.epfl.scala.bsp
+import ch.epfl.scala.bsp.BuildTargetIdentifier
+import ch.epfl.scala.bsp.DiagnosticSeverity
 import ch.epfl.scala.bsp.Uri
-import ch.epfl.scala.bsp.{BuildTargetIdentifier, DiagnosticSeverity}
 import ch.epfl.scala.bsp.endpoints.Build
 
+import bloop.engine.State
+
 import monix.execution.atomic.AtomicInt
-import io.circe.derivation.JsonCodec
-import java.nio.file.Path
+import sbt.internal.inc.bloop.ZincInternals
+import xsbti.Severity
 
 /**
  * Creates a logger that will forward all the messages to the underlying bsp client.

--- a/frontend/src/main/scala/bloop/reporter/BspProjectReporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/BspProjectReporter.scala
@@ -2,20 +2,16 @@ package bloop.reporter
 
 import java.io.File
 
+import scala.collection.concurrent.TrieMap
+import scala.util.Try
+
+import ch.epfl.scala.bsp
+
 import bloop.data.Project
 import bloop.io.AbsolutePath
-import bloop.logging.{BspServerLogger, CompilationEvent, ObservedLogger}
-import bloop.util.AnalysisUtils
-import xsbti.Position
-import ch.epfl.scala.bsp
-import sbt.util.InterfaceUtil
-import xsbti.compile.CompileAnalysis
+import bloop.logging.BspServerLogger
+import bloop.logging.CompilationEvent
 
-import scala.collection.concurrent.TrieMap
-import scala.collection.mutable
-import scala.util.Try
-import scala.concurrent.Promise
-import bloop.CompileOutPaths
 import monix.execution.atomic.AtomicInt
 import xsbti.VirtualFile
 

--- a/frontend/src/main/scala/bloop/reporter/LogReporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/LogReporter.scala
@@ -1,21 +1,14 @@
 package bloop.reporter
 import java.io.File
 
-import bloop.data.Project
-import bloop.io.AbsolutePath
-import bloop.logging.{Logger, ObservedLogger}
-
 import ch.epfl.scala.bsp
 
-import xsbti.compile.CompileAnalysis
-import xsbti.{Position, Severity}
-import sbt.util.InterfaceUtil
+import bloop.data.Project
+import bloop.io.AbsolutePath
+import bloop.logging.Logger
 
-import scala.collection.mutable
-import scala.collection.concurrent.TrieMap
-import bloop.logging.CompilationEvent
+import xsbti.Severity
 import xsbti.VirtualFile
-import bloop.util.AnalysisUtils
 
 final class LogReporter(
     val project: Project,

--- a/frontend/src/main/scala/bloop/reporter/ReporterInputs.scala
+++ b/frontend/src/main/scala/bloop/reporter/ReporterInputs.scala
@@ -1,8 +1,8 @@
 package bloop.reporter
 
 import bloop.data.Project
-import bloop.logging.{Logger, ObservedLogger}
 import bloop.io.AbsolutePath
+import bloop.logging.Logger
 
 case class ReporterInputs[UseSiteLogger <: Logger](
     project: Project,

--- a/frontend/src/main/scala/bloop/reporter/package.scala
+++ b/frontend/src/main/scala/bloop/reporter/package.scala
@@ -1,10 +1,10 @@
 package bloop
 
-import bloop.data.Project
-import bloop.reporter.Reporter
-
 import java.util.concurrent.ConcurrentHashMap
+
 import scala.collection.JavaConverters._
+
+import bloop.data.Project
 
 package object reporter {
   type ConcurrentSet[A] = ConcurrentHashMap.KeySetView[A, java.lang.Boolean]

--- a/frontend/src/main/scala/bloop/testing/DiscoveredTestFrameworks.scala
+++ b/frontend/src/main/scala/bloop/testing/DiscoveredTestFrameworks.scala
@@ -1,6 +1,7 @@
 package bloop.testing
 import bloop.engine.tasks.toolchains.ScalaJsToolchain
-import bloop.exec.{JvmProcessForker}
+import bloop.exec.JvmProcessForker
+
 import sbt.testing.Framework
 
 sealed trait DiscoveredTestFrameworks {

--- a/frontend/src/main/scala/bloop/testing/LoggingEventHandler.scala
+++ b/frontend/src/main/scala/bloop/testing/LoggingEventHandler.scala
@@ -1,26 +1,20 @@
 package bloop.testing
 
-import bloop.logging.DebugFilter
-import bloop.logging.Logger
-import bloop.util.TimeFormat
-import ch.epfl.scala.bsp
+import scala.collection.mutable
+import scala.meta.jsonrpc.JsonRpcClient
+
 import ch.epfl.scala.bsp.BuildTargetIdentifier
-import ch.epfl.scala.bsp.endpoints.Build
-import ch.epfl.scala.bsp.endpoints.BuildTarget
 import ch.epfl.scala.debugadapter.DebuggeeListener
 import ch.epfl.scala.debugadapter.testing.TestSuiteEvent
 import ch.epfl.scala.debugadapter.testing.TestSuiteEventHandler
 import ch.epfl.scala.debugadapter.testing.TestUtils
+
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+import bloop.util.TimeFormat
+
 import sbt.testing.Event
-import sbt.testing.Selector
 import sbt.testing.Status
-import sbt.testing.TestSelector
-
-import scala.collection.mutable
-import scala.meta.jsonrpc.JsonRpcClient
-import scala.util.Try
-
-import collection.JavaConverters._
 
 trait BloopTestSuiteEventHandler extends TestSuiteEventHandler {
   def report(): Unit
@@ -36,7 +30,7 @@ class LoggingEventHandler(logger: Logger) extends BloopTestSuiteEventHandler {
   protected var suitesDuration = 0L
   protected var suitesPassed = 0
   protected var suitesAborted = 0
-  protected val testsFailedBySuite =
+  protected val testsFailedBySuite: mutable.SortedMap[SuiteName, Map[TestName, FailureMessage]] =
     mutable.SortedMap.empty[SuiteName, Map[TestName, FailureMessage]]
   protected var suitesTotal = 0
 

--- a/frontend/src/main/scala/bloop/testing/TestInternals.scala
+++ b/frontend/src/main/scala/bloop/testing/TestInternals.scala
@@ -2,35 +2,39 @@ package bloop.testing
 
 import java.util.regex.Pattern
 
+import scala.collection.mutable
+import scala.util.control.NonFatal
+
+import ch.epfl.scala.debugadapter.testing.TestSuiteEvent
+
 import bloop.DependencyResolution
-import bloop.cli.{CommonOptions, ExitStatus}
+import bloop.cli.CommonOptions
+import bloop.cli.ExitStatus
 import bloop.config.Config
 import bloop.config.Config.TestArgument
 import bloop.engine.ExecutionContext
-import bloop.exec.{Forker, JvmProcessForker}
+import bloop.exec.Forker
+import bloop.exec.JvmProcessForker
 import bloop.io.AbsolutePath
-import bloop.logging.{DebugFilter, Logger}
-import ch.epfl.scala.debugadapter.testing.TestSuiteEvent
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+
 import monix.eval.Task
 import monix.execution.atomic.AtomicBoolean
-import sbt.testing.{
-  AnnotatedFingerprint,
-  Event,
-  Fingerprint,
-  Framework,
-  Runner,
-  SubclassFingerprint,
-  TaskDef
-}
 import org.scalatools.testing.{Framework => OldFramework}
 import sbt.internal.inc.Analysis
-import sbt.internal.inc.classpath.{FilteredLoader, IncludePackagesFilter}
+import sbt.internal.inc.classpath.FilteredLoader
+import sbt.internal.inc.classpath.IncludePackagesFilter
+import sbt.testing.AnnotatedFingerprint
+import sbt.testing.Event
+import sbt.testing.Fingerprint
+import sbt.testing.Framework
+import sbt.testing.Runner
+import sbt.testing.SubclassFingerprint
+import sbt.testing.TaskDef
 import xsbt.api.Discovered
 import xsbti.api.ClassLike
 import xsbti.compile.CompileAnalysis
-
-import scala.collection.mutable
-import scala.util.control.NonFatal
 
 final case class FingerprintInfo[+Print <: Fingerprint](
     name: String,
@@ -49,7 +53,7 @@ object TestInternals {
   // Cache the resolution of test agent files since it's static (cannot be lazy because depends on logger)
   @volatile private var testAgentFiles: Option[Array[AbsolutePath]] = None
 
-  lazy val filteredLoader = {
+  lazy val filteredLoader: FilteredLoader = {
     val filter = new IncludePackagesFilter(
       Set(
         "jdk.",

--- a/frontend/src/main/scala/bloop/testing/TestServer.scala
+++ b/frontend/src/main/scala/bloop/testing/TestServer.scala
@@ -1,19 +1,26 @@
 package bloop.testing
 
-import java.io.{ObjectInputStream, ObjectOutputStream}
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
 import java.net.ServerSocket
-
-import bloop.cli.CommonOptions
-import bloop.config.Config
-import bloop.logging.{DebugFilter, Logger}
-import ch.epfl.scala.debugadapter.testing.TestSuiteEvent
-import monix.eval.Task
-import monix.execution.misc.NonFatal
-import sbt.{ForkConfiguration, ForkTags}
-import sbt.testing.{Event, Framework, TaskDef}
 
 import scala.concurrent.Promise
 import scala.util.Try
+
+import ch.epfl.scala.debugadapter.testing.TestSuiteEvent
+
+import bloop.cli.CommonOptions
+import bloop.config.Config
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+
+import monix.eval.Task
+import monix.execution.misc.NonFatal
+import sbt.ForkConfiguration
+import sbt.ForkTags
+import sbt.testing.Event
+import sbt.testing.Framework
+import sbt.testing.TaskDef
 
 /**
  * Implements the protocol that the forked remote JVM talks with the host process.

--- a/frontend/src/main/scala/bloop/util/CommandsDocGenerator.scala
+++ b/frontend/src/main/scala/bloop/util/CommandsDocGenerator.scala
@@ -1,19 +1,21 @@
 package bloop.util
 
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Paths}
-
-import bloop.Cli
-import bloop.cli.{CliParsers, Commands, CommonOptions}
-import bloop.engine.Run
-import caseapp.{Name, ValueDescription}
-import caseapp.core.Arg
-import caseapp.core.help.Help
-import caseapp.core.util.NameOps._
+import java.nio.file.Files
+import java.nio.file.Paths
 
 import scala.util.control.NonFatal
+
+import bloop.Cli
+import bloop.cli.Commands
+import bloop.cli.CommonOptions
+import bloop.engine.Run
 import bloop.io.Environment.lineSeparator
+
+import caseapp.ValueDescription
+import caseapp.core.Arg
 import caseapp.core.util.Formatter
+import caseapp.core.util.NameOps._
 
 object CommandsDocGenerator {
   private final val docsContentDelimiter =

--- a/frontend/src/main/scala/bloop/util/CrossPlatform.scala
+++ b/frontend/src/main/scala/bloop/util/CrossPlatform.scala
@@ -3,7 +3,7 @@ package bloop.util
 import java.util.Locale
 
 object CrossPlatform {
-  val OS = System.getProperty("os.name").toLowerCase(Locale.ENGLISH)
+  val OS: String = System.getProperty("os.name").toLowerCase(Locale.ENGLISH)
   val isWindows: Boolean = OS.contains("windows")
   val isMac: Boolean = OS.contains("mac")
 }

--- a/frontend/src/main/scala/bloop/util/JavaCompat.scala
+++ b/frontend/src/main/scala/bloop/util/JavaCompat.scala
@@ -3,8 +3,8 @@ package bloop.util
 import java.util.Optional
 import java.util.function.Supplier
 
-import xsbti.T2
 import sbt.util.InterfaceUtil
+import xsbti.T2
 
 object JavaCompat {
   implicit def toSupplier[T](thunk: => T): Supplier[T] = thunk

--- a/frontend/src/main/scala/bloop/util/ProxySetup.scala
+++ b/frontend/src/main/scala/bloop/util/ProxySetup.scala
@@ -1,13 +1,15 @@
 package bloop.util
 
-import java.net.URI
 import java.net.MalformedURLException
+import java.net.URI
+
+import scala.collection.JavaConverters._
+import scala.util.Try
 
 import bloop.logging.Logger
-import _root_.monix.execution.atomic.{Atomic, AtomicAny}
 
-import scala.util.Try
-import scala.collection.JavaConverters._
+import _root_.monix.execution.atomic.Atomic
+import _root_.monix.execution.atomic.AtomicAny
 
 object ProxySetup {
   private case class ProxySettings(host: String, port: Int, nonProxyHosts: Option[String])
@@ -46,7 +48,7 @@ object ProxySetup {
     final case object HttpProxy extends Proxy {
       val propertyNameHost = "http.proxyHost"
       val propertyNamePort = "http.proxyPort"
-      val propertyNameNoProxyHosts = Some("http.nonProxyHosts")
+      val propertyNameNoProxyHosts: Some[String] = Some("http.nonProxyHosts")
       val defaultPort = 80
       val envVar = "http_proxy"
     }
@@ -54,7 +56,7 @@ object ProxySetup {
     final case object FtpProxy extends Proxy {
       val propertyNameHost = "ftp.proxyHost"
       val propertyNamePort = "ftp.proxyPort"
-      val propertyNameNoProxyHosts = Some("ftp.nonProxyHosts")
+      val propertyNameNoProxyHosts: Some[String] = Some("ftp.nonProxyHosts")
       val defaultPort = 80
       val envVar = "ftp_proxy"
     }

--- a/frontend/src/main/scala/bloop/util/SystemProperties.scala
+++ b/frontend/src/main/scala/bloop/util/SystemProperties.scala
@@ -1,8 +1,8 @@
 package bloop.util
 
-import bloop.logging.Logger
-
 import scala.concurrent.duration.FiniteDuration
+
+import bloop.logging.Logger
 
 object SystemProperties {
   private def parseLong(repr: String): Option[Long] = {

--- a/frontend/src/main/scala/bloop/util/TimeFormat.scala
+++ b/frontend/src/main/scala/bloop/util/TimeFormat.scala
@@ -1,7 +1,7 @@
 package bloop.util
 
+import java.util.concurrent.TimeUnit
 import java.{util => ju}
-import ju.concurrent.TimeUnit
 
 object TimeFormat {
   def readableMillis(nanos: Long): String = {

--- a/frontend/src/main/scala/bloop/util/monix/BloopBufferTimedObservable.scala
+++ b/frontend/src/main/scala/bloop/util/monix/BloopBufferTimedObservable.scala
@@ -1,14 +1,20 @@
 package bloop.util.monix
 
 import java.util.concurrent.TimeUnit
-import monix.execution.Ack.{Continue, Stop}
-import monix.execution.cancelables.{CompositeCancelable, MultiAssignmentCancelable}
-import monix.execution.{Ack, Cancelable}
-import monix.reactive.Observable
-import monix.reactive.observers.Subscriber
+
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
+
+import monix.execution.Ack
+import monix.execution.Ack.Continue
+import monix.execution.Ack.Stop
+import monix.execution.Cancelable
+import monix.execution.cancelables.CompositeCancelable
+import monix.execution.cancelables.MultiAssignmentCancelable
+import monix.reactive.Observable
+import monix.reactive.observers.Subscriber
 
 final class BloopBufferTimedObservable[+A](
     source: Observable[A],

--- a/frontend/src/main/scala/bloop/util/monix/FoldLeftAsyncConsumer.scala
+++ b/frontend/src/main/scala/bloop/util/monix/FoldLeftAsyncConsumer.scala
@@ -1,16 +1,21 @@
 package bloop.util.monix
 
-import monix.eval.{Callback, Task}
-import monix.execution.Ack.{Continue, Stop}
-import monix.execution.cancelables.{AssignableCancelable, CompositeCancelable}
-import monix.execution.misc.NonFatal
-import monix.execution.{Ack, Cancelable, Scheduler}
-import monix.reactive.observers.Subscriber
-import monix.reactive.{Consumer, Observable}
-
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
-import monix.execution.CancelableFuture
+
+import monix.eval.Callback
+import monix.eval.Task
+import monix.execution.Ack
+import monix.execution.Ack.Continue
+import monix.execution.Ack.Stop
+import monix.execution.Cancelable
+import monix.execution.Scheduler
+import monix.execution.cancelables.AssignableCancelable
+import monix.execution.cancelables.CompositeCancelable
+import monix.execution.misc.NonFatal
+import monix.reactive.Consumer
+import monix.reactive.Observable
+import monix.reactive.observers.Subscriber
 
 // Fork of `FoldLeftAsyncConsumer` from Monix, not thread-safe
 final class FoldLeftAsyncConsumer[A, R](

--- a/frontend/src/main/scala/bloop/util/monix/WhileBusyDropEventsAndSignalOperator.scala
+++ b/frontend/src/main/scala/bloop/util/monix/WhileBusyDropEventsAndSignalOperator.scala
@@ -1,16 +1,16 @@
 package bloop.util.monix
 
+import scala.collection.mutable
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+
 import monix.execution.Ack
-import monix.execution.Ack.{Continue, Stop}
+import monix.execution.Ack.Continue
+import monix.execution.Ack.Stop
 import monix.execution.misc.NonFatal
 import monix.reactive.observables.ObservableLike.Operator
 import monix.reactive.observers.Subscriber
-import monix.execution.atomic.AtomicBoolean
-
-import scala.concurrent.Future
-import scala.collection.mutable
-import scala.util.Success
-import scala.util.Failure
 
 final class BloopWhileBusyDropEventsAndSignalOperator[A](onOverflow: Seq[A] => A)
     extends Operator[A, A] {

--- a/frontend/src/main/scala/sbt/SerializableFingerprints.scala
+++ b/frontend/src/main/scala/sbt/SerializableFingerprints.scala
@@ -1,7 +1,10 @@
 package sbt
 
 import java.io.Serializable
-import sbt.testing.{AnnotatedFingerprint, Fingerprint, SubclassFingerprint}
+
+import sbt.testing.AnnotatedFingerprint
+import sbt.testing.Fingerprint
+import sbt.testing.SubclassFingerprint
 
 /**
  * This object is there only to instantiate the subclasses of Fingerprint that are

--- a/frontend/src/test/scala/bloop/AutoCompleteSpec.scala
+++ b/frontend/src/test/scala/bloop/AutoCompleteSpec.scala
@@ -1,16 +1,19 @@
 package bloop
 
-import bloop.cli.{CliOptions, Commands, completion}
+import bloop.cli.CliOptions
+import bloop.cli.Commands
+import bloop.cli.completion
 import bloop.engine.Run
 import bloop.io.Environment.lineSeparator
 import bloop.logging.RecordingLogger
 import bloop.util.TestUtil
+
 import org.junit.Test
 
 class AutoCompleteSpec {
 
   @Test
-  def zshCompletions =
+  def zshCompletions: Unit =
     check(
       completion.ZshFormat,
       """
@@ -46,7 +49,7 @@ class AutoCompleteSpec {
     )
 
   @Test
-  def fishCompletions =
+  def fishCompletions: Unit =
     check(
       completion.FishFormat,
       """
@@ -82,7 +85,7 @@ class AutoCompleteSpec {
     )
 
   @Test
-  def bashCompletions =
+  def bashCompletions: Unit =
     check(
       completion.BashFormat,
       """

--- a/frontend/src/test/scala/bloop/BaseCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/BaseCompileSpec.scala
@@ -1,31 +1,35 @@
 package bloop
 
-import bloop.config.Config
-import bloop.io.{AbsolutePath, RelativePath, Paths => BloopPaths}
-import bloop.io.Environment.{lineSeparator, LineSplitter}
-import bloop.logging.RecordingLogger
-import bloop.cli.{Commands, ExitStatus}
-import bloop.engine.{Feedback, Run, State, ExecutionContext}
-import bloop.engine.caches.ResultsCache
-import bloop.util.{TestUtil, BuildUtil}
-
-import java.nio.file.{Files, Paths}
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 
-import monix.eval.Task
-import monix.execution.misc.NonFatal
-import monix.execution.CancelableFuture
 import bloop.cli.CommonOptions
+import bloop.cli.ExitStatus
+import bloop.config.Config
+import bloop.engine.ExecutionContext
+import bloop.engine.Feedback
 import bloop.engine.NoPool
-import java.io.ByteArrayOutputStream
-import java.io.PrintStream
-import java.nio.charset.StandardCharsets
+import bloop.io.AbsolutePath
+import bloop.io.Environment.LineSplitter
+import bloop.io.Environment.lineSeparator
+import bloop.io.RelativePath
+import bloop.io.{Paths => BloopPaths}
+import bloop.logging.RecordingLogger
 import bloop.testing.DiffAssertions
 import bloop.util.BaseTestProject
+import bloop.util.BuildUtil
+import bloop.util.TestUtil
+
+import monix.eval.Task
+import monix.execution.misc.NonFatal
 
 abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
   protected def TestProject: BaseTestProject
@@ -1107,7 +1111,6 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
       }
 
       assertDiagnosticsResult(compiledState.getLastResultFor(`A`), 1)
-      import bloop.testing.DiffAssertions
       assertNoDiff(
         logger.renderErrors(exceptContaining = "Failed to compile"),
         cannotFindSymbolError

--- a/frontend/src/test/scala/bloop/BloopLoggerSpec.scala
+++ b/frontend/src/test/scala/bloop/BloopLoggerSpec.scala
@@ -1,21 +1,24 @@
 package bloop
 
-import java.io.{
-  BufferedReader,
-  ByteArrayInputStream,
-  ByteArrayOutputStream,
-  InputStreamReader,
-  PrintStream
-}
+import java.io.BufferedReader
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStreamReader
+import java.io.PrintStream
 
-import bloop.logging.{BloopLogger, DebugFilter}
+import scala.Console.RED
+import scala.Console.RESET
+import scala.collection.mutable
+
+import bloop.logging.BloopLogger
+import bloop.logging.DebugFilter
 import bloop.util.UUIDUtil
-import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.experimental.categories.Category
-
-import scala.Console.{RED, RESET}
-import scala.collection.mutable
 
 @Category(Array(classOf[bloop.FastTests]))
 class BloopLoggerSpec {

--- a/frontend/src/test/scala/bloop/BuildLoaderSpec.scala
+++ b/frontend/src/test/scala/bloop/BuildLoaderSpec.scala
@@ -2,18 +2,20 @@ package bloop
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import bloop.engine.{Build, BuildLoader, State}
-import bloop.io.{AbsolutePath, Paths}
-import bloop.logging.{Logger, RecordingLogger}
-import bloop.util.TestUtil
-import bloop.testing.BaseSuite
-import bloop.data.WorkspaceSettings
-import bloop.internal.build.BuildInfo
-import bloop.tracing.TraceProperties
-import monix.eval.Task
-import com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException
+
 import scala.util.Try
+
 import bloop.data.TraceSettings
+import bloop.data.WorkspaceSettings
+import bloop.engine.Build
+import bloop.internal.build.BuildInfo
+import bloop.io.AbsolutePath
+import bloop.logging.RecordingLogger
+import bloop.testing.BaseSuite
+import bloop.tracing.TraceProperties
+import bloop.util.TestUtil
+
+import monix.eval.Task
 
 object BuildLoaderSpec extends BaseSuite {
   val semanticdbVersion = "4.4.34"
@@ -44,7 +46,7 @@ object BuildLoaderSpec extends BaseSuite {
     }
   }
 
-  val sameSettings =
+  val sameSettings: WorkspaceSettings =
     WorkspaceSettings.fromSemanticdbSettings(
       "0.2.0",
       semanticdbVersion,

--- a/frontend/src/test/scala/bloop/CliSpec.scala
+++ b/frontend/src/test/scala/bloop/CliSpec.scala
@@ -1,16 +1,22 @@
 package bloop
 
 import java.nio.file.Files
+import java.nio.file.Path
 
-import bloop.cli.{BspProtocol, Commands, ExitStatus, Validate}
-import bloop.engine.{Action, Exit, Feedback, Print, Run}
-import bloop.util.UUIDUtil
-import org.junit.Test
-import bloop.util.TestUtil
+import bloop.cli.BspProtocol
+import bloop.cli.Commands
+import bloop.cli.ExitStatus
+import bloop.cli.Validate
+import bloop.engine.Action
+import bloop.engine.Exit
+import bloop.engine.Feedback
+import bloop.engine.Print
+import bloop.engine.Run
 import bloop.testing.BaseSuite
+import bloop.util.UUIDUtil
 
 object CliSpec extends BaseSuite {
-  val tempDir = Files.createTempDirectory("validate")
+  val tempDir: Path = Files.createTempDirectory("validate")
   tempDir.toFile.deleteOnExit()
 
   test("fail at wrong end of pipe name") {
@@ -194,7 +200,7 @@ object CliSpec extends BaseSuite {
     checkReservedPort(23)
   }
 
-  def uniqueId = UUIDUtil.randomUUID.take(8)
+  def uniqueId: String = UUIDUtil.randomUUID.take(8)
   def checkIsCliError(action: Action, expected: String): Unit = {
     action match {
       case Print(obtained, _, Exit(code))

--- a/frontend/src/test/scala/bloop/ConsoleSpec.scala
+++ b/frontend/src/test/scala/bloop/ConsoleSpec.scala
@@ -1,15 +1,13 @@
 package bloop
 
-import bloop.testing.BaseSuite
-import bloop.util.TestUtil
-import bloop.logging.RecordingLogger
-import bloop.util.TestProject
 import bloop.cli.ExitStatus
-import scala.util.Properties
-import java.nio.file.Paths
+import bloop.internal.build.BuildInfo
 import bloop.io.AbsolutePath
 import bloop.io.Environment.lineSeparator
-import bloop.internal.build.BuildInfo
+import bloop.logging.RecordingLogger
+import bloop.testing.BaseSuite
+import bloop.util.TestProject
+import bloop.util.TestUtil
 
 object ConsoleSpec extends BaseSuite {
   test("default ammonite console works in multi-build project") {

--- a/frontend/src/test/scala/bloop/DagSpec.scala
+++ b/frontend/src/test/scala/bloop/DagSpec.scala
@@ -1,14 +1,20 @@
 package bloop
 
 import bloop.config.Config
+import bloop.data.Origin
 import bloop.data.Project
-import bloop.data.SourcesGlobs
-import bloop.engine.Dag.{DagResult, RecursiveTrace}
-import bloop.engine.{Aggregate, Dag, Leaf, Parent}
+import bloop.engine.Aggregate
+import bloop.engine.Dag
+import bloop.engine.Dag.DagResult
+import bloop.engine.Dag.RecursiveTrace
+import bloop.engine.Leaf
+import bloop.engine.Parent
 import bloop.logging.RecordingLogger
 import bloop.util.TestUtil
+
+import org.junit.Assert
+import org.junit.Test
 import org.junit.experimental.categories.Category
-import org.junit.{Assert, Test}
 
 @Category(Array(classOf[bloop.FastTests]))
 class DagSpec {
@@ -19,7 +25,7 @@ class DagSpec {
   private val dummyPath = bloop.io.AbsolutePath.completelyUnsafe("")
 
   // format: OFF
-  def dummyOrigin = TestUtil.syntheticOriginFor(dummyPath)
+  def dummyOrigin: Origin = TestUtil.syntheticOriginFor(dummyPath)
   def dummyProject(name: String, dependencies: List[String]): Project =
     Project(name, dummyPath, None, dependencies, Some(dummyInstance), Nil, Nil, compileOptions,
       dummyPath, Nil, Nil, Nil, Nil, None, Nil, Config.TestOptions.empty, dummyPath, dummyPath,
@@ -27,19 +33,19 @@ class DagSpec {
   // format: ON
 
   private object TestProjects {
-    val a = dummyProject("a", List())
-    val b = dummyProject("b", List("a"))
-    val c = dummyProject("c", List("a"))
-    val d = dummyProject("d", List("c", "a"))
-    val e = dummyProject("e", List())
-    val f = dummyProject("f", List("d"))
-    val fWithError = dummyProject("f", List("z"))
-    val complete = List(a, b, c, d, e, f)
-    val completeWithFailedDependency = List(a, b, c, d, e, fWithError)
-    val g = dummyProject("g", List("g"))
-    val recursive = List(a, b, c, d, e, f)
-    val h = dummyProject("h", List("i"))
-    val i = dummyProject("i", List("h"))
+    val a: Project = dummyProject("a", List())
+    val b: Project = dummyProject("b", List("a"))
+    val c: Project = dummyProject("c", List("a"))
+    val d: Project = dummyProject("d", List("c", "a"))
+    val e: Project = dummyProject("e", List())
+    val f: Project = dummyProject("f", List("d"))
+    val fWithError: Project = dummyProject("f", List("z"))
+    val complete: List[Project] = List(a, b, c, d, e, f)
+    val completeWithFailedDependency: List[Project] = List(a, b, c, d, e, fWithError)
+    val g: Project = dummyProject("g", List("g"))
+    val recursive: List[Project] = List(a, b, c, d, e, f)
+    val h: Project = dummyProject("h", List("i"))
+    val i: Project = dummyProject("i", List("h"))
   }
 
   def fromMap(projectsMap: Map[String, Project]): List[Dag[Project]] = Dag.fromMap(projectsMap).dags
@@ -202,15 +208,15 @@ class DagSpec {
      *
      * Note that dependencies flow from top to bottom.
      */
-    val a = dummyProject("a", List())
-    val b = dummyProject("b", List("a"))
-    val c = dummyProject("c", List("a"))
-    val d = dummyProject("d", List("c", "a"))
-    val e = dummyProject("e", List("d"))
-    val f = dummyProject("f", List())
-    val g = dummyProject("g", List("f"))
-    val h = dummyProject("h", List("f"))
-    val i = dummyProject("i", List("h"))
+    val a: Project = dummyProject("a", List())
+    val b: Project = dummyProject("b", List("a"))
+    val c: Project = dummyProject("c", List("a"))
+    val d: Project = dummyProject("d", List("c", "a"))
+    val e: Project = dummyProject("e", List("d"))
+    val f: Project = dummyProject("f", List())
+    val g: Project = dummyProject("g", List("f"))
+    val h: Project = dummyProject("h", List("f"))
+    val i: Project = dummyProject("i", List("h"))
   }
 
   @Test def TestDagReduction(): Unit = {

--- a/frontend/src/test/scala/bloop/DebugFilterSpec.scala
+++ b/frontend/src/test/scala/bloop/DebugFilterSpec.scala
@@ -1,9 +1,15 @@
 package bloop
 
-import bloop.cli.{Commands, CommonOptions, ExitStatus}
+import bloop.cli.Commands
+import bloop.cli.CommonOptions
+import bloop.cli.ExitStatus
+import bloop.engine.Exit
+import bloop.engine.Print
+import bloop.engine.Run
 import bloop.logging.DebugFilter
-import bloop.engine.{Exit, Print, Run}
-import org.junit.{Assert, Test}
+
+import org.junit.Assert
+import org.junit.Test
 
 class DebugFilterSpec {
   @Test

--- a/frontend/src/test/scala/bloop/DeduplicationSpec.scala
+++ b/frontend/src/test/scala/bloop/DeduplicationSpec.scala
@@ -1,28 +1,29 @@
 package bloop
 
-import bloop.config.Config
-import bloop.io.RelativePath
-import bloop.io.Environment.{lineSeparator, LineSplitter}
-import bloop.logging.RecordingLogger
-import bloop.cli.{Commands, ExitStatus, BspProtocol}
-import bloop.engine.ExecutionContext
-import bloop.util.{TestProject, TestUtil, BuildUtil, SystemProperties}
-
-import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 
+import scala.collection.mutable
 import scala.concurrent.Await
 import scala.concurrent.Promise
-import scala.collection.mutable
-import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 
-import monix.eval.Task
-import monix.execution.CancelableFuture
-
 import ch.epfl.scala.{bsp => scalabsp}
-import bloop.logging.Logger
+
+import bloop.cli.BspProtocol
+import bloop.cli.ExitStatus
+import bloop.config.Config
+import bloop.engine.ExecutionContext
+import bloop.io.Environment.LineSplitter
+import bloop.io.Environment.lineSeparator
+import bloop.io.RelativePath
+import bloop.logging.RecordingLogger
+import bloop.util.BuildUtil
 import bloop.util.CrossPlatform
+import bloop.util.SystemProperties
+import bloop.util.TestProject
+import bloop.util.TestUtil
+
+import monix.eval.Task
 
 object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
   // Use only TCP to run deduplication
@@ -142,7 +143,6 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
           secondCompiledState.compileHandle(build.userProject, delaySecondNoop)
         )
 
-        import java.util.concurrent.TimeoutException
         val (firstNoopState, secondNoopState) = TestUtil.blockOnTask(noopCompiles, 5)
 
         assert(firstNoopState.status == ExitStatus.Ok)

--- a/frontend/src/test/scala/bloop/FileWatchingSpec.scala
+++ b/frontend/src/test/scala/bloop/FileWatchingSpec.scala
@@ -1,25 +1,27 @@
 package bloop
 
-import bloop.testing.BaseSuite
-import bloop.config.Config
-import bloop.data.Project
-import bloop.io.{AbsolutePath, Paths => BloopPaths}
-import bloop.io.Environment.lineSeparator
-import bloop.logging.{RecordingLogger, PublisherLogger, DebugFilter}
-import bloop.cli.{Commands, ExitStatus}
-import bloop.engine.{Feedback, Run, State, ExecutionContext, Dag, Build}
-import bloop.engine.caches.ResultsCache
-import bloop.util.{TestProject, TestUtil, BuildUtil}
-
-import monix.eval.Task
-import monix.reactive.{Observable, MulticastStrategy}
-
-import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration.FiniteDuration
+
+import bloop.cli.ExitStatus
+import bloop.config.Config
+import bloop.data.Project
+import bloop.engine.Dag
+import bloop.engine.ExecutionContext
+import bloop.io.AbsolutePath
+import bloop.io.Environment.lineSeparator
+import bloop.logging.DebugFilter
+import bloop.logging.PublisherLogger
+import bloop.logging.RecordingLogger
+import bloop.testing.BaseSuite
+import bloop.util.TestProject
+import bloop.util.TestUtil
+
+import monix.eval.Task
 import monix.execution.misc.NonFatal
-import bloop.data.SourcesGlobs
+import monix.reactive.MulticastStrategy
+import monix.reactive.Observable
 
 object FileWatchingSpec extends BaseSuite {
   System.setProperty("file-watcher-batch-window-ms", "100")
@@ -446,7 +448,6 @@ object FileWatchingSpec extends BaseSuite {
       Observable.multicast[String](MulticastStrategy.publish)
 
     val received = new StringBuilder()
-    import monix.reactive.Consumer
 
     import bloop.util.monix.FoldLeftAsyncConsumer
     val slowConsumer = FoldLeftAsyncConsumer.consume[Unit, Seq[String]](()) {
@@ -463,7 +464,6 @@ object FileWatchingSpec extends BaseSuite {
 
     import bloop.util.monix.BloopBufferTimedObservable
     val a: Observable[Seq[String]] = new BloopBufferTimedObservable(observable, 40.millis, 0)
-    import monix.reactive.OverflowStrategy
 
     val consumingTask =
       new BloopBufferTimedObservable(observable, 40.millis, 0)

--- a/frontend/src/test/scala/bloop/ForkerSpec.scala
+++ b/frontend/src/test/scala/bloop/ForkerSpec.scala
@@ -1,21 +1,23 @@
 package bloop
 
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.Duration
+
 import bloop.cli.ExitStatus
-import bloop.dap.DebuggeeLogger
 import bloop.data.JdkConfig
-import bloop.exec.{Forker, JvmProcessForker}
+import bloop.exec.Forker
+import bloop.exec.JvmProcessForker
 import bloop.io.AbsolutePath
 import bloop.logging.RecordingLogger
 import bloop.util.TestUtil
-import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Paths}
-import java.util.concurrent.TimeUnit
-import org.junit.Assert.{assertEquals, assertNotEquals}
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 import org.junit.experimental.categories.Category
-import scala.collection.mutable
-import scala.concurrent.duration.Duration
 
 @Category(Array(classOf[bloop.FastTests]))
 class ForkerSpec {
@@ -45,8 +47,10 @@ class ForkerSpec {
          |}""".stripMargin
   }
 
-  val dependencies = Map.empty[String, Set[String]]
-  val runnableProject = Map(TestUtil.RootProject -> Map("A.scala" -> ArtificialSources.`A.scala`))
+  val dependencies: Map[String, Set[String]] = Map.empty[String, Set[String]]
+  val runnableProject: Map[String, Map[String, String]] = Map(
+    TestUtil.RootProject -> Map("A.scala" -> ArtificialSources.`A.scala`)
+  )
 
   private def run(
       cwd: AbsolutePath,

--- a/frontend/src/test/scala/bloop/GenericTestSpec.scala
+++ b/frontend/src/test/scala/bloop/GenericTestSpec.scala
@@ -1,12 +1,14 @@
 package bloop
 
 import bloop.cli.Commands
+import bloop.engine.Run
 import bloop.io.AbsolutePath
 import bloop.io.Environment.lineSeparator
 import bloop.logging.RecordingLogger
 import bloop.util.TestUtil
-import bloop.engine.Run
-import org.junit.{Assert, Test}
+
+import org.junit.Assert
+import org.junit.Test
 
 class GenericTestSpec {
   @Test

--- a/frontend/src/test/scala/bloop/HydraCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/HydraCompileSpec.scala
@@ -1,15 +1,15 @@
 package bloop
 
-import java.net.URI
 import java.nio.file.Paths
-
-import bloop.{DependencyResolution => BloopDependencyResolution}
-import bloop.io.AbsolutePath
-import bloop.logging.Logger
-import coursierapi.MavenRepository
 
 import scala.concurrent.ExecutionContext
 import scala.tools.nsc.Properties
+
+import bloop.io.AbsolutePath
+import bloop.logging.Logger
+import bloop.{DependencyResolution => BloopDependencyResolution}
+
+import coursierapi.MavenRepository
 
 object HydraCompileSpec extends BaseCompileSpec {
   override protected val TestProject = HydraTestProject
@@ -17,7 +17,7 @@ object HydraCompileSpec extends BaseCompileSpec {
   override protected def extraCompilationMessageOutput: String =
     " [E-1] Using 1 Hydra worker to compile Scala sources."
 
-  override protected def processOutput(message: String) = {
+  override protected def processOutput(message: String): String = {
     val regex = raw" \[E-1\] License will expire in \d+ days.\n"
     message.replaceAll(regex, "")
   }

--- a/frontend/src/test/scala/bloop/LoadProjectSpec.scala
+++ b/frontend/src/test/scala/bloop/LoadProjectSpec.scala
@@ -1,16 +1,15 @@
 package bloop
 
 import bloop.config.Config
-import bloop.data.Project
 import bloop.data.Platform
-import bloop.data.JdkConfig
-import bloop.io.Paths
+import bloop.data.Project
 import bloop.io.AbsolutePath
 import bloop.logging.RecordingLogger
-import bloop.util.TestUtil
-import org.junit.Test
-import bloop.util.TestProject
 import bloop.testing.BloopHelpers
+import bloop.util.TestProject
+import bloop.util.TestUtil
+
+import org.junit.Test
 
 class LoadProjectSpec extends BloopHelpers {
   @Test def LoadJavaProject(): Unit = {

--- a/frontend/src/test/scala/bloop/ProcessLoggerSpec.scala
+++ b/frontend/src/test/scala/bloop/ProcessLoggerSpec.scala
@@ -1,6 +1,8 @@
 package bloop
 
-import bloop.logging.{ProcessLogger, RecordingLogger}
+import bloop.logging.ProcessLogger
+import bloop.logging.RecordingLogger
+
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.experimental.categories.Category
@@ -9,7 +11,7 @@ import org.junit.experimental.categories.Category
 class ProcessLoggerSpec {
 
   @Test
-  def loggerToOutputStream = {
+  def loggerToOutputStream: Unit = {
     val logger = new RecordingLogger
     val stream = ProcessLogger.toOutputStream(logger.info)
     stream.write("hello".getBytes("UTF-8"))
@@ -23,7 +25,7 @@ class ProcessLoggerSpec {
   }
 
   @Test
-  def loggerToPrintStream = {
+  def loggerToPrintStream: Unit = {
     val logger = new RecordingLogger
     val stream = ProcessLogger.toPrintStream(logger.info)
     stream.println("hello")

--- a/frontend/src/test/scala/bloop/RunSpec.scala
+++ b/frontend/src/test/scala/bloop/RunSpec.scala
@@ -5,23 +5,32 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 
-import bloop.bsp.BspServer
-import bloop.cli.{Commands, ExitStatus}
-import bloop.config.Config.JvmConfig
-import bloop.data.JdkConfig
-import bloop.logging.RecordingLogger
-import bloop.util.{TestProject, TestUtil}
-import bloop.util.TestUtil.{checkAfterCleanCompilation, getProject, loadTestProject, runAndCheck}
-import bloop.engine.tasks.Tasks
-import bloop.engine.{Dag, ExecutionContext, Run, State}
-import bloop.testing.BloopHelpers
-import org.junit.Assert.{assertEquals, assertTrue}
-import org.junit.experimental.categories.Category
-import org.junit.{Assert, Test}
-
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
+
+import bloop.cli.Commands
+import bloop.cli.ExitStatus
+import bloop.data.JdkConfig
+import bloop.engine.Dag
+import bloop.engine.ExecutionContext
+import bloop.engine.Run
+import bloop.engine.State
+import bloop.engine.tasks.Tasks
+import bloop.logging.RecordingLogger
+import bloop.testing.BloopHelpers
+import bloop.util.TestProject
+import bloop.util.TestUtil
+import bloop.util.TestUtil.checkAfterCleanCompilation
+import bloop.util.TestUtil.getProject
+import bloop.util.TestUtil.loadTestProject
+import bloop.util.TestUtil.runAndCheck
+
+import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.experimental.categories.Category
 
 @Category(Array(classOf[bloop.FastTests]))
 class RunSpec extends BloopHelpers {
@@ -33,33 +42,33 @@ class RunSpec extends BloopHelpers {
   private val args = List("arg0", "arg1", "multiple words")
 
   private object ArtificialSources {
-    val RunnableClass0 = s"""package $packageName
-                            |object $mainClassName0 {
-                            |  def main(args: Array[String]): Unit = {
-                            |    println(s"$mainClassName0: $${args.mkString(", ")}")
-                            |  }
-                            |}""".stripMargin
-    val RunnableClass1 = s"""package $packageName
-                            |object $mainClassName1 {
-                            |  def main(args: Array[String]): Unit = {
-                            |    println(s"$mainClassName1: $${args.mkString(", ")}")
-                            |  }
-                            |}""".stripMargin
-    val NotRunnable = s"""package $packageName
-                         |object NotRunnable {
-                         |  def foo(): Int = 42
-                         |}""".stripMargin
-    val InheritedRunnable = s"""package $packageName
-                               |class BaseRunnable {
-                               |  def main(args: Array[String]): Unit = {
-                               |    println(s"$mainClassName2: $${args.mkString(", ")}")
-                               |  }
-                               |}
-                               |object $mainClassName2 extends BaseRunnable""".stripMargin
+    val RunnableClass0: String = s"""package $packageName
+                                    |object $mainClassName0 {
+                                    |  def main(args: Array[String]): Unit = {
+                                    |    println(s"$mainClassName0: $${args.mkString(", ")}")
+                                    |  }
+                                    |}""".stripMargin
+    val RunnableClass1: String = s"""package $packageName
+                                    |object $mainClassName1 {
+                                    |  def main(args: Array[String]): Unit = {
+                                    |    println(s"$mainClassName1: $${args.mkString(", ")}")
+                                    |  }
+                                    |}""".stripMargin
+    val NotRunnable: String = s"""package $packageName
+                                 |object NotRunnable {
+                                 |  def foo(): Int = 42
+                                 |}""".stripMargin
+    val InheritedRunnable: String = s"""package $packageName
+                                       |class BaseRunnable {
+                                       |  def main(args: Array[String]): Unit = {
+                                       |    println(s"$mainClassName2: $${args.mkString(", ")}")
+                                       |  }
+                                       |}
+                                       |object $mainClassName2 extends BaseRunnable""".stripMargin
   }
 
   @Test
-  def doesntDetectNonRunnableClasses() = {
+  def doesntDetectNonRunnableClasses(): Unit = {
     val projectName = "test-project"
     val projectsStructure = Map(projectName -> Map("A.scala" -> ArtificialSources.NotRunnable))
     val jdkConfig = JdkConfig.default
@@ -77,7 +86,7 @@ class RunSpec extends BloopHelpers {
   }
 
   @Test
-  def canDetectOneMainClass() = {
+  def canDetectOneMainClass(): Unit = {
     val projectName = "test-project"
     val projectsStructure = Map(projectName -> Map("A.scala" -> ArtificialSources.RunnableClass0))
     val jdkConfig = JdkConfig.default
@@ -96,7 +105,7 @@ class RunSpec extends BloopHelpers {
   }
 
   @Test
-  def canDetectMultipleMainClasses() = {
+  def canDetectMultipleMainClasses(): Unit = {
     val projectName = "test-project"
     val projectsStructure = Map(
       projectName -> Map(
@@ -255,7 +264,7 @@ class RunSpec extends BloopHelpers {
   }
 
   @Test
-  def canRunApplicationThatRequiresInput = {
+  def canRunApplicationThatRequiresInput: Unit = {
     object Sources {
       val `A.scala` =
         """object Foo {
@@ -288,7 +297,7 @@ class RunSpec extends BloopHelpers {
   }
 
   @Test
-  def canCancelNeverEndingApplication = {
+  def canCancelNeverEndingApplication: Unit = {
     object Sources {
       val `A.scala` =
         """object Foo {

--- a/frontend/src/test/scala/bloop/ScalaVersionsSpec.scala
+++ b/frontend/src/test/scala/bloop/ScalaVersionsSpec.scala
@@ -1,16 +1,15 @@
 package bloop
-import monix.eval.Task
-import bloop.util.TestUtil
-import bloop.logging.RecordingLogger
+import scala.concurrent.duration.FiniteDuration
+
+import bloop.cli.ExitStatus
 import bloop.engine.ExecutionContext
 import bloop.io.AbsolutePath
+import bloop.logging.RecordingLogger
 import bloop.util.TestProject
-import bloop.cli.ExitStatus
-import scala.concurrent.duration.FiniteDuration
-import bloop.engine.State
-import java.util.concurrent.TimeoutException
+import bloop.util.TestUtil
+
+import monix.eval.Task
 import monix.execution.misc.NonFatal
-import java.lang.management.ManagementFactory
 
 object ScalaVersionsSpec extends bloop.testing.BaseSuite {
   test("cross-compile build to latest Scala versions") {

--- a/frontend/src/test/scala/bloop/SourcesGlobsCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/SourcesGlobsCompileSpec.scala
@@ -1,16 +1,11 @@
 package bloop
 
-import bloop.logging.RecordingLogger
-import scala.concurrent.Promise
-import bloop.util.TestUtil
 import java.nio.file.Files
-import scala.concurrent.Await
-import scala.concurrent.duration.FiniteDuration
-import bloop.util.TestProject
-import java.util.concurrent.TimeUnit
-import bloop.cli.ExitStatus
+
 import bloop.config.Config
-import bloop.data.SourcesGlobs
+import bloop.logging.RecordingLogger
+import bloop.util.TestProject
+import bloop.util.TestUtil
 
 object SourcesGlobsCompileSpec extends bloop.testing.BaseSuite {
 

--- a/frontend/src/test/scala/bloop/TestFilterSpec.scala
+++ b/frontend/src/test/scala/bloop/TestFilterSpec.scala
@@ -1,11 +1,9 @@
 package bloop
 
-import bloop.cli.Commands
-import bloop.logging.RecordingLogger
 import bloop.testing.TestInternals
-import bloop.util.TestUtil
-import bloop.engine.Run
-import org.junit.Assert.{assertFalse, assertTrue}
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class TestFilterSpec {

--- a/frontend/src/test/scala/bloop/TestSchedulers.scala
+++ b/frontend/src/test/scala/bloop/TestSchedulers.scala
@@ -1,7 +1,9 @@
 package bloop
-import java.util.concurrent.{Executors, ThreadFactory}
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
 
-import monix.execution.{ExecutionModel, Scheduler}
+import monix.execution.ExecutionModel
+import monix.execution.Scheduler
 import monix.execution.atomic.Atomic
 
 object TestSchedulers {

--- a/frontend/src/test/scala/bloop/TestSpec.scala
+++ b/frontend/src/test/scala/bloop/TestSpec.scala
@@ -1,28 +1,22 @@
 package bloop
 
-import bloop.config.Config
-import bloop.io.{AbsolutePath, RelativePath, Paths => BloopPaths}
-import bloop.io.Environment.lineSeparator
-import bloop.logging.RecordingLogger
-import bloop.cli.{Commands, ExitStatus}
-import bloop.engine.{Feedback, Run, State, ExecutionContext}
-import bloop.engine.caches.ResultsCache
-import bloop.util.{TestProject, TestUtil, BuildUtil}
-import bloop.testing.ProjectBaseSuite
-
-import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import scala.concurrent.duration.FiniteDuration
 
-import monix.eval.Task
-import monix.execution.CancelableFuture
+import bloop.cli.ExitStatus
+import bloop.engine.ExecutionContext
+import bloop.io.AbsolutePath
+import bloop.io.Environment.lineSeparator
+import bloop.logging.RecordingLogger
+import bloop.testing.ProjectBaseSuite
+import bloop.util.TestProject
+import bloop.util.TestUtil
 
 abstract class BaseTestSpec(val projectName: String, buildName: String)
     extends ProjectBaseSuite(buildName) {
-  val testOnlyOnJava8 = buildName == "cross-test-build-scalajs-0.6"
+  val testOnlyOnJava8: Boolean = buildName == "cross-test-build-scalajs-0.6"
   testProject("project compiles", testOnlyOnJava8) { (build, logger) =>
     val project = build.projectFor(projectName)
     val compiledState = build.state.compile(project)

--- a/frontend/src/test/scala/bloop/TracerSpec.scala
+++ b/frontend/src/test/scala/bloop/TracerSpec.scala
@@ -1,8 +1,9 @@
 package bloop
 
-import bloop.tracing.BraveTracer
 import bloop.testing.BaseSuite
+import bloop.tracing.BraveTracer
 import bloop.tracing.TraceProperties
+
 import monix.eval.Task
 
 object TracerSpec extends BaseSuite {

--- a/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
@@ -2,30 +2,47 @@ package bloop.bsp
 
 import java.io.File
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path}
-import java.util.concurrent.{ConcurrentHashMap, ExecutionException}
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutionException
 
-import bloop.engine.{State, Run}
-import bloop.cli.{Commands, Validate, CliOptions, BspProtocol}
-import bloop.engine.ExecutionContext
-import bloop.engine.caches.ResultsCache
-import bloop.internal.build.BuildInfo
-import bloop.io.{AbsolutePath, RelativePath}
-import bloop.io.Environment.END_OF_LINE_MATCHER
-import bloop.logging.{BspClientLogger, DebugFilter, RecordingLogger, Slf4jAdapter}
-import bloop.util.{UUIDUtil, TestUtil}
+import scala.collection.mutable
+import scala.concurrent.Promise
+import scala.concurrent.duration.FiniteDuration
+import scala.meta.jsonrpc.BaseProtocolMessage
+import scala.meta.jsonrpc.LanguageClient
+import scala.meta.jsonrpc.LanguageServer
+import scala.meta.jsonrpc.Response
+import scala.meta.jsonrpc.Services
 
 import ch.epfl.scala.bsp
 import ch.epfl.scala.bsp.endpoints
+
+import bloop.cli.BspProtocol
+import bloop.cli.CliOptions
+import bloop.cli.Commands
+import bloop.cli.Validate
+import bloop.engine.ExecutionContext
+import bloop.engine.Run
+import bloop.engine.State
+import bloop.engine.caches.ResultsCache
+import bloop.internal.build.BuildInfo
+import bloop.io.AbsolutePath
+import bloop.io.Environment.END_OF_LINE_MATCHER
+import bloop.io.RelativePath
+import bloop.logging.BspClientLogger
+import bloop.logging.DebugFilter
+import bloop.logging.RecordingLogger
+import bloop.logging.Slf4jAdapter
+import bloop.util.TestUtil
+import bloop.util.UUIDUtil
+
 import monix.eval.Task
-import monix.execution.{ExecutionModel, Scheduler}
+import monix.execution.ExecutionModel
+import monix.execution.Scheduler
 import monix.{eval => me}
 import sbt.internal.util.MessageOnlyException
-
-import scala.collection.mutable
-import scala.concurrent.duration.FiniteDuration
-import scala.meta.jsonrpc.{BaseProtocolMessage, LanguageClient, LanguageServer, Response, Services}
-import scala.concurrent.Promise
 
 object BspClientTest extends BspClientTest
 trait BspClientTest {

--- a/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
@@ -1,21 +1,23 @@
 package bloop.bsp
 
-import bloop.engine.State
-import bloop.config.Config
-import bloop.cli.{ExitStatus, BspProtocol}
-import bloop.util.{TestUtil, TestProject}
-import bloop.logging.RecordingLogger
-import bloop.internal.build.BuildInfo
+import java.nio.file.Files
 import java.nio.file.attribute.FileTime
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.FiniteDuration
+
+import bloop.cli.BspProtocol
+import bloop.cli.ExitStatus
+import bloop.internal.build.BuildInfo
 import bloop.io.AbsolutePath
 import bloop.io.Environment.lineSeparator
 import bloop.io.{Paths => BloopPaths}
-import java.nio.file.Files
+import bloop.logging.RecordingLogger
+import bloop.util.TestProject
+import bloop.util.TestUtil
+
 import monix.eval.Task
-import bloop.engine.ExecutionContext
-import java.util.concurrent.TimeUnit
-import scala.concurrent.duration.FiniteDuration
-import java.time.Instant
 
 object TcpBspCompileSpec extends BspCompileSpec(BspProtocol.Tcp)
 object LocalBspCompileSpec extends BspCompileSpec(BspProtocol.Local)

--- a/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
@@ -1,15 +1,19 @@
 package bloop.bsp
 
-import bloop.io.Environment.lineSeparator
-import bloop.cli.{ExitStatus, BspProtocol}
-import bloop.util.{TestUtil, TestProject}
-import bloop.logging.{RecordingLogger, BspClientLogger}
+import scala.concurrent.duration.FiniteDuration
+
+import bloop.cli.BspProtocol
+import bloop.cli.ExitStatus
 import bloop.internal.build.BuildInfo
+import bloop.io.Environment.lineSeparator
+import bloop.logging.BspClientLogger
+import bloop.logging.RecordingLogger
+import bloop.util.TestProject
+import bloop.util.TestUtil
 
 import monix.eval.Task
-import monix.execution.{Scheduler, ExecutionModel}
-
-import scala.concurrent.duration.FiniteDuration
+import monix.execution.ExecutionModel
+import monix.execution.Scheduler
 
 object TcpBspConnectionSpec extends BspConnectionSpec(BspProtocol.Tcp)
 object LocalBspConnectionSpec extends BspConnectionSpec(BspProtocol.Local)
@@ -248,7 +252,6 @@ class BspConnectionSpec(
             import ch.epfl.scala.bsp
             import ch.epfl.scala.bsp.endpoints.BuildTarget
 
-            import BuildTarget.compile._
             bspState.client0
               .requestAndForget(
                 BuildTarget.compile.method,
@@ -265,7 +268,6 @@ class BspConnectionSpec(
       // Time out is 5 to check cancellation works and we don't finish until end
       // of compilation, which would take more than 6 seconds as there are 12 sleeps
       val safeDelay = FiniteDuration(5, "s")
-      import java.util.concurrent.TimeoutException
       TestUtil.await(safeDelay, poolFor1Client)(createHangingCompilationViaBsp)
     }
   }

--- a/frontend/src/test/scala/bloop/bsp/BspIntellijClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspIntellijClientSpec.scala
@@ -1,12 +1,15 @@
 package bloop.bsp
 
+import ch.epfl.scala.bsp.WorkspaceBuildTargetsResult
+
 import bloop.cli.BspProtocol
+import bloop.data.TraceSettings
 import bloop.data.WorkspaceSettings
 import bloop.logging.RecordingLogger
 import bloop.tracing.TraceProperties
-import bloop.util.{CrossPlatform, TestProject, TestUtil}
-import ch.epfl.scala.bsp.WorkspaceBuildTargetsResult
-import bloop.data.TraceSettings
+import bloop.util.CrossPlatform
+import bloop.util.TestProject
+import bloop.util.TestUtil
 
 object LocalBspIntellijClientSpec extends BspIntellijClientSpec(BspProtocol.Local)
 object TcpBspIntellijClientSpec extends BspIntellijClientSpec(BspProtocol.Tcp)

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -1,31 +1,27 @@
 package bloop.bsp
 
-import bloop.io.AbsolutePath
-import bloop.io.Environment.{lineSeparator, LineSplitter}
-import bloop.cli.BspProtocol
-import bloop.util.TestUtil
-import bloop.util.TestProject
-import bloop.logging.RecordingLogger
-import bloop.logging.BspClientLogger
-import bloop.cli.ExitStatus
-import bloop.data.WorkspaceSettings
-import bloop.internal.build.BuildInfo
-import bloop.bsp.BloopBspDefinitions.BloopExtraBuildParams
-
-import java.nio.file.{Files, Paths}
-
-import io.circe.JsonObject
-import io.circe.Json
-
-import monix.execution.Scheduler
-import monix.execution.ExecutionModel
-import monix.eval.Task
+import java.nio.file.Paths
 
 import scala.concurrent.duration.FiniteDuration
+import scala.util.Random
 
 import ch.epfl.scala.bsp.endpoints.BuildTarget.scalacOptions
+
+import bloop.bsp.BloopBspDefinitions.BloopExtraBuildParams
+import bloop.cli.BspProtocol
+import bloop.cli.ExitStatus
+import bloop.data.WorkspaceSettings
 import bloop.engine.ExecutionContext
-import scala.util.Random
+import bloop.internal.build.BuildInfo
+import bloop.io.AbsolutePath
+import bloop.io.Environment.LineSplitter
+import bloop.io.Environment.lineSeparator
+import bloop.logging.BspClientLogger
+import bloop.logging.RecordingLogger
+import bloop.util.TestProject
+import bloop.util.TestUtil
+
+import monix.eval.Task
 
 object LocalBspMetalsClientSpec extends BspMetalsClientSpec(BspProtocol.Local)
 object TcpBspMetalsClientSpec extends BspMetalsClientSpec(BspProtocol.Tcp)

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -1,25 +1,23 @@
 package bloop.bsp
 
-import java.io.File
 import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 
-import bloop.engine.State
+import ch.epfl.scala.bsp.JvmEnvironmentItem
+import ch.epfl.scala.bsp.ScalacOptionsItem
+import ch.epfl.scala.bsp.Uri
+
+import bloop.bsp.BloopBspDefinitions.BloopExtraBuildParams
+import bloop.cli.BspProtocol
+import bloop.cli.ExitStatus
 import bloop.config.Config
 import bloop.io.AbsolutePath
-import bloop.cli.{BspProtocol, ExitStatus}
-import bloop.util.{TestProject, TestUtil}
 import bloop.logging.RecordingLogger
-import bloop.internal.build.BuildInfo
-import java.nio.file.{Files, Path, Paths}
-import java.util.stream.Collectors
-
-import scala.collection.JavaConverters._
-import ch.epfl.scala.bsp.{JvmEnvironmentItem, ScalacOptionsItem, Uri}
-import bloop.bsp.BloopBspDefinitions.BloopExtraBuildParams
-import io.circe.Json
 import bloop.testing.DiffAssertions.TestFailedException
-import bloop.data.SourcesGlobs
-import scala.collection.immutable
+import bloop.util.TestProject
+import bloop.util.TestUtil
 
 object TcpBspProtocolSpec extends BspProtocolSpec(BspProtocol.Tcp)
 object LocalBspProtocolSpec extends BspProtocolSpec(BspProtocol.Local)

--- a/frontend/src/test/scala/bloop/bsp/BspSbtClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspSbtClientSpec.scala
@@ -1,14 +1,17 @@
 package bloop.bsp
 
-import bloop.util.{TestUtil, TestProject}
-import bloop.cli.BspProtocol
-import bloop.logging.RecordingLogger
-import bloop.cli.ExitStatus
-import monix.eval.Task
-import bloop.engine.ExecutionContext
-import scala.concurrent.duration.FiniteDuration
 import java.util.concurrent.TimeUnit
-import scala.util.Random
+
+import scala.concurrent.duration.FiniteDuration
+
+import bloop.cli.BspProtocol
+import bloop.cli.ExitStatus
+import bloop.engine.ExecutionContext
+import bloop.logging.RecordingLogger
+import bloop.util.TestProject
+import bloop.util.TestUtil
+
+import monix.eval.Task
 
 object TcpBspSbtClientSpec extends BspSbtClientSpec(BspProtocol.Tcp)
 

--- a/frontend/src/test/scala/bloop/bsp/ProjectUrisSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/ProjectUrisSpec.scala
@@ -1,9 +1,8 @@
 package bloop.bsp
 
-import java.nio.file.Paths
-
 import bloop.io.AbsolutePath
-import org.junit.{Assert, Test}
+
+import org.junit.Test
 
 class ProjectUrisSpec {
   @Test def ParseUriWindows(): Unit = {

--- a/frontend/src/test/scala/bloop/dap/DebugAdapterConnection.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugAdapterConnection.scala
@@ -1,24 +1,28 @@
 package bloop.dap
 
-import java.net.{InetSocketAddress, Socket, URI}
+import java.io.Closeable
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.net.URI
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.Promise
 
 import bloop.dap.DebugTestEndpoints._
+import bloop.engine.ExecutionContext
+
 import com.microsoft.java.debug.core.protocol.Events
 import com.microsoft.java.debug.core.protocol.Requests._
-import com.microsoft.java.debug.core.protocol.Types.Capabilities
-import monix.eval.Task
-import monix.execution.Scheduler
-import scala.concurrent.Promise
-import java.io.Closeable
-import bloop.engine.ExecutionContext
-import java.util.concurrent.TimeUnit
-import monix.execution.Cancelable
-import com.microsoft.java.debug.core.protocol.Responses.SetBreakpointsResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.ContinueResponseBody
+import com.microsoft.java.debug.core.protocol.Responses.EvaluateResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.ScopesResponseBody
+import com.microsoft.java.debug.core.protocol.Responses.SetBreakpointsResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.StackTraceResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.VariablesResponseBody
-import com.microsoft.java.debug.core.protocol.Responses.EvaluateResponseBody
+import com.microsoft.java.debug.core.protocol.Types.Capabilities
+import monix.eval.Task
+import monix.execution.Cancelable
+import monix.execution.Scheduler
 
 /**
  * Manages a connection with a debug adapter.
@@ -29,7 +33,7 @@ private[dap] final class DebugAdapterConnection(
     adapter: DebugAdapterProxy
 ) extends Closeable {
   // Complete the promise in the background whenever the socket is closed
-  val closedPromise = Promise[Unit]()
+  val closedPromise: Promise[Unit] = Promise[Unit]()
   var cancelCompleter: Cancelable = Cancelable.empty
   cancelCompleter = ExecutionContext.ioScheduler.scheduleAtFixedRate(
     100,

--- a/frontend/src/test/scala/bloop/dap/DebugAdapterProxy.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugAdapterProxy.scala
@@ -1,24 +1,31 @@
 package bloop.dap
 
-import java.net.{Socket, SocketException}
+import java.net.Socket
+import java.net.SocketException
 import java.nio.ByteBuffer
 
+import scala.collection.mutable
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.meta.jsonrpc.BaseProtocolMessage
+import scala.meta.jsonrpc.MessageWriter
+
 import bloop.bsp.BloopLanguageClient
+import bloop.engine.ExecutionContext
+
+import com.microsoft.java.debug.core.protocol.Events
+import com.microsoft.java.debug.core.protocol.Events.DebugEvent
+import com.microsoft.java.debug.core.protocol.JsonUtils
+import com.microsoft.java.debug.core.protocol.Messages
 import com.microsoft.java.debug.core.protocol.Messages.ProtocolMessage
-import com.microsoft.java.debug.core.protocol.{JsonUtils, Messages}
 import monix.eval.Task
-import monix.execution.{Ack, Scheduler}
+import monix.execution.Ack
+import monix.execution.Scheduler
+import monix.reactive.MulticastStrategy
+import monix.reactive.Observable
+import monix.reactive.Observer
 import monix.reactive.observables.ObservableLike.Operator
 import monix.reactive.observers.Subscriber
-import monix.reactive.{Observable, Observer}
-
-import scala.collection.mutable
-import scala.concurrent.{Future, Promise}
-import scala.meta.jsonrpc.{BaseProtocolMessage, MessageWriter}
-import monix.reactive.MulticastStrategy
-import bloop.engine.ExecutionContext
-import com.microsoft.java.debug.core.protocol.Events.DebugEvent
-import com.microsoft.java.debug.core.protocol.Events
 
 /**
  * Handles communication with the debug adapter.

--- a/frontend/src/test/scala/bloop/dap/DebugBspBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugBspBaseSuite.scala
@@ -1,16 +1,20 @@
 package bloop.dap
 
+import scala.collection.mutable
+import scala.concurrent.Promise
+
+import ch.epfl.scala.bsp
+
 import bloop.TestSchedulers
 import bloop.bsp.BloopBspDefinitions.BloopExtraBuildParams
 import bloop.bsp.BspBaseSuite
-import bloop.cli.{BspProtocol, Commands}
+import bloop.cli.BspProtocol
+import bloop.cli.Commands
 import bloop.engine.State
 import bloop.io.AbsolutePath
 import bloop.logging.BspClientLogger
-import ch.epfl.scala.bsp
+
 import monix.execution.Scheduler
-import scala.collection.mutable
-import scala.concurrent.Promise
 
 abstract class DebugBspBaseSuite extends BspBaseSuite {
   protected val debugDefaultScheduler: Scheduler =

--- a/frontend/src/test/scala/bloop/dap/DebugProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugProtocolSpec.scala
@@ -2,13 +2,13 @@ package bloop.dap
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import bloop.logging.RecordingLogger
-import bloop.util.{TestProject, TestUtil}
+
 import ch.epfl.scala.bsp
 import ch.epfl.scala.bsp.DebugSessionParamsDataKind._
-import monix.eval.Task
-import scala.concurrent.duration.FiniteDuration
-import java.util.concurrent.TimeUnit
+
+import bloop.logging.RecordingLogger
+import bloop.util.TestProject
+import bloop.util.TestUtil
 
 object DebugProtocolSpec extends DebugBspBaseSuite {
   test("starts a debug session") {

--- a/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
@@ -1,34 +1,50 @@
 package bloop.dap
 
-import bloop.ScalaInstance
-import bloop.cli.ExitStatus
-import bloop.data.{Platform, Project}
-import bloop.engine.{ExecutionContext, State}
-import bloop.engine.tasks.{RunMode, Tasks}
-import bloop.io.AbsolutePath
-import bloop.io.Environment.lineSeparator
-import bloop.logging.LoggerAction.LogInfoMessage
-import bloop.logging.{Logger, LoggerAction, ObservedLogger, RecordingLogger}
-import bloop.reporter.ReporterAction
-import bloop.util.{TestProject, TestUtil}
+import java.net.ConnectException
+import java.net.SocketException
+import java.net.SocketTimeoutException
+import java.util.NoSuchElementException
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util.concurrent.TimeUnit.SECONDS
+
+import scala.collection.mutable
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
+
 import ch.epfl.scala.bsp.ScalaMainClass
 import ch.epfl.scala.debugadapter._
+
+import bloop.ScalaInstance
+import bloop.bsp.ScalaTestSuiteSelection
+import bloop.bsp.ScalaTestSuites
+import bloop.cli.ExitStatus
+import bloop.data.Platform
+import bloop.data.Project
+import bloop.engine.ExecutionContext
+import bloop.engine.State
+import bloop.engine.tasks.RunMode
+import bloop.engine.tasks.Tasks
+import bloop.internal.build.BuildTestInfo
+import bloop.io.AbsolutePath
+import bloop.io.Environment.lineSeparator
+import bloop.logging.Logger
+import bloop.logging.LoggerAction
+import bloop.logging.LoggerAction.LogInfoMessage
+import bloop.logging.ObservedLogger
+import bloop.logging.RecordingLogger
+import bloop.reporter.ReporterAction
+import bloop.util.TestProject
+import bloop.util.TestUtil
+
 import com.microsoft.java.debug.core.protocol.Requests.SetBreakpointArguments
 import com.microsoft.java.debug.core.protocol.Types
 import com.microsoft.java.debug.core.protocol.Types.SourceBreakpoint
 import monix.eval.Task
 import monix.execution.Ack
 import monix.reactive.Observer
-import bloop.internal.build.BuildTestInfo
-
-import java.net.{ConnectException, SocketException, SocketTimeoutException}
-import java.util.NoSuchElementException
-import java.util.concurrent.TimeUnit.{MILLISECONDS, SECONDS}
-import scala.collection.mutable
-import scala.concurrent.duration.{Duration, FiniteDuration}
-import scala.concurrent.{Future, Promise, TimeoutException}
-import bloop.bsp.ScalaTestSuites
-import bloop.bsp.ScalaTestSuiteSelection
 
 object DebugServerSpec extends DebugBspBaseSuite {
   private val ServerNotListening = new IllegalStateException("Server is not accepting connections")

--- a/frontend/src/test/scala/bloop/dap/DebugTestClient.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugTestClient.scala
@@ -2,7 +2,6 @@ package bloop.dap
 
 import java.net.URI
 
-import bloop.dap.DebugTestProtocol.Response
 import com.microsoft.java.debug.core.protocol.Events
 import com.microsoft.java.debug.core.protocol.Types.Capabilities
 import monix.eval.Task

--- a/frontend/src/test/scala/bloop/dap/DebugTestEndpoints.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugTestEndpoints.scala
@@ -1,14 +1,16 @@
 package bloop.dap
 
 import bloop.dap.DebugTestProtocol._
+
+import com.microsoft.java.debug.core.protocol.Events
 import com.microsoft.java.debug.core.protocol.Requests._
-import com.microsoft.java.debug.core.protocol.{Events, Types}
-import com.microsoft.java.debug.core.protocol.Responses.SetBreakpointsResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.ContinueResponseBody
+import com.microsoft.java.debug.core.protocol.Responses.EvaluateResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.ScopesResponseBody
+import com.microsoft.java.debug.core.protocol.Responses.SetBreakpointsResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.StackTraceResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.VariablesResponseBody
-import com.microsoft.java.debug.core.protocol.Responses.EvaluateResponseBody
+import com.microsoft.java.debug.core.protocol.Types
 
 private[dap] object DebugTestEndpoints {
   val Initialize = new Request[InitializeArguments, Types.Capabilities]("initialize")

--- a/frontend/src/test/scala/bloop/dap/DebugTestProtocol.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugTestProtocol.scala
@@ -1,13 +1,16 @@
 package bloop.dap
 
+import scala.reflect.ClassTag
+import scala.reflect.classTag
+import scala.util.Try
+
 import com.microsoft.java.debug.core.protocol.Events.DebugEvent
-import com.microsoft.java.debug.core.protocol.JsonUtils.{fromJson, toJson, toJsonTree}
+import com.microsoft.java.debug.core.protocol.JsonUtils.fromJson
+import com.microsoft.java.debug.core.protocol.JsonUtils.toJson
+import com.microsoft.java.debug.core.protocol.JsonUtils.toJsonTree
 import com.microsoft.java.debug.core.protocol.Messages
 import monix.eval.Task
 import monix.execution.atomic.Atomic
-
-import scala.reflect.{ClassTag, classTag}
-import scala.util.Try
 
 private[dap] object DebugTestProtocol {
   sealed trait Response[+A]

--- a/frontend/src/test/scala/bloop/io/ClasspathHasherSpec.scala
+++ b/frontend/src/test/scala/bloop/io/ClasspathHasherSpec.scala
@@ -2,19 +2,18 @@ package bloop.io
 
 import java.util.concurrent.TimeUnit
 
-import bloop.logging.RecordingLogger
-import bloop.util.TestUtil
-import bloop.tracing.BraveTracer
-import bloop.DependencyResolution
-
-import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Await
 import scala.concurrent.Promise
+import scala.concurrent.duration.FiniteDuration
+
+import bloop.DependencyResolution
+import bloop.logging.RecordingLogger
+import bloop.tracing.BraveTracer
+import bloop.tracing.TraceProperties
+import bloop.util.TestUtil
 
 import monix.eval.Task
-
 import sbt.internal.inc.bloop.internal.BloopStamps
-import bloop.tracing.TraceProperties
 
 object ClasspathHasherSpec extends bloop.testing.BaseSuite {
   ignore("cancellation works OK") {

--- a/frontend/src/test/scala/bloop/io/SourceHasherSpec.scala
+++ b/frontend/src/test/scala/bloop/io/SourceHasherSpec.scala
@@ -1,13 +1,13 @@
 package bloop.io
 
+import scala.concurrent.Await
+import scala.concurrent.Promise
+import scala.concurrent.duration.FiniteDuration
+
 import bloop.io.Environment.lineSeparator
 import bloop.logging.RecordingLogger
-import scala.concurrent.Promise
-import bloop.util.TestUtil
-import java.nio.file.Files
-import scala.concurrent.Await
-import scala.concurrent.duration.FiniteDuration
 import bloop.util.TestProject
+import bloop.util.TestUtil
 
 object SourceHasherSpec extends bloop.testing.BaseSuite {
   flakyTest("cancellation works", 3) {

--- a/frontend/src/test/scala/bloop/io/SourcesGlobsSpec.scala
+++ b/frontend/src/test/scala/bloop/io/SourcesGlobsSpec.scala
@@ -1,17 +1,15 @@
 package bloop.io
 
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.Promise
+
+import bloop.data.SourcesGlobs
 import bloop.io.Environment.lineSeparator
 import bloop.logging.RecordingLogger
-import scala.concurrent.Promise
-import bloop.util.TestUtil
-import java.nio.file.Files
-import scala.concurrent.Await
-import scala.concurrent.duration.FiniteDuration
 import bloop.util.TestProject
-import java.util.concurrent.TimeUnit
-import bloop.cli.ExitStatus
-import bloop.config.Config
-import bloop.data.SourcesGlobs
+import bloop.util.TestUtil
+
 import sbt.internal.inc.PlainVirtualFileConverter
 
 object SourcesGlobsSpec extends bloop.testing.BaseSuite {
@@ -57,7 +55,6 @@ object SourcesGlobsSpec extends bloop.testing.BaseSuite {
           ioScheduler
         )
         val Right(result) = TestUtil.await(10, TimeUnit.SECONDS)(hashedSources)
-        import scala.collection.JavaConverters._
         val obtainedFilenames = result
           .map { file =>
             val path = AbsolutePath(PlainVirtualFileConverter.converter.toPath(file.source))

--- a/frontend/src/test/scala/bloop/logging/PublisherLogger.scala
+++ b/frontend/src/test/scala/bloop/logging/PublisherLogger.scala
@@ -1,7 +1,5 @@
 package bloop.logging
 
-import java.util.concurrent.ConcurrentLinkedQueue
-
 import monix.reactive.Observer
 
 final class PublisherLogger(

--- a/frontend/src/test/scala/bloop/nailgun/NailgunSpec.scala
+++ b/frontend/src/test/scala/bloop/nailgun/NailgunSpec.scala
@@ -1,23 +1,25 @@
 package bloop.nailgun
 
-import bloop.io.{AbsolutePath, RelativePath}
-import bloop.io.Environment.lineSeparator
-import bloop.testing.BaseSuite
-import bloop.logging.RecordingLogger
-import bloop.internal.build.BuildInfo
-import bloop.util.TestUtil
-import bloop.util.JavaRuntime
-
-import java.nio.file.{Paths, Files}
-import java.util.concurrent.TimeUnit
 import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
+
+import bloop.internal.build.BuildInfo
+import bloop.io.AbsolutePath
+import bloop.io.Environment.lineSeparator
+import bloop.io.RelativePath
+import bloop.logging.RecordingLogger
+import bloop.testing.BaseSuite
+import bloop.util.JavaRuntime
+import bloop.util.TestUtil
 
 object NailgunSpec extends BaseSuite with NailgunTestUtils {
-  val workspace = AbsolutePath(Files.createTempDirectory("bloop-test-workspace"))
-  val simpleBuild = loadBuildFromResources("simple-build", workspace, new RecordingLogger)
+  val workspace: AbsolutePath = AbsolutePath(Files.createTempDirectory("bloop-test-workspace"))
+  val simpleBuild: TestBuild = loadBuildFromResources("simple-build", workspace, new RecordingLogger)
   val configDir = simpleBuild.state.build.origin.underlying
 
-  val jvmLine =
+  val jvmLine: String =
     s"Running on Java ${JavaRuntime.current} v${JavaRuntime.version} (${JavaRuntime.home})"
 
   def withServerInProject[T](op: (RecordingLogger, Client) => T): T =

--- a/frontend/src/test/scala/bloop/nailgun/NailgunTestUtils.scala
+++ b/frontend/src/test/scala/bloop/nailgun/NailgunTestUtils.scala
@@ -1,27 +1,29 @@
 package bloop.nailgun
 
 import java.io.PrintStream
-
-import java.nio.file.{Files, Path, Paths}
-import java.util.concurrent.{ExecutionException, TimeUnit}
-
-import bloop.Server
-import bloop.bsp.BspServer
-import bloop.testing.BaseSuite
-import bloop.logging.{DebugFilter, ProcessLogger, RecordingLogger}
-import bloop.util.{TestUtil, CrossPlatform}
-
-import com.martiansoftware.nailgun.{BloopThreadLocalInputStream, NGServer, ThreadLocalPrintStream}
-
-import monix.eval.Task
-import monix.execution.misc.NonFatal
-import monix.execution.Scheduler
-
-import org.apache.commons.io.IOUtils
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
 
 import scala.concurrent.Await
 import scala.concurrent.duration.FiniteDuration
-import java.nio.charset.StandardCharsets
+
+import bloop.Server
+import bloop.logging.DebugFilter
+import bloop.logging.ProcessLogger
+import bloop.logging.RecordingLogger
+import bloop.testing.BaseSuite
+import bloop.util.CrossPlatform
+import bloop.util.TestUtil
+
+import com.martiansoftware.nailgun.BloopThreadLocalInputStream
+import com.martiansoftware.nailgun.ThreadLocalPrintStream
+import monix.eval.Task
+import monix.execution.Scheduler
+import org.apache.commons.io.IOUtils
 
 /**
  * Base class for writing test for the nailgun integration.

--- a/frontend/src/test/scala/bloop/testing/BaseSuite.scala
+++ b/frontend/src/test/scala/bloop/testing/BaseSuite.scala
@@ -1,23 +1,25 @@
 package bloop.testing
 
-import bloop.Compiler
-import bloop.cli.ExitStatus
-import bloop.io.AbsolutePath
-import bloop.io.ParallelOps
-import bloop.io.Paths.AttributedPath
-import bloop.util.JavaCompat._
-import bloop.util.{TestProject, TestUtil}
-import bloop.reporter.Problem
-import bloop.engine.ExecutionContext
-import bloop.engine.caches.LastSuccessfulResult
-
+import scala.collection.JavaConverters._
 import scala.concurrent.Await
-import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.language.experimental.macros
-import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
+import bloop.Compiler
+import bloop.cli.ExitStatus
+import bloop.engine.ExecutionContext
+import bloop.engine.caches.LastSuccessfulResult
+import bloop.io.AbsolutePath
+import bloop.io.Paths.AttributedPath
+import bloop.logging.BspServerLogger
+import bloop.logging.RecordingLogger
+import bloop.reporter.Problem
+import bloop.util.TestProject
+import bloop.util.TestUtil
+
+import monix.eval.Task
+import monix.execution.misc.NonFatal
 import utest.TestSuite
 import utest.Tests
 import utest.asserts.Asserts
@@ -25,14 +27,8 @@ import utest.framework.Formatter
 import utest.framework.TestCallTree
 import utest.framework.Tree
 import utest.ufansi.Attrs
-import utest.ufansi.Str
 import utest.ufansi.Color
-
-import monix.eval.Task
-import bloop.io.Paths
-import monix.execution.misc.NonFatal
-import bloop.logging.RecordingLogger
-import bloop.logging.BspServerLogger
+import utest.ufansi.Str
 
 abstract class BaseSuite extends TestSuite with BloopHelpers {
   val pprint = _root_.pprint.PPrinter.BlackWhite

--- a/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
+++ b/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
@@ -1,27 +1,34 @@
 package bloop.testing
 
-import bloop.Compiler
-import bloop.data.Project
-import bloop.io.{AbsolutePath, RelativePath, ParallelOps}
-import bloop.io.ParallelOps.CopyMode
-import bloop.cli.Commands
-import bloop.logging.{RecordingLogger, Logger}
-import bloop.util.{TestProject, TestUtil}
-import bloop.engine.caches.LastSuccessfulResult
-import bloop.engine.{State, Run, ExecutionContext, BuildLoader, Dag}
-import bloop.config.Config
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 
+import bloop.Compiler
+import bloop.cli.Commands
+import bloop.data.Project
+import bloop.data.WorkspaceSettings
+import bloop.engine.BuildLoader
+import bloop.engine.Dag
+import bloop.engine.ExecutionContext
+import bloop.engine.Run
+import bloop.engine.State
+import bloop.engine.caches.LastSuccessfulResult
+import bloop.io.AbsolutePath
+import bloop.io.ParallelOps
+import bloop.io.ParallelOps.CopyMode
+import bloop.io.RelativePath
+import bloop.logging.Logger
+import bloop.logging.RecordingLogger
+import bloop.util.TestProject
+import bloop.util.TestUtil
+
 import monix.eval.Task
 import monix.execution.CancelableFuture
-
-import java.nio.file.{Files, Path}
-import java.nio.charset.StandardCharsets
-import bloop.data.WorkspaceSettings
 import monix.execution.Scheduler
-import bloop.config.ConfigCodecs
 
 trait BloopHelpers {
   def loadState(
@@ -115,7 +122,6 @@ trait BloopHelpers {
       newBaseDir: String,
       logger: Logger
   ): TestProject = {
-    import _root_.io.circe.parser
     val bytes = Files.readAllBytes(configFile)
     val contents = new String(bytes, StandardCharsets.UTF_8)
     val newContents = contents.replace(previousBaseDir, newBaseDir)

--- a/frontend/src/test/scala/bloop/testing/DiffAssertions.scala
+++ b/frontend/src/test/scala/bloop/testing/DiffAssertions.scala
@@ -1,9 +1,8 @@
 package bloop.testing
 
-import bloop.util.Diff
-
-import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
+
+import bloop.util.Diff
 
 import utest.ufansi.Color
 

--- a/frontend/src/test/scala/bloop/testing/LoggingEventHandlerSpec.scala
+++ b/frontend/src/test/scala/bloop/testing/LoggingEventHandlerSpec.scala
@@ -1,8 +1,15 @@
 package bloop.testing
 
-import bloop.logging.{DebugFilter, Logger, RecordingLogger}
 import ch.epfl.scala.debugadapter.testing.TestSuiteEvent
-import sbt.testing.{Event, Fingerprint, OptionalThrowable, Selector, Status, TestSelector}
+
+import bloop.logging.RecordingLogger
+
+import sbt.testing.Event
+import sbt.testing.Fingerprint
+import sbt.testing.OptionalThrowable
+import sbt.testing.Selector
+import sbt.testing.Status
+import sbt.testing.TestSelector
 
 object LoggingEventHandlerSpec extends BaseSuite {
   test("logs and displays short summary of successful run") {
@@ -87,7 +94,7 @@ object LoggingEventHandlerSpec extends BaseSuite {
     override def throwable(): OptionalThrowable = new OptionalThrowable()
   }
 
-  def failedEvent(suite: String, testName: String, failedMessage: String) = new Event {
+  def failedEvent(suite: String, testName: String, failedMessage: String): Event = new Event {
     override def fullyQualifiedName(): String = ""
     override def fingerprint(): Fingerprint = ???
     override def selector(): Selector = new TestSelector(testName)

--- a/frontend/src/test/scala/bloop/testing/ProjectBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/testing/ProjectBaseSuite.scala
@@ -1,11 +1,13 @@
 package bloop.testing
 
 import java.nio.file.Files
-import bloop.io.{AbsolutePath, Paths}
+
+import bloop.io.AbsolutePath
+import bloop.io.Paths
 import bloop.logging.RecordingLogger
 
 class ProjectBaseSuite(buildName: String) extends BaseSuite {
-  val workspace = AbsolutePath(Files.createTempDirectory(s"workspace-${buildName}"))
+  val workspace: AbsolutePath = AbsolutePath(Files.createTempDirectory(s"workspace-${buildName}"))
   val build: TestBuild = {
     val logger = new RecordingLogger(ansiCodesSupported = false)
     loadBuildFromResources(buildName, workspace, logger)

--- a/frontend/src/test/scala/bloop/testing/TestPrinterSpec.scala
+++ b/frontend/src/test/scala/bloop/testing/TestPrinterSpec.scala
@@ -1,5 +1,4 @@
 package bloop.testing
-import bloop.util.TestUtil
 import ch.epfl.scala.debugadapter.testing.TestUtils
 
 object TestPrinterSpec extends BaseSuite {

--- a/frontend/src/test/scala/bloop/util/TestProject.scala
+++ b/frontend/src/test/scala/bloop/util/TestProject.scala
@@ -1,23 +1,26 @@
 package bloop.util
 
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path}
+import java.nio.file.Files
+import java.nio.file.Path
+
+import scala.concurrent.ExecutionContext
+import scala.tools.nsc.Properties
+
+import ch.epfl.scala.bsp
 
 import bloop.ScalaInstance
 import bloop.bsp.ProjectUris
 import bloop.config.Config
 import bloop.config.Config.Platform
-import bloop.data.JdkConfig
-import bloop.io.{AbsolutePath, Paths, RelativePath}
-import bloop.logging.{Logger, NoopLogger}
-import bloop.util.TestUtil.ProjectArchetype
 import bloop.config.ConfigCodecs
-
-import ch.epfl.scala.bsp
-
-import scala.tools.nsc.Properties
-import scala.concurrent.ExecutionContext
 import bloop.data.ClientInfo.CliClientInfo
+import bloop.data.JdkConfig
+import bloop.io.AbsolutePath
+import bloop.io.RelativePath
+import bloop.logging.Logger
+import bloop.logging.NoopLogger
+import bloop.util.TestUtil.ProjectArchetype
 
 final case class TestProject(
     config: Config.Project,

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -1,65 +1,75 @@
 package bloop.util
 
 import java.io.File
-import java.nio.charset.Charset
+import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.attribute.FileTime
-import java.nio.file.{Files, Path, Paths}
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
-import bloop.io.Environment.{lineSeparator, LineSplitter}
-import bloop.{CompilerCache, ScalaInstance}
-import bloop.cli.Commands
-import bloop.config.Config
-import bloop.config.Config.CompileOrder
-import bloop.data.{ClientInfo, Origin, Project, JdkConfig}
-import bloop.engine.{Action, Build, BuildLoader, ExecutionContext, Interpreter, Run, State}
-import bloop.engine.caches.ResultsCache
-import bloop.internal.build.BuildInfo
-import bloop.io.Paths.delete
-import bloop.io.{AbsolutePath, RelativePath}
-import bloop.logging.{
-  BloopLogger,
-  BspClientLogger,
-  BufferedLogger,
-  DebugFilter,
-  Logger,
-  RecordingLogger
-}
-
-import _root_.monix.eval.Task
-import _root_.monix.execution.Scheduler
-
-import org.junit.Assert
-import sbt.internal.inc.bloop.ZincInternals
-
-import scala.concurrent.duration.{Duration, FiniteDuration, TimeUnit}
-import scala.concurrent.{Await, ExecutionException}
+import scala.concurrent.Await
+import scala.concurrent.ExecutionException
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.TimeUnit
 import scala.meta.jsonrpc.Services
 import scala.tools.nsc.Properties
 import scala.util.control.NonFatal
-import bloop.data.WorkspaceSettings
+
+import bloop.CompilerCache
+import bloop.ScalaInstance
+import bloop.cli.Commands
+import bloop.config.Config
+import bloop.config.Config.CompileOrder
+import bloop.data.JdkConfig
 import bloop.data.LoadedProject
+import bloop.data.Origin
+import bloop.data.Project
+import bloop.data.WorkspaceSettings
+import bloop.engine.Action
+import bloop.engine.Build
+import bloop.engine.BuildLoader
+import bloop.engine.ExecutionContext
+import bloop.engine.Interpreter
+import bloop.engine.Run
+import bloop.engine.State
+import bloop.engine.caches.ResultsCache
+import bloop.io.AbsolutePath
+import bloop.io.Environment.LineSplitter
+import bloop.io.Environment.lineSeparator
+import bloop.io.Paths.delete
+import bloop.io.RelativePath
+import bloop.logging.BloopLogger
+import bloop.logging.BspClientLogger
+import bloop.logging.BufferedLogger
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+import bloop.logging.RecordingLogger
+
+import _root_.monix.eval.Task
+import _root_.monix.execution.Scheduler
+import org.junit.Assert
 import sbt.internal.inc.BloopComponentCompiler
-import java.util.concurrent.TimeoutException
+import xsbti.ComponentProvider
 
 object TestUtil {
-  def projectDir(base: Path, name: String) = base.resolve(name)
-  def sourcesDir(base: Path, name: String) = projectDir(base, name).resolve("src")
-  def targetDir(base: Path, name: String) = projectDir(base.resolve("target"), name)
-  def classesDir(base: Path, name: String) = targetDir(base, name).resolve("classes")
+  def projectDir(base: Path, name: String): Path = base.resolve(name)
+  def sourcesDir(base: Path, name: String): Path = projectDir(base, name).resolve("src")
+  def targetDir(base: Path, name: String): Path = projectDir(base.resolve("target"), name)
+  def classesDir(base: Path, name: String): Path = targetDir(base, name).resolve("classes")
   def getBaseFromConfigDir(configDir: Path): Path = configDir.getParent.getParent
   def getProject(name: String, state: State): Project =
     state.build.getProjectFor(name).getOrElse(sys.error(s"Project '$name' does not exist!"))
 
-  val jdkVersion = sys.props("java.version")
-  def isJdk8 = jdkVersion.startsWith("8") || jdkVersion.startsWith("1.8")
+  val jdkVersion: String = sys.props("java.version")
+  def isJdk8: Boolean = jdkVersion.startsWith("8") || jdkVersion.startsWith("1.8")
 
   def runOnlyOnJava8(thunk: => Unit): Unit = {
     if (isJdk8) thunk
     else ()
   }
 
-  final val componentProvider =
+  final val componentProvider: ComponentProvider =
     BloopComponentCompiler.getComponentProvider(bloop.io.Paths.getCacheDirectory("components"))
 
   private var singleCompilerCache: CompilerCache = null
@@ -94,7 +104,7 @@ object TestUtil {
       failure: Boolean = false,
       useSiteLogger: Option[Logger] = None,
       order: CompileOrder = Config.Mixed
-  )(afterCompile: State => Unit = (_ => ())) = {
+  )(afterCompile: State => Unit = (_ => ())): Unit = {
     testState(structures, dependencies, scalaInstance, jdkConfig, order) { (state: State) =>
       def action(state0: State): Unit = {
         val state = useSiteLogger.map(logger => state0.copy(logger = logger)).getOrElse(state0)

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/BloopParameters.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/BloopParameters.scala
@@ -2,10 +2,12 @@ package bloop.integrations.gradle
 
 import java.io.File
 
-import org.gradle.api.provider.Property
+import bloop.integrations.gradle.syntax._
+
 import org.gradle.api.Project
-import org.gradle.api.tasks.{Input, Optional}
-import syntax._
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 
 /**
  * Project extension to configure Bloop.

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
@@ -1,8 +1,11 @@
 package bloop.integrations.gradle
 
-import bloop.integrations.gradle.tasks.{BloopInstallTask, ConfigureBloopInstallTask}
-import org.gradle.api.{Plugin, Project}
-import syntax._
+import bloop.integrations.gradle.syntax._
+import bloop.integrations.gradle.tasks.BloopInstallTask
+import bloop.integrations.gradle.tasks.ConfigureBloopInstallTask
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
 
 /**
  * Main entry point of the gradle bloop plugin.

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/syntax.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/syntax.scala
@@ -1,23 +1,22 @@
 package bloop.integrations.gradle
 
 import java.io.File
+import java.nio.file.Path
+
+import scala.collection.JavaConverters._
+import scala.reflect.ClassTag
 
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.internal.api.TestedVariant
-
+import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.plugins.JavaApplication
 import org.gradle.api.tasks.SourceSet
-import org.gradle.api.{Project, Task, GradleException}
-
-import scala.collection.JavaConverters._
-import scala.reflect.ClassTag
-import scala.util.control.NonFatal
-import java.nio.file.Path
+import org.gradle.api.tasks.SourceSetContainer
 
 object syntax {
 

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/BloopInstallTask.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/BloopInstallTask.scala
@@ -1,20 +1,23 @@
 package bloop.integrations.gradle.tasks
 
 import java.io.File
+import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Files
+
+import scala.collection.JavaConverters._
+import scala.util.Failure
+import scala.util.Success
 
 import bloop.integrations.gradle.BloopParametersExtension
 import bloop.integrations.gradle.model.BloopConverter
-import bloop.integrations.gradle.model.BloopConverter.SourceSetDep
 import bloop.integrations.gradle.syntax._
-import org.gradle.api.tasks.{SourceSet, TaskAction}
-import org.gradle.api.{DefaultTask, Project}
-import com.android.builder.model.SourceProvider
-import com.android.build.gradle.api.BaseVariant
 
-import scala.collection.JavaConverters._
-import scala.util.{Failure, Success}
-import java.nio.file.FileAlreadyExistsException
+import com.android.build.gradle.api.BaseVariant
+import com.android.builder.model.SourceProvider
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.TaskAction
 
 /**
  * Define a Gradle task that generates bloop configuration files from a Gradle project.

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/ConfigureBloopInstallTask.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/ConfigureBloopInstallTask.scala
@@ -1,11 +1,16 @@
 package bloop.integrations.gradle.tasks
 
-import bloop.integrations.gradle.syntax._
-import org.gradle.api.tasks.{SourceSet, TaskAction}
-import org.gradle.api.{DefaultTask, GradleException, Project, Task}
-
 import scala.collection.JavaConverters._
+
+import bloop.integrations.gradle.syntax._
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.TaskAction
 
 /**
  * Task to set the bloopInstall tasks's inputs

--- a/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
+++ b/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
@@ -1,27 +1,36 @@
 package bloop.integrations.gradle
 
 import java.io.File
-import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.Files
+import java.nio.file.Paths
+
+import scala.util.Properties
+
 import bloop.cli.Commands
-import bloop.config.Config.Platform.Jvm
-import bloop.config.{Config, Tag}
-import bloop.config.Config.{CompileSetup, JavaThenScala, Mixed, Platform, TestFramework}
+import bloop.config.Config
+import bloop.config.Config.CompileSetup
+import bloop.config.Config.JavaThenScala
+import bloop.config.Config.Mixed
+import bloop.config.Config.Platform
+import bloop.config.Config.TestFramework
+import bloop.config.Tag
 import bloop.config.utils.BaseConfigSuite
 import bloop.data.WorkspaceSettings
-import bloop.engine.{Build, Run, State}
+import bloop.engine.Build
+import bloop.engine.BuildLoader
+import bloop.engine.Run
+import bloop.engine.State
 import bloop.io.AbsolutePath
 import bloop.logging.BloopLogger
 import bloop.util.TestUtil
-import org.gradle.testkit.runner.{BuildResult, GradleRunner}
-import org.gradle.testkit.runner.TaskOutcome._
-import org.junit._
-import org.junit.Assert._
-import org.junit.rules.TemporaryFolder
-import bloop.engine.BuildLoader
+
 import io.github.classgraph.ClassGraph
-import scala.collection.JavaConverters._
-import scala.util.Properties
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome._
+import org.junit.Assert._
+import org.junit._
+import org.junit.rules.TemporaryFolder
 
 /*
  * To remote debug the ConfigGenerationSuite...

--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -1,30 +1,30 @@
 package bloop.integrations.maven
 
 import java.io.File
-import java.nio.file.{Files, Path, Paths}
-import java.{util => ju}
-import bloop.config.{Config, Tag}
-import org.apache.maven.artifact.repository.ArtifactRepository
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+import scala.collection.JavaConverters._
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import bloop.config.Config
+import bloop.config.Tag
+
+import org.apache.maven.artifact.Artifact
 import org.apache.maven.execution.MavenSession
 import org.apache.maven.model.Resource
+import org.apache.maven.plugin.MavenPluginManager
+import org.apache.maven.plugin.Mojo
+import org.apache.maven.plugin.MojoExecution
 import org.apache.maven.plugin.logging.Log
-import org.apache.maven.plugin.{MavenPluginManager, Mojo, MojoExecution}
 import org.apache.maven.project.MavenProject
-import org.apache.maven.artifact.Artifact
-import org.apache.maven.shared.invoker.DefaultInvocationRequest
 import org.codehaus.plexus.util.xml.Xpp3Dom
-import org.eclipse.aether.resolution.ArtifactRequest
 import org.eclipse.aether.artifact.DefaultArtifact
-import org.eclipse.aether.repository.RemoteRepository
-import org.eclipse.aether.repository.Authentication
-import org.eclipse.aether.util.repository.AuthenticationBuilder
-import org.eclipse.aether.repository.AuthenticationContext
-import org.eclipse.aether.repository
-
+import org.eclipse.aether.resolution.ArtifactRequest
 import scala_maven.AppLauncher
-import scala.util.{Failure, Success, Try}
-import scala.collection.JavaConverters._
-import scala.collection.mutable.Buffer
 
 object MojoImplementation {
   private val ScalaMavenGroupArtifact = "net.alchim31.maven:scala-maven-plugin"

--- a/integrations/sbt-bloop/src/main/scala-sbt-1.0/bloop/integrations/sbt/Compat.scala
+++ b/integrations/sbt-bloop/src/main/scala-sbt-1.0/bloop/integrations/sbt/Compat.scala
@@ -1,9 +1,15 @@
 package bloop.integrations.sbt
 
 import bloop.config.Config
+
+import sbt.Artifact
+import sbt.Def
+import sbt.Exec
+import sbt.Keys
+import sbt.SettingKey
 import sbt.io.syntax.File
-import sbt.{Artifact, Exec, Keys, SettingKey, Def}
 import sbt.librarymanagement.ScalaModuleInfo
+import sbt.util.CacheStore
 
 object Compat {
   type CompileAnalysis = xsbti.compile.CompileAnalysis
@@ -24,7 +30,7 @@ object Compat {
 
   implicit def fileToRichFile(file: File): sbt.RichFile = new sbt.RichFile(file)
 
-  def generateCacheFile(s: Keys.TaskStreams, id: String) =
+  def generateCacheFile(s: Keys.TaskStreams, id: String): CacheStore =
     s.cacheStoreFactory make id
 
   def toBloopArtifact(a: Artifact, f: File): Config.Artifact = {

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/Feedback.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/Feedback.scala
@@ -1,6 +1,7 @@
 package bloop.integration.sbt
 
-import sbt.{ProjectRef, ResolvedProject}
+import sbt.ProjectRef
+import sbt.ResolvedProject
 
 object Feedback {
   def unknownConfigurations(p: ResolvedProject, confs: Seq[String], from: ProjectRef): String = {

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -1,41 +1,45 @@
 package bloop.integrations.sbt
 
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path}
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.concurrent.ConcurrentHashMap
 
-import bloop.config.{Config, Tag}
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import bloop.config.Config
+import bloop.config.Tag
 import bloop.config.util.ConfigUtil
 import bloop.integration.sbt.Feedback
-import sbt.{
-  AutoPlugin,
-  ClasspathDep,
-  ClasspathDependency,
-  Compile,
-  ConfigKey,
-  Configuration,
-  Def,
-  File,
-  Global,
-  Inc,
-  Keys,
-  LocalRootProject,
-  Logger,
-  ProjectRef,
-  ResolvedProject,
-  Test,
-  IntegrationTest,
-  ThisBuild,
-  ThisProject,
-  KeyRanks,
-  Optional,
-  Provided,
-  Value
-}
-import xsbti.compile.CompileOrder
 
-import scala.util.{Try, Success, Failure}
-import java.util.concurrent.ConcurrentHashMap
-import java.nio.file.StandardCopyOption
+import sbt.AutoPlugin
+import sbt.ClasspathDep
+import sbt.ClasspathDependency
+import sbt.Compile
+import sbt.ConfigKey
+import sbt.Configuration
+import sbt.Def
+import sbt.File
+import sbt.Global
+import sbt.Inc
+import sbt.IntegrationTest
+import sbt.KeyRanks
+import sbt.Keys
+import sbt.LocalRootProject
+import sbt.Logger
+import sbt.Optional
+import sbt.ProjectRef
+import sbt.Provided
+import sbt.ResolvedProject
+import sbt.TaskKey
+import sbt.Test
+import sbt.ThisBuild
+import sbt.ThisProject
+import sbt.Value
+import xsbti.compile.CompileOrder
 
 object BloopPlugin extends AutoPlugin {
   import sbt.plugins.JvmPlugin
@@ -49,7 +53,7 @@ object BloopPlugin extends AutoPlugin {
 }
 
 object BloopKeys {
-  import Compat.{CompileAnalysis, CompileResult}
+  import Compat.CompileResult
   import sbt.{SettingKey, TaskKey, AttributeKey, ScopedKey, settingKey, taskKey}
 
   val bloopTargetName: SettingKey[String] =
@@ -99,25 +103,25 @@ object BloopKeys {
       KeyRanks.Invisible
     )
 
-  val bloopDefinitionKey = AttributeKey[ScopedKey[_]](
+  val bloopDefinitionKey: AttributeKey[ScopedKey[_]] = AttributeKey[ScopedKey[_]](
     "bloop-definition-key",
     "Internal: used to map a task back to its ScopedKey.",
     KeyRanks.Invisible
   )
 
-  val bloopCompileProxy = AttributeKey[sbt.ScopedKey[_]](
+  val bloopCompileProxy: AttributeKey[ScopedKey[_]] = AttributeKey[sbt.ScopedKey[_]](
     "bloopCompileProxy",
     "Internal: used to map a task back to its ScopedKey.",
     KeyRanks.Invisible
   )
 
-  val bloopCompileEntrypoint = AttributeKey[sbt.ScopedKey[_]](
+  val bloopCompileEntrypoint: AttributeKey[ScopedKey[_]] = AttributeKey[sbt.ScopedKey[_]](
     "bloopCompileEntrypoint",
     "Internal: used to map a task back to its ScopedKey.",
     KeyRanks.Invisible
   )
 
-  val bloopWaitForCompile = AttributeKey[sbt.ScopedKey[_]](
+  val bloopWaitForCompile: AttributeKey[ScopedKey[_]] = AttributeKey[sbt.ScopedKey[_]](
     "bloopWaitForCompile",
     "Internal: used to map a task back to its ScopedKey.",
     KeyRanks.Invisible
@@ -128,7 +132,7 @@ object BloopDefaults {
   import Compat._
   import sbt.{Task, Defaults, State}
 
-  val productDirectoriesUndeprecatedKey =
+  val productDirectoriesUndeprecatedKey: TaskKey[Seq[File]] =
     sbt.TaskKey[Seq[File]]("productDirectories", rank = KeyRanks.CTask)
 
   private lazy val cwd: String = System.getProperty("user.dir")
@@ -424,7 +428,6 @@ object BloopDefaults {
         (c: Configuration) => c.name
       ).filterNot(c => c == config || resolvedConfig.exists(_ == c))
 
-      import scala.collection.JavaConverters._
       val data = Keys.settingsData.value
       val thisProjectRef = Keys.thisProjectRef.value
       val eligibleConfigs = activeProjectConfigs.filter { c =>

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/ScalaNativeKeys.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/ScalaNativeKeys.scala
@@ -2,17 +2,23 @@ package bloop.integrations.sbt
 
 import java.io.File
 
+import sbt.SettingKey
+import sbt.TaskKey
+
 object ScalaNativeKeys {
   import sbt.{settingKey, taskKey}
-  val nativeClang = taskKey[File]("Location of the clang compiler.")
-  val nativeClangPP = taskKey[File]("Location of the clang++ compiler.")
-  val nativeLinkStubs = settingKey[Boolean]("Whether to link `@stub` methods, or ignore them.")
-  val nativeLink = taskKey[File]("Generates native binary without running it.")
-  val nativeMode = settingKey[String]("Compilation mode, either \"debug\" or \"release\".")
-  val nativeGC = settingKey[String]("GC choice, either \"none\", \"boehm\" or \"immix\".")
+  val nativeClang: TaskKey[File] = taskKey[File]("Location of the clang compiler.")
+  val nativeClangPP: TaskKey[File] = taskKey[File]("Location of the clang++ compiler.")
+  val nativeLinkStubs: SettingKey[Boolean] =
+    settingKey[Boolean]("Whether to link `@stub` methods, or ignore them.")
+  val nativeLink: TaskKey[File] = taskKey[File]("Generates native binary without running it.")
+  val nativeMode: SettingKey[String] =
+    settingKey[String]("Compilation mode, either \"debug\" or \"release\".")
+  val nativeGC: SettingKey[String] =
+    settingKey[String]("GC choice, either \"none\", \"boehm\" or \"immix\".")
 
-  val nativeCompileOptions =
+  val nativeCompileOptions: TaskKey[Seq[String]] =
     taskKey[Seq[String]]("Additional options are passed to clang during compilation.")
-  val nativeLinkingOptions =
+  val nativeLinkingOptions: TaskKey[Seq[String]] =
     taskKey[Seq[String]]("Additional options that are passed to clang during linking.")
 }

--- a/launcher-core/src/main/scala/bloop/launcher/Launcher.scala
+++ b/launcher-core/src/main/scala/bloop/launcher/Launcher.scala
@@ -2,27 +2,24 @@ package bloop.launcher
 
 import java.io._
 import java.net.Socket
-import java.net.URL
-import java.nio.charset.{Charset, StandardCharsets}
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 import java.nio.file._
 
-import scala.util.Try
 import scala.concurrent.Promise
+import scala.util.Try
 
-import bloop.launcher.LauncherStatus.{
-  FailedLauncherStatus,
-  FailedToConnectToServer,
-  FailedToInstallBloop,
-  FailedToOpenBspConnection,
-  FailedToParseArguments,
-  SuccessfulRun
-}
-import bloop.launcher.bsp.{BspBridge, BspConnection}
-import bloop.launcher.core.Feedback
-import bloop.bloopgun.util.Environment
-import bloop.bloopgun.core.{Shell, ServerStatus}
 import bloop.bloopgun.BloopgunCli
 import bloop.bloopgun.Defaults
+import bloop.bloopgun.core.Shell
+import bloop.launcher.LauncherStatus.FailedLauncherStatus
+import bloop.launcher.LauncherStatus.FailedToConnectToServer
+import bloop.launcher.LauncherStatus.FailedToOpenBspConnection
+import bloop.launcher.LauncherStatus.FailedToParseArguments
+import bloop.launcher.LauncherStatus.SuccessfulRun
+import bloop.launcher.bsp.BspBridge
+import bloop.launcher.bsp.BspConnection
+import bloop.launcher.core.Feedback
 
 object Launcher
     extends LauncherMain(

--- a/launcher-core/src/main/scala/bloop/launcher/bsp/BspBridge.scala
+++ b/launcher-core/src/main/scala/bloop/launcher/bsp/BspBridge.scala
@@ -1,26 +1,31 @@
 package bloop.launcher.bsp
 
-import java.io.{Closeable, IOException, InputStream, OutputStream, PrintStream}
-import java.net.Socket
-import java.nio.charset.StandardCharsets
-import java.nio.file.Path
-
-import bloop.launcher.core.Feedback
-import bloop.bloopgun.core.Shell
-import bloop.bloopgun.util.Environment
-import bloop.launcher.{printError, printQuoted, println}
-import bloop.sockets.UnixDomainSocket
-import bloop.bloopgun.core.Shell.StatusCommand
-
-import scala.collection.mutable.ListBuffer
-import scala.concurrent.Promise
-import bloop.bloopgun.BloopgunCli
 import java.io.ByteArrayOutputStream
+import java.io.Closeable
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PrintStream
+import java.net.Socket
+import java.nio.ByteBuffer
 import java.nio.channels.Channels
 import java.nio.channels.ReadableByteChannel
 import java.nio.channels.WritableByteChannel
-import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.nio.file.Path
+
+import scala.concurrent.Promise
+
+import bloop.bloopgun.BloopgunCli
+import bloop.bloopgun.core.Shell
+import bloop.bloopgun.core.Shell.StatusCommand
+import bloop.bloopgun.util.Environment
+import bloop.launcher.core.Feedback
+import bloop.launcher.printError
+import bloop.launcher.printQuoted
+import bloop.launcher.println
+import bloop.sockets.UnixDomainSocket
 
 final class BspBridge(
     clientIn: InputStream,

--- a/launcher-core/src/main/scala/bloop/launcher/package.scala
+++ b/launcher-core/src/main/scala/bloop/launcher/package.scala
@@ -21,7 +21,7 @@ package object launcher {
    * SHELL path implies preference for '\n' instead of Windows default.
    * @return '\n' if SHELL path recognized, system line.separator otherwise.
    */
-  lazy val lineSeparator = Option(System.getenv("SHELL")) match {
+  lazy val lineSeparator: String = Option(System.getenv("SHELL")) match {
     case Some(sh) if sh.toLowerCase.matches("/.*/bin/[a-z]*sh(.exe)") => "\n"
     case _ => System.getProperty("line.separator", "\n")
   }

--- a/launcher-test/src/test/scala/bloop/launcher/GlobalSettingsSpec.scala
+++ b/launcher-test/src/test/scala/bloop/launcher/GlobalSettingsSpec.scala
@@ -1,12 +1,14 @@
 package bloop.launcher
 
 import java.nio.file.Files
+
 import scala.concurrent.Promise
+
 import bloop.bloopgun.util.Environment
 import bloop.internal.build.BuildInfo
 
 object GlobalSettingsSpec extends LauncherBaseSuite(BuildInfo.version, BuildInfo.bspVersion, 9014) {
-  val launcherArguments = Array(bloopVersion, "--skip-bsp-connection")
+  val launcherArguments: Array[String] = Array(bloopVersion, "--skip-bsp-connection")
 
   def writeJsonSettings(json: String): Unit = {
     val settings = Environment.bloopGlobalSettingsPath

--- a/launcher-test/src/test/scala/bloop/launcher/LauncherBaseSuite.scala
+++ b/launcher-test/src/test/scala/bloop/launcher/LauncherBaseSuite.scala
@@ -1,28 +1,26 @@
 package bloop.launcher
 
-import bloop.io.Paths
-import bloop.io.AbsolutePath
-import bloop.io.Environment.LineSplitter
-import bloop.testing.BaseSuite
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.{util => ju}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Promise
+
+import bloop.bloopgun.BloopgunCli
+import bloop.bloopgun.ServerConfig
 import bloop.bloopgun.core.Shell
 import bloop.bloopgun.util.Environment
 import bloop.internal.build.BuildTestInfo
-
-import java.nio.file.Files
-import java.io.InputStream
-import java.io.OutputStream
-import java.nio.charset.StandardCharsets
-import java.io.ByteArrayOutputStream
-
-import scala.concurrent.Promise
-import scala.collection.JavaConverters._
-
-import java.io.ByteArrayInputStream
-import bloop.bloopgun.BloopgunCli
-import java.io.PrintStream
-import bloop.bloopgun.ServerConfig
-import bloop.bloopgun.core.ServerStatus
-import snailgun.logging.SnailgunLogger
+import bloop.io.AbsolutePath
+import bloop.io.Environment.LineSplitter
+import bloop.io.Paths
+import bloop.testing.BaseSuite
 
 /**
  * Defines a base suite to test the launcher. The test suite hijacks system
@@ -35,16 +33,16 @@ abstract class LauncherBaseSuite(
     val bspVersion: String,
     val bloopServerPort: Int
 ) extends BaseSuite {
-  val defaultConfig = ServerConfig(port = Some(bloopServerPort))
+  val defaultConfig: ServerConfig = ServerConfig(port = Some(bloopServerPort))
 
-  val oldEnv = System.getenv()
-  val oldCwd = AbsolutePath(System.getProperty("user.dir"))
-  val oldHomeDir = AbsolutePath(System.getProperty("user.home"))
-  val oldIvyHome = Option(System.getProperty("ivy.home"))
-  val oldCoursierCacheDir = Option(System.getProperty("coursier.cache"))
-  val ivyHome = oldHomeDir.resolve(".ivy2")
-  val coursierCacheDir = AbsolutePath(coursierapi.Cache.create().getLocation)
-  val bloopBinDirectory = AbsolutePath(Files.createTempDirectory("bsp-bin"))
+  val oldEnv: ju.Map[String, String] = System.getenv()
+  val oldCwd: AbsolutePath = AbsolutePath(System.getProperty("user.dir"))
+  val oldHomeDir: AbsolutePath = AbsolutePath(System.getProperty("user.home"))
+  val oldIvyHome: Option[String] = Option(System.getProperty("ivy.home"))
+  val oldCoursierCacheDir: Option[String] = Option(System.getProperty("coursier.cache"))
+  val ivyHome: AbsolutePath = oldHomeDir.resolve(".ivy2")
+  val coursierCacheDir: AbsolutePath = AbsolutePath(coursierapi.Cache.create().getLocation)
+  val bloopBinDirectory: AbsolutePath = AbsolutePath(Files.createTempDirectory("bsp-bin"))
 
   protected val shellWithPython = new Shell(true, true)
 
@@ -56,8 +54,8 @@ abstract class LauncherBaseSuite(
   System.setProperty("coursier.cache", coursierCacheDir.syntax)
 
   // Hijack so that lookup for bloop in PATH fails even if this machine has bloop installed
-  val hijackedBloop = bloopBinDirectory.resolve("bloop")
-  val hijackedBloopServer = bloopBinDirectory.resolve("blp-server")
+  val hijackedBloop: AbsolutePath = bloopBinDirectory.resolve("bloop")
+  val hijackedBloopServer: AbsolutePath = bloopBinDirectory.resolve("blp-server")
   writeFile(hijackedBloop, "I am not a script and I must fail to be executed")
   // Add empty contents to blp-server so that `ServerStatus.findServerToRun` doesn't find a valid server
   writeFile(hijackedBloopServer, "")

--- a/launcher-test/src/test/scala/bloop/launcher/LauncherSpec.scala
+++ b/launcher-test/src/test/scala/bloop/launcher/LauncherSpec.scala
@@ -1,26 +1,11 @@
 package bloop.launcher
 
-import java.io._
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
+import scala.concurrent.Promise
 
-import bloop.internal.build.BuildInfo
 import bloop.bloopgun.util.Environment
-import bloop.logging.{BspClientLogger, RecordingLogger}
-import bloop.util.TestUtil
-import monix.eval.Task
-import monix.execution.{ExecutionModel, Scheduler}
-import sbt.internal.util.MessageOnlyException
-
-import scala.concurrent.{Await, Promise}
-import scala.concurrent.duration.FiniteDuration
-import scala.meta.jsonrpc._
-import scala.util.control.NonFatal
-import bloop.bloopgun.ServerConfig
-
-import bloop.launcher.core.{Feedback => LauncherFeedback}
 import bloop.bloopgun.util.{Feedback => BloopgunFeedback}
-import bloop.bloopgun.core.AvailableAtPath
+import bloop.internal.build.BuildInfo
+import bloop.launcher.core.{Feedback => LauncherFeedback}
 
 object LatestStableLauncherSpec extends LauncherSpec("1.4.11")
 object LatestMainLauncherSpec extends LauncherSpec(BuildInfo.version)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")

--- a/shared/src/main/scala/bloop/io/AbsolutePath.scala
+++ b/shared/src/main/scala/bloop/io/AbsolutePath.scala
@@ -3,7 +3,9 @@ package bloop.io
 
 import java.io.File
 import java.net.URI
-import java.nio.file.{Files, Path, Paths => NioPaths}
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.{Paths => NioPaths}
 
 final class AbsolutePath private (val underlying: Path) extends AnyVal {
   def syntax: String = toString

--- a/shared/src/main/scala/bloop/io/ByteHasher.scala
+++ b/shared/src/main/scala/bloop/io/ByteHasher.scala
@@ -1,9 +1,9 @@
 package bloop.io
 
-import java.io.{File, RandomAccessFile}
-import java.io.BufferedInputStream
+import java.io.File
+import java.io.RandomAccessFile
 import java.nio.ByteBuffer
-import java.nio.file.{Path, Files}
+
 import net.jpountz.xxhash.XXHashFactory
 
 object ByteHasher {

--- a/shared/src/main/scala/bloop/io/Paths.scala
+++ b/shared/src/main/scala/bloop/io/Paths.scala
@@ -1,22 +1,23 @@
 package bloop.io
 
 import java.io.IOException
-import java.nio.file.attribute.{BasicFileAttributes, FileTime}
-import java.nio.file.{
-  DirectoryNotEmptyException,
-  FileSystems,
-  FileVisitOption,
-  FileVisitResult,
-  FileVisitor,
-  Files,
-  Path,
-  SimpleFileVisitor,
-  Paths => NioPaths
-}
-import java.util
-import io.github.soc.directories.ProjectDirectories
-import scala.collection.mutable
+import java.nio.file.DirectoryNotEmptyException
+import java.nio.file.FileSystems
+import java.nio.file.FileVisitOption
+import java.nio.file.FileVisitResult
+import java.nio.file.FileVisitor
+import java.nio.file.Files
 import java.nio.file.NoSuchFileException
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.FileTime
+import java.nio.file.{Paths => NioPaths}
+import java.util
+
+import scala.collection.mutable
+
+import io.github.soc.directories.ProjectDirectories
 
 object Paths {
   private val projectDirectories = ProjectDirectories.from("", "", "bloop")

--- a/shared/src/main/scala/bloop/io/RelativePath.scala
+++ b/shared/src/main/scala/bloop/io/RelativePath.scala
@@ -2,7 +2,8 @@ package bloop.io
 
 import java.io.File
 import java.net.URI
-import java.nio.file.{Path, Paths => NioPaths}
+import java.nio.file.Path
+import java.nio.file.{Paths => NioPaths}
 
 final class RelativePath private (val underlying: Path) extends AnyVal {
   def syntax: String = toString

--- a/shared/src/main/scala/bloop/logging/CompilationEvent.scala
+++ b/shared/src/main/scala/bloop/logging/CompilationEvent.scala
@@ -1,9 +1,11 @@
 package bloop.logging
 
-import ch.epfl.scala.bsp
-import bloop.reporter.Problem
 import java.io.File
+
+import ch.epfl.scala.bsp
+
 import bloop.io.AbsolutePath
+import bloop.reporter.Problem
 
 sealed abstract class CompilationEvent
 


### PR DESCRIPTION
We have to agree on scalafix settings. Currently, they are very similar to the ones that can be found in Metals.

What I've found is that `RemoveUnused` have strange behavior - sometimes it removes only `val name =` and lefts right side of the assignment :/ 
Moreover, we have to be very careful, for example here https://github.com/scalacenter/bloop/blob/1b6633ae67ce0ba508caa947cf88b3daf459ee96/frontend/src/main/scala/bloop/Cli.scala#L508-L518 
there is a side effect (`runAsync`) that is assigned to the variable and we can't remove both sides. Probably the best way would be to iterate manually over those unused warnings.

scalafix can be run on frontend by `frontend/scalafix`

cc: @tgodzik 