### PR TITLE
bugfix: Retry test if socket was taken 

### DIFF
--- a/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
@@ -36,7 +36,7 @@ class BspConnectionSpec(
         Task {
           val logger = new RecordingLogger(ansiCodesSupported = false)
           val bspLogger = new BspClientLogger(logger)
-          val bspCommand = createBspCommand(configDir)
+          def bspCommand() = createBspCommand(configDir)
           val state = TestUtil.loadTestProject(configDir.underlying, logger)
 
           // Run the clients on our own unbounded IO scheduler to allow client concurrency
@@ -173,7 +173,7 @@ class BspConnectionSpec(
       def createHangingCompilationViaBsp: Task[Unit] = {
         Task {
           val bspLogger = new BspClientLogger(logger)
-          val bspCommand = createBspCommand(configDir)
+          def bspCommand() = createBspCommand(configDir)
           val state = TestUtil.loadTestProject(configDir.underlying, logger)
 
           // Run the clients on our own unbounded IO scheduler to allow client concurrency

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -264,7 +264,7 @@ class BspMetalsClientSpec(
             javaSemanticdbVersion = Some(javaSemanticdbVersion)
           )
           val bspLogger = new BspClientLogger(logger)
-          val bspCommand = createBspCommand(configDir)
+          def bspCommand() = createBspCommand(configDir)
           val state = TestUtil.loadTestProject(configDir.underlying, logger)
           val scheduler = Some(ExecutionContext.ioScheduler)
           val bspState = openBspConnection(

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -363,7 +363,7 @@ class BspProtocolSpec(
     val bspLogger = new BspClientLogger(logger)
     val configDir = TestUtil.createSimpleRecursiveBuild(RelativePath("bloop-config"))
     val state = TestUtil.loadTestProject(configDir.underlying, logger)
-    val bspCommand = createBspCommand(configDir)
+    def bspCommand() = createBspCommand(configDir)
     openBspConnection(state, bspCommand, configDir, bspLogger).withinSession { state =>
       val workspaceTargets = state.workspaceTargets
       assert(workspaceTargets.targets.isEmpty)

--- a/frontend/src/test/scala/bloop/dap/DebugBspBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugBspBaseSuite.scala
@@ -22,7 +22,7 @@ abstract class DebugBspBaseSuite extends BspBaseSuite {
 
   override def protocol: BspProtocol = if (isWindows) BspProtocol.Tcp else BspProtocol.Local
 
-  override def openBspConnection[T](
+  override def openBspConnectionUnsafe[T](
       state: State,
       cmd: Commands.ValidatedBsp,
       configDirectory: AbsolutePath,
@@ -34,7 +34,7 @@ abstract class DebugBspBaseSuite extends BspBaseSuite {
       compileStartPromises: Option[mutable.HashMap[bsp.BuildTargetIdentifier, Promise[Unit]]] = None
   ): UnmanagedBspTestState = {
     val ioScheduler = userIOScheduler.orElse(Some(debugDefaultScheduler))
-    super.openBspConnection(
+    super.openBspConnectionUnsafe(
       state,
       cmd,
       configDirectory,


### PR DESCRIPTION
It seems despite the randomness it can fail quite often, so instead we should retry.

Ideally we would specify 0 and use the system suggested port, but there is no way sensible way to propagate that to the tests.