### PR TITLE
fix(ci): ensure release sbt version is the same as the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
         # cmd.
         # Keep the sbt version in sync with `sbt-ci-release.bat`.
         run: |
-          sbt -sbt-version 1.7.2 version
+          sbt -sbt-version 1.8.0 version
         shell: bash
       - name: Publish GraalVM Native artifacts
         run: >-

--- a/bin/sbt-ci-release.bat
+++ b/bin/sbt-ci-release.bat
@@ -1,2 +1,2 @@
 Rem Keep ci.yaml in sync with the sbt version
-sbt -sbt-version 1.7.2 bloopgun/graalvm-native-image:packageBin
+sbt -sbt-version 1.8.0 bloopgun/graalvm-native-image:packageBin


### PR DESCRIPTION
I actually have no idea if this is the cause or not, but the windows native image is [failing](https://github.com/scalacenter/bloop/actions/runs/3786069067/jobs/6436982906) with what you see below:

```
[error] com.oracle.svm.core.util.UserError$UserException: Main entry point class '@C:\Users\RUNNER~1\AppData\Local\Temp\native-image-classpath14131537784930832467.txt' not found.
[error] 	at com.oracle.svm.core.util.UserError.abort(UserError.java:68)
[error] 	at com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:313)
[error] 	at com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:531)
[error] 	at com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:119)
[error] 	at com.oracle.svm.hosted.NativeImageGeneratorRunner$JDK9Plus.main(NativeImageGeneratorRunner.java:[56](https://github.com/scalacenter/bloop/actions/runs/3786069067/jobs/6436982906#step:8:57)8)
[error] Error: Image build request failed with exit status 1
[error] java.lang.RuntimeException: Failed to run List(C:/Users/runneradmin/.jabba/jdk/graalvm-ce-java11@21.1.0/bin/native-image.cmd, @C:\Users\RUNNER~1\AppData\Local\Temp\native-image-classpath14131537784930832467.txt, -H:Name=bloopgun-core, --no-server, --enable-http, --enable-https, -H:EnableURLProtocols=http,https, --enable-all-security-services, --no-fallback, -H:ReflectionConfigurationFiles=D:\a\bloop\bloop\bloopgun\src\main\graal\reflection.json, --allow-incomplete-classpath, -H:+ReportExceptionStackTraces, -J-Djava.security.properties=D:\a\bloop\bloop\bloopgun\src\main\graal\java.security.overrides, -Djava.security.properties=D:\a\bloop\bloop\bloopgun\src\main\graal\java.security.overrides, --initialize-at-build-time=scala.Symbol, --initialize-at-build-time=scala.Function1, --initialize-at-build-time=scala.Function2, --initialize-at-build-time=scala.runtime.StructuralCallSite, --initialize-at-build-time=scala.runtime.EmptyMethodCache, bloop.bloopgun.Bloopgun), exit status: 1
```

I don't fully understand why anything I changed would be affecting this, but the one thing that could possibly be a bit wonky is that the windows release is still using 1.7.2, which should actually be causing issues due to scala-xml issues. So no idea if that's being swallowed or what, but this is just an attempt tof ix that. Either way it should be updated to match the build version of sbt.