### PR TITLE
chore(deps): bump scalaz to 7.3.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,6 @@ lazy val backend = project
     libraryDependencies ++= List(
       Dependencies.nailgun,
       Dependencies.scalazCore,
-      Dependencies.scalazConcurrent,
       Dependencies.coursierInterface,
       Dependencies.libraryManagement,
       Dependencies.sourcecode,

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -28,6 +28,7 @@ import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigParseOptions
 import com.typesafe.config.ConfigSyntax
+import scalaz.Cord
 import xsbti.compile.ClasspathOptions
 import xsbti.compile.CompileOrder
 
@@ -274,7 +275,10 @@ final case class Project(
 object Project {
   private implicit val filter: DebugFilter.All.type = DebugFilter.All
   final implicit val ps: scalaz.Show[Project] =
-    new scalaz.Show[Project] { override def shows(f: Project): String = f.name }
+    new scalaz.Show[Project] {
+      override def shows(f: Project): String = f.name
+      override def show(f: Project): Cord = Cord(shows(f))
+    }
 
   final class ProjectReadException(msg: String, cause: Throwable)
       extends RuntimeException(msg, cause)

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileResult.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileResult.scala
@@ -10,6 +10,8 @@ import bloop.reporter.Problem
 import bloop.task.Task
 import bloop.util.CacheHashCode
 
+import scalaz.Cord
+
 sealed trait CompileResult[+R] {
   def result: R
 }
@@ -134,5 +136,6 @@ object FinalCompileResult {
           }
       }
     }
+    override def show(f: FinalCompileResult): Cord = Cord(shows(f))
   }
 }

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -21,6 +21,7 @@ import bloop.bsp.BloopRpcServices
 import bloop.cli.Commands
 import bloop.config.Config
 import bloop.config.Config.CompileOrder
+import bloop.config.Tag
 import bloop.data.JdkConfig
 import bloop.data.LoadedProject
 import bloop.data.Origin
@@ -49,7 +50,6 @@ import bloop.logging.RecordingLogger
 
 import _root_.bloop.task.Task
 import _root_.monix.execution.Scheduler
-import bloop.config.Tag
 import org.junit.Assert
 import sbt.internal.inc.BloopComponentCompiler
 import xsbti.ComponentProvider

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
 
   val bspVersion = "2.1.0-M3"
 
-  val scalazVersion = "7.2.35"
+  val scalazVersion = "7.3.7"
   val lmVersion = "1.8.0"
   val configDirsVersion = "26"
   val caseAppVersion = "2.0.6"
@@ -57,7 +57,6 @@ object Dependencies {
   val libraryManagement = "org.scala-sbt" %% "librarymanagement-ivy" % lmVersion
   val log4j = "org.apache.logging.log4j" % "log4j-core" % "2.19.0"
   val scalazCore = "org.scalaz" %% "scalaz-core" % scalazVersion
-  val scalazConcurrent = "org.scalaz" %% "scalaz-concurrent" % scalazVersion
   val coursierInterface = "io.get-coursier" % "interface" % "1.0.6"
   val coursierInterfaceSubs = "io.get-coursier" % "interface-svm-subs" % "1.0.6"
   val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.2"


### PR DESCRIPTION
So this isn't used very much at all, only for the Show typeclass, and
that's what was breaking here due to the introduction of `Cord`. I think
my little hack is fine, it' just creates the cord out of the result of
the `shows` method. However, I'm not 100% sure, so let's run the tests
and see. I also removed scalaz concurrent because from what I can tell,
it wasn't being used and with the new version, it's not there anymore.

Supersedes #1938
