### PR TITLE
Remove class directories in `clean`

### DIFF
--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -38,12 +38,14 @@ object Tasks {
    * @param includeDeps Do not run clean for dependencies.
    * @return The new state of Bloop after cleaning.
    */
-  def clean(state: State, targets: List[Project], includeDeps: Boolean): Task[State] = Task {
+  def clean(state: State, targets: List[Project], includeDeps: Boolean): Task[State] = {
     val allTargetsToClean =
       if (!includeDeps) targets
       else targets.flatMap(t => Dag.dfs(state.build.getDagFor(t))).distinct
-    val newResults = state.results.cleanSuccessful(allTargetsToClean)
-    state.copy(results = newResults)
+    state.results.cleanSuccessful(allTargetsToClean.toSet, state.client, state.logger).map {
+      newResults =>
+        state.copy(results = newResults)
+    }
   }
 
   /**


### PR DESCRIPTION
Previously, `bloop clean` would only clear the results cache, but the
class files would be left untouched on the disk. This commit changes
this, so that the `clean` command doesn't exit until the classfiles of
the last result, and the classes directory of the current client are
deleted.

Fixes #1388