### PR TITLE
Bump scala-debug-adapter to 3.0.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,7 +55,7 @@ object Dependencies {
   val asmVersion = "7.0"
   val snailgunVersion = "0.4.0"
   val ztExecVersion = "1.11"
-  val debugAdapterVersion = "3.0.2"
+  val debugAdapterVersion = "3.0.4"
 
   import sbt.librarymanagement.syntax.stringToOrganization
   val zinc = "org.scala-sbt" %% "zinc" % zincVersion


### PR DESCRIPTION
It brings:
- [Better log points](https://github.com/scalacenter/scala-debug-adapter/releases/tag/v3.0.3)
- More logs to understand the flakiness of some unit tests in Metals
- A few bug fixes
