### PR TITLE
fix: ensure valid scalajs-logging version in ScalaJsToolchain

### DIFF
--- a/frontend/src/main/scala/bloop/engine/tasks/toolchains/ScalaJsToolchain.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/toolchains/ScalaJsToolchain.scala
@@ -147,7 +147,7 @@ object ScalaJsToolchain extends ToolchainCompanion[ScalaJsToolchain] {
         DependencyResolution
           .Artifact("org.scala-js", s"scalajs-env-jsdom-nodejs_$scalaVersion", "1.1.0"),
         DependencyResolution
-          .Artifact("org.scala-js", s"scalajs-logging_$scalaVersion", "1.4.0")
+          .Artifact("org.scala-js", s"scalajs-logging_$scalaVersion", "1.1.1")
       )
   }
 


### PR DESCRIPTION
Trying to figure out why the ScalaJS tests are so flaky. When doing that I realized we had an invalid version in here that wasn't able to resolve since 1.4.0 doesn't exist. This may help if we ensure that it can actually be resolved.