### PR TITLE
Add sbt-vspp for publishing the BLOOP SBT plug-in in a Maven-consistent format

### DIFF
--- a/docs/build-tools/sbt.md
+++ b/docs/build-tools/sbt.md
@@ -21,6 +21,11 @@ Install bloop by adding the following line to your `project/plugins.sbt`:
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "@VERSION@")
 ```
 
+If this does not work due to using an internal Artifactory, use instead:
+```sbt
+libraryDependencies += "ch.epfl.scala" % "sbt-bloop_2.12_1.0" % "@VERSION@"
+```
+
 After that, start up sbt or reload your sbt shell to load the plugin.
 
 ## Export your build

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -18,6 +18,7 @@ val `bloop-build` = project
     addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.6.0"),
     addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0"),
     addSbtPlugin("ohnosequences" % "sbt-github-release" % "0.7.0"),
+    addSbtPlugin("com.scalawilliam.esbeetee" % "sbt-vspp" % "0.4.11"),
     addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4"),
     addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0"),
     addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.3"),


### PR DESCRIPTION
This is to enable usage of Bloop/Metals in Enterprise environments where only the valid-POM format is accepted for JAR downloads (meaning most SBT plug-ins don't work -- currently making Scala unusable from VS Code at organizations with stricter security policies), for thousands of developers.

--

How this is tested locally:

`publishM2`, then in the target project that uses sbt-bloop, in its `project/metals.sbt` add, e.g.:

```
libraryDependencies += "ch.epfl.scala" % "sbt-bloop_2.12_1.0" % "1.5.2-13-15ded987-20220726-1436"
// only needed if published to local .m2 via publishM2
resolvers += Resolver.mavenLocal
```

More background here - https://github.com/esbeetee/sbt-vspp - more than happy to hop on a video call to discuss - as I appreciate that this is a non-issue for those that have a direct connection to Maven Central.