### PR TITLE
Allow configuration to be stored in $BLOOP_CONFIG

### DIFF
--- a/bloopgun/src/main/scala/bloop/bloopgun/util/Environment.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/util/Environment.scala
@@ -23,7 +23,8 @@ object Environment {
 
   def cwd: Path = Paths.get(System.getProperty("user.dir"))
   def homeDirectory: Path = Paths.get(System.getProperty("user.home"))
-  def defaultBloopDirectory: Path = homeDirectory.resolve(".bloop")
+  def defaultBloopDirectory: Path =
+    sys.env.get("BLOOP_CONFIG").map(Paths.get).getOrElse(homeDirectory.resolve(".bloop"))
   def bloopGlobalSettingsPath: Path = defaultBloopDirectory.resolve("bloop.json")
 
   def bloopGlobalSettings(logger: Logger): Either[String, GlobalSettings] = {

--- a/docs/server.md
+++ b/docs/server.md
@@ -22,7 +22,7 @@ For example, `bloop server`:
 
 1. Finds the location of a bootstrapped jar automatically in the bloop installation
    directory
-1. Runs the server with the JVM options configured in `$HOME/.bloop/bloop.json`, see
+1. Runs the server with the JVM options configured in `$HOME/.bloop/bloop.json` or `$BLOOP_CONFIG/bloop.json` if `$BLOOP_CONFIG` is set, see
    [custom Java options](#custom-java-options).
 1. Provides a way to evolve the way the server is run and managed in the future, which
    makes it especially compatibility-friendly.


### PR DESCRIPTION
Currently bloop (or by extension metals) generates bloop configuration data in `$HOME/.bloop`.
This change proposes to enable the user to change the directory where bloop expects global configuration to be found.
My rational for this is that I like my dev configuration to live with the project I am currently working on, ie `$HOME/projects/foo/.config/bloop`. As I work a lot in agency with different tools / tech stacks, this helps greatly in keeping project contained and reduce clutter, configuration issue, cache issues etc.

I will open the respective metals PR as soon (or if at all) this is ready for merge.