### PR TITLE
Discover test classes only in test projects

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -581,7 +581,7 @@ final class BloopBspServices(
           Task.now((state, Right(ScalaTestClassesResult(Nil))))
 
         case Right(projects) =>
-          val subTasks = projects.toList.map {
+          val subTasks = projects.toList.filter(p => TestTask.isTestProject(p._2)).map {
             case (id, project) =>
               val task = TestTask.findTestNamesWithFramework(project, state)
               val item = task.map { classes =>

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -130,7 +130,7 @@ object Tasks {
       mode: RunMode
   ): Task[TestRuns] = {
 
-    val testTasks = projectsToTest.map { project =>
+    val testTasks = projectsToTest.filter(TestTask.isTestProject).map { project =>
       // note: mutable state here, to collect all `TestSuiteEvent.Results` produced while running tests
       // it should be fine, since it's scoped to this particular evaluation of `TestTask.runTestSuites`
       val resultsBuilder = List.newBuilder[TestSuiteEvent.Results]

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -42,6 +42,20 @@ object TestTask {
   implicit private val logContext: DebugFilter = DebugFilter.Test
 
   /**
+   * Does the given project represent a test project? Test project are projects tagged with either
+   * `test` or `integration-test`.
+   *
+   * See [[Tag.Test]], [[Tag.IntegrationTest]]
+   *
+   * @param project The project to test
+   * @return true if `project` is a test project, false otherwise.
+   */
+  def isTestProject(project: Project): Boolean = {
+    project.tags.contains(Tag.Test) ||
+    project.tags.contains(Tag.IntegrationTest)
+  }
+
+  /**
    * Run discovered test suites for a given project and return a status code.
    *
    * @param state The state with which to test.
@@ -65,10 +79,9 @@ object TestTask {
       mode: RunMode
   ): Task[Int] = {
     import state.logger
-    val isTestProject = project.tags.contains(Tag.Test) ||
-      project.tags.contains(Tag.IntegrationTest)
+    val isTest = isTestProject(project)
     def handleEmptyTestFrameworks: Task[Int] = {
-      if (isTestProject) {
+      if (isTest) {
         logger.error(s"Missing configured test frameworks in ${project.name}")
         Task.now(1)
       } else {
@@ -85,7 +98,7 @@ object TestTask {
         logger.warn(s"Skipping test for ${project.name} because compiler result is empty")
         Task.now(0)
       } else {
-        if (isTestProject) {
+        if (isTest) {
           logger.error(s"Missing compilation to test ${project.name}")
           Task.now(1)
         } else {

--- a/frontend/src/test/scala/bloop/GenericTestSpec.scala
+++ b/frontend/src/test/scala/bloop/GenericTestSpec.scala
@@ -78,8 +78,15 @@ class GenericTestSpec {
 
     val logger = new RecordingLogger(ansiCodesSupported = false)
     val deps = Map("I" -> Set("H", "G", "F"), "H" -> Set("F"))
+    val testProjects = Set("F", "G", "H", "I")
     val junitJars = bloop.internal.build.BuildTestInfo.junitTestJars.map(AbsolutePath.apply).toArray
-    TestUtil.testState(structure, deps, userLogger = Some(logger), extraJars = junitJars) { state =>
+    TestUtil.testState(
+      structure,
+      deps,
+      userLogger = Some(logger),
+      extraJars = junitJars,
+      testProjects = testProjects
+    ) { state =>
       val action = Run(Commands.Test(List("F"), cascade = true, args = List("-v", "-a")))
       val compiledState = TestUtil.blockingExecute(action, state)
       Assert.assertTrue("Unexpected compilation error", compiledState.status.isOk)

--- a/frontend/src/test/scala/bloop/TestSpec.scala
+++ b/frontend/src/test/scala/bloop/TestSpec.scala
@@ -405,7 +405,7 @@ object NoTestFrameworksSpec extends ProjectBaseSuite("no-test-frameworks") {
       val testState = build.state.test(project)
       try {
         assert(testState.status.isOk)
-        assert(logger.warnings.contains("Missing configured test frameworks in myProject"))
+        // No message is logged - this is not a test target, and therefore it is ignored.
       } catch { case err: AssertionError => logger.dump(); throw err }
   }
 }

--- a/frontend/src/test/scala/bloop/util/TestProject.scala
+++ b/frontend/src/test/scala/bloop/util/TestProject.scala
@@ -13,6 +13,7 @@ import bloop.bsp.ProjectUris
 import bloop.config.Config
 import bloop.config.Config.Platform
 import bloop.config.ConfigCodecs
+import bloop.config.Tag
 import bloop.data.ClientInfo.CliClientInfo
 import bloop.data.JdkConfig
 import bloop.io.AbsolutePath
@@ -199,7 +200,7 @@ abstract class BaseTestProject {
       test = Some(testConfig),
       platform = Some(platform),
       resolution = None,
-      tags = None,
+      tags = if (enableTests) Some(Tag.Test :: Nil) else None,
       if (sourceGenerators.isEmpty) None
       else Some(sourceGenerators)
     )


### PR DESCRIPTION
Previously, Bloop would inspect all projects to try and find test classes. This is not necessary, because only classes that live in test projects should be run.

This commit filters out test projects from the analysis, so that it runs faster.