### PR TITLE
bugfix: Catch and log StackOverflowError

### DIFF
--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopHighLevelCompiler.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopHighLevelCompiler.scala
@@ -133,6 +133,10 @@ final class BloopHighLevelCompiler(
               logger
             )
           } catch {
+            case t: StackOverflowError =>
+              val msg = "Encountered StackOverflowError coming from the compiler. You might need to restart Bloop build server"
+              logger.error(s"${msg}:\n${t.getStackTrace().mkString("\n")}")
+              throw new CompileFailed(new Array(0), msg, new Array(0), t)
             case NonFatal(t) =>
               // If scala compilation happens, complete the java promise so that it doesn't block
               JavaCompleted.tryFailure(t)

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopHighLevelCompiler.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopHighLevelCompiler.scala
@@ -134,7 +134,7 @@ final class BloopHighLevelCompiler(
             )
           } catch {
             case t: StackOverflowError =>
-              val msg = "Encountered StackOverflowError coming from the compiler. You might need to restart Bloop build server"
+              val msg = "Encountered a StackOverflowError coming from the compiler. You might need to restart your Bloop build server"
               logger.error(s"${msg}:\n${t.getStackTrace().mkString("\n")}")
               throw new CompileFailed(new Array(0), msg, new Array(0), t)
             case NonFatal(t) =>


### PR DESCRIPTION
Previously, when the compiler threw a StackOverflowException Bloop would hang and nver return a results. Now, it logs the proper error and translates the exception.

Related to https://github.com/VirtusLab/scala-cli/issues/1781