### PR TITLE
bugfix: Remove potentially problematic println

### DIFF
--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -379,7 +379,7 @@ object Cli {
 
       val session = runTaskWithCliClient(configDirectory, action, taskToInterpret, pool, logger)
       val exitSession = Task.defer {
-        cleanUpNonStableCliDirectories(session.client, cliOptions.common.ngout)
+        cleanUpNonStableCliDirectories(session.client)
       }
 
       session.task
@@ -438,15 +438,13 @@ object Cli {
   }
 
   def cleanUpNonStableCliDirectories(
-      client: CliClientInfo,
-      out: PrintStream
+      client: CliClientInfo
   ): Task[Unit] = {
     if (client.useStableCliDirs) Task.unit
     else {
       val deleteTasks = client.getCreatedCliDirectories.map { freshDir =>
         if (!freshDir.exists) Task.unit
         else {
-          out.println(s"Preparing to delete dir ${freshDir}")
           Task.eval(Paths.delete(freshDir)).asyncBoundary
         }
       }


### PR DESCRIPTION
It seems that https://github.com/scalacenter/bloop/issues/1847 is hanging on trying to lock the out object and since the println here is not really useful I think it's fine to remove and check if that helps.

The stack trace mostly shows a lot of thread stuck on that println actually.