### PR TITLE
Support scala android plugin on Gradle

### DIFF
--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/BloopInstallTask.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/tasks/BloopInstallTask.scala
@@ -44,7 +44,7 @@ class BloopInstallTask extends DefaultTask with PluginUtils with TaskLogging {
 
   def runBloopPlugin(): Unit = {
     val parameters = extension.createParameters
-    val converter = new BloopConverter(parameters, info)
+    val converter = new BloopConverter(parameters)
     val targetDir: File = parameters.targetDir
     info(s"Generating Bloop configuration to ${targetDir.getAbsolutePath}")
 
@@ -97,7 +97,7 @@ object ScalaJavaInstall {
     val targetFile = targetDir / s"$projectName.json"
     // Let's keep the error message as similar to the one in the sbt plugin as possible
     info(s"Generated ${targetFile.getAbsolutePath}")
-    converter.toBloopConfig(projectName, project, sourceSet, targetDir) match {
+    converter.toBloopConfig(project, sourceSet, targetDir) match {
       case Failure(reason) =>
         info(s"Skipping ${project.getName}/${sourceSet.getName} because: $reason")
       case Success(bloopConfig) =>


### PR DESCRIPTION
Currently any Gradle Android projects only get a `java` section not a `scala` section in the Bloop json exports because there's no real link between the Android sourcesets and java/scala sourcesets so the `ScalaCompile` info is just floating about.

This PR assumes that if the project has `ScalaCompile` applied to it then that info should be exported.

So https://github.com/dsvdsv/scala-android-plugin is now supported.  It looks dead as it doesn't support later versions of Gradle or Android, but why not.
I've left the test for it commented out as the `GradleRunner` seems to apply plugins in a different order than real-life Gradle so the test fails on configuration.  Testing this on a local `build.gradle` file appears to work.

Hopefully this should solve https://github.com/scalameta/metals/issues/4036