### PR TITLE
bugfix: Don't fail test if socket was already closed

### DIFF
--- a/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
@@ -750,7 +750,12 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
       val closeTask = {
         lsClient.request(endpoints.Build.shutdown, bsp.Shutdown()).flatMap { _ =>
           Task.fromFuture(lsClient.notify(endpoints.Build.exit, bsp.Exit())).map { _ =>
-            socket.close()
+            try {
+              socket.close()
+            } catch {
+              case e: Throwable =>
+                logger.warn("Error closing socket", e)
+            }
             cleanUpLastResources(cmd)
           }
         }


### PR DESCRIPTION
Seems that the socket might already be closed at that point and an exception is caused causing frequent flaky tests.