### PR TITLE
fix: revert sbt-jmh update

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -2,6 +2,7 @@ updates.ignore = [
   { groupId = "com.github.plokhotnyuk.jsoniter-scala" },
   { groupId = "ch.epfl.scala", artifactId = "nailgun-server" },
   { groupId = "ch.epfl.scala", artifactId = "sbt-release-early" }
+  { groupId = "pl.project13.scala", artifactId = "sbt-jmh" }
 ]
 commits.message = "build(deps): Update ${artifactName} from ${currentVersion} to ${nextVersion}"
 updates.limit = 5

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -21,7 +21,8 @@ val `bloop-build` = project
     addSbtPlugin("com.scalawilliam.esbeetee" % "sbt-vspp" % "0.4.11"),
     addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0"),
     addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0"),
-    addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3"),
+    // Bumping this will causes issues. For now just lock it
+    addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7"),
     addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1"),
     addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.1.1+4-9d76569a"),
     addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.6"),


### PR DESCRIPTION
Locally I'm having issues ever since I merged in #1940. This
reverts that update and locks the version for now. After ripping
stuff out and cleaning up I'll dig further into this.
