### PR TITLE
Support traversal mode in `Dag.dfs`

### DIFF
--- a/frontend/src/it/scala/bloop/CommunityBuild.scala
+++ b/frontend/src/it/scala/bloop/CommunityBuild.scala
@@ -153,7 +153,7 @@ abstract class CommunityBuild(val buildpressHomeDir: AbsolutePath) {
 
       val newLoaded = LoadedProject.RawProject(rootProject) :: allProjectsInBuild
       val state = initialState.copy(build = initialState.build.copy(loadedProjects = newLoaded))
-      val allReachable = Dag.dfs(state.build.getDagFor(rootProject))
+      val allReachable = Dag.dfs(state.build.getDagFor(rootProject), Dag.PreOrder)
       val reachable = allReachable.filter(_ != rootProject)
       val cleanAction = Run(Commands.Clean(reachable.map(_.name)), Exit(ExitStatus.Ok))
       val cleanedState = execute(cleanAction, state)

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -1098,7 +1098,7 @@ final class BloopBspServices(
 
       // Collect the projects' sources following the projects topological sorting, so that
       // source generators that depend on other source generators' outputs can run correctly.
-      val collectSourcesTasks = Dag.topologicalSort(dag).map { project =>
+      val collectSourcesTasks = Dag.dfs(dag, mode = Dag.PostOrder).map { project =>
         val unmanagedSources = project.allUnmanagedSourceFilesAndDirectories.map { sources =>
           sources.map(sourceItem(_, isGenerated = false))
         }

--- a/frontend/src/main/scala/bloop/dap/BloopDebuggeeRunner.scala
+++ b/frontend/src/main/scala/bloop/dap/BloopDebuggeeRunner.scala
@@ -285,7 +285,7 @@ object BloopDebuggeeRunner {
 
   private def getLibraries(dag: Dag[Project]): Seq[ClassPathEntry] = {
     Dag
-      .dfs(dag)
+      .dfs(dag, mode = Dag.PreOrder)
       .flatMap(_.resolution)
       .flatMap(_.modules)
       .distinct
@@ -307,7 +307,7 @@ object BloopDebuggeeRunner {
   }
 
   private def getClassDirectories(dag: Dag[Project], client: ClientInfo): Seq[ClassPathEntry] = {
-    Dag.dfs(dag).map { project =>
+    Dag.dfs(dag, mode = Dag.PreOrder).map { project =>
       val sourceBuffer = mutable.Buffer.empty[SourceEntry]
       for (sourcePath <- project.sources) {
         if (sourcePath.isDirectory) {

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -127,7 +127,7 @@ final case class Project(
     val cp = (this.genericClassesDir :: rawClasspath).toBuffer
 
     // Add the resources right before the classes directory if found in the classpath
-    Dag.dfs(dag).foreach { p =>
+    Dag.dfs(dag, mode = Dag.PreOrder).foreach { p =>
       val genericClassesDir = p.genericClassesDir
       val uniqueClassesDir = client.getUniqueClassesDirFor(p, forceGeneration = true)
       val index = cp.indexOf(genericClassesDir)

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -117,7 +117,7 @@ object Interpreter {
   private[bloop] def watch(projects: List[Project], state: State)(
       f: State => Task[State]
   ): Task[State] = {
-    val reachable = Dag.dfs(getProjectsDag(projects, state))
+    val reachable = Dag.dfs(getProjectsDag(projects, state), mode = Dag.PreOrder)
     val projectsSourcesAndDirs = reachable.map { project =>
       for {
         unmanaged <- project.allUnmanagedSourceFilesAndDirectories
@@ -339,7 +339,10 @@ object Interpreter {
         if (!cmd.cascade) {
           val projectsToTest = {
             if (!cmd.includeDependencies) userSelectedProjects
-            else userSelectedProjects.flatMap(p => Dag.dfs(state.build.getDagFor(p)))
+            else
+              userSelectedProjects.flatMap(p =>
+                Dag.dfs(state.build.getDagFor(p), mode = Dag.PreOrder)
+              )
           }
 
           (userSelectedProjects, projectsToTest)

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -268,7 +268,7 @@ object CompileTask {
 
     val client = state.client
     CompileGraph.traverse(dag, client, store, setup(_), compile(_)).flatMap { pdag =>
-      val partialResults = Dag.dfs(pdag)
+      val partialResults = Dag.dfs(pdag, mode = Dag.PreOrder)
       val finalResults = partialResults.map(r => PartialCompileResult.toFinalResult(r))
       Task.gatherUnordered(finalResults).map(_.flatten).flatMap { results =>
         val cleanUpTasksToRunInBackground =

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -41,7 +41,7 @@ object Tasks {
   def clean(state: State, targets: List[Project], includeDeps: Boolean): Task[State] = {
     val allTargetsToClean =
       if (!includeDeps) targets
-      else targets.flatMap(t => Dag.dfs(state.build.getDagFor(t))).distinct
+      else targets.flatMap(t => Dag.dfs(state.build.getDagFor(t), mode = Dag.PreOrder)).distinct
     state.results.cleanSuccessful(allTargetsToClean.toSet, state.client, state.logger).map {
       newResults =>
         state.copy(results = newResults)

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
@@ -432,7 +432,7 @@ object CompileGraph {
                   Task.now(Parent(PartialFailure(project, BlockURI, blocked), dagResults))
                 } else {
                   val results: List[PartialSuccess] = {
-                    val transitive = dagResults.flatMap(Dag.dfs(_)).distinct
+                    val transitive = dagResults.flatMap(Dag.dfs(_, mode = Dag.PreOrder)).distinct
                     transitive.collect { case s: PartialSuccess => s }
                   }
 

--- a/frontend/src/test/scala/bloop/DagSpec.scala
+++ b/frontend/src/test/scala/bloop/DagSpec.scala
@@ -167,7 +167,7 @@ class DagSpec {
 
   @Test def EmptyDfs(): Unit = {
     val dags = fromMap(Map())
-    val dfss = dags.map(dag => Dag.dfs(dag))
+    val dfss = dags.map(dag => Dag.dfs(dag, mode = Dag.PreOrder))
     assert(dfss.isEmpty, "DFS for empty dag is empty")
   }
 
@@ -175,7 +175,7 @@ class DagSpec {
     import TestProjects.a
     val projectsMap = List(a.name -> a).toMap
     val dags = fromMap(projectsMap)
-    val dfss = dags.map(dag => Dag.dfs(dag))
+    val dfss = dags.map(dag => Dag.dfs(dag, mode = Dag.PreOrder))
     assert(dfss.size == 1)
     assert(dfss.head == List(a), s"DFS for simple dag does not contain $a")
   }
@@ -183,7 +183,7 @@ class DagSpec {
   @Test def CompleteDfs(): Unit = {
     val projectsMap = TestProjects.complete.map(p => p.name -> p).toMap
     val dags = fromMap(projectsMap)
-    val dfss = dags.map(dag => Dag.dfs(dag))
+    val dfss = dags.map(dag => Dag.dfs(dag, mode = Dag.PreOrder))
     assert(dfss.size == 3)
     assert(dfss.head == List(TestProjects.e))
     assert(dfss.tail.head == List(TestProjects.f, TestProjects.d, TestProjects.c, TestProjects.a))
@@ -286,7 +286,7 @@ class DagSpec {
     import ComplexDag._
     val allProjects = List(a, b, c, d, e, f, g, h, i)
     val dags = fromMap(allProjects.map(p => p.name -> p).toMap)
-    val sorted = Dag.topologicalSort(Aggregate(dags))
+    val sorted = Dag.dfs(Aggregate(dags), mode = Dag.PostOrder)
     assertAppearsBefore(sorted, a, List(b, c, d, e))
     assertAppearsBefore(sorted, c, List(d, e))
     assertAppearsBefore(sorted, d, List(e))

--- a/frontend/src/test/scala/bloop/FileWatchingSpec.scala
+++ b/frontend/src/test/scala/bloop/FileWatchingSpec.scala
@@ -489,7 +489,7 @@ object FileWatchingSpec extends BaseSuite {
   }
 
   private def numberDirsOf(dag: Dag[Project]): Int = {
-    val reachable = Dag.dfs(dag)
+    val reachable = Dag.dfs(dag, mode = Dag.PreOrder)
     val allSources = reachable.iterator.flatMap(_.sources.toList).map(_.underlying).toList
     allSources.filter { p =>
       val s = p.toString

--- a/frontend/src/test/scala/bloop/RunSpec.scala
+++ b/frontend/src/test/scala/bloop/RunSpec.scala
@@ -162,7 +162,7 @@ class RunSpec extends BloopHelpers {
         case Some(rootWithAggregation) =>
           val dag = state.build.getDagFor(rootWithAggregation)
           // Create dependent resources so that they appear in the full dependency classpath
-          val dependentResources = Dag.dfs(dag).flatMap(_.resources)
+          val dependentResources = Dag.dfs(dag, mode = Dag.PreOrder).flatMap(_.resources)
           dependentResources.foreach { resource =>
             if (resource.exists) ()
             else Files.createDirectories(resource.underlying)


### PR DESCRIPTION
Previously, `Dag.dfs` would always do pre-order traversal. This commit adds a `mode` parameter which allows to select pre-order or post-order traversal. Also, this commit replaces calls to `Dag.topologicalSort` with `Dag.dfs` with `mode = PostOrder`.