### PR TITLE
sbt-bloop and buildpress don't depend on launcher

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -687,7 +687,7 @@ def defineShadedSbtPlugin(
 }
 
 lazy val sbtBloop10: Project = project
-  .dependsOn(jsonConfig212.jvm, launcher, bloop4j)
+  .dependsOn(jsonConfig212.jvm)
   .enablePlugins(ScriptedPlugin)
   .disablePlugins(ScalafixPlugin)
   .in(integrations / "sbt-bloop")
@@ -696,14 +696,7 @@ lazy val sbtBloop10: Project = project
 
 lazy val sbtBloop10Shaded: Project =
   defineShadedSbtPlugin("sbtBloop10Shaded", Sbt1Version, sbtBloop10).settings(
-    scalaVersion := (sbtBloop10 / scalaVersion).value,
-    // Add dependencies that are not shaded and are required to be unchanged to work at runtime
-    libraryDependencies ++= List(
-      "net.java.dev.jna" % "jna" % "4.5.0",
-      "net.java.dev.jna" % "jna-platform" % "4.5.0",
-      "com.google.code.gson" % "gson" % "2.7",
-      "com.google.code.findbugs" % "jsr305" % "3.0.2"
-    )
+    scalaVersion := (sbtBloop10 / scalaVersion).value
   )
 
 lazy val sbtBloop013 = project
@@ -821,7 +814,7 @@ lazy val buildpressConfig = (project in file("buildpress-config"))
   )
 
 lazy val buildpress = project
-  .dependsOn(launcher, bloopShared, buildpressConfig)
+  .dependsOn(bloopgun, bloopShared, buildpressConfig)
   .settings(buildpressSettings)
   .settings(
     scalaVersion := Scala212Version,

--- a/project/project/build.sbt
+++ b/project/project/build.sbt
@@ -11,13 +11,6 @@ val emptySbtPlugin = project
   .settings(sharedSettings)
   .settings(sbtPlugin := true)
 
-val directDependencies = List(
-  "net.java.dev.jna" % "jna" % "4.5.0",
-  "net.java.dev.jna" % "jna-platform" % "4.5.0",
-  "com.google.code.gson" % "gson" % "2.7",
-  "com.google.code.findbugs" % "jsr305" % "3.0.2"
-)
-
 val sbtBloopBuildShadedJar = project
   .in(file("target")./("sbt-bloop-build-shaded"))
   .enablePlugins(BloopShadingPlugin)
@@ -28,14 +21,9 @@ val sbtBloopBuildShadedJar = project
     name := "sbt-bloop-build-shaded",
     scalacOptions in Compile :=
       (scalacOptions in Compile).value.filterNot(_ == "-deprecation"),
-    libraryDependencies ++= directDependencies,
     libraryDependencies ++= List(
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.4.0",
-      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.4.0",
-      "org.zeroturnaround" % "zt-exec" % "1.11",
-      "me.vican.jorge" %% "snailgun-cli" % "0.3.1",
-      "io.get-coursier" % "interface" % "1.0.4",
-      "ch.epfl.scala" % "bsp4j" % "2.0.0-M4+10-61e61e87"
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.4.0"
     ),
     toShadeClasses := {
       build.Shading.toShadeClasses(
@@ -73,30 +61,9 @@ val sbtBloopBuildShadedJar = project
 
     },
     shadingNamespace := "shaded.build",
-    shadeIgnoredNamespaces := Set("com.google.gson", "org.slf4j", "scala"),
+    shadeIgnoredNamespaces := Set("scala"),
     shadeNamespaces := Set(
-      "com.github.plokhotnyuk.jsoniter_scala",
-      "machinist",
-      "snailgun",
-      "org.zeroturnaround",
-      "io.github.soc",
-      "scopt",
-      "macrocompat",
-      "coursierapi",
-      "io.github.alexarchambault",
-      "org.fusesource",
-      "concurrentrefhashmap",
-      "shapeless",
-      "argonaut",
-      "org.checkerframework",
-      "com.google.guava",
-      "com.google.common",
-      "com.google.j2objc",
-      "com.google.thirdparty",
-      "com.google.errorprone",
-      "org.codehaus",
-      "ch.epfl.scala.bsp4j",
-      "org.eclipse"
+      "com.github.plokhotnyuk.jsoniter_scala"
     ),
     // Let's add our sbt plugin sources to the module
     unmanagedSourceDirectories in Compile ++= {
@@ -107,11 +74,6 @@ val sbtBloopBuildShadedJar = project
         baseDir / "config" / ".jvm" / "src" / "main" / "scala",
         baseDir / "config" / "src" / "main" / "scala",
         baseDir / "config" / "src" / "main" / "scala-2.11-13",
-        baseDir / "sockets" / "src" / "main" / "java",
-        baseDir / "bloop4j" / "src" / "main" / "java",
-        baseDir / "bloop4j" / "src" / "main" / "scala",
-        baseDir / "bloopgun" / "src" / "main" / "scala",
-        baseDir / "launcher" / "src" / "main" / "scala",
         pluginMainDir / "scala",
         pluginMainDir / s"scala-sbt-${Keys.sbtBinaryVersion.value}"
       )
@@ -148,7 +110,6 @@ val sbtBloopBuildShadedNakedJar = project
   .settings(sharedSettings)
   .settings(
     name := "sbt-bloop-build-shaded-naked",
-    libraryDependencies ++= directDependencies,
     products in Compile := {
       val packagedPluginJar = (packageBin in Compile in sbtBloopBuildShadedJar).value.toPath
 


### PR DESCRIPTION
It seems these are spurious dependencies (maybe these are there for historical reasons?). sbt-bloop only needs bloop-config, and buildpress is fine with just bloopgun and bloop-shared.