### PR TITLE
show stack traces of `Error`s thrown in asynchronous code

### DIFF
--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -96,7 +96,7 @@ object Cli {
       case x: java.util.concurrent.ExecutionException =>
         // print stack trace of fatal errors thrown in asynchronous code, see https://stackoverflow.com/questions/17265022/what-is-a-boxed-error-in-scala
         // the stack trace is somehow propagated all the way to the client when printing this
-        x.getCause.printStackTrace()
+        x.getCause.printStackTrace(ngContext.out)
         ngContext.exit(ExitStatus.UnexpectedError.code)
     }
   }

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -89,8 +89,16 @@ object Cli {
       else parse(args, nailgunOptions)
     }
 
-    val exitStatus = run(cmd, NailgunPool(ngContext))
-    ngContext.exit(exitStatus.code)
+    try {
+      val exitStatus = run(cmd, NailgunPool(ngContext))
+      ngContext.exit(exitStatus.code)
+    } catch {
+      case x: java.util.concurrent.ExecutionException =>
+        // print stack trace of fatal errors thrown in asynchronous code, see https://stackoverflow.com/questions/17265022/what-is-a-boxed-error-in-scala
+        // the stack trace is somehow propagated all the way to the client when printing this
+        x.getCause.printStackTrace()
+        ngContext.exit(ExitStatus.UnexpectedError.code)
+    }
   }
 
   val commands: Seq[String] = Commands.RawCommand.help.messages.flatMap(_._1.headOption.toSeq)

--- a/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
+++ b/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
@@ -1,6 +1,5 @@
 package bloop.testing
 
-import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 


### PR DESCRIPTION
Bloop will only report `Boxed error`, see https://stackoverflow.com/questions/17265022/what-is-a-boxed-error-in-scala

I guess there might be a better place to put this. I wound up with some `ClassDefNotFoundError` and the likes when debugging