### PR TITLE
bugfix: Allow to run using DAP in Java only projects

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -631,10 +631,7 @@ final class BloopBspServices(
             }
           )
         case bsp.DebugSessionParamsDataKind.ScalaAttachRemote =>
-          BloopDebuggeeRunner.forAttachRemote(state, ioScheduler, projects) match {
-            case Right(adapter) => Right(adapter)
-            case Left(error) => Left(JsonRpcResponse.invalidRequest(error))
-          }
+          Right(BloopDebuggeeRunner.forAttachRemote(state, ioScheduler, projects))
         case dataKind => Left(JsonRpcResponse.invalidRequest(s"Unsupported data kind: $dataKind"))
       }
     }

--- a/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
@@ -547,7 +547,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
         val `Main.scala` = srcFor("Main.scala")
         val breakpoints = breakpointsArgs(`Main.scala`, 3)
 
-        val Right(attachRemoteProcessRunner) =
+        val attachRemoteProcessRunner =
           BloopDebuggeeRunner.forAttachRemote(
             state.compile(project).toTestState.state,
             defaultScheduler,
@@ -755,7 +755,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
         val `Main.scala` = srcFor("Main.scala")
         val breakpoints = breakpointsArgs(`Main.scala`, 4)
 
-        val Right(attachRemoteProcessRunner) =
+        val attachRemoteProcessRunner =
           BloopDebuggeeRunner.forAttachRemote(
             testState.state,
             defaultScheduler,


### PR DESCRIPTION
This popped up in https://github.com/scalameta/metals/pull/4078

I will follow up with a quick 1.5.2 release.