### PR TITLE
bugfix: Properly clean up orphan directories for internal classes

### DIFF
--- a/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
@@ -170,6 +170,16 @@ object ResultsCache {
   ): Task[ResultsCache] = {
     import bloop.util.JavaCompat.EnrichOptional
 
+    /**
+     * Orphaned internal directories are directories that are not used by any
+     * client and that are currently not the internal classes directory of any project.
+     *
+     * These are usually deleted by Bloop right away, but in some cases there might be left,
+     * which means it's safe to delete them.
+     *
+     * An example path cleaned up by this method is:
+     * .bloop/mtest/bloop-internal-classes/classes-Metals-12MpgYmRSGOOK5fxouxTqg==-iWRxh-luRTOxk3bOx9UAfg==
+     */
     def cleanUpOrphanedInternalDirs(
         project: Project,
         analysisClassesDir: AbsolutePath
@@ -177,7 +187,7 @@ object ResultsCache {
       if (!cleanOrphanedInternalDirs) Task.unit
       else {
         val internalClassesDir =
-          CompileOutPaths.createInternalClassesRootDir(project.genericClassesDir)
+          CompileOutPaths.createInternalClassesRootDir(project.out)
         // This is a surprise, skip any cleanup if internal analysis dir doesn't
         // live under the internal classes dir root assigned to the project
         if (internalClassesDir != analysisClassesDir.getParent) Task.unit

--- a/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
@@ -193,12 +193,14 @@ class BspCompileSpec(
       // Add extra client classes directory
       val projectA = compiledState.getProjectFor(`A`)
       val bspClientsRootDir = projectA.clientClassesRootDirectory
-      val orphanClientClassesDirName = projectA.genericClassesDir.underlying.getFileName().toString
-      val orphanClientClassesDir =
-        bspClientsRootDir.resolve(s"$orphanClientClassesDirName-test-123aAfd12i23")
+      val orphanClientClassesDir = bspClientsRootDir.resolve(s"classes-test-123aAfd12i23")
       Files.createDirectories(orphanClientClassesDir.underlying)
       val fileTime = FileTime.from(Instant.now().minusSeconds(120))
       Files.setLastModifiedTime(orphanClientClassesDir.underlying, fileTime)
+
+      val orphanInternalClassesDir = projectA.out.resolve(s"classes-test-123aAfd12i23")
+      Files.createDirectories(orphanInternalClassesDir.underlying)
+      Files.setLastModifiedTime(orphanInternalClassesDir.underlying, fileTime)
 
       loadBspState(workspace, projects, logger) { bspState =>
         // Ask for scala options to force client to create a client classes dir for `A`
@@ -214,7 +216,7 @@ class BspCompileSpec(
           var check: Boolean = true
           while (check) {
             // The task cleaning up client classes directories should have removed the extra dir
-            check = orphanClientClassesDir.exists
+            check = orphanClientClassesDir.exists && orphanInternalClassesDir.exists
             Thread.sleep(100)
           }
         }.timeoutTo(


### PR DESCRIPTION
It seems that the genericClassesDir is not being used at all by the compiler, so cleaning orphan directories in it was not achieving anything.

We might need to figure out how to use `genericClassesDir` and whether it needs to be used at all, but for now this fixes the issue of large .bloop directory.