### PR TITLE
Truncate file timestamp in `AttributedPath` to milliseconds

### DIFF
--- a/frontend/src/main/scala/bloop/data/Origin.scala
+++ b/frontend/src/main/scala/bloop/data/Origin.scala
@@ -8,7 +8,7 @@ import bloop.util.CacheHashCode
 
 case class Origin(path: AbsolutePath, lastModifiedtime: FileTime, size: Long, hash: Int)
     extends CacheHashCode {
-  def toAttributedPath: AttributedPath = AttributedPath(path, lastModifiedtime, size)
+  def toAttributedPath: AttributedPath = AttributedPath.of(path, lastModifiedtime, size)
 }
 
 object Origin {

--- a/frontend/src/test/scala/bloop/testing/BaseSuite.scala
+++ b/frontend/src/test/scala/bloop/testing/BaseSuite.scala
@@ -142,11 +142,11 @@ abstract class BaseSuite extends TestSuite with BloopHelpers {
         val osInsensitivePath = ap.path.syntax.replace(prefixPath, "").replace(File.separator, "/")
         val maskedRelativePath = AbsolutePath(osInsensitivePath)
         if (!maskedRelativePath.syntax.startsWith("/classes-")) {
-          ap.copy(path = maskedRelativePath)
+          ap.withPath(maskedRelativePath)
         } else {
           // Remove '/classes-*' from path
           val newPath = maskedRelativePath.syntax.split(File.separatorChar).tail.tail.mkString("/")
-          ap.copy(path = AbsolutePath("/" + newPath))
+          ap.withPath(AbsolutePath("/" + newPath))
         }
       }
 


### PR DESCRIPTION
- this makes it consistent between old and new JVMs, and makes a bunch of tests happy which among other things diff file timestamps