### PR TITLE
Fixing typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ support many different workflows and allow bespoke integrations.
 | 💻 Install bloop in your computer or CI server by following [our **Installation page**](https://scalacenter.github.io/bloop/setup) |
 | 📚 Learn more about bloop and how to use it from your favorite build tool and editor in <a href="https://scalacenter.github.io/bloop">our website</a> |
 | ⚙️ Tool author? Integrate your tool with bloop by reading the [Integration Guide](https://scalacenter.github.io/bloop/docs/integration) |
-| ❓Questions? Unsure if bloop is useful for your use case? Ask right away in our [Dicord channel](https://discord.gg/KWF9zMhJWS)! |
+| ❓Questions? Unsure if bloop is useful for your use case? Ask right away in our [Discord channel](https://discord.gg/KWF9zMhJWS)! |
 
 [discord]: https://discord.gg/KWF9zMhJWS
 [contributing]: https://scalacenter.github.io/bloop/docs/developer-documentation/


### PR DESCRIPTION
"Dicord" -> "Discord"