### PR TITLE
refactor(ci): migrate to sbt-ci-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,10 +248,9 @@ jobs:
     env:
       CI: true
       SKIP_TEST_RESOURCES_GENERATION: true
-      SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USER }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-      PGP_PASSWORD: ${{ secrets.PGP_PASSWORD }}
-      PGP_PASSPHRASE: ${{ secrets.PGP_PASSWORD }}
+      PGP_SECRET: ${{ secrets.PGP_SECRET }}
       PGP_PUBLIC_KEY: ${{ secrets.PGP_PUBLIC_KEY }}
       PGP_PRIVATE_KEY: ${{ secrets.PGP_PRIVATE_KEY }}
       GITHUB_DEPLOY_KEY: ${{ secrets.GITHUB_DEPLOY_KEY }}
@@ -283,18 +282,13 @@ jobs:
         run: |
           yarn install
           touch ~/.profile
-          mkdir "$HOME/.ssh"
-          mkdir "$HOME/.sbt"
-          mkdir "$HOME/.sbt/gpg"
           git config --global user.name "Bloopoid"
           git config --global user.email "bloop@vican.me"
           git config --global push.default simple
-          echo "$PGP_PUBLIC_KEY" > "$HOME/.sbt/gpg/pubring.asc"
-          echo "$PGP_PRIVATE_KEY" > "$HOME/.sbt/gpg/secring.asc"
           ls -l bloop-artifacts
           mkdir -p frontend/target
           mv bloop-artifacts frontend/target/graalvm-binaries
-          ./bin/sbt-ci-publish.sh "releaseBloop" "docs/docusaurusPublishGhpages"
+          ./bin/sbt-ci-publish.sh "ci-release" "docs/docusaurusPublishGhpages"
         shell: bash
       - name: Cut GitHub release and update installers on ${{ matrix.os }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,11 +248,10 @@ jobs:
     env:
       CI: true
       SKIP_TEST_RESOURCES_GENERATION: true
-      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USER }}
+      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
       PGP_SECRET: ${{ secrets.PGP_SECRET }}
-      PGP_PUBLIC_KEY: ${{ secrets.PGP_PUBLIC_KEY }}
-      PGP_PRIVATE_KEY: ${{ secrets.PGP_PRIVATE_KEY }}
       GITHUB_DEPLOY_KEY: ${{ secrets.GITHUB_DEPLOY_KEY }}
       BLOOPOID_GITHUB_TOKEN: ${{ secrets.BLOOPOID_GITHUB_TOKEN }}
       BLOOPOID_SSH_PUBLIC_KEY: ${{ secrets.BLOOPOID_SSH_PUBLIC_KEY }}

--- a/bin/set-up-keys.sh
+++ b/bin/set-up-keys.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -o nounset
-
-mkdir "$HOME/.gnupg"
-echo "$PGP_PUBLIC_KEY" > "$HOME/.gnupg/pubring.asc"
-echo "$PGP_PRIVATE_KEY" > "$HOME/.gnupg/secring.asc"

--- a/build.sbt
+++ b/build.sbt
@@ -170,6 +170,7 @@ lazy val frontend: Project = project
     scalafixSettings,
     testSettings,
     testSuiteSettings,
+    releaseSettings,
     Defaults.itSettings,
     BuildDefaults.frontendTestBuildSettings,
     inConfig(Compile)(

--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,6 @@ ThisBuild / dynverSeparator := "-"
 
 ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.6.0"
 
-ThisBuild / versionScheme := Some("early-semver")
-
 // Add hook for scalafmt validation
 Global / onLoad ~= { old =>
   if (!scala.util.Properties.isWin) {
@@ -288,6 +286,7 @@ lazy val launcherTest = project
   .dependsOn(launcher, frontend % "test->test")
   .settings(
     name := "bloop-launcher-test",
+    (publish / skip) := true,
     scalafixSettings,
     testSuiteSettings,
     (Test / fork) := true,
@@ -451,20 +450,22 @@ lazy val twitterIntegrationProjects = project
   )
 
 val allProjects = Seq(
-  bloopShared,
   backend,
-  frontend,
   benchmarks,
-  sbtBloop,
-  nativeBridge04,
+  bloopgun,
+  bloopgun213,
+  bloopShared,
+  buildpress,
+  buildpressConfig,
+  frontend,
   jsBridge06,
   jsBridge1,
   launcher,
   launcher213,
   launcherTest,
-  sockets,
-  bloopgun,
-  bloopgun213
+  nativeBridge04,
+  sbtBloop,
+  sockets
 )
 
 val allProjectReferences = allProjects.map(p => LocalProject(p.id))

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,8 @@ ThisBuild / dynverSeparator := "-"
 
 ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.6.0"
 
+ThisBuild / versionScheme := Some("early-semver")
+
 // Add hook for scalafmt validation
 Global / onLoad ~= { old =>
   if (!scala.util.Properties.isWin) {

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -2,7 +2,6 @@ package build
 
 import java.io.File
 
-import ch.epfl.scala.sbt.release.Feedback
 import com.jsuereth.sbtpgp.SbtPgp.{autoImport => Pgp}
 import sbt._
 import sbt.io.IO
@@ -10,21 +9,20 @@ import sbt.io.syntax.fileToRichFile
 import sbt.librarymanagement.syntax.stringToOrganization
 import sbt.util.FileFunction
 import sbtdynver.GitDescribeOutput
-import ch.epfl.scala.sbt.release.ReleaseEarlyPlugin.{autoImport => ReleaseEarlyKeys}
 import sbt.internal.BuildLoader
 import sbt.librarymanagement.MavenRepository
 import sbt.util.Logger
 import sbtbuildinfo.BuildInfoPlugin.{autoImport => BuildInfoKeys}
+import com.geirsson.CiReleasePlugin
 
 object BuildPlugin extends AutoPlugin {
   import sbt.plugins.JvmPlugin
   import sbt.plugins.IvyPlugin
   import com.jsuereth.sbtpgp.SbtPgp
-  import ch.epfl.scala.sbt.release.ReleaseEarlyPlugin
 
   override def trigger: PluginTrigger = allRequirements
   override def requires: Plugins =
-    JvmPlugin && ReleaseEarlyPlugin && SbtPgp && IvyPlugin
+    JvmPlugin && CiReleasePlugin && IvyPlugin
   val autoImport = BuildKeys
 
   override def globalSettings: Seq[Def.Setting[_]] =
@@ -81,9 +79,6 @@ object BuildKeys {
   val createLocalArchPackage = Def.taskKey[Unit]("Create local ArchLinux package build files")
   val bloopCoursierJson = Def.taskKey[File]("Generate a versioned install script")
   val bloopLocalCoursierJson = Def.taskKey[File]("Generate a versioned install script")
-  val releaseEarlyAllModules = Def.taskKey[Unit]("Release early all modules")
-  val releaseSonatypeBundle = Def.taskKey[Unit]("Release sonatype bundle, do nothing if no release")
-  val publishLocalAllModules = Def.taskKey[Unit]("Publish all modules locally")
 
   // This has to be change every time the bloop config files format changes.
   val schemaVersion = Def.settingKey[String]("The schema version for our bloop build.")
@@ -171,9 +166,7 @@ object BuildKeys {
     Keys.name := name,
     Keys.sbtPlugin := true,
     Keys.sbtVersion := sbtVersion,
-    Keys.target := (file("integrations") / "sbt-bloop" / "target" / sbtVersion).getAbsoluteFile,
-    Keys.publishMavenStyle :=
-      ReleaseEarlyKeys.releaseEarlyWith.value == ReleaseEarlyKeys.SonatypePublisher
+    Keys.target := (file("integrations") / "sbt-bloop" / "target" / sbtVersion).getAbsoluteFile
   )
 
   def benchmarksSettings(dep: Reference): Seq[Def.Setting[_]] = List(
@@ -240,9 +233,6 @@ object BuildImplementation {
       val sonatypeStaging = Resolver.sonatypeOssRepos("staging")
       (oldResolvers ++ sonatypeStaging).distinct
     },
-    ReleaseEarlyKeys.releaseEarlyWith := {
-      ReleaseEarlyKeys.SonatypePublisher
-    },
     Keys.startYear := Some(2017),
     Keys.autoAPIMappings := true,
     Keys.publishMavenStyle := true,
@@ -275,7 +265,6 @@ object BuildImplementation {
   )
 
   final val projectSettings: Seq[Def.Setting[_]] = Seq(
-    ReleaseEarlyKeys.releaseEarlyPublish := BuildDefaults.releaseEarlyPublish.value,
     Keys.scalacOptions := {
       CrossVersion.partialVersion(Keys.scalaVersion.value) match {
         case Some((2, 13)) =>
@@ -426,36 +415,6 @@ object BuildImplementation {
           Seq("-Xmx1024M", "-Dplugin.version=" + Keys.version.value)
       }
     )
-
-    val releaseEarlyPublish: Def.Initialize[Task[Unit]] = Def.task {
-      val logger = Keys.streams.value.log
-      val name = Keys.name.value
-      // We force publishSigned for all of the modules, yes or yes.
-      logger.info(Feedback.logReleaseSonatype(name))
-      Pgp.PgpKeys.publishSigned.value
-    }
-
-    def releaseEarlyAllModules(projects: Seq[sbt.ProjectReference]): Def.Initialize[Task[Unit]] = {
-      Def.taskDyn {
-        val filter = sbt.ScopeFilter(
-          sbt.inProjects(projects: _*),
-          sbt.inConfigurations(sbt.Compile)
-        )
-
-        ReleaseEarlyKeys.releaseEarly.all(filter).map(_ => ())
-      }
-    }
-
-    def publishLocalAllModules(projects: Seq[sbt.ProjectReference]): Def.Initialize[Task[Unit]] = {
-      Def.taskDyn {
-        val filter = sbt.ScopeFilter(
-          sbt.inProjects(projects: _*),
-          sbt.inConfigurations(sbt.Compile)
-        )
-
-        Keys.publishLocal.all(filter).map(_ => ())
-      }
-    }
 
     // From sbt-sensible https://gitlab.com/fommil/sbt-sensible/issues/5, legal requirement
     val getLicense: Def.Initialize[Task[Seq[File]]] = Def.task {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.8.0

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -13,7 +13,7 @@ val `bloop-build` = project
     // Bumping this will causes issues. For now just lock it
     addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7"),
     addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1"),
-    addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.1.1+4-9d76569a"),
+    addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11"),
     addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.6"),
     addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools" % "1.1.1"),
     addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1"),

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -16,7 +16,7 @@ val `bloop-build` = project
     addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11"),
     addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.6"),
     addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools" % "1.1.1"),
-    addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1"),
+    addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.11"),
     libraryDependencies ++= List(
       "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.1.202206130422-r",
       "org.eclipse.jgit" % "org.eclipse.jgit.ssh.jsch" % "5.13.1.202206130422-r",


### PR DESCRIPTION
This pr changes the way we do releases and migrates us away from the
forked sbt-release-early that's no longer maintained and is also
bringing in some old versions of scala-xml which will be problematic
when we try to update our sbt stuff.

Plus this simplifies the release a little bit. The one difference is
that we'll now be publishing actual `-SNAPSHOT` into sonatype snapshots.

Refs: https://github.com/scalacenter/bloop/issues/1680