### PR TITLE
Bump scala-debug-adapter with fixes for Scala 3

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -631,7 +631,10 @@ final class BloopBspServices(
             }
           )
         case bsp.DebugSessionParamsDataKind.ScalaAttachRemote =>
-          Right(BloopDebuggeeRunner.forAttachRemote(state, ioScheduler, projects))
+          BloopDebuggeeRunner.forAttachRemote(state, ioScheduler, projects) match {
+            case Right(adapter) => Right(adapter)
+            case Left(error) => Left(JsonRpcResponse.invalidRequest(error))
+          }
         case dataKind => Left(JsonRpcResponse.invalidRequest(s"Unsupported data kind: $dataKind"))
       }
     }

--- a/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
@@ -547,7 +547,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
         val `Main.scala` = srcFor("Main.scala")
         val breakpoints = breakpointsArgs(`Main.scala`, 3)
 
-        val attachRemoteProcessRunner =
+        val Right(attachRemoteProcessRunner) =
           BloopDebuggeeRunner.forAttachRemote(
             state.compile(project).toTestState.state,
             defaultScheduler,
@@ -755,7 +755,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
         val `Main.scala` = srcFor("Main.scala")
         val breakpoints = breakpointsArgs(`Main.scala`, 4)
 
-        val attachRemoteProcessRunner =
+        val Right(attachRemoteProcessRunner) =
           BloopDebuggeeRunner.forAttachRemote(
             testState.state,
             defaultScheduler,
@@ -1002,6 +1002,8 @@ object DebugServerSpec extends DebugBspBaseSuite {
       def run(listener: DebuggeeListener): CancelableFuture[Unit] = {
         DapCancellableFuture.runAsync(task.map(_ => ()), defaultScheduler)
       }
+
+      def scalaVersion: String = "2.12.15"
     }
 
     startDebugServer(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,7 +55,7 @@ object Dependencies {
   val asmVersion = "7.0"
   val snailgunVersion = "0.4.0"
   val ztExecVersion = "1.11"
-  val debugAdapterVersion = "2.2.0-M1"
+  val debugAdapterVersion = "2.2.0-M2"
 
   import sbt.librarymanagement.syntax.stringToOrganization
   val zinc = "org.scala-sbt" %% "zinc" % zincVersion


### PR DESCRIPTION
The most recent milestone works much better thanks to @adpi2 :tada: !

I plan to release 1.5.1 next, because the clean functionality got fixed.