### PR TITLE
Take into account build tool-supplied bridge JARs

### DIFF
--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -290,7 +290,14 @@ object Project {
         else {
           val scalaJars = scala.jars.map(AbsolutePath.apply)
           Some(
-            ScalaInstance(scala.organization, scala.name, scala.version, scalaJars, logger)
+            ScalaInstance(
+              scala.organization,
+              scala.name,
+              scala.version,
+              scalaJars,
+              logger,
+              scala.bridgeJars.map(_.map(AbsolutePath(_)))
+            )
           )
         }
       }

--- a/frontend/src/test/scala/bloop/util/TestProject.scala
+++ b/frontend/src/test/scala/bloop/util/TestProject.scala
@@ -160,7 +160,8 @@ abstract class BaseTestProject {
       scalacOptions,
       allJars.map(_.underlying).toList,
       None,
-      Some(setup)
+      Some(setup),
+      None
     )
 
     val javacConfig = Config.Java(javacOptions)

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -1032,7 +1032,7 @@ object BloopDefaults {
             val c = Keys.classpathOptions.value
             val java = Config.Java(javacOptions)
             val compileSetup = Config.CompileSetup(compileOrder, c.bootLibrary, c.compiler, c.extra, c.autoBoot, c.filterLibrary)
-            val `scala` = Config.Scala(scalaOrg, scalaName, scalaVersion, scalacOptions, allScalaJars, None, Some(compileSetup))
+            val `scala` = Config.Scala(scalaOrg, scalaName, scalaVersion, scalacOptions, allScalaJars, None, Some(compileSetup), None)
             val resources = Some(bloopResourcesTask.value)
 
             val sbt = None // Written by `postGenerate` instead

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -47,7 +47,7 @@ object Dependencies {
   val snailgunVersion = "0.4.0"
   val ztExecVersion = "1.12"
   val debugAdapterVersion = "4.0.4"
-  val bloopConfigVersion = "1.5.5"
+  val bloopConfigVersion = "2.0.0"
   val semanticdbVersion = "4.8.15"
   val zinc = "org.scala-sbt" %% "zinc" % zincVersion
   val bsp4s = "ch.epfl.scala" %% "bsp4s" % bspVersion


### PR DESCRIPTION
This change allows build tools to supply bridge JARs themselves, so that the Bloop server doesn't have to fetch them itself later on. This allows to fetch those JARs from non-standard repositories, that the Bloop server doesn't know about.

Needs https://github.com/scalacenter/bloop-config/pull/20