### PR TITLE
refactor(test): bump maxDuration in js tests

### DIFF
--- a/bridges/scalajs-1/src/test/scala/bloop/scalajs/ScalaJsToolchainSpec.scala
+++ b/bridges/scalajs-1/src/test/scala/bloop/scalajs/ScalaJsToolchainSpec.scala
@@ -69,7 +69,7 @@ class ScalaJsToolchainSpec {
     logger.getMessages.assertContain("Hello, world!", atLevel = "info")
   }
 
-  private final val maxDuration = Duration.apply(45, TimeUnit.SECONDS)
+  private final val maxDuration = Duration.apply(60, TimeUnit.SECONDS)
   private implicit class RichLogs(logs: List[(String, String)]) {
     def assertContain(needle: String, atLevel: String): Unit = {
       def failMessage: String =


### PR DESCRIPTION
This is consistently failing with messages like:

```
[error] Test bloop.scalajs.ScalaJsToolchainSpec.canLinkScalaJsProject failed: java.util.concurrent.TimeoutException: Futures timed out after [45 seconds], took 46.973 sec
```

My naive hope is that just bumping this might make this test less flaky.