### PR TITLE
Fix resolution of test-jar artifacts

### DIFF
--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -10,6 +10,7 @@ import scala.util.Success
 import scala.util.Try
 import bloop.config.Config
 import bloop.config.Tag
+import org.apache.maven.RepositoryUtils
 import org.apache.maven.artifact.Artifact
 import org.apache.maven.artifact.ArtifactUtils
 import org.apache.maven.execution.MavenSession
@@ -84,15 +85,7 @@ object MojoImplementation {
         val suffix = if (classifier.nonEmpty) s":$classifier" else ""
         log.info("Resolving artifact: " + artifact + suffix)
         val request = new ArtifactRequest()
-        request.setArtifact(
-          new DefaultArtifact(
-            artifact.getGroupId(),
-            artifact.getArtifactId(),
-            classifier,
-            artifact.getType(),
-            artifact.getVersion()
-          )
-        )
+        request.setArtifact(RepositoryUtils.toArtifact(artifact))
         request.setRepositories(mojo.getRemoteRepositories())
         val result = mojo.getRepoSystem().resolveArtifact(session.getRepositorySession(), request)
         log.info("SUCCESS " + artifact)

--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -185,9 +185,10 @@ object MojoImplementation {
         case a: Artifact => a.getArtifactId() == "scala-library"
       }
       val allArtifacts = if (hasScalaLibrary) artifacts else artifacts ++ libraryAndDependencies
+      val isJar = Set("jar", "test-jar")
       val modules =
         allArtifacts.collect {
-          case art: Artifact if art.getType() == "jar" && isNotReactorProjectArtifact(art) =>
+          case art: Artifact if isJar(art.getType()) && isNotReactorProjectArtifact(art) =>
             if (art.getArtifactId() == "scala-library")
               scalaContext match {
                 case Some(context) =>

--- a/integrations/maven-bloop/src/test/resources/test_jars/pom.xml
+++ b/integrations/maven-bloop/src/test/resources/test_jars/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>test_jars</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>test_jars</name>
+  <description>A minimal Scala project using the Maven build tool.</description>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <encoding>UTF-8</encoding>
+    <scala.version>2.13.6</scala.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>2.13.6</version>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-tags_2.13</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+      <version>3.3.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src/main/scala</sourceDirectory>
+    <testSourceDirectory>src/test/scala</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <!-- see http://davidb.github.com/scala-maven-plugin -->
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.3.2</version>
+        <configuration></configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <args></args>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Update: this is indeed a separate issue with the fix provided in https://github.com/scalacenter/bloop/pull/1747/commits/3a1d935f9c37bc8ad26ffdeb79ad367f6302971a

---

_context:_

The problem I saw is related to #1727, but in the case of a test-jar external dependency - it wasn't being added to test scope classpath at all.

~~While tinkering at it, I also noticed that manual translation between Aether and Maven's `Artifact` types is not required, as there seems to be a method for that, used in Maven's own sources.~~ Turns out it's not part of public API so it's better not to use it.

And finally, I added a test to specifically verify that `<...>-tests.jar` is resolved.

I think this "fix" is somewhat different to #1727, and is worth a separate review.