### PR TITLE
Fix timeout in DebugProtocolTests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,12 +112,12 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - uses: actions/setup-java@v3
+      - uses: coursier/setup-action@v1
         with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.jdk }}
-          cache: 'sbt'
+          jvm: 'temurin:11.0.18'
         if: matrix.jdk == '11'
+      
+      - uses: coursier/cache-action@v6
 
       - uses: graalvm/setup-graalvm@v1
         with:
@@ -239,10 +239,9 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - uses: actions/setup-java@v3
+      - uses: coursier/setup-action@v1
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          jvm: 'temurin:11.0.18'
       - uses: actions/setup-node@v3
         with:
           node-version: "16"


### PR DESCRIPTION
For some mysterious reason, traversing the `src.zip` of JDK Temurin 11.0.18 installed by `actions/setup-java` is very very slow. It takes up to 40 second, the first time, and then it takes about 500 ms. That's why the `DebugProtocolSpec` times out.

But if I install the exact same JDK with `coursier/setup-action`, the issue disappears. Similarly, if I manually download and extract the JDK, it fixes the issue. So it seems there is something wrong with `actions/setup-java`, about how it installs this JDK, but I don't know exactly what.

Switching to `coursier/setup-action` solves the issue.