### PR TITLE
chore: downgrade release ubuntu version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,10 +142,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-20.04, macOS-latest]
         jdk: [graalvm-ce-java11@21.1.0]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             artifact: bloop-linux
           - os: macos-latest
             artifact: bloop-macos
@@ -248,7 +248,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         jdk: [adopt@1.8]
     env:
       CI: true


### PR DESCRIPTION
It seems that if we build with the newer version and try to run on ubuntu 20 it will fail with missing `GLIBC_2.34'

I updated my local ubuntu version and it seems to work, but it might be problematic for some users with older version.