### PR TITLE
Improve `test` BSP service

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -722,8 +722,8 @@ final class BloopBspServices(
                 Task.sequence(mappings.map { case (_, p) => test(p, state) })
 
               sequentialTestExecution.materialize.map {
-                case Success(testRunss) =>
-                  testRunss.reduceOption(_ ++ _) match {
+                case Success(testRunsSeq) =>
+                  testRunsSeq.reduceOption(_ ++ _) match {
                     case None =>
                       (newState, Right(bsp.TestResult(originId, bsp.StatusCode.Ok, None, None)))
                     case Some(testRuns) =>

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -24,8 +24,14 @@ import ch.epfl.scala.bsp.CompileResult
 import ch.epfl.scala.bsp.StatusCode
 import ch.epfl.scala.bsp.Uri
 import ch.epfl.scala.bsp.endpoints
+import ch.epfl.scala.bsp.CompileResult
+import ch.epfl.scala.bsp.MessageType
 import ch.epfl.scala.bsp.SbtBuildTarget.encodeSbtBuildTarget
 import ch.epfl.scala.bsp.ScalaBuildTarget.encodeScalaBuildTarget
+import ch.epfl.scala.bsp.ShowMessageParams
+import ch.epfl.scala.bsp.StatusCode
+import ch.epfl.scala.bsp.Uri
+import ch.epfl.scala.bsp.endpoints
 import ch.epfl.scala.debugadapter.DebugServer
 import ch.epfl.scala.debugadapter.DebuggeeRunner
 

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -371,7 +371,7 @@ object Interpreter {
             handler,
             cmd.parallel,
             RunMode.Normal
-          )
+          ).map(testRuns => state.mergeStatus(testRuns.status))
         }
       }
 

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -362,16 +362,18 @@ object Interpreter {
 
           val handler = new LoggingEventHandler(state.logger)
 
-          Tasks.test(
-            state,
-            projectsToTest,
-            cmd.args,
-            testFilter,
-            ScalaTestSuites.empty,
-            handler,
-            cmd.parallel,
-            RunMode.Normal
-          ).map(testRuns => state.mergeStatus(testRuns.status))
+          Tasks
+            .test(
+              state,
+              projectsToTest,
+              cmd.args,
+              testFilter,
+              ScalaTestSuites.empty,
+              handler,
+              cmd.parallel,
+              RunMode.Normal
+            )
+            .map(testRuns => state.mergeStatus(testRuns.status))
         }
       }
 

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -131,6 +131,8 @@ object Tasks {
   ): Task[TestRuns] = {
 
     val testTasks = projectsToTest.map { project =>
+      // note: mutable state here, to collect all `TestSuiteEvent.Results` produced while running tests
+      // it should be fine, since it's scoped to this particular evaluation of `TestTask.runTestSuites`
       val resultsBuilder = List.newBuilder[TestSuiteEvent.Results]
       val handleAndStore = new LoggingEventHandler(state.logger) {
         override def report(): Unit = testEventHandler.report()

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -144,7 +144,17 @@ object Tasks {
       }
 
       val cwd = project.workingDirectory
-      TestTask.runTestSuites(state, project, cwd, userTestOptions, testFilter, testClasses, handleAndStore, mode)
+      TestTask
+        .runTestSuites(
+          state,
+          project,
+          cwd,
+          userTestOptions,
+          testFilter,
+          testClasses,
+          handleAndStore,
+          mode
+        )
         .map { exitCode => TestRun(project, exitCode, resultsBuilder.result()) }
     }
 

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -93,6 +93,22 @@ object Tasks {
     state
   }
 
+  case class TestRun(project: Project, exitCode: Int, results: List[TestSuiteEvent.Results]) {
+    def testsFailed: Boolean =
+      results.exists(_.events.exists(e => TestFailedStatus.contains(e.status())))
+    def processFailed: Boolean =
+      exitCode != 0
+    def failed: Option[ExitStatus] =
+      if (processFailed || testsFailed) Some(ExitStatus.TestExecutionError) else None
+  }
+
+  case class TestRuns(runs: List[TestRun]) {
+    def ++(other: TestRuns): TestRuns =
+      TestRuns(runs ++ other.runs)
+    def status: ExitStatus =
+      runs.view.flatMap(_.failed).headOption.getOrElse(ExitStatus.Ok)
+  }
+
   /**
    * Run the tests for all projects in `projectsToTest`.
    *
@@ -112,53 +128,33 @@ object Tasks {
       testEventHandler: BloopTestSuiteEventHandler,
       runInParallel: Boolean = false,
       mode: RunMode
-  ): Task[State] = {
-    import state.logger
-    implicit val logContext: DebugFilter = DebugFilter.Test
+  ): Task[TestRuns] = {
 
-    var failure = false
     val testTasks = projectsToTest.map { project =>
-      /* Intercept test failures to set the correct error code */
-      val failureHandler = new LoggingEventHandler(state.logger) {
+      val resultsBuilder = List.newBuilder[TestSuiteEvent.Results]
+      val handleAndStore = new LoggingEventHandler(state.logger) {
         override def report(): Unit = testEventHandler.report()
         override def handle(event: TestSuiteEvent): Unit = {
           testEventHandler.handle(event)
           event match {
-            case TestSuiteEvent.Results(_, ev)
-                if ev.exists(e => TestFailedStatus.contains(e.status())) =>
-              failure = true
+            case x: TestSuiteEvent.Results => resultsBuilder += x
             case _ => ()
           }
         }
       }
 
       val cwd = project.workingDirectory
-      TestTask.runTestSuites(
-        state,
-        project,
-        cwd,
-        userTestOptions,
-        testFilter,
-        testClasses,
-        failureHandler,
-        mode
-      )
+      TestTask.runTestSuites(state, project, cwd, userTestOptions, testFilter, testClasses, handleAndStore, mode)
+        .map { exitCode => TestRun(project, exitCode, resultsBuilder.result()) }
     }
 
-    val runAll: List[Task[Int]] => Task[List[Int]] =
-      if (runInParallel) {
-        Task.gather
-      } else {
-        Task.sequence
-      }
+    def runAll[A]: List[Task[A]] => Task[List[A]] =
+      if (runInParallel) Task.gather else Task.sequence
 
-    runAll(testTasks).map { exitCodes =>
+    runAll(testTasks).map { testRuns =>
       // When the test execution is over report no matter what the result is
       testEventHandler.report()
-      logger.debug(s"Test suites failed: $failure")
-      val isOk = !failure && exitCodes.forall(_ == 0)
-      if (isOk) state.mergeStatus(ExitStatus.Ok)
-      else state.copy(status = ExitStatus.TestExecutionError)
+      TestRuns(testRuns)
     }
   }
 

--- a/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
@@ -199,6 +199,52 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
       }
     }
 
+    def testTask(
+        project: TestProject,
+        originId: Option[String] = None,
+        arguments: Option[List[String]] = None,
+        dataKind: Option[String] = None,
+        data: Option[Json] = None,
+        clearDiagnostics: Boolean = true
+    ): Task[ManagedBspTestState] = {
+      runAfterTargets(project) { target =>
+        // Handle internal state before sending test request
+        if (clearDiagnostics) diagnostics.clear()
+        currentCompileIteration.increment(1)
+        val params = bsp.TestParams(List(target), originId, arguments, dataKind, data)
+
+        BuildTarget.test.request(params).flatMap {
+          case Right(r) =>
+            // `headL` returns latest saved state from bsp because source is behavior subject
+            serverStates.headL.map { state =>
+              new ManagedBspTestState(
+                state,
+                r.statusCode,
+                currentCompileIteration,
+                diagnostics,
+                client0,
+                serverStates
+              )
+            }
+          case Left(e) => fail(s"Compilation error for request ${e.id}:\n${e.error}")
+        }
+      }
+    }
+
+    def test(
+        project: TestProject,
+        originId: Option[String] = None,
+        arguments: Option[List[String]] = None,
+        dataKind: Option[String] = None,
+        data: Option[Json] = None,
+        clearDiagnostics: Boolean = true,
+        timeout: Long = 5
+    ): ManagedBspTestState = {
+      val task = testTask(project, originId, arguments, dataKind, data, clearDiagnostics)
+
+      TestUtil.await(FiniteDuration(timeout, "s"))(task)
+    }
+
     def cleanTask(project: TestProject): Task[ManagedBspTestState] = {
       runAfterTargets(project) { target =>
         rpcRequest(BuildTarget.cleanCache, bsp.CleanCacheParams(List(target))).flatMap { r =>

--- a/frontend/src/test/scala/bloop/bsp/BspTestSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspTestSpec.scala
@@ -1,0 +1,59 @@
+package bloop.bsp
+
+import bloop.cli.BspProtocol
+import bloop.cli.ExitStatus
+import bloop.io.AbsolutePath
+import bloop.logging.RecordingLogger
+import bloop.util.TestProject
+import bloop.util.TestUtil
+
+object TcpBspTestSpec extends BspTestSpec(BspProtocol.Tcp)
+object LocalBspTestSpec extends BspTestSpec(BspProtocol.Local)
+
+class BspTestSpec(override val protocol: BspProtocol) extends BspBaseSuite {
+
+  val junitJars = System
+    .getProperty("java.class.path")
+    .split(java.io.File.pathSeparator)
+    .collect { case path if path.contains("junit") => AbsolutePath(path) }
+
+  test("bsp test succeeds") {
+    TestUtil.withinWorkspace { workspace =>
+      val sources = List(
+        """/main/scala/FooTest.scala
+          |class FooTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(true)
+          |}
+          """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+
+      val A = TestProject(workspace, "a", sources, jars = junitJars)
+      loadBspState(workspace, List(A), logger) { state =>
+        val testResult: ManagedBspTestState = state.test(A)
+        assertExitStatus(testResult, ExitStatus.Ok)
+      }
+    }
+  }
+
+  test("bsp test fails") {
+    TestUtil.withinWorkspace { workspace =>
+      val sources = List(
+        """/main/scala/FooTest.scala
+          |class FooTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.fail()
+          |}
+          """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+
+      val A = TestProject(workspace, "a", sources, jars = junitJars)
+      loadBspState(workspace, List(A), logger) { state =>
+        val testResult: ManagedBspTestState = state.test(A)
+        assertExitStatus(testResult, ExitStatus.TestExecutionError)
+      }
+    }
+  }
+}

--- a/frontend/src/test/scala/bloop/bsp/BspTestSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspTestSpec.scala
@@ -6,16 +6,16 @@ import bloop.io.AbsolutePath
 import bloop.logging.RecordingLogger
 import bloop.util.TestProject
 import bloop.util.TestUtil
+import bloop.internal.build.BuildTestInfo
+import bloop.ScalaInstance
 
 object TcpBspTestSpec extends BspTestSpec(BspProtocol.Tcp)
 object LocalBspTestSpec extends BspTestSpec(BspProtocol.Local)
 
 class BspTestSpec(override val protocol: BspProtocol) extends BspBaseSuite {
 
-  val junitJars = System
-    .getProperty("java.class.path")
-    .split(java.io.File.pathSeparator)
-    .collect { case path if path.contains("junit") => AbsolutePath(path) }
+  val junitJars = BuildTestInfo.junitTestJars.map(AbsolutePath.apply)
+  private val scalaVersion = "2.12.15"
 
   test("bsp test succeeds") {
     TestUtil.withinWorkspace { workspace =>
@@ -29,9 +29,16 @@ class BspTestSpec(override val protocol: BspProtocol) extends BspBaseSuite {
 
       val logger = new RecordingLogger(ansiCodesSupported = false)
 
-      val A = TestProject(workspace, "a", sources, jars = junitJars)
+      val compilerJars = ScalaInstance
+        .resolve("org.scala-lang", "scala-compiler", scalaVersion, logger)
+        .allJars
+        .map(AbsolutePath.apply)
+
+      val A =
+        TestProject(workspace, "a", sources, enableTests = true, jars = compilerJars ++ junitJars)
       loadBspState(workspace, List(A), logger) { state =>
-        val testResult: ManagedBspTestState = state.test(A)
+        val compiled = state.compile(A)
+        val testResult = compiled.toTestState.test(A)
         assertExitStatus(testResult, ExitStatus.Ok)
       }
     }
@@ -40,18 +47,26 @@ class BspTestSpec(override val protocol: BspProtocol) extends BspBaseSuite {
   test("bsp test fails") {
     TestUtil.withinWorkspace { workspace =>
       val sources = List(
-        """/main/scala/FooTest.scala
+        """/FooTest.scala
           |class FooTest {
-          |  @org.junit.Test def foo(): Unit = org.junit.Assert.fail()
+          |  @org.junit.Test def foo(): Unit = {
+          |    org.junit.Assert.fail()
+          |  }
           |}
           """.stripMargin
       )
 
       val logger = new RecordingLogger(ansiCodesSupported = false)
+      val compilerJars = ScalaInstance
+        .resolve("org.scala-lang", "scala-compiler", scalaVersion, logger)
+        .allJars
+        .map(AbsolutePath.apply)
 
-      val A = TestProject(workspace, "a", sources, jars = junitJars)
+      val A =
+        TestProject(workspace, "a", sources, enableTests = true, jars = compilerJars ++ junitJars)
       loadBspState(workspace, List(A), logger) { state =>
-        val testResult: ManagedBspTestState = state.test(A)
+        val compiled = state.compile(A)
+        val testResult = compiled.toTestState.test(A)
         assertExitStatus(testResult, ExitStatus.TestExecutionError)
       }
     }


### PR DESCRIPTION
- add `TestRun` and `TestRuns` structures to aggregate all produced `TestSuiteEvent.Results`.
- propagate all test results back up to service
- use test results to return `bsp.StatusCode.Error` on failed tests (Fixing #960)
- ensure that the compilation before test finished with `StatusCode.Ok`