### PR TITLE
Fix scoop install script

### DIFF
--- a/project/ReleaseUtils.scala
+++ b/project/ReleaseUtils.scala
@@ -204,14 +204,14 @@ object ReleaseUtils {
        |  "url": "${artifacts.bloopCoursier.url}",
        |  "hash": "sha256:${artifacts.bloopCoursier.sha}",
        |  "depends": "coursier",
-       |  "bin": "bloop",
+       |  "bin": "bloop.bat",
        |  "env_add_path": "$$dir",
        |  "env_set": {
        |    "BLOOP_HOME": "$$dir",
        |    "BLOOP_IN_SCOOP": "true"
        |  },
        |  "installer": {
-       |    "script": "coursier install --install-dir $$dir --default-channels=false --channel $$dir bloop"
+       |    "script": "coursier install --install-dir $$dir bloop:$version"
        |  }
        |}
         """.stripMargin


### PR DESCRIPTION
Previously it would try to find `bloop.json` in $dir, which did not exists as we were downloading coursier-bloop.json.

Now, we just install specific Bloop version using the default channels, which should work correctly.