### PR TITLE
chore: Remove java-debug and ignore updates for nailgun, release-early

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,7 @@
 updates.ignore = [
   { groupId = "com.github.plokhotnyuk.jsoniter-scala" },
+  { groupId = "ch.epfl.scala", artifactId = "nailgun-server" },
+  { groupId = "ch.epfl.scala", artifactId = "sbt-release-early" }
 ]
 commits.message = "build(deps): Update ${artifactName} from ${currentVersion} to ${nextVersion}"
 updates.limit = 5

--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,6 @@ lazy val backend = project
     buildInfoKeys := BloopBackendInfoKeys,
     buildInfoObject := "BloopScalaInfo",
     libraryDependencies ++= List(
-      Dependencies.javaDebug,
       Dependencies.nailgun,
       Dependencies.scalazCore,
       Dependencies.scalazConcurrent,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,6 @@ object Dependencies {
   val zincVersion = "1.7.2"
 
   val bspVersion = "2.0.0"
-  val javaDebugVersion = "0.21.0+1-7f1080f1"
 
   val scalazVersion = "7.2.20"
   val scalaXmlVersion = "1.2.0"
@@ -62,7 +61,6 @@ object Dependencies {
   val bsp4s = "ch.epfl.scala" %% "bsp4s" % bspVersion
   val bsp4j = "ch.epfl.scala" % "bsp4j" % bspVersion
   val nailgun = "ch.epfl.scala" % "nailgun-server" % nailgunVersion
-  val javaDebug = "ch.epfl.scala" % "com-microsoft-java-debug-core" % javaDebugVersion
 
   val configDirectories = "dev.dirs" % "directories" % configDirsVersion
   val libraryManagement = "org.scala-sbt" %% "librarymanagement-ivy" % lmVersion


### PR DESCRIPTION
javaDebug is brought in by scala-debug-adapter, so no need to define it here.

Nailgun version should fixed, since it's the one Bloop works with (dropping the fork would be awesome.)

Release-early should be replaced by sbt-ci-release so don't want to change the version and risk regression. Especially since it's not actively maintained.