### PR TITLE
fix: bloop.task.Task - avoid materializing fallback task in timeoutTo

### DIFF
--- a/backend/src/main/scala/bloop/task/Task.scala
+++ b/backend/src/main/scala/bloop/task/Task.scala
@@ -164,11 +164,14 @@ sealed trait Task[+A] { self =>
     Task
       .chooseFirstOf(
         self,
-        Task.sleep(duration).flatMap(_ => backup)
+        Task.sleep(duration)
       )
-      .map {
-        case Left((a, _)) => a
-        case Right((_, b)) => b
+      .flatMap {
+        case Left((a, _)) =>
+          Task.now(a)
+        case Right((a, _)) =>
+          a.cancel()
+          backup
       }
   }
 

--- a/backend/src/test/scala/bloop/task/TaskSpec.scala
+++ b/backend/src/test/scala/bloop/task/TaskSpec.scala
@@ -183,4 +183,15 @@ class TaskSpec {
 
   }
 
+  @Test
+  def timeoutTo2: Unit = {
+    val ref = new AtomicBoolean(true)
+    val t1 = Task.unit.delayExecution(500.milli)
+    val t2 = Task(ref.set(false))
+    val withTimeout = t1.timeoutTo(1.second, t2)
+
+    Await.result((withTimeout *> Task.sleep(2.seconds)).runAsync, 3.second)
+    assertEquals(true, ref.get())
+  }
+
 }


### PR DESCRIPTION
Reported by @kpodsiad

Prevosuly, even if a task was completing in defined duration the fallaback effect were anyway exectured.