### PR TITLE
Implement buildTarget/inverseSources BSP endpoint

### DIFF
--- a/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
@@ -290,6 +290,19 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
       TestUtil.await(FiniteDuration(5, "s"))(dependencySourcesTask)
     }
 
+    def requestInverseSources(document: AbsolutePath): bsp.InverseSourcesResult = {
+      val inverseSourcesTask = {
+        endpoints.BuildTarget.inverseSources
+          .request(bsp.InverseSourcesParams(bsp.TextDocumentIdentifier(bsp.Uri(document.toBspUri))))
+          .map {
+            case Left(error) => fail(s"Received error ${error}")
+            case Right(targets) => targets
+          }
+      }
+
+      TestUtil.await(FiniteDuration(5, "s"))(inverseSourcesTask)
+    }
+
     import bloop.cli.ExitStatus
     def toBspStatus(status: ExitStatus): bsp.StatusCode = {
       status match {

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -540,4 +540,32 @@ class BspProtocolSpec(
     }
   }
 
+  test("inverse sources request works") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      loadBspBuildFromResources("cross-test-build-scalajs-0.6", workspace, logger) { build =>
+        val mainProject = build.projectFor("test-project")
+        val testProject = build.projectFor("test-project-test")
+        val mainJsProject = build.projectFor("test-projectJS")
+        val testJsProject = build.projectFor("test-projectJS-test")
+        val rootMain = build.projectFor("cross-test-build-scalajs-0-6")
+        val rootTest = build.projectFor("cross-test-build-scalajs-0-6-test")
+
+        def checkInverseSources(project: TestProject): Unit = {
+          project.sources.foreach { source =>
+            val inverseSourcesResult = build.state.requestInverseSources(source)
+            assert(inverseSourcesResult.targets.contains(project.bspId))
+          }
+        }
+
+        checkInverseSources(mainProject)
+        checkInverseSources(testProject)
+        checkInverseSources(mainJsProject)
+        checkInverseSources(testJsProject)
+        checkInverseSources(rootMain)
+        checkInverseSources(rootTest)
+      }
+    }
+  }
+
 }

--- a/frontend/src/test/scala/bloop/util/TestProject.scala
+++ b/frontend/src/test/scala/bloop/util/TestProject.scala
@@ -24,8 +24,8 @@ final case class TestProject(
     deps: Option[List[TestProject]]
 ) {
   def baseDir: AbsolutePath = AbsolutePath(config.directory)
+  def sources: List[AbsolutePath] = config.sources.map(AbsolutePath(_))
   def srcFor(relPath: String, exists: Boolean = true): AbsolutePath = {
-    val sources = config.sources.map(AbsolutePath(_))
     if (exists) TestProject.srcFor(sources, relPath)
     else {
       val targetPath = RelativePath(relPath.stripPrefix(java.io.File.separator))


### PR DESCRIPTION
Previously, the BSP endpoint `buildTarget/inverseSources` was not
implemented, even though Bloop declares itself as supporting this
endpoint.

This commit provides an implementation of this endpoint.