### PR TITLE
Add support for source generators in Bloop

### DIFF
--- a/config/src/main/scala-2.10/bloop/config/ConfigCodecs.scala
+++ b/config/src/main/scala-2.10/bloop/config/ConfigCodecs.scala
@@ -218,6 +218,9 @@ object ConfigCodecs {
   implicit val sourcesGlobsEncoder: ObjectEncoder[SourcesGlobs] = deriveEncoder
   implicit val sourcesGlobsDecoder: Decoder[SourcesGlobs] = deriveDecoder
 
+  implicit val sourceGeneratorEncoder: ObjectEncoder[SourceGenerator] = deriveEncoder
+  implicit val sourceGeneratorDecoder: Decoder[SourceGenerator] = deriveDecoder
+
   implicit val projectEncoder: ObjectEncoder[Project] = deriveEncoder
   implicit val projectDecoder: Decoder[Project] = deriveDecoder
 

--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -236,6 +236,12 @@ object Config {
       excludes: List[String]
   )
 
+  case class SourceGenerator(
+      sourcesGlobs: List[SourcesGlobs],
+      outputDirectory: Path,
+      argv: List[String]
+  )
+
   case class Project(
       name: String,
       directory: Path,
@@ -254,12 +260,13 @@ object Config {
       test: Option[Test],
       platform: Option[Platform],
       resolution: Option[Resolution],
-      tags: Option[List[String]]
+      tags: Option[List[String]],
+      sourceGenerators: Option[List[SourceGenerator]]
   )
 
   object Project {
     // FORMAT: OFF
-    private[bloop] val empty: Project = Project("", emptyPath, None, List(), None, None, List(), List(),  emptyPath, emptyPath, None, None, None, None, None, None, None, None)
+    private[bloop] val empty: Project = Project("", emptyPath, None, List(), None, None, List(), List(),  emptyPath, emptyPath, None, None, None, None, None, None, None, None, None)
     // FORMAT: ON
 
     def analysisFileName(projectName: String): String = s"$projectName-analysis.bin"
@@ -328,6 +335,7 @@ object Config {
         Some(Test(List(), TestOptions(Nil, Nil))),
         Some(platform),
         Some(Resolution(Nil)),
+        None,
         None
       )
 

--- a/config/src/main/scala/bloop/config/Config.scala
+++ b/config/src/main/scala/bloop/config/Config.scala
@@ -239,7 +239,7 @@ object Config {
   case class SourceGenerator(
       sourcesGlobs: List[SourcesGlobs],
       outputDirectory: Path,
-      argv: List[String]
+      command: List[String]
   )
 
   case class Project(

--- a/docs/assets/bloop-schema.json
+++ b/docs/assets/bloop-schema.json
@@ -4,6 +4,44 @@
   "title": "Bloop configuration file ",
   "description": "The JSON Schema for the bloop configuration file.",
   "definitions": {
+    "sourcesGlobs": {
+      "$id": "/properties/project/properties/sourcesGlobs",
+      "type": "object",
+      "properties": {
+        "directory": {
+          "$id": "/properties/project/properties/sourcesGlobs/properties/directory",
+          "title": "The Directory Schema",
+          "type": "string",
+          "examples": [
+            "/home/code/src"
+          ]
+        },
+        "walkDepth": {
+          "$id": "/properties/project/properties/sourcesGlobs/properties/walkDepth",
+          "title": "The WalkDepth Schema",
+          "type": "number",
+          "examples": [
+            1
+          ]
+        },
+        "includes": {
+          "$id": "/properties/project/properties/sourcesGlobs/properties/includes",
+          "title": "The Includes Schema",
+          "type": "string",
+          "examples": [
+            "glob:*.scala"
+          ]
+        },
+        "excludes": {
+          "$id": "/properties/project/properties/sourcesGlobs/properties/excludes",
+          "title": "The Excludes Schema",
+          "type": "string",
+          "examples": [
+            "glob:*Test.scala"
+          ]
+        }
+      }
+    },
     "jvmPlatform": {
       "$id": "/properties/project/properties/jvmPlatform",
       "type": "object",
@@ -372,6 +410,13 @@
             ]
           }
         },
+        "sourcesGlobs": {
+          "$id": "/properties/project/properties/sourcesGlobs",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/sourcesGlobs"
+          }
+        },
         "dependencies": {
           "$id": "/properties/project/properties/dependencies",
           "type": "array",
@@ -654,6 +699,42 @@
               "test",
               "library"
             ]
+          }
+        }
+      },
+      "sourceGenerators": {
+        "$id": "/properties/project/properties/sourceGenerators",
+        "type": "array",
+        "title": "The SourceGenerators Schema",
+        "description": "The source generators used by this project",
+        "items": {
+          "$id": "/properties/project/properties/sourceGenerators/items",
+          "type": "object",
+          "properties": {
+            "sourcesGlobs": {
+              "$id": "/properties/project/properties/sourceGenerators/properties/sourcesGlobs",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/sourcesGlobs"
+              }
+            },
+            "outputDirectory": {
+              "$id": "/properties/project/properties/sourceGenerators/properties/outputDirectory",
+              "type": "string",
+              "examples": [
+                "/home/code/generated-sources"
+              ]
+            },
+            "argv": {
+              "$id": "/properties/project/properties/sourceGenerators/properties/argv",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "examples": [
+                ["/bin/my-generator.sh", "arg0", "arg1"]
+              ]
+            }
           }
         }
       }

--- a/docs/assets/bloop-schema.json
+++ b/docs/assets/bloop-schema.json
@@ -725,8 +725,8 @@
                 "/home/code/generated-sources"
               ]
             },
-            "argv": {
-              "$id": "/properties/project/properties/sourceGenerators/properties/argv",
+            "command": {
+              "$id": "/properties/project/properties/sourceGenerators/properties/command",
               "type": "array",
               "items": {
                 "type": "string"

--- a/frontend/src/it/scala/bloop/CommunityBuild.scala
+++ b/frontend/src/it/scala/bloop/CommunityBuild.scala
@@ -21,7 +21,7 @@ import bloop.engine.{
   Run,
   State
 }
-import bloop.engine.caches.ResultsCache
+import bloop.engine.caches.{ResultsCache, SourceGeneratorCache}
 import bloop.io.AbsolutePath
 import bloop.logging.{BloopLogger, Logger, NoopLogger}
 import bloop.task.Task
@@ -95,7 +95,7 @@ abstract class CommunityBuild(val buildpressHomeDir: AbsolutePath) {
     val loadedProjects = BuildLoader.loadSynchronously(configDirectory, logger)
     val workspaceSettings = WorkspaceSettings.readFromFile(configDirectory, logger)
     val build = Build(configDirectory, loadedProjects, workspaceSettings)
-    val state = State.forTests(build, compilerCache, logger)
+    val state = State.forTests(build, compilerCache, SourceGeneratorCache.empty, logger)
     state.copy(results = ResultsCache.emptyForTests)
   }
 
@@ -139,6 +139,7 @@ abstract class CommunityBuild(val buildpressHomeDir: AbsolutePath) {
         sources = Nil,
         sourcesGlobs = Nil,
         sourceRoots = None,
+        sourceGenerators = Nil,
         testFrameworks = Nil,
         testOptions = Config.TestOptions.empty,
         out = dummyClassesDir,

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -1089,7 +1089,9 @@ final class BloopBspServices(
             .sequence {
               parentGenerators.reverse.map { project =>
                 val generators = project.sourceGenerators
-                val tasks = generators.map(state.sourceGeneratorCache.update(_, state.logger))
+                val tasks = generators.map(
+                  state.sourceGeneratorCache.update(_, state.logger, state.commonOptions)
+                )
                 Task.gatherUnordered(tasks)
               }
             }

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -359,10 +359,11 @@ object Project {
     val sourceRoots = project.sourceRoots.map(_.map(AbsolutePath.apply))
 
     val tags = project.tags.getOrElse(Nil)
+    val projectDirectory = AbsolutePath(project.directory)
 
     Project(
       project.name,
-      AbsolutePath(project.directory),
+      projectDirectory,
       project.workspaceDir.map(AbsolutePath.apply),
       project.dependencies,
       instance,
@@ -375,7 +376,7 @@ object Project {
       project.sources.map(AbsolutePath.apply),
       SourcesGlobs.fromConfig(project, logger),
       sourceRoots,
-      project.sourceGenerators.getOrElse(Nil).map(SourceGenerator.fromConfig),
+      project.sourceGenerators.getOrElse(Nil).map(SourceGenerator.fromConfig(projectDirectory, _)),
       project.test.map(_.frameworks).getOrElse(Nil),
       project.test.map(_.options).getOrElse(Config.TestOptions.empty),
       AbsolutePath(project.out),

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -121,8 +121,8 @@ object Interpreter {
     val projectsSourcesAndDirs = reachable.map { project =>
       for {
         unmanaged <- project.allUnmanagedSourceFilesAndDirectories
-        generatorInputs <- project.allGeneratorInputs
-      } yield unmanaged ++ generatorInputs
+        generatorSourceDirs = project.sourceGenerators.flatMap(_.sourcesGlobs.map(_.directory))
+      } yield unmanaged ++ generatorSourceDirs
     }
     val groupTasks =
       projectsSourcesAndDirs.grouped(8).map(group => Task.gatherUnordered(group)).toList

--- a/frontend/src/main/scala/bloop/engine/SourceGenerator.scala
+++ b/frontend/src/main/scala/bloop/engine/SourceGenerator.scala
@@ -1,0 +1,144 @@
+package bloop.engine
+
+import java.nio.file.FileSystems
+
+import scala.collection.mutable
+import scala.sys.process._
+import scala.util.control.NoStackTrace
+
+import bloop.config.Config
+import bloop.data.SourcesGlobs
+import bloop.io.AbsolutePath
+import bloop.io.ByteHasher
+import bloop.io.Paths
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+import bloop.task.Task
+
+final case class SourceGenerator(
+    sourcesGlobs: List[SourcesGlobs],
+    outputDirectory: AbsolutePath,
+    argv: List[String]
+) {
+
+  /**
+   * Run this source generator if needed.
+   *
+   * If the inputs and outputs of this generator are unchanged, then this is a no-op.
+   *
+   * @param previous The previous known state of this source generator.
+   * @param logger The logger to report source generator messages.
+   * @return The new known inpouts and outputs of this source generator.
+   */
+  def update(previous: SourceGenerator.Run, logger: Logger): Task[SourceGenerator.Run] =
+    needsUpdate(previous).flatMap {
+      case SourceGenerator.NoChanges =>
+        Task.now(previous)
+      case SourceGenerator.InputChanges(newInputs) =>
+        logger.debug("Changes detected to inputs of source generator")(DebugFilter.Compilation)
+        run(newInputs, logger)
+      case SourceGenerator.OutputChanges(inputs) =>
+        logger.debug("Changes detected to outputs of source generator")(DebugFilter.Compilation)
+        run(inputs, logger)
+    }
+
+  /**
+   * The list of sources that this source generator consumes.
+   *
+   * @return The list of sources that this source generator consumes.
+   */
+  def getSources: Task[List[AbsolutePath]] = Task {
+    val buf = mutable.ListBuffer.empty[AbsolutePath]
+    for (glob <- sourcesGlobs) glob.walkThrough(buf += _)
+    buf.result()
+  }
+
+  private def run(inputs: Map[AbsolutePath, Int], logger: Logger): Task[SourceGenerator.Run] = {
+    Task {
+      val command = (argv :+ outputDirectory.syntax) ++ inputs.keys.map(_.syntax)
+      logger.debug { () =>
+        command.mkString(s"Running source generator:${System.lineSeparator()}$$ ", " ", "")
+      }
+      command.!(processLogger(logger))
+    }.flatMap {
+      case 0 =>
+        hashOutputs.map(SourceGenerator.PreviousRun(inputs, _))
+      case exitCode =>
+        Task.raiseError(new SourceGenerator.SourceGeneratorException(exitCode))
+    }
+  }
+
+  private def needsUpdate(previous: SourceGenerator.Run): Task[SourceGenerator.Changes] = {
+    previous match {
+      case SourceGenerator.NoRun =>
+        hashInputs.map(SourceGenerator.InputChanges(_))
+      case SourceGenerator.PreviousRun(inputs, outputs) =>
+        hashInputs.flatMap { newInputs =>
+          if (newInputs != inputs) Task.now(SourceGenerator.InputChanges(newInputs))
+          else {
+            hashOutputs.map { newOutputs =>
+              if (newOutputs != outputs) SourceGenerator.OutputChanges(newInputs)
+              else SourceGenerator.NoChanges
+            }
+          }
+        }
+    }
+  }
+
+  private def hashInputs: Task[Map[AbsolutePath, Int]] = {
+    for (inputs <- getSources) yield hashFiles(inputs)
+  }
+
+  private def hashOutputs: Task[Map[AbsolutePath, Int]] = Task {
+    val outputs = Paths.pathFilesUnder(outputDirectory, "glob:**")
+    hashFiles(outputs)
+  }
+
+  private def hashFiles(files: List[AbsolutePath]): Map[AbsolutePath, Int] =
+    files.map(f => f -> ByteHasher.hashFileContents(f.toFile)).toMap
+
+  private def processLogger(logger: Logger): ProcessLogger = {
+    new ProcessLogger() {
+      override def out(s: => String): Unit = logger.debug(s)(DebugFilter.Compilation)
+      override def err(s: => String): Unit = logger.error(s)
+      override def buffer[T](f: => T): T = f
+    }
+  }
+}
+
+object SourceGenerator {
+
+  sealed trait Run
+  case object NoRun extends Run
+  case class PreviousRun(knownInputs: Map[AbsolutePath, Int], knownOutputs: Map[AbsolutePath, Int])
+      extends Run
+
+  private sealed trait Changes
+  private case object NoChanges extends Changes
+  private case class InputChanges(newInputs: Map[AbsolutePath, Int]) extends Changes
+  private case class OutputChanges(inputs: Map[AbsolutePath, Int]) extends Changes
+
+  def fromConfig(generator: Config.SourceGenerator): SourceGenerator = {
+    val sourcesGlobs = generator.sourcesGlobs.map {
+      case Config.SourcesGlobs(directory, depth, includes, excludes) =>
+        val fs = FileSystems.getDefault
+        val includeMatcher = includes.map(fs.getPathMatcher)
+        val excludeMatcher = excludes.map(fs.getPathMatcher)
+        SourcesGlobs(
+          AbsolutePath(directory),
+          depth.getOrElse(Int.MaxValue),
+          includeMatcher,
+          excludeMatcher
+        )
+    }
+    new SourceGenerator(
+      sourcesGlobs,
+      AbsolutePath(generator.outputDirectory),
+      generator.argv
+    )
+  }
+
+  class SourceGeneratorException(exitCode: Int)
+      extends RuntimeException(s"Source generator failed (non-zero exit code: $exitCode).")
+      with NoStackTrace
+}

--- a/frontend/src/main/scala/bloop/engine/SourceGenerator.scala
+++ b/frontend/src/main/scala/bloop/engine/SourceGenerator.scala
@@ -20,7 +20,7 @@ final case class SourceGenerator(
     cwd: AbsolutePath,
     sourcesGlobs: List[SourcesGlobs],
     outputDirectory: AbsolutePath,
-    argv: List[String]
+    command: List[String]
 ) {
 
   /**
@@ -64,12 +64,12 @@ final case class SourceGenerator(
       logger: Logger,
       opts: CommonOptions
   ): Task[SourceGenerator.Run] = {
-    val command = (argv :+ outputDirectory.syntax) ++ inputs.keys.map(_.syntax)
+    val cmd = (command :+ outputDirectory.syntax) ++ inputs.keys.map(_.syntax)
     logger.debug { () =>
-      command.mkString(s"Running source generator:${System.lineSeparator()}$$ ", " ", "")
+      cmd.mkString(s"Running source generator:${System.lineSeparator()}$$ ", " ", "")
     }
 
-    Forker.run(cwd, command, logger, opts).flatMap {
+    Forker.run(cwd, cmd, logger, opts).flatMap {
       case 0 =>
         hashOutputs.map(SourceGenerator.PreviousRun(inputs, _))
       case exitCode =>
@@ -136,7 +136,7 @@ object SourceGenerator {
       cwd,
       sourcesGlobs,
       AbsolutePath(generator.outputDirectory),
-      generator.argv
+      generator.command
     )
   }
 

--- a/frontend/src/main/scala/bloop/engine/caches/SourceGeneratorCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/SourceGeneratorCache.scala
@@ -1,0 +1,28 @@
+package bloop.engine.caches
+
+import java.util.concurrent.ConcurrentHashMap
+
+import bloop.engine.SourceGenerator
+import bloop.io.AbsolutePath
+import bloop.logging.Logger
+import bloop.task.Task
+
+final class SourceGeneratorCache private (
+    cache: ConcurrentHashMap[SourceGenerator, SourceGenerator.Run]
+) {
+  def update(sourceGenerator: SourceGenerator, logger: Logger): Task[List[AbsolutePath]] = {
+    val previous = getStateFor(sourceGenerator)
+    sourceGenerator.update(previous, logger).map {
+      case SourceGenerator.NoRun => Nil
+      case SourceGenerator.PreviousRun(_, outputs) => outputs.keys.toList.sortBy(_.syntax)
+    }
+  }
+
+  private def getStateFor(sourceGenerator: SourceGenerator): SourceGenerator.Run = {
+    Option(cache.get(sourceGenerator)).getOrElse(SourceGenerator.NoRun)
+  }
+}
+
+object SourceGeneratorCache {
+  def empty: SourceGeneratorCache = new SourceGeneratorCache(new ConcurrentHashMap())
+}

--- a/frontend/src/main/scala/bloop/engine/caches/SourceGeneratorCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/SourceGeneratorCache.scala
@@ -2,6 +2,7 @@ package bloop.engine.caches
 
 import java.util.concurrent.ConcurrentHashMap
 
+import bloop.cli.CommonOptions
 import bloop.engine.SourceGenerator
 import bloop.io.AbsolutePath
 import bloop.logging.Logger
@@ -10,9 +11,13 @@ import bloop.task.Task
 final class SourceGeneratorCache private (
     cache: ConcurrentHashMap[SourceGenerator, SourceGenerator.Run]
 ) {
-  def update(sourceGenerator: SourceGenerator, logger: Logger): Task[List[AbsolutePath]] = {
+  def update(
+      sourceGenerator: SourceGenerator,
+      logger: Logger,
+      opts: CommonOptions
+  ): Task[List[AbsolutePath]] = {
     val previous = getStateFor(sourceGenerator)
-    sourceGenerator.update(previous, logger).map {
+    sourceGenerator.update(previous, logger, opts).map {
       case SourceGenerator.NoRun => Nil
       case SourceGenerator.PreviousRun(_, outputs) => outputs.keys.toList.sortBy(_.syntax)
     }

--- a/frontend/src/main/scala/bloop/engine/caches/StateCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/StateCache.scala
@@ -40,6 +40,7 @@ final class StateCache(cache: ConcurrentHashMap[AbsolutePath, StateCache.CachedS
         cachedState.build,
         cachedState.results,
         cachedState.compilerCache,
+        cachedState.sourceGeneratorCache,
         client,
         pool,
         commonOptions,
@@ -148,12 +149,18 @@ object StateCache {
   private[StateCache] case class CachedState(
       build: Build,
       results: ResultsCache,
-      compilerCache: bloop.CompilerCache
+      compilerCache: bloop.CompilerCache,
+      sourceGeneratorCache: SourceGeneratorCache
   )
 
   private[StateCache] object CachedState {
     def fromState(state: State): CachedState = {
-      StateCache.CachedState(state.build, state.results, state.compilerCache)
+      StateCache.CachedState(
+        state.build,
+        state.results,
+        state.compilerCache,
+        state.sourceGeneratorCache
+      )
     }
   }
 

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -250,7 +250,20 @@ object CompileTask {
       val dir = state.client.getUniqueClassesDirFor(inputs.project, forceGeneration = true)
       val underlying = createReporter(ReporterInputs(inputs.project, cwd, rawLogger))
       val reporter = new ObservedReporter(logger, underlying)
-      CompileBundle.computeFrom(inputs, dir, reporter, last, prev, cancel, logger, obs, t, o)
+      val sourceGeneratorCache = state.sourceGeneratorCache
+      CompileBundle.computeFrom(
+        inputs,
+        sourceGeneratorCache,
+        dir,
+        reporter,
+        last,
+        prev,
+        cancel,
+        logger,
+        obs,
+        t,
+        o
+      )
     }
 
     val client = state.client

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
@@ -10,6 +10,7 @@ import bloop.cli.CommonOptions
 import bloop.data.Project
 import bloop.engine.Feedback
 import bloop.engine.caches.LastSuccessfulResult
+import bloop.engine.caches.SourceGeneratorCache
 import bloop.io.AbsolutePath
 import bloop.logging.DebugFilter
 import bloop.logging.Logger
@@ -150,6 +151,7 @@ object CompileBundle {
   implicit val filter: DebugFilter.Compilation.type = bloop.logging.DebugFilter.Compilation
   def computeFrom(
       inputs: CompileDefinitions.BundleInputs,
+      sourceGeneratorCache: SourceGeneratorCache,
       clientExternalClassesDir: AbsolutePath,
       reporter: ObservedReporter,
       lastSuccessful: LastSuccessfulResult,
@@ -181,7 +183,14 @@ object CompileBundle {
 
       val sourceHashesTask = tracer.traceTaskVerbose("discovering and hashing sources") { _ =>
         bloop.io.SourceHasher
-          .findAndHashSourcesInProject(project, 20, cancelCompilation, ioScheduler)
+          .findAndHashSourcesInProject(
+            project,
+            sourceGeneratorCache,
+            20,
+            cancelCompilation,
+            ioScheduler,
+            logger
+          )
           .map(res => res.map(_.sortBy(_.source.id())))
           .executeOn(ioScheduler)
       }

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
@@ -185,11 +185,10 @@ object CompileBundle {
         bloop.io.SourceHasher
           .findAndHashSourcesInProject(
             project,
-            sourceGeneratorCache,
+            sourceGeneratorCache.update(_, logger, options),
             20,
             cancelCompilation,
-            ioScheduler,
-            logger
+            ioScheduler
           )
           .map(res => res.map(_.sortBy(_.source.id())))
           .executeOn(ioScheduler)

--- a/frontend/src/test/resources/source-generator.py
+++ b/frontend/src/test/resources/source-generator.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+import os
+import shutil
+import sys
+import time
+
+is_py2 = sys.version[0] == "2"
+if is_py2:
+    def print_out(s):
+        print >> sys.stdout, s
+
+
+    def print_err(s):
+        print >> sys.stderr, s
+
+
+else:
+    def print_out(s):
+        print(s, sys.stdout)
+
+
+    def print_err(s):
+        print(s, sys.stderr)
+
+
+def main(output_dir, args):
+    shutil.rmtree(output_dir, ignore_errors=True)
+    os.makedirs(output_dir)
+
+    arg_length = len(args)
+
+    buf = []
+    buf.append("package generated")
+    buf.append("// generated at %f" % time.time())
+    buf.append("object NameLengths {")
+    buf.append("  val args_%d = %d" % (arg_length, arg_length))
+    buf.append("  val nameLengths: Map[String, Int] = Map(")
+    for input_file in args:
+        file_size = os.path.getsize(input_file)
+        buf.append('    "%s" -> %d,' % (input_file.replace('\\', '/'), file_size))
+    buf.append("  )")
+    buf.append("}")
+
+    with open("%s/NameLengths_%d.scala" % (output_dir, arg_length), "w") as f:
+        f.write("\n".join(buf))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print_err("Needs at least one argument.")
+        sys.exit(1)
+    elif "fail_now" in sys.argv:
+        print_err("Test failure.")
+        sys.exit(1)
+    else:
+        output_directory = sys.argv[1]
+        args = sys.argv[2:]
+        main(output_directory, args)
+

--- a/frontend/src/test/scala/bloop/DagSpec.scala
+++ b/frontend/src/test/scala/bloop/DagSpec.scala
@@ -28,7 +28,7 @@ class DagSpec {
   def dummyOrigin: Origin = TestUtil.syntheticOriginFor(dummyPath)
   def dummyProject(name: String, dependencies: List[String]): Project =
     Project(name, dummyPath, None, dependencies, Some(dummyInstance), Nil, Nil, compileOptions,
-      dummyPath, Nil, Nil, Nil, Nil, None, Nil, Config.TestOptions.empty, dummyPath, dummyPath,
+      dummyPath, Nil, Nil, Nil, Nil, None, Nil, Nil, Config.TestOptions.empty, dummyPath, dummyPath,
       Project.defaultPlatform(logger, Nil, Nil), None, None, Nil, dummyOrigin)
   // format: ON
 

--- a/frontend/src/test/scala/bloop/FileWatchingSpec.scala
+++ b/frontend/src/test/scala/bloop/FileWatchingSpec.scala
@@ -368,7 +368,7 @@ object FileWatchingSpec extends BaseSuite {
         sourcesGlobs =
           Config.SourcesGlobs(generatorSources.underlying, None, List("glob:test.in"), Nil) :: Nil,
         outputDirectory = workspace.underlying.resolve("source-generator-output"),
-        argv = generator
+        command = generator
       )
       val `A` = TestProject(workspace, "a", List(source), sourceGenerators = List(sourceGenerator))
       val projects = List(`A`)

--- a/frontend/src/test/scala/bloop/FileWatchingSpec.scala
+++ b/frontend/src/test/scala/bloop/FileWatchingSpec.scala
@@ -10,6 +10,7 @@ import bloop.config.Config
 import bloop.data.Project
 import bloop.engine.Dag
 import bloop.engine.ExecutionContext
+import bloop.internal.build.BuildTestInfo
 import bloop.io.AbsolutePath
 import bloop.io.Environment.lineSeparator
 import bloop.logging.DebugFilter
@@ -17,6 +18,7 @@ import bloop.logging.PublisherLogger
 import bloop.logging.RecordingLogger
 import bloop.task.Task
 import bloop.testing.BaseSuite
+import bloop.util.CrossPlatform
 import bloop.util.TestProject
 import bloop.util.TestUtil
 
@@ -24,7 +26,12 @@ import monix.reactive.MulticastStrategy
 import monix.reactive.Observable
 
 object FileWatchingSpec extends BaseSuite {
+  private val generator: List[String] =
+    if (CrossPlatform.isWindows) List("python", BuildTestInfo.sampleSourceGenerator.getAbsolutePath)
+    else List(BuildTestInfo.sampleSourceGenerator.getAbsolutePath)
+
   System.setProperty("file-watcher-batch-window-ms", "100")
+
   test("simulate an incremental compiler session with file watching enabled") {
     TestUtil.withinWorkspace { workspace =>
       import ExecutionContext.ioScheduler
@@ -344,6 +351,56 @@ object FileWatchingSpec extends BaseSuite {
                 |""".stripMargin
           )
         }
+      }
+    }
+  }
+
+  test("watcher matches source generator inputs") {
+    TestUtil.withinWorkspace { workspace =>
+      import ExecutionContext.ioScheduler
+      val source =
+        """/A.scala
+          |object A { val x = generated.NameLengths.args_1 }
+          |""".stripMargin
+      val generatorSources = workspace.resolve("generator-inputs").createDirectories
+      writeFile(generatorSources.resolve("test.in"), "foobar")
+      val sourceGenerator = Config.SourceGenerator(
+        sourcesGlobs =
+          Config.SourcesGlobs(generatorSources.underlying, None, List("glob:test.in"), Nil) :: Nil,
+        outputDirectory = workspace.underlying.resolve("source-generator-output"),
+        argv = generator
+      )
+      val `A` = TestProject(workspace, "a", List(source), sourceGenerators = List(sourceGenerator))
+      val projects = List(`A`)
+      val initialState = loadState(workspace, projects, new RecordingLogger())
+      val compiledState = initialState.compile(`A`)
+      assert(compiledState.status == ExitStatus.Ok)
+      assertValidCompilationState(compiledState, projects)
+
+      val (logObserver, logsObservable) =
+        Observable.multicast[(String, String)](MulticastStrategy.replay)(ioScheduler)
+      val logger = new PublisherLogger(logObserver, DebugFilter.All)
+
+      compiledState.withLogger(logger).compileHandle(`A`, watch = true)
+
+      val HasIterationStoppedMsg = s"Watching 2"
+      def waitUntilIteration(totalIterations: Int): Task[Unit] =
+        waitUntilWatchIteration(logsObservable, totalIterations, HasIterationStoppedMsg, None)
+
+      def testValidLatestState: TestState = {
+        val state = compiledState.getLatestSavedStateGlobally()
+        assert(state.status == ExitStatus.Ok)
+        assertValidCompilationState(state, projects)
+        state
+      }
+
+      TestUtil.await(FiniteDuration(20, TimeUnit.SECONDS), ExecutionContext.ioScheduler) {
+        for {
+          _ <- waitUntilIteration(1)
+          _ <- Task(testValidLatestState)
+          _ <- Task(writeFile(generatorSources.resolve("test.in"), "updated"))
+          _ <- waitUntilIteration(2)
+        } yield ()
       }
     }
   }

--- a/frontend/src/test/scala/bloop/SourceGeneratorBspSpec.scala
+++ b/frontend/src/test/scala/bloop/SourceGeneratorBspSpec.scala
@@ -1,0 +1,121 @@
+package bloop
+
+import ch.epfl.scala.bsp.SourceItem
+import ch.epfl.scala.bsp.SourceItemKind
+import ch.epfl.scala.bsp.SourcesItem
+import ch.epfl.scala.bsp.Uri
+
+import bloop.bsp.BspBaseSuite
+import bloop.cli.BspProtocol
+import bloop.config.Config
+import bloop.internal.build.BuildTestInfo
+import bloop.logging.RecordingLogger
+import bloop.util.CrossPlatform
+import bloop.util.TestProject
+import bloop.util.TestUtil
+
+object TcpBspSourceGeneratorSpec extends BspSourceGeneratorSpec(BspProtocol.Tcp)
+object LocalBspSourceGeneratorSpec extends BspSourceGeneratorSpec(BspProtocol.Local)
+
+abstract class BspSourceGeneratorSpec(override val protocol: BspProtocol) extends BspBaseSuite {
+  private val generator =
+    if (CrossPlatform.isWindows) List("python", BuildTestInfo.sampleSourceGenerator.getAbsolutePath)
+    else List(BuildTestInfo.sampleSourceGenerator.getAbsolutePath)
+
+  test("sources request works") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val output = workspace.resolve("source-generator-output")
+      val sourceGenerator = Config.SourceGenerator(
+        sourcesGlobs = Nil,
+        outputDirectory = output.underlying,
+        argv = generator
+      )
+      val `A` = TestProject(workspace, "a", Nil, sourceGenerators = sourceGenerator :: Nil)
+
+      loadBspState(workspace, `A` :: Nil, logger) { state =>
+        val obtained = state.requestSources(`A`).items
+        val expected = SourcesItem(
+          `A`.bspId,
+          List(
+            SourceItem(
+              Uri(workspace.resolve("a").resolve("src").toBspUri),
+              SourceItemKind.Directory,
+              generated = false
+            ),
+            SourceItem(
+              Uri(output.resolve("NameLengths_0.scala").toBspUri),
+              SourceItemKind.File,
+              generated = true
+            )
+          ),
+          None
+        )
+        assertEquals(obtained, expected :: Nil)
+      }
+    }
+  }
+
+  test("sources request with dependent source generators works") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+
+      val outputA = workspace.resolve("source-generator-output-A")
+      val sourceGeneratorA = Config.SourceGenerator(
+        sourcesGlobs = List(
+          Config.SourcesGlobs(workspace.underlying, None, "glob:*.test_input" :: Nil, Nil)
+        ),
+        outputDirectory = outputA.underlying,
+        argv = generator
+      )
+      val `A` = TestProject(workspace, "a", Nil, sourceGenerators = sourceGeneratorA :: Nil)
+
+      // The inputs of the source generator of project A
+      List(
+        "file_one.test_input",
+        "file_two.test_input",
+        "file_three.test_input",
+        "excluded_file.whatever"
+      ).foreach { file =>
+        writeFile(workspace.resolve(file), "")
+      }
+
+      val outputB = workspace.resolve("source-generator-output-B")
+      val sourceGeneratorB = Config.SourceGenerator(
+        sourcesGlobs = List(
+          Config.SourcesGlobs(outputA.underlying, None, "glob:*.scala" :: Nil, Nil)
+        ),
+        outputDirectory = outputB.underlying,
+        argv = generator
+      )
+      val `B` = TestProject(
+        workspace,
+        "b",
+        Nil,
+        directDependencies = `A` :: Nil,
+        sourceGenerators = sourceGeneratorB :: Nil
+      )
+
+      loadBspState(workspace, `A` :: `B` :: Nil, logger) { state =>
+        val obtained = state.requestSources(`B`).items
+        val expected = SourcesItem(
+          `B`.bspId,
+          List(
+            SourceItem(
+              Uri(workspace.resolve("b").resolve("src").toBspUri),
+              SourceItemKind.Directory,
+              generated = false
+            ),
+            SourceItem(
+              Uri(outputB.resolve("NameLengths_1.scala").toBspUri),
+              SourceItemKind.File,
+              generated = true
+            )
+          ),
+          None
+        )
+        assertEquals(obtained, expected :: Nil)
+      }
+    }
+  }
+}

--- a/frontend/src/test/scala/bloop/SourceGeneratorSpec.scala
+++ b/frontend/src/test/scala/bloop/SourceGeneratorSpec.scala
@@ -45,7 +45,7 @@ object SourceGeneratorSpec extends bloop.testing.BaseSuite {
           Config.SourcesGlobs(workspace.underlying, None, "glob:*.test_input" :: Nil, Nil)
         ),
         outputDirectory = generatedSourcesA,
-        argv = generator
+        command = generator
       )
       val `A` = TestProject(workspace, "a", sourcesA, sourceGenerators = sourceGeneratorA :: Nil)
 
@@ -72,7 +72,7 @@ object SourceGeneratorSpec extends bloop.testing.BaseSuite {
           Config.SourcesGlobs(generatedSourcesA, None, "glob:*.scala" :: Nil, Nil)
         ),
         outputDirectory = generatedSourcesB,
-        argv = generator
+        command = generator
       )
       val `B` = TestProject(
         workspace,
@@ -97,7 +97,7 @@ object SourceGeneratorSpec extends bloop.testing.BaseSuite {
       val sourceGenerator = Config.SourceGenerator(
         sourcesGlobs = Nil,
         outputDirectory = workspace.underlying.resolve("source-generator-output"),
-        argv = generator ++ List("fail_now")
+        command = generator ++ List("fail_now")
       )
       val `A` = TestProject(workspace, "a", Nil, sourceGenerators = sourceGenerator :: Nil)
       val projects = List(`A`)
@@ -222,7 +222,7 @@ object SourceGeneratorSpec extends bloop.testing.BaseSuite {
     val sourceGenerator = Config.SourceGenerator(
       sourcesGlobs = List(Config.SourcesGlobs(workspace.underlying, None, includeGlobs, Nil)),
       outputDirectory = workspace.underlying.resolve("source-generator-output"),
-      argv = generator
+      command = generator
     )
     val `A` = TestProject(workspace, "a", Nil, sourceGenerators = sourceGenerator :: Nil)
     val projects = List(`A`)

--- a/frontend/src/test/scala/bloop/SourceGeneratorSpec.scala
+++ b/frontend/src/test/scala/bloop/SourceGeneratorSpec.scala
@@ -1,0 +1,245 @@
+package bloop
+
+import bloop.Compiler.Result.Success
+import bloop.cli.ExitStatus
+import bloop.config.Config
+import bloop.internal.build.BuildTestInfo
+import bloop.io.AbsolutePath
+import bloop.logging.RecordingLogger
+import bloop.util.CrossPlatform
+import bloop.util.TestProject
+import bloop.util.TestUtil
+
+object SourceGeneratorSpec extends bloop.testing.BaseSuite {
+
+  private val generator: List[String] =
+    if (CrossPlatform.isWindows) List("python", BuildTestInfo.sampleSourceGenerator.getAbsolutePath)
+    else List(BuildTestInfo.sampleSourceGenerator.getAbsolutePath)
+
+  test("compile a project having a source generator") {
+    singleProjectWithSourceGenerator("glob:*.in" :: Nil) { (workspace, project, state) =>
+      writeFile(project.srcFor("Foo.scala", exists = false), assertNInputs(n = 3))
+      writeFile(workspace.resolve("file_one.in"), "file one")
+      writeFile(workspace.resolve("file_two.in"), "file two")
+      writeFile(workspace.resolve("file_three.in"), "file three")
+      writeFile(workspace.resolve("excluded.whatever"), "this one is excluded")
+
+      val compiledState = state.compile(project)
+      assertExitStatus(compiledState, ExitStatus.Ok)
+      assertValidCompilationState(compiledState, project :: Nil)
+    }
+  }
+
+  test("compile projects with dependent source generators") {
+    TestUtil.withinWorkspace { workspace =>
+      val sourcesA = List(
+        """/main/scala/Foo.scala
+          |class Foo {
+          |  val expectedArgsLength = generated.NameLengths.args_3
+          |  val test = generated.NameLengths.nameLengths
+          |}""".stripMargin
+      )
+      val generatedSourcesA = workspace.resolve("source-generator-output-A").underlying
+      val sourceGeneratorA = Config.SourceGenerator(
+        sourcesGlobs = List(
+          Config.SourcesGlobs(workspace.underlying, None, "glob:*.test_input" :: Nil, Nil)
+        ),
+        outputDirectory = generatedSourcesA,
+        argv = generator
+      )
+      val `A` = TestProject(workspace, "a", sourcesA, sourceGenerators = sourceGeneratorA :: Nil)
+
+      // The inputs of the source generator of project A
+      List(
+        "file_one.test_input",
+        "file_two.test_input",
+        "file_three.test_input",
+        "excluded_file.whatever"
+      ).foreach { file =>
+        workspace.resolve(file).toFile.createNewFile()
+      }
+
+      val sourcesB = List(
+        """/main/scala/Foo.scala
+          |class Foo {
+          |  val expectedArgsLength = generated.NameLengths.args_1
+          |  val test = generated.NameLengths.nameLengths
+          |}""".stripMargin
+      )
+      val generatedSourcesB = workspace.resolve("source-generator-output-B").underlying
+      val sourceGeneratorB = Config.SourceGenerator(
+        sourcesGlobs = List(
+          Config.SourcesGlobs(generatedSourcesA, None, "glob:*.scala" :: Nil, Nil)
+        ),
+        outputDirectory = generatedSourcesB,
+        argv = generator
+      )
+      val `B` = TestProject(
+        workspace,
+        "b",
+        sourcesB,
+        directDependencies = `A` :: Nil,
+        sourceGenerators = sourceGeneratorB :: Nil
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val projects = List(`A`, `B`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.compile(`B`)
+      assertExitStatus(compiledState, ExitStatus.Ok)
+      assertValidCompilationState(compiledState, projects)
+    }
+  }
+
+  test("source generator failure yields compilation failure") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val sourceGenerator = Config.SourceGenerator(
+        sourcesGlobs = Nil,
+        outputDirectory = workspace.underlying.resolve("source-generator-output"),
+        argv = generator ++ List("fail_now")
+      )
+      val `A` = TestProject(workspace, "a", Nil, sourceGenerators = sourceGenerator :: Nil)
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.compile(`A`)
+      assertExitStatus(compiledState, ExitStatus.CompilationError)
+    }
+  }
+
+  test("source generator is run when there are no matching input files") {
+    singleProjectWithSourceGenerator("glob:*.in" :: Nil) { (_, project, state) =>
+      writeFile(project.srcFor("test.scala", exists = false), assertNInputs(n = 0))
+      val compiledState = state.compile(project)
+      assertExitStatus(compiledState, ExitStatus.Ok)
+    }
+  }
+
+  test("source generator is re-run when an input file is removed") {
+    singleProjectWithSourceGenerator("glob:*.in" :: Nil) { (workspace, project, state) =>
+      writeFile(workspace.resolve("hello.in"), "hello")
+      writeFile(project.srcFor("test.scala", exists = false), assertNInputs(n = 1))
+      val compiledState1 = state.compile(project)
+      assertExitStatus(compiledState1, ExitStatus.Ok)
+
+      workspace.resolve("hello.in").toFile.delete()
+      writeFile(project.srcFor("test.scala"), assertNInputs(n = 0))
+
+      val compiledState2 = compiledState1.compile(project)
+      assertExitStatus(compiledState2, ExitStatus.Ok)
+    }
+  }
+
+  test("source generator is re-run when an input file is added") {
+    singleProjectWithSourceGenerator("glob:*.in" :: Nil) { (workspace, project, state) =>
+      writeFile(workspace.resolve("hello.in"), "hello")
+      writeFile(project.srcFor("test.scala", exists = false), assertNInputs(n = 1))
+      val compiledState1 = state.compile(project)
+      assertExitStatus(compiledState1, ExitStatus.Ok)
+
+      writeFile(workspace.resolve("goodbye.in"), "goodbye")
+      writeFile(project.srcFor("test.scala"), assertNInputs(n = 2))
+
+      val compiledState2 = compiledState1.compile(project)
+      assertExitStatus(compiledState2, ExitStatus.Ok)
+    }
+  }
+
+  test("source generator is re-run when an input file is modified") {
+    singleProjectWithSourceGenerator("glob:*.in" :: Nil) { (workspace, project, state) =>
+      writeFile(workspace.resolve("hello.in"), "hello")
+      writeFile(project.srcFor("test.scala", exists = false), assertNInputs(n = 1))
+      val compiledState1 = state.compile(project)
+      val origHash = sourceHashFor("NameLengths_1.scala", project, compiledState1)
+      assertExitStatus(compiledState1, ExitStatus.Ok)
+
+      writeFile(workspace.resolve("hello.in"), "goodbye")
+
+      val compiledState2 = compiledState1.compile(project)
+      assertExitStatus(compiledState2, ExitStatus.Ok)
+
+      val newHash = sourceHashFor("NameLengths_1.scala", project, compiledState2)
+      assertNotEquals(origHash, newHash)
+    }
+  }
+
+  test("source generator is re-run when an output file is modified") {
+    singleProjectWithSourceGenerator("glob:*.in" :: Nil) { (workspace, project, state) =>
+      val generatorOutput = project.config.sourceGenerators
+        .flatMap(_.headOption)
+        .map(p => AbsolutePath(p.outputDirectory))
+      writeFile(workspace.resolve("hello.in"), "hello")
+      writeFile(project.srcFor("test.scala", exists = false), assertNInputs(n = 1))
+      val compiledState1 = state.compile(project)
+      val origHash = sourceHashFor("NameLengths_1.scala", project, compiledState1)
+      assertExitStatus(compiledState1, ExitStatus.Ok)
+
+      generatorOutput.foreach { out =>
+        writeFile(out.resolve("NameLengths_1.scala"), "won't compile -- must rerun generator.")
+      }
+
+      val compiledState2 = compiledState1.compile(project)
+      assertExitStatus(compiledState2, ExitStatus.Ok)
+
+      val newHash = sourceHashFor("NameLengths_1.scala", project, compiledState2)
+      assertNotEquals(origHash, newHash)
+    }
+  }
+
+  test("source generator is re-run when an output file is deleted") {
+    singleProjectWithSourceGenerator("glob:*.in" :: Nil) { (workspace, project, state) =>
+      val generatorOutput = project.config.sourceGenerators
+        .flatMap(_.headOption)
+        .map(p => AbsolutePath(p.outputDirectory))
+      writeFile(workspace.resolve("hello.in"), "hello")
+      writeFile(project.srcFor("test.scala", exists = false), assertNInputs(n = 1))
+      val compiledState1 = state.compile(project)
+      val origHash = sourceHashFor("NameLengths_1.scala", project, compiledState1)
+      assertExitStatus(compiledState1, ExitStatus.Ok)
+
+      generatorOutput.foreach { out =>
+        out.resolve("NameLengths_1.scala").toFile.delete()
+      }
+
+      val compiledState2 = compiledState1.compile(project)
+      assertExitStatus(compiledState2, ExitStatus.Ok)
+
+      val newHash = sourceHashFor("NameLengths_1.scala", project, compiledState2)
+      assertNotEquals(origHash, newHash)
+    }
+  }
+
+  private def assertNInputs(n: Int): String =
+    s"""class Foo {
+       |  val length = generated.NameLengths.args_${n}
+       |  val test = generated.NameLengths.nameLengths
+       |}""".stripMargin
+
+  private def singleProjectWithSourceGenerator(includeGlobs: List[String])(
+      op: (AbsolutePath, TestProject, TestState) => Unit
+  ): Unit = TestUtil.withinWorkspace { workspace =>
+    val logger = new RecordingLogger(ansiCodesSupported = false)
+    val sourceGenerator = Config.SourceGenerator(
+      sourcesGlobs = List(Config.SourcesGlobs(workspace.underlying, None, includeGlobs, Nil)),
+      outputDirectory = workspace.underlying.resolve("source-generator-output"),
+      argv = generator
+    )
+    val `A` = TestProject(workspace, "a", Nil, sourceGenerators = sourceGenerator :: Nil)
+    val projects = List(`A`)
+    val state = loadState(workspace, projects, logger)
+
+    op(workspace, `A`, state)
+  }
+
+  private def sourceHashFor(name: String, project: TestProject, state: TestState): Option[Int] = {
+    state.getLastResultFor(project) match {
+      case Success(inputs, _, _, _, _, _, _) =>
+        inputs.sources.collectFirst {
+          case UniqueCompileInputs.HashedSource(source, hash) if source.name == name =>
+            hash
+        }
+      case _ =>
+        None
+    }
+  }
+}

--- a/frontend/src/test/scala/bloop/io/SourceHasherSpec.scala
+++ b/frontend/src/test/scala/bloop/io/SourceHasherSpec.scala
@@ -41,11 +41,10 @@ object SourceHasherSpec extends bloop.testing.BaseSuite {
       val sourceHashesTask =
         SourceHasher.findAndHashSourcesInProject(
           projectA,
-          state.state.sourceGeneratorCache,
+          state.state.sourceGeneratorCache.update(_, logger, state.state.commonOptions),
           2,
           cancelPromise,
-          ioScheduler,
-          logger
+          ioScheduler
         )
       val running = sourceHashesTask.runAsync(ioScheduler)
 
@@ -59,11 +58,10 @@ object SourceHasherSpec extends bloop.testing.BaseSuite {
       val sourceHashesTask2 =
         SourceHasher.findAndHashSourcesInProject(
           projectA,
-          state.state.sourceGeneratorCache,
+          state.state.sourceGeneratorCache.update(_, logger, state.state.commonOptions),
           2,
           cancelPromise2,
-          ioScheduler,
-          logger
+          ioScheduler
         )
       val running2 = sourceHashesTask2.runAsync(ioScheduler)
       val uncancelledResult = Await.result(running2, FiniteDuration(20, "s"))

--- a/frontend/src/test/scala/bloop/io/SourceHasherSpec.scala
+++ b/frontend/src/test/scala/bloop/io/SourceHasherSpec.scala
@@ -39,7 +39,14 @@ object SourceHasherSpec extends bloop.testing.BaseSuite {
       val projectA = state.getProjectFor(`A`)
 
       val sourceHashesTask =
-        SourceHasher.findAndHashSourcesInProject(projectA, 2, cancelPromise, ioScheduler)
+        SourceHasher.findAndHashSourcesInProject(
+          projectA,
+          state.state.sourceGeneratorCache,
+          2,
+          cancelPromise,
+          ioScheduler,
+          logger
+        )
       val running = sourceHashesTask.runAsync(ioScheduler)
 
       Thread.sleep(2)
@@ -50,7 +57,14 @@ object SourceHasherSpec extends bloop.testing.BaseSuite {
       assert(cancelledResult.isLeft)
 
       val sourceHashesTask2 =
-        SourceHasher.findAndHashSourcesInProject(projectA, 2, cancelPromise2, ioScheduler)
+        SourceHasher.findAndHashSourcesInProject(
+          projectA,
+          state.state.sourceGeneratorCache,
+          2,
+          cancelPromise2,
+          ioScheduler,
+          logger
+        )
       val running2 = sourceHashesTask2.runAsync(ioScheduler)
       val uncancelledResult = Await.result(running2, FiniteDuration(20, "s"))
       assert(uncancelledResult.isRight)

--- a/frontend/src/test/scala/bloop/io/SourcesGlobsSpec.scala
+++ b/frontend/src/test/scala/bloop/io/SourcesGlobsSpec.scala
@@ -50,9 +50,11 @@ object SourcesGlobsSpec extends bloop.testing.BaseSuite {
         )
         val hashedSources = SourceHasher.findAndHashSourcesInProject(
           project,
+          state.sourceGeneratorCache,
           1,
           Promise[Unit](),
-          ioScheduler
+          ioScheduler,
+          logger
         )
         val Right(result) = TestUtil.await(10, TimeUnit.SECONDS)(hashedSources)
         val obtainedFilenames = result

--- a/frontend/src/test/scala/bloop/io/SourcesGlobsSpec.scala
+++ b/frontend/src/test/scala/bloop/io/SourcesGlobsSpec.scala
@@ -50,11 +50,10 @@ object SourcesGlobsSpec extends bloop.testing.BaseSuite {
         )
         val hashedSources = SourceHasher.findAndHashSourcesInProject(
           project,
-          state.sourceGeneratorCache,
+          state.sourceGeneratorCache.update(_, logger, state.commonOptions),
           1,
           Promise[Unit](),
-          ioScheduler,
-          logger
+          ioScheduler
         )
         val Right(result) = TestUtil.await(10, TimeUnit.SECONDS)(hashedSources)
         val obtainedFilenames = result

--- a/frontend/src/test/scala/bloop/util/TestProject.scala
+++ b/frontend/src/test/scala/bloop/util/TestProject.scala
@@ -110,7 +110,8 @@ abstract class BaseTestProject {
       runtimeJvmConfig: Option[Config.JvmConfig] = None,
       order: Config.CompileOrder = Config.Mixed,
       jars: Array[AbsolutePath] = Array(),
-      sourcesGlobs: List[Config.SourcesGlobs] = Nil
+      sourcesGlobs: List[Config.SourcesGlobs] = Nil,
+      sourceGenerators: List[Config.SourceGenerator] = Nil
   ): TestProject = {
     val projectBaseDir = Files.createDirectories(baseDir.underlying.resolve(name))
     val ProjectArchetype(sourceDir, outDir, resourceDir, classes, runtimeResourceDir) =
@@ -198,7 +199,9 @@ abstract class BaseTestProject {
       test = Some(testConfig),
       platform = Some(platform),
       resolution = None,
-      tags = None
+      tags = None,
+      if (sourceGenerators.isEmpty) None
+      else Some(sourceGenerators)
     )
 
     TestProject(config, Some(directDependencies))

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -464,7 +464,7 @@ object TestUtil {
 
   /** Creates an empty workspace where operations can happen. */
   def withinWorkspace[T](op: AbsolutePath => T): T = {
-    val temp = Files.createTempDirectory("bloop-test-workspace")
+    val temp = Files.createTempDirectory("bloop-test-workspace").toRealPath()
     try op(AbsolutePath(temp))
     finally delete(AbsolutePath(temp))
   }

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -34,6 +34,7 @@ import bloop.engine.Interpreter
 import bloop.engine.Run
 import bloop.engine.State
 import bloop.engine.caches.ResultsCache
+import bloop.engine.caches.SourceGeneratorCache
 import bloop.io.AbsolutePath
 import bloop.io.Environment.LineSplitter
 import bloop.io.Environment.lineSeparator
@@ -256,7 +257,8 @@ object TestUtil {
     }
     val workspaceSettings = WorkspaceSettings.readFromFile(configDirectory, logger)
     val build = Build(configDirectory, transformedProjects, workspaceSettings)
-    val state = State.forTests(build, TestUtil.getCompilerCache(logger), logger)
+    val state =
+      State.forTests(build, TestUtil.getCompilerCache(logger), SourceGeneratorCache.empty, logger)
     val state1 = state.copy(commonOptions = state.commonOptions.copy(env = runAndTestProperties))
     if (!emptyResults) state1 else state1.copy(results = ResultsCache.emptyForTests)
   }
@@ -333,7 +335,8 @@ object TestUtil {
       }
       val loaded = projects.map(p => LoadedProject.RawProject(p))
       val build = Build(temp, loaded.toList, None)
-      val state = State.forTests(build, TestUtil.getCompilerCache(logger), logger)
+      val state =
+        State.forTests(build, TestUtil.getCompilerCache(logger), SourceGeneratorCache.empty, logger)
       try op(state)
       catch {
         case NonFatal(t) =>
@@ -402,6 +405,7 @@ object TestUtil {
       sources = sourceDirectories,
       sourcesGlobs = Nil,
       sourceRoots = None,
+      sourceGenerators = Nil,
       testFrameworks = testFrameworks,
       testOptions = Config.TestOptions.empty,
       out = out,
@@ -517,7 +521,7 @@ object TestUtil {
     val classesDir = Files.createDirectory(outDir.resolve("classes"))
 
     // format: OFF
-    val configFileG = bloop.config.Config.File(Config.File.LatestVersion, Config.Project("g", baseDir, Option(baseDir), Nil, None, None, List("g"), Nil, outDir, classesDir, None, None, None, None, None, None, None, None))
+    val configFileG = bloop.config.Config.File(Config.File.LatestVersion, Config.Project("g", baseDir, Option(baseDir), Nil, None, None, List("g"), Nil, outDir, classesDir, None, None, None, None, None, None, None, None, None))
     bloop.config.write(configFileG, jsonTargetG)
     // format: ON
 

--- a/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/integrations/gradle-bloop/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -221,7 +221,8 @@ class BloopConverter(parameters: BloopParameters) {
           test = testConfig,
           platform = None,
           resolution = if (modules.isEmpty) None else Some(Config.Resolution(modules)),
-          tags = if (tags.isEmpty) None else Some(tags)
+          tags = if (tags.isEmpty) None else Some(tags),
+          sourceGenerators = None
         )
       } yield Config.File(Config.File.LatestVersion, bloopProject)
     }
@@ -383,7 +384,8 @@ class BloopConverter(parameters: BloopParameters) {
           test = getTestConfig(testTask),
           platform = getPlatform(project, sourceSet, testTask, runtimeClasspath),
           resolution = if (modules.isEmpty) None else Some(Config.Resolution(modules)),
-          tags = if (tags.isEmpty) None else Some(tags)
+          tags = if (tags.isEmpty) None else Some(tags),
+          sourceGenerators = None
         )
       } yield Config.File(Config.File.LatestVersion, bloopProject)
     }

--- a/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
+++ b/integrations/gradle-bloop/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
@@ -20,6 +20,7 @@ import bloop.engine.Build
 import bloop.engine.BuildLoader
 import bloop.engine.Run
 import bloop.engine.State
+import bloop.engine.caches.SourceGeneratorCache
 import bloop.io.AbsolutePath
 import bloop.logging.BloopLogger
 import bloop.util.TestUtil
@@ -3597,7 +3598,7 @@ abstract class ConfigGenerationSuite extends BaseConfigSuite {
     val loadedProjects = BuildLoader.loadSynchronously(configDirectory, logger)
     val workspaceSettings = WorkspaceSettings.readFromFile(configDirectory, logger)
     val build = Build(configDirectory, loadedProjects, workspaceSettings)
-    State.forTests(build, TestUtil.getCompilerCache(logger), logger)
+    State.forTests(build, TestUtil.getCompilerCache(logger), SourceGeneratorCache.empty, logger)
   }
 
   private def compileBloopProject(

--- a/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/integrations/maven-bloop/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -285,7 +285,7 @@ object MojoImplementation {
           case a: Resource => Option(Paths.get(a.getDirectory()))
           case _ => None
         })
-        val project = Config.Project(name, baseDirectory, Some(root.toPath), sourceDirs, None, None, fullDependencies, classpath, out, classesDir, resources, `scala`, java, sbt, test, platform, resolution, Some(tags))
+        val project = Config.Project(name, baseDirectory, Some(root.toPath), sourceDirs, None, None, fullDependencies, classpath, out, classesDir, resources, `scala`, java, sbt, test, platform, resolution, Some(tags), None)
         Config.File(Config.File.LatestVersion, project)
       }
       // FORMAT: ON

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -1034,7 +1034,7 @@ object BloopDefaults {
             val sbt = None // Written by `postGenerate` instead
             val project = Config.Project(projectName, baseDirectory, Option(buildBaseDirectory.toPath), sources, None, None, dependenciesAndAggregates,
               classpath, out, classesDir, resources, Some(`scala`), Some(java), sbt, Some(testOptions), Some(platform), resolution,
-              Some(tags))
+              Some(tags), None)
             Config.File(Config.File.LatestVersion, project)
           }
           // format: ON

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -555,8 +555,14 @@ object BuildImplementation {
               val junitJars = jars.filter(j => j.contains("junit") || j.contains("hamcrest"))
               "junitTestJars" -> junitJars
           }
+          val sampleSourceGenerator = (Test / Keys.resourceDirectory).value / "source-generator.py"
 
-          List(junitTestJars, BuildKeys.bloopCoursierJson, (ThisBuild / Keys.baseDirectory))
+          List(
+            "sampleSourceGenerator" -> sampleSourceGenerator,
+            junitTestJars,
+            BuildKeys.bloopCoursierJson,
+            (ThisBuild / Keys.baseDirectory)
+          )
         },
         (Test / BuildInfoKeys.buildInfoPackage) := "bloop.internal.build",
         (Test / BuildInfoKeys.buildInfoObject) := "BuildTestInfo"


### PR DESCRIPTION
This commit changes the Bloop project definition to add a new field,
`sourceGenerators`, which can be used to define source generators.

Source generators are parts of the build that are run when Bloop gathers
the sources of a project (either when queried via BSP or when
compiling).

Source generators are configured with globs matching input files, an
output directory, and a program to run. When the inputs or known outputs
of a source generator change, the source generator is automatically
re-run. When there are no changes, the result of a source generator is
cached.

The command to execute to run a source generator will be built from the
configured `argv`, followed by the output directory and the input files.