### PR TITLE
Correctly pick up test-jar dependency sources

### DIFF
--- a/integrations/maven-bloop/src/test/scala/bloop/integrations/maven/MavenConfigGenerationSuite.scala
+++ b/integrations/maven-bloop/src/test/scala/bloop/integrations/maven/MavenConfigGenerationSuite.scala
@@ -189,6 +189,16 @@ class MavenConfigGenerationSuite extends BaseConfigSuite {
 
       assert(hasTag(configFile, Tag.Library))
       val testJar = configFile.project.resolution.get.modules.find(_.name == "spark-tags_2.13")
+      assert(
+        testJar.forall(
+          _.artifacts.exists(e =>
+            e.classifier == Some("sources") && e.path
+              .getFileName()
+              .toString()
+              .endsWith("-test-sources.jar")
+          )
+        )
+      )
       assert(testJar.exists { m =>
         m.artifacts.exists(_.path.toString().endsWith("spark-tags_2.13-3.3.0-tests.jar"))
       })


### PR DESCRIPTION
### fixes

test-jar dependencies not only have a different suffix for regular jars `-tests.jar`, but they also have a different one for test sources :D `-test-sources.jar` notice that it's `test` not `tests`.

They also need to have a different classifier (`test-sources`).

### refactoring

`resolveArtifact` now takes `sources: Boolean` parameter instead of a wider `classifier: Option[String]` - we only ever use it to download sources, so we can tighten down the method contract.

I would also argue that `resolveArtifact` needs to return `case class ResolvedArtifact(af: Artifact, sources: Boolean, file: File)` so that we don't need to do this string manipulation with jar names, but it would involve larger refactoring than what I'm ready to commit to in this PR.