### PR TITLE
fix: sbt-bloop - add cause to error log if bloopGenerate fails

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -1057,8 +1057,8 @@ object BloopDefaults {
           Some(outFile)
         }
     }.result.map {
-      case Inc(_) =>
-        logger.error(s"Couldn't run bloopGenerate for $projectName")
+      case Inc(cause) =>
+        logger.error(s"Couldn't run bloopGenerate for $projectName. Cause:\n$cause")
         None
       case Value(maybeFile) =>
         maybeFile


### PR DESCRIPTION
This should help with investigations in #1713