### PR TITLE
Run source generators in topological order

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Dag.scala
+++ b/frontend/src/main/scala/bloop/engine/Dag.scala
@@ -8,6 +8,7 @@ import bloop.data.Project
 import bloop.util.CacheHashCode
 
 import scalaz.Show
+import scala.collection.immutable.ListSet
 
 /**
  * A [[Dag]] is a Directed Acyclic Graph where each node contains a value of T
@@ -364,5 +365,17 @@ object Dag {
        |${nodes.mkString("  ", "\n  ", "\n  ")}
        |${edges.mkString("  ", "\n  ", "")}
        |}""".stripMargin
+  }
+
+  def topologicalSort[T](dag: Dag[T]): List[T] = {
+    def inner(buf: ListSet[T], dag: Dag[T]): ListSet[T] = dag match {
+      case Leaf(value) =>
+        buf + value
+      case Parent(value, children) =>
+        children.foldLeft(buf)(inner(_, _)) + value
+      case Aggregate(dags) =>
+        dags.foldLeft(buf)(inner(_, _))
+    }
+    inner(ListSet.empty, dag).toList
   }
 }

--- a/frontend/src/test/scala/bloop/DagSpec.scala
+++ b/frontend/src/test/scala/bloop/DagSpec.scala
@@ -62,6 +62,17 @@ class DagSpec {
     case Leaf(f) => assert(f == p, s"$f is not $p")
   }
 
+  private def assertAppearsBefore[T](elems: List[T], ancestor: T, successor: T): Unit = {
+    Assert.assertTrue(
+      s"$ancestor doesnt appear before $successor in $elems",
+      elems.indexOf(ancestor) < elems.indexOf(successor)
+    )
+  }
+
+  private def assertAppearsBefore[T](elems: List[T], ancestor: T, successors: List[T]): Unit = {
+    successors.foreach(assertAppearsBefore(elems, ancestor, _))
+  }
+
   @Test def EmptyDAG(): Unit = {
     val dags = fromMap(Map())
     assert(dags.isEmpty)
@@ -268,5 +279,18 @@ class DagSpec {
     Assert.assertEquals("all case 7", Set(i, h), allInverseDeps(List(h, i)))
     Assert.assertEquals("all case 8", Set(i, h), allInverseDeps(List(h)))
     Assert.assertEquals("all case 9", Set(i), allInverseDeps(List(i)))
+  }
+
+  @Test
+  def TestTopologicalSort(): Unit = {
+    import ComplexDag._
+    val allProjects = List(a, b, c, d, e, f, g, h, i)
+    val dags = fromMap(allProjects.map(p => p.name -> p).toMap)
+    val sorted = Dag.topologicalSort(Aggregate(dags))
+    assertAppearsBefore(sorted, a, List(b, c, d, e))
+    assertAppearsBefore(sorted, c, List(d, e))
+    assertAppearsBefore(sorted, d, List(e))
+    assertAppearsBefore(sorted, f, List(g, h, i))
+    assertAppearsBefore(sorted, h, List(i))
   }
 }


### PR DESCRIPTION
Previously, the `buildTarget/sources` BSP request could fail in cases where the build included source generators that depend on the output of other source generators. This issue would happen because, in this case, the ordering in which the source generators would run wasn't clearly defined.

During a compilation task, this problem would not appear because the source generators would always be run after their dependencies have run.

To fix this problem in the BSP services, Bloop will now run the source generators in the topological order.