### PR TITLE
fix: do not expose mutable env properties in State

### DIFF
--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -263,9 +263,7 @@ object TestUtil {
   }
 
   private[bloop] def runAndTestProperties = {
-    val props = new bloop.cli.CommonOptions.PrettyProperties()
-    props.put("BLOOP_OWNER", "owner")
-    props
+    new bloop.cli.CommonOptions.PrettyProperties(Map("BLOOP_OWNER" -> "owner"))
   }
 
   /**


### PR DESCRIPTION
fixes https://github.com/scalameta/metals/issues/5025

- change mutable PrettyProperties to wrapper over immutable Map
- adjust forker's implementations logic so they are not even aware of env parameters. They're handled one step before

I was thinking about some tests but immutable data structure should be just enough to prevent such cases in the future