### PR TITLE
refactor: Use the actual timeouts defined for tests in DebugServerSpec

### DIFF
--- a/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
@@ -23,7 +23,6 @@ import bloop.bsp.ScalaTestSuites
 import bloop.cli.ExitStatus
 import bloop.data.Platform
 import bloop.data.Project
-import bloop.engine.ExecutionContext
 import bloop.engine.State
 import bloop.engine.tasks.RunMode
 import bloop.engine.tasks.Tasks
@@ -46,38 +45,36 @@ import com.microsoft.java.debug.core.protocol.Types
 import com.microsoft.java.debug.core.protocol.Types.SourceBreakpoint
 import monix.execution.Ack
 import monix.reactive.Observer
+import scala.concurrent.Await
+import bloop.engine.ExecutionContext
 
 object DebugServerSpec extends DebugBspBaseSuite {
   private val ServerNotListening = new IllegalStateException("Server is not accepting connections")
   private val Success: ExitStatus = ExitStatus.Ok
   private val resolver = new BloopDebugToolsResolver(NoopLogger)
 
-  test("cancelling server closes server connection") {
+  testTask("cancelling server closes server connection", FiniteDuration(10, SECONDS)) {
     startDebugServer(Task.now(Success)) { server =>
-      val test = for {
+      for {
         _ <- Task(server.cancel())
         serverClosed <- waitForServerEnd(server)
       } yield {
         assert(serverClosed)
       }
-
-      TestUtil.await(FiniteDuration(10, SECONDS), ExecutionContext.ioScheduler)(test)
     }
   }
 
-  test("cancelling server closes client connection") {
+  testTask("cancelling server closes client connection", FiniteDuration(10, SECONDS)) {
     startDebugServer(Task.now(Success)) { server =>
-      val test = for {
+      for {
         client <- server.startConnection
         _ <- Task(server.cancel())
         _ <- Task.fromFuture(client.closedPromise.future)
       } yield ()
-
-      TestUtil.await(FiniteDuration(10, SECONDS), ExecutionContext.ioScheduler)(test)
     }
   }
 
-  test("sends exit and terminated events when cancelled") {
+  testTask("sends exit and terminated events when cancelled", FiniteDuration(30, SECONDS)) {
     TestUtil.withinWorkspace { workspace =>
       val main =
         """|/Main.scala
@@ -91,11 +88,11 @@ object DebugServerSpec extends DebugBspBaseSuite {
       val logger = new RecordingLogger(ansiCodesSupported = false)
       val project = TestProject(workspace, "p", List(main))
 
-      loadBspState(workspace, List(project), logger) { state =>
+      loadBspStateWithTask(workspace, List(project), logger) { state =>
         val runner = mainRunner(project, state)
 
         startDebugServer(runner) { server =>
-          val test = for {
+          for {
             client <- server.startConnection
             _ <- client.initialize()
             _ <- client.launch()
@@ -105,14 +102,15 @@ object DebugServerSpec extends DebugBspBaseSuite {
             _ <- client.terminated
             _ <- Task.fromFuture(client.closedPromise.future)
           } yield ()
-
-          TestUtil.await(FiniteDuration(30, SECONDS), ExecutionContext.ioScheduler)(test)
         }
       }
     }
   }
 
-  test("closes the client when debuggee finished and terminal events are sent") {
+  testTask(
+    "closes the client when debuggee finished and terminal events are sent",
+    FiniteDuration(60, SECONDS)
+  ) {
     TestUtil.withinWorkspace { workspace =>
       val main =
         """|/main/scala/Main.scala
@@ -126,11 +124,11 @@ object DebugServerSpec extends DebugBspBaseSuite {
       val logger = new RecordingLogger(ansiCodesSupported = false)
       val project = TestProject(workspace, "r", List(main))
 
-      loadBspState(workspace, List(project), logger) { state =>
+      loadBspStateWithTask(workspace, List(project), logger) { state =>
         val runner = mainRunner(project, state)
 
         startDebugServer(runner) { server =>
-          val test = for {
+          for {
             client <- server.startConnection
             _ <- client.initialize()
             _ <- client.launch()
@@ -149,14 +147,15 @@ object DebugServerSpec extends DebugBspBaseSuite {
               "Hello, World!"
             )
           }
-
-          TestUtil.await(FiniteDuration(60, SECONDS), ExecutionContext.ioScheduler)(test)
         }
       }
     }
   }
 
-  test("accepts arguments and jvm options and environment variables") {
+  testTask(
+    "accepts arguments and jvm options and environment variables",
+    FiniteDuration(60, SECONDS)
+  ) {
     TestUtil.withinWorkspace { workspace =>
       val main =
         """|/main/scala/Main.scala
@@ -172,7 +171,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
       val logger = new RecordingLogger(ansiCodesSupported = false)
       val project = TestProject(workspace, "r", List(main))
 
-      loadBspState(workspace, List(project), logger) { state =>
+      loadBspStateWithTask(workspace, List(project), logger) { state =>
         val runner = mainRunner(
           project,
           state,
@@ -182,7 +181,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
         )
 
         startDebugServer(runner) { server =>
-          val test = for {
+          for {
             client <- server.startConnection
             _ <- client.initialize()
             _ <- client.launch()
@@ -201,14 +200,12 @@ object DebugServerSpec extends DebugBspBaseSuite {
               "hello\nworld!"
             )
           }
-
-          TestUtil.await(FiniteDuration(60, SECONDS), ExecutionContext.ioScheduler)(test)
         }
       }
     }
   }
 
-  test("supports scala and java breakpoints") {
+  testTask("supports scala and java breakpoints", FiniteDuration(60, SECONDS)) {
     TestUtil.withinWorkspace { workspace =>
       object Sources {
         val javaClass: String =
@@ -254,7 +251,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
       val logger = new RecordingLogger(ansiCodesSupported = false)
       val project = TestProject(workspace, "r", List(Sources.scalaMain, Sources.javaClass))
 
-      loadBspState(workspace, List(project), logger) { state =>
+      loadBspStateWithTask(workspace, List(project), logger) { state =>
         val runner = mainRunner(project, state)
 
         val buildProject = state.toTestState.getProjectFor(project)
@@ -266,7 +263,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
         val javaBreakpoints = breakpointsArgs(`HelloJava.java`, 3, 7)
 
         startDebugServer(runner) { server =>
-          val test = for {
+          for {
             client <- server.startConnection
             _ <- client.initialize()
             _ <- client.launch()
@@ -308,14 +305,15 @@ object DebugServerSpec extends DebugBspBaseSuite {
                  |""".stripMargin
             )
           }
-
-          TestUtil.await(FiniteDuration(60, SECONDS), ExecutionContext.ioScheduler)(test)
         }
       }
     }
   }
 
-  test("requesting stack traces and variables after breakpoints works") {
+  testTask(
+    "requesting stack traces and variables after breakpoints works",
+    FiniteDuration(60, SECONDS)
+  ) {
     TestUtil.withinWorkspace { workspace =>
       val source = """|/Main.scala
                       |object Main {
@@ -333,7 +331,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
       val logger = new RecordingLogger(ansiCodesSupported = false)
       val project = TestProject(workspace, "r", List(source))
 
-      loadBspState(workspace, List(project), logger) { state =>
+      loadBspStateWithTask(workspace, List(project), logger) { state =>
         val runner = mainRunner(project, state)
 
         val buildProject = state.toTestState.getProjectFor(project)
@@ -343,7 +341,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
         val breakpoints = breakpointsArgs(`Main.scala`, 4)
 
         startDebugServer(runner) { server =>
-          val test = for {
+          for {
             client <- server.startConnection
             _ <- client.initialize()
             _ <- client.launch()
@@ -379,24 +377,25 @@ object DebugServerSpec extends DebugBspBaseSuite {
                  |""".stripMargin
             )
           }
-
-          TestUtil.await(FiniteDuration(60, SECONDS), ExecutionContext.ioScheduler)(test)
         }
       }
     }
   }
 
-  test("sends exit and terminated events when cannot run debuggee") {
+  testTask(
+    "sends exit and terminated events when cannot run debuggee",
+    FiniteDuration(60, SECONDS)
+  ) {
     TestUtil.withinWorkspace { workspace =>
       // note that there is nothing that can be run (no sources)
       val project = TestProject(workspace, "p", Nil)
 
       val logger = new RecordingLogger(ansiCodesSupported = false)
-      loadBspState(workspace, List(project), logger) { state =>
+      loadBspStateWithTask(workspace, List(project), logger) { state =>
         val runner = mainRunner(project, state)
 
         startDebugServer(runner) { server =>
-          val test = for {
+          for {
             client <- server.startConnection
             _ <- client.initialize()
             _ <- client.launch()
@@ -405,16 +404,17 @@ object DebugServerSpec extends DebugBspBaseSuite {
             _ <- client.exited
             _ <- client.terminated
           } yield ()
-
-          TestUtil.await(FiniteDuration(60, SECONDS), ExecutionContext.ioScheduler)(test)
         }
       }
     }
   }
 
-  test("does not accept a connection unless the previous session requests a restart") {
+  testTask(
+    "does not accept a connection unless the previous session requests a restart",
+    FiniteDuration(5, SECONDS)
+  ) {
     startDebugServer(Task.now(Success)) { server =>
-      val test = for {
+      for {
         firstClient <- server.startConnection
         secondClient <- server.startConnection
         requestBeforeRestart <- secondClient.initialize().timeout(FiniteDuration(1, SECONDS)).failed
@@ -423,30 +423,26 @@ object DebugServerSpec extends DebugBspBaseSuite {
       } yield {
         assert(requestBeforeRestart.isInstanceOf[TimeoutException])
       }
-
-      TestUtil.await(FiniteDuration(5, SECONDS), ExecutionContext.ioScheduler)(test)
     }
   }
 
-  test("responds to launch when jvm could not be started") {
+  testTask("responds to launch when jvm could not be started", FiniteDuration(20, SECONDS)) {
     // note that the runner is not starting the jvm
     // therefore the debuggee address will never be bound
     val runner = Task.now(Success)
 
     startDebugServer(runner) { server =>
-      val test = for {
+      for {
         client <- server.startConnection
         _ <- client.initialize()
         cause <- client.launch().failed
       } yield {
         assertContains(cause.getMessage, "Operation timed out")
       }
-
-      TestUtil.await(FiniteDuration(20, SECONDS), ExecutionContext.ioScheduler)(test)
     }
   }
 
-  test("restarting closes current client and debuggee") {
+  testTask("restarting closes current client and debuggee", FiniteDuration(15, SECONDS)) {
     val cancelled = Promise[Boolean]()
     val awaitCancellation = Task
       .fromFuture(cancelled.future)
@@ -455,7 +451,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
       .doOnCancel(complete(cancelled, true))
 
     startDebugServer(awaitCancellation) { server =>
-      val test = for {
+      for {
         firstClient <- server.startConnection
         _ <- firstClient.disconnect(restart = true)
         secondClient <- server.startConnection
@@ -469,12 +465,10 @@ object DebugServerSpec extends DebugBspBaseSuite {
         // Second client should still be connected despite the first one was closed
         assert(debuggeeCanceled, !secondClientClosed)
       }
-
-      TestUtil.await(FiniteDuration(15, SECONDS), ExecutionContext.ioScheduler)(test)
     }
   }
 
-  test("disconnecting closes server, client and debuggee") {
+  testTask("disconnecting closes server, client and debuggee", FiniteDuration(20, SECONDS)) {
     val cancelled = Promise[Boolean]()
     val awaitCancellation = Task
       .fromFuture(cancelled.future)
@@ -483,7 +477,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
       .doOnCancel(complete(cancelled, true))
 
     startDebugServer(awaitCancellation) { server =>
-      val test = for {
+      for {
         client <- server.startConnection
         _ <- client.disconnect(restart = false)
         debuggeeCanceled <- Task.fromFuture(cancelled.future)
@@ -492,42 +486,36 @@ object DebugServerSpec extends DebugBspBaseSuite {
       } yield {
         assert(debuggeeCanceled, serverClosed)
       }
-
-      TestUtil.await(FiniteDuration(20, SECONDS), ExecutionContext.ioScheduler)(test)
     }
   }
 
-  test("closes the client even though the debuggee cannot close") {
+  testTask("closes the client even though the debuggee cannot close", FiniteDuration(20, SECONDS)) {
     val blockedDebuggee = Promise[Nothing]
 
     startDebugServer(Task.fromFuture(blockedDebuggee.future)) { server =>
-      val test = for {
+      for {
         client <- server.startConnection
         _ <- Task(server.cancel())
         _ <- Task.fromFuture(client.closedPromise.future)
       } yield ()
-
-      TestUtil.await(FiniteDuration(20, SECONDS), ExecutionContext.ioScheduler)(test)
     }
   }
 
-  test("propagates launch failure cause") {
+  testTask("propagates launch failure cause", FiniteDuration(20, SECONDS)) {
     val task = Task.raiseError(new Exception(ExitStatus.RunError.name))
 
     startDebugServer(task) { server =>
-      val test = for {
+      for {
         client <- server.startConnection
         _ <- client.initialize()
         response <- client.launch().failed
       } yield {
         assert(response.getMessage.contains(ExitStatus.RunError.name))
       }
-
-      TestUtil.await(FiniteDuration(20, SECONDS), ExecutionContext.ioScheduler)(test)
     }
   }
 
-  test("attaches to a remote process and sets breakpoint") {
+  testTask("attaches to a remote process and sets breakpoint", FiniteDuration(120, SECONDS)) {
     TestUtil.withinWorkspace { workspace =>
       val main =
         """|/Main.scala
@@ -541,7 +529,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
       val logger = new RecordingLogger(ansiCodesSupported = false)
       val project = TestProject(workspace, "r", List(main))
 
-      loadBspState(workspace, List(project), logger) { state =>
+      loadBspStateWithTask(workspace, List(project), logger) { state =>
         val testState = state.compile(project).toTestState
         val buildProject = testState.getProjectFor(project)
         def srcFor(srcName: String) =
@@ -557,7 +545,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
           )
 
         startDebugServer(attachRemoteProcessRunner) { server =>
-          val test = for {
+          for {
             port <- startRemoteProcess(buildProject, testState)
             client <- server.startConnection
             _ <- client.initialize()
@@ -582,14 +570,12 @@ object DebugServerSpec extends DebugBspBaseSuite {
               ""
             )
           }
-
-          TestUtil.await(FiniteDuration(120, SECONDS), ExecutionContext.ioScheduler)(test)
         }
       }
     }
   }
 
-  test("evaluate expression in main debuggee") {
+  testTask("evaluate expression in main debuggee", FiniteDuration(60, SECONDS)) {
     TestUtil.withinWorkspace { workspace =>
       val source = """|/Main.scala
                       |object Main {
@@ -612,7 +598,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
         scalaVersion = Some("2.12.15")
       )
 
-      loadBspState(workspace, List(project), logger) { state =>
+      loadBspStateWithTask(workspace, List(project), logger) { state =>
         val runner = mainRunner(project, state)
 
         val buildProject = state.toTestState.getProjectFor(project)
@@ -622,7 +608,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
         val breakpoints = breakpointsArgs(`Main.scala`, 4)
 
         startDebugServer(runner) { server =>
-          val test = for {
+          for {
             client <- server.startConnection
             _ <- client.initialize()
             _ <- client.launch()
@@ -645,14 +631,12 @@ object DebugServerSpec extends DebugBspBaseSuite {
             assertNoDiff(evaluation.`type`, "String")
             assertNoDiff(evaluation.result, "\"foo\"")
           }
-
-          TestUtil.await(FiniteDuration(60, SECONDS), ExecutionContext.ioScheduler)(test)
         }
       }
     }
   }
 
-  test("evaluate expression in test suite") {
+  testTask("evaluate expression in test suite", FiniteDuration(60, SECONDS)) {
     TestUtil.withinWorkspace { workspace =>
       val source =
         """/MySuite.scala
@@ -686,7 +670,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
         scalaVersion = Some(scalaVersion)
       )
 
-      loadBspState(workspace, List(project), logger) { state =>
+      loadBspStateWithTask(workspace, List(project), logger) { state =>
         val runner = testRunner(project, state)
 
         val buildProject = state.toTestState.getProjectFor(project)
@@ -696,7 +680,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
         val breakpoints = breakpointsArgs(`MySuite.scala`, 5)
 
         startDebugServer(runner) { server =>
-          val test = for {
+          for {
             client <- server.startConnection
             _ <- client.initialize()
             _ <- client.launch()
@@ -719,14 +703,12 @@ object DebugServerSpec extends DebugBspBaseSuite {
             assertNoDiff(evaluation.`type`, "String")
             assertNoDiff(evaluation.result, "\"foo\"")
           }
-
-          TestUtil.await(FiniteDuration(60, SECONDS), ExecutionContext.ioScheduler)(test)
         }
       }
     }
   }
 
-  test("evaluate expression in attached debuggee") {
+  testTask("evaluate expression in attached debuggee", FiniteDuration(120, SECONDS)) {
     TestUtil.withinWorkspace { workspace =>
       val source = """|/Main.scala
                       |object Main {
@@ -749,7 +731,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
         scalaVersion = Some("2.12.15")
       )
 
-      loadBspState(workspace, List(project), logger) { state =>
+      loadBspStateWithTask(workspace, List(project), logger) { state =>
         val testState = state.compile(project).toTestState
         val buildProject = testState.getProjectFor(project)
         def srcFor(srcName: String) =
@@ -765,7 +747,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
           )
 
         startDebugServer(attachRemoteProcessRunner) { server =>
-          val test = for {
+          for {
             port <- startRemoteProcess(buildProject, testState)
             client <- server.startConnection
             _ <- client.initialize()
@@ -788,14 +770,12 @@ object DebugServerSpec extends DebugBspBaseSuite {
             assertNoDiff(evaluation.`type`, "String")
             assertNoDiff(evaluation.result, "\"foo\"")
           }
-
-          TestUtil.await(FiniteDuration(120, SECONDS), ExecutionContext.ioScheduler)(test)
         }
       }
     }
   }
 
-  test("run only single test") {
+  testTask("run only single test", FiniteDuration(60, SECONDS)) {
     TestUtil.withinWorkspace { workspace =>
       val source =
         """/MySuite.scala
@@ -830,7 +810,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
         scalaVersion = Some(scalaVersion)
       )
 
-      loadBspState(workspace, List(project), logger) { state =>
+      loadBspStateWithTask(workspace, List(project), logger) { state =>
         val testClasses =
           ScalaTestSuites(
             List(
@@ -845,7 +825,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
         val runner = testRunner(project, state, testClasses)
 
         startDebugServer(runner) { server =>
-          val test = for {
+          for {
             client <- server.startConnection
             _ <- client.initialize()
             _ <- client.launch()
@@ -862,8 +842,6 @@ object DebugServerSpec extends DebugBspBaseSuite {
             assert(logger.debugs.contains("Test MySuite.test1 started"))
             assert(logger.debugs.contains("Test MySuite.test2 ignored"))
           }
-
-          TestUtil.await(FiniteDuration(60, SECONDS), ExecutionContext.ioScheduler)(test)
         }
       }
     }
@@ -995,7 +973,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
     }
   }
 
-  def startDebugServer(task: Task[ExitStatus])(f: TestServer => Any): Unit = {
+  def startDebugServer(task: Task[ExitStatus])(f: TestServer => Task[Unit]): Task[Unit] = {
     val debuggee = new Debuggee {
       override def modules: Seq[Module] = Seq.empty
       override def libraries: Seq[Library] = Seq.empty
@@ -1019,7 +997,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
   def startDebugServer(
       debuggee: Debuggee,
       gracePeriod: Duration = Duration(5, SECONDS)
-  )(f: TestServer => Any): Unit = {
+  )(f: TestServer => Task[Unit]): Task[Unit] = {
     val logger = new RecordingLogger(ansiCodesSupported = false)
     val dapLogger = new DebugServerLogger(logger)
     val debugTools = DebugTools(debuggee, resolver, dapLogger)
@@ -1029,12 +1007,10 @@ object DebugServerSpec extends DebugBspBaseSuite {
     Task.fromFuture(server.start()).runAsync(defaultScheduler)
 
     val testServer = new TestServer(server)
-    val test = Task(f(testServer))
+    f(testServer)
       .doOnFinish(_ => Task(testServer.close()))
       .doOnCancel(Task(testServer.close()))
 
-    TestUtil.await(35, SECONDS)(test)
-    ()
   }
 
   private final class TestServer(val server: DebugServer) extends AutoCloseable {

--- a/frontend/src/test/scala/bloop/testing/BaseSuite.scala
+++ b/frontend/src/test/scala/bloop/testing/BaseSuite.scala
@@ -564,24 +564,12 @@ abstract class BaseSuite extends TestSuite with BloopHelpers {
     myTests += FlatTest(name, () => { fun; () })
   }
 
-  def testAsync(name: String, maxDuration: Duration = Duration("20s"))(
-      run: => Unit
-  ): Unit = {
-    test(name) {
-      Await.result(Task { run }.runAsync(ExecutionContext.scheduler), maxDuration)
-    }
+  def testTask(name: String, maxDuration: Duration = Duration("20s"))(fun: => Task[Unit]): Unit = {
+    myTests += FlatTest(
+      name,
+      () => { TestUtil.await(maxDuration, ExecutionContext.ioScheduler)(fun) }
+    )
   }
-
-  /*
-  def testAsync(name: String, maxDuration: Duration = Duration("10min"))(
-      run: => Future[Unit]
-  ): Unit = {
-    test(name) {
-      val fut = run
-      Await.result(fut, maxDuration)
-    }
-  }
-   */
 
   def fail(msg: String, stackBump: Int = 0): Nothing = {
     val ex = new DiffAssertions.TestFailedException(msg)

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -469,6 +469,12 @@ object TestUtil {
     finally delete(AbsolutePath(temp))
   }
 
+  /** Creates an empty workspace where operations can happen. */
+  def withinWorkspace[T](op: AbsolutePath => Task[T]): Task[T] = {
+    val temp = Files.createTempDirectory("bloop-test-workspace").toRealPath()
+    op(AbsolutePath(temp)).doOnFinish(_ => Task(delete(AbsolutePath(temp))))
+  }
+
   def withTemporaryFile[T](op: Path => T): T = {
     val temp = Files.createTempFile("tmp", "")
     try op(temp)


### PR DESCRIPTION
Previously, we would always timeout after 35 seconds, because that was the timeout set in startDebugServer. Now, we forward the task up to the test and wait the amount specified in each test.