### PR TITLE
Fix duplicate compiler classpath and bootclasspath options

### DIFF
--- a/backend/src/main/scala/sbt/internal/inc/bloop/BloopZincCompiler.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/BloopZincCompiler.scala
@@ -137,7 +137,7 @@ object BloopZincCompiler {
         val analysis = invalidateAnalysisFromSetup(config.currentSetup, previousSetup, incrementalOptions.ignoredScalacOptions(), setOfSources, prev, manager, logger)
 
         // Scala needs the explicit type signature to infer the function type arguments
-        val compile: (Set[VirtualFile], DependencyChanges, AnalysisCallback, ClassFileManager) => Task[Unit] = compiler.compile(_, _, _, _, cancelPromise, classpathOptions)
+        val compile: (Set[VirtualFile], DependencyChanges, AnalysisCallback, ClassFileManager) => Task[Unit] = compiler.compile(_, _, _, _, cancelPromise)
         BloopIncremental
           .compile(
             setOfSources,


### PR DESCRIPTION
Previously we created compiler arguments on the Bloop side and it turns out that it's already being done in Zinc, so this way we duplicate some of the options. Now, we just use the user scalacOptions, while Zinc takes cares of the other options.

Fixes https://github.com/scalameta/metals/issues/3766