### PR TITLE
fix: limit the amount of logs that launcher keeps in memory

### DIFF
--- a/launcher-test/src/test/scala/bloop/launcher/BspBridgeSpec.scala
+++ b/launcher-test/src/test/scala/bloop/launcher/BspBridgeSpec.scala
@@ -1,0 +1,26 @@
+package bloop.launcher
+
+import java.io.PrintStream
+
+import bloop.launcher.bsp.BspBridge
+import bloop.testing.BaseSuite
+
+object BspBridgeSpec extends BaseSuite {
+
+  test("logs-recording") {
+    val recorder = BspBridge.LogsRecordingStream(maxLines = 3)
+    val printStream = new PrintStream(recorder)
+    (0 to 10).foreach(i => printStream.println(i))
+    printStream.print("last")
+
+    assertEquals(
+      recorder.logs.toList,
+      List(
+        "8",
+        "9",
+        "10",
+        "last"
+      )
+    )
+  }
+}


### PR DESCRIPTION
I'm noticed that this outputStream might produce an unhandled OOM error when it used from Metals (~80MB in memory).
Can be reproduced on long running session with a lot of diagnostics.