### PR TITLE
Fix test BSP service by not using stale state

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -724,7 +724,7 @@ final class BloopBspServices(
           compileProjects(mappings, state, args, originId, logger).flatMap {
             case (newState, Right(CompileResult(_, StatusCode.Ok, _, _))) =>
               val sequentialTestExecution: Task[Seq[Tasks.TestRuns]] =
-                Task.sequence(mappings.map { case (_, p) => test(p, state) })
+                Task.sequence(mappings.map { case (_, p) => test(p, newState) })
 
               sequentialTestExecution.materialize.map {
                 case Success(testRunsSeq) =>


### PR DESCRIPTION
Hey again, this is a followup to #1769 . There, I was stuck for a long while on the new tests for the `test` BSP service.

It failed like this:
```
[warn] Skipping test for a because compiler result is empty
``` 

@tgodzik made the tests green, and merged it. thanks again.

So then, imagine my surprise when I saw the same error with bloop 1.5.4 when trying to run tests through BSP. 

So I dug a bit further and discovered that when running tests bloop will (naturally) first compile, and then run tests. The problem is that the `State` produced by the compilation is not propagated to the test code, and the previous state is used instead. So if the code hadn't been compiled before for instance, test will see no class files.

For this PR I did a slight revert to the test code in the first commit (keeping the seemingly necessary changes)
The fix is in the second commit, where it propagates the correct state.