### PR TITLE
Upgrade sbt-librarymanagement to 1.1.5 due to CVEs in its 1.0.x tree.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
 
   val scalazVersion = "7.2.20"
   val scalaXmlVersion = "1.2.0"
-  val lmVersion = "1.0.0"
+  val lmVersion = "1.1.5"
   val configDirsVersion = "26"
   val caseAppVersion = "2.0.6"
   val sourcecodeVersion = "0.1.4"


### PR DESCRIPTION
Thank you so much for your help with #1766 - the plug-in is now usable in enterprise!

However one of the dependencies did not pass the screening for CVEs - under bloop-backend there is sbt-librarymanagement 1.0.0 (see here for CVE info -- https://mvnrepository.com/artifact/org.scala-sbt/librarymanagement-core_2.12/1.0.0 ). For an upgrade path, I checked 1.0.4 which is the highest in 1.0.x, but its dependency on jsch still has a CVE, so the next one up without dependent CVEs would be a 1.1.x series, of which 1.1.5 is the highest. The latest available overall is 1.7.0 but I imagine depending on that could potentially cause some breakages if e.g. we're using Bloop from SBT 1.4.x and using a librarymanagement from 1.7.x.

![image](https://user-images.githubusercontent.com/2464813/182023701-8be1c648-f9af-4bf1-820a-1a03df226a2f.png)

I was also wondering if the dep should aso be set as `% "provided"` as I'd expect it to be provided by SBT anyway.