### PR TITLE
fix: update jvmOpts to not mention bloop-sbt-already-installed

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,3 +1,2 @@
 -XX:ReservedCodeCacheSize=512m
--Dmetals.bloop-sbt-already-installed=true
 -Dsbt.execute.extrachecks=true


### PR DESCRIPTION
This was added so Metals wouldn't add a metals.sbt. Now that we are no longer
dogfooding we don't need this set and instead _want_ metals to create this.
