### PR TITLE
Fix copying tasty files on incremental compilation

### DIFF
--- a/backend/src/main/scala/bloop/BloopClassFileManager.scala
+++ b/backend/src/main/scala/bloop/BloopClassFileManager.scala
@@ -180,14 +180,21 @@ final class BloopClassFileManager(
       // invalidations can happen in both paths, no-op if missing
       allInvalidatedClassFilesForProject.-=(generatedClassFile)
       allInvalidatedClassFilesForProject.-=(rebasedClassFile)
-      supportedCompileProducts.foreach { supportedProductSuffix =>
-        val productName = rebasedClassFile
+
+      def productFile(classFile: File, supportedProductSuffix: String) = {
+        val productName = classFile
           .getName()
           .stripSuffix(".class") + supportedProductSuffix
-        val productAssociatedToClassFile =
-          new File(rebasedClassFile.getParentFile, productName)
-        if (productAssociatedToClassFile.exists())
-          allInvalidatedExtraCompileProducts.-=(productAssociatedToClassFile)
+        new File(classFile.getParentFile, productName)
+      }
+      supportedCompileProducts.foreach { supportedProductSuffix =>
+        val generatedProductName = productFile(generatedClassFile, supportedProductSuffix)
+        val rebasedProductName = productFile(rebasedClassFile, supportedProductSuffix)
+
+        if (generatedProductName.exists() || rebasedProductName.exists()) {
+          allInvalidatedExtraCompileProducts.-=(generatedProductName)
+          allInvalidatedExtraCompileProducts.-=(rebasedProductName)
+        }
       }
     }
 

--- a/frontend/src/test/scala/bloop/testing/BaseSuite.scala
+++ b/frontend/src/test/scala/bloop/testing/BaseSuite.scala
@@ -425,7 +425,6 @@ abstract class BaseSuite extends TestSuite with BloopHelpers {
         val stamps = analysis.readStamps
         assert(stamps.getAllProductStamps.asScala.nonEmpty)
         assert(stamps.getAllSourceStamps.asScala.nonEmpty)
-        //assert(stamps.getAllBinaryStamps.asScala.nonEmpty)
 
         assert(takeDirectorySnapshot(latestResult.classesDir).nonEmpty)
         val projectClassesDir =

--- a/frontend/src/test/scala/bloop/util/TestProject.scala
+++ b/frontend/src/test/scala/bloop/util/TestProject.scala
@@ -124,7 +124,12 @@ abstract class BaseTestProject {
     val version = scalaVersion.getOrElse(Properties.versionNumberString)
 
     val finalScalaOrg = scalaOrg.getOrElse("org.scala-lang")
-    val finalScalaCompiler = scalaCompiler.getOrElse("scala-compiler")
+    val finalScalaCompiler = scalaCompiler.getOrElse {
+      if (version.startsWith("3."))
+        "scala3-compiler_3"
+      else
+        "scala-compiler"
+    }
     val instance =
       mkScalaInstance(finalScalaOrg, finalScalaCompiler, scalaVersion, jars.toList, NoopLogger)
 


### PR DESCRIPTION
Previously, we removed both generatedClassFile and rebasedClassFile from invalidations, but we only did it for rebased product files such as `.tasty`. Now we do it for both

I am not 100% sure why sometimes invalidations happen for rebased and sometimes for generated files, but that can happen according to the comment above.

What happened here is that the generated files existed, but the rebased one was in the invalidation list, so later on we would skip it.

This was causing the issues in https://github.com/scalameta/metals/pull/3706