### PR TITLE
Support Scala 3's Best Effort compilation

### DIFF
--- a/backend/src/main/scala/bloop/BloopClassFileManager.scala
+++ b/backend/src/main/scala/bloop/BloopClassFileManager.scala
@@ -40,8 +40,6 @@ final class BloopClassFileManager(
   private[this] val weakClassFileInvalidations = new mutable.HashSet[Path]()
   private[this] val generatedFiles = new mutable.HashSet[File]
 
-  // Supported compile products by the class file manager
-  private[this] val supportedCompileProducts = List(".sjsir", ".nir", ".tasty", ".betasty")
   // Files backed up during compilation
   private[this] val movedFiles = new mutable.HashMap[File, File]
 
@@ -140,7 +138,7 @@ final class BloopClassFileManager(
 
     val invalidatedExtraCompileProducts = classes.flatMap { classFile =>
       val prefixClassName = classFile.getName().stripSuffix(".class")
-      supportedCompileProducts.flatMap { supportedProductSuffix =>
+      BloopClassFileManager.supportedCompileProducts.flatMap { supportedProductSuffix =>
         val productName = prefixClassName + supportedProductSuffix
         val productAssociatedToClassFile = new File(classFile.getParentFile, productName)
         if (!productAssociatedToClassFile.exists()) Nil
@@ -186,7 +184,7 @@ final class BloopClassFileManager(
           .stripSuffix(".class") + supportedProductSuffix
         new File(classFile.getParentFile, productName)
       }
-      supportedCompileProducts.foreach { supportedProductSuffix =>
+      BloopClassFileManager.supportedCompileProducts.foreach { supportedProductSuffix =>
         val generatedProductName = productFile(generatedClassFile, supportedProductSuffix)
         val rebasedProductName = productFile(rebasedClassFile, supportedProductSuffix)
 
@@ -318,6 +316,9 @@ final class BloopClassFileManager(
 }
 
 object BloopClassFileManager {
+  // Supported compile products by the class file manager
+  val supportedCompileProducts = List(".sjsir", ".nir", ".tasty", ".betasty")
+
   def link(link: Path, target: Path): Try[Unit] = {
     Try {
       // Make sure parent directory for link exists

--- a/backend/src/main/scala/bloop/BloopClassFileManager.scala
+++ b/backend/src/main/scala/bloop/BloopClassFileManager.scala
@@ -41,7 +41,7 @@ final class BloopClassFileManager(
   private[this] val generatedFiles = new mutable.HashSet[File]
 
   // Supported compile products by the class file manager
-  private[this] val supportedCompileProducts = List(".sjsir", ".nir", ".tasty")
+  private[this] val supportedCompileProducts = List(".sjsir", ".nir", ".tasty", ".betasty")
   // Files backed up during compilation
   private[this] val movedFiles = new mutable.HashMap[File, File]
 
@@ -215,7 +215,8 @@ final class BloopClassFileManager(
             clientTracer: BraveTracer
         ) => {
           clientTracer.traceTaskVerbose("copy new products to external classes dir") { _ =>
-            val config = ParallelOps.CopyConfiguration(5, CopyMode.ReplaceExisting, Set.empty)
+            val config =
+              ParallelOps.CopyConfiguration(5, CopyMode.ReplaceExisting, Set.empty, Set.empty)
             val clientExternalBestEffortDir =
               clientExternalClassesDir.underlying.resolve("META-INF/best-effort")
 
@@ -291,7 +292,8 @@ final class BloopClassFileManager(
             else
               clientTracer.traceTask("populate empty classes dir") { _ =>
                 // Prepopulate external classes dir even though compilation failed
-                val config = ParallelOps.CopyConfiguration(1, CopyMode.NoReplace, Set.empty)
+                val config =
+                  ParallelOps.CopyConfiguration(1, CopyMode.NoReplace, Set.empty, Set.empty)
                 ParallelOps
                   .copyDirectories(config)(
                     Paths.get(readOnlyClassesDirPath),

--- a/backend/src/main/scala/bloop/io/ParallelOps.scala
+++ b/backend/src/main/scala/bloop/io/ParallelOps.scala
@@ -44,7 +44,8 @@ object ParallelOps {
   case class CopyConfiguration private (
       parallelUnits: Int,
       mode: CopyMode,
-      denylist: Set[Path]
+      denylist: Set[Path],
+      denyDirs: Set[Path]
   )
 
   case class FileWalk(visited: List[Path], target: List[Path])
@@ -87,7 +88,11 @@ object ParallelOps {
       def visitFile(file: Path, attributes: BasicFileAttributes): FileVisitResult = {
         if (isCancelled.get) FileVisitResult.TERMINATE
         else {
-          if (attributes.isDirectory || configuration.denylist.contains(file)) ()
+          if (
+            attributes.isDirectory || configuration.denylist.contains(
+              file
+            ) || configuration.denyDirs.find(file.startsWith(_)).isDefined
+          ) ()
           else {
             val rebasedFile = currentTargetDirectory.resolve(file.getFileName)
             if (configuration.denylist.contains(rebasedFile)) ()

--- a/backend/src/main/scala/bloop/util/BestEffortUtils.scala
+++ b/backend/src/main/scala/bloop/util/BestEffortUtils.scala
@@ -1,0 +1,67 @@
+package bloop.util
+
+import java.security.MessageDigest
+
+import java.math.BigInteger
+import java.nio.file.Files
+import scala.collection.JavaConverters._
+import java.nio.file.Path
+import bloop.io.AbsolutePath
+
+object BestEffortUtils {
+
+  case class BestEffortProducts(compileProducts: bloop.CompileProducts, hash: String)
+
+  /* Hashes results of a projects compilation, to mimic how it would have been handled in zinc.
+   * Returns SHA-1 of a project.
+   *
+   * Since currently for best-effort compilation we are unable to use neither incremental compilation,
+   * nor the data supplied by zinc (like the compilation analysis files, which are not able to be generated
+   * since the compiler is able to skip the necessary phases for now), this custom implementation
+   * is meant to keep the best-effort projects from being unnecessarily recompiled.
+   */
+  def hashResult(
+      outputDir: Path,
+      sources: Array[AbsolutePath],
+      classpath: Array[AbsolutePath]
+  ): String = {
+    val md = MessageDigest.getInstance("SHA-1")
+
+    md.update("<outputs>".getBytes())
+    if (Files.exists(outputDir)) {
+      Files.walk(outputDir).iterator().asScala.foreach { path =>
+        if (Files.isRegularFile(path)) {
+          md.update(path.toString.getBytes())
+          md.update(Files.readAllBytes(path))
+        }
+      }
+    }
+
+    md.update("<inputs>".getBytes())
+    sources.foreach { sourceFilePath =>
+      val underlying = sourceFilePath.underlying
+      if (Files.exists(underlying) && Files.isRegularFile(underlying)) {
+        md.update(Files.readAllBytes(underlying))
+      }
+    }
+
+    md.update("<classpath>".getBytes())
+    classpath.map(_.underlying).foreach { classpathFile =>
+      if (!Files.exists(classpathFile)) ()
+      else if (Files.isRegularFile(classpathFile)) {
+        md.update(Files.readAllBytes(classpathFile))
+      } else if (Files.isDirectory(classpathFile)) {
+        if (outputDir != classpathFile) {
+          Files.walk(classpathFile).iterator().asScala.foreach { file =>
+            if (Files.isRegularFile(file)) {
+              md.update(Files.readAllBytes(file))
+            }
+          }
+        }
+      }
+    }
+
+    val digest = new BigInteger(1, md.digest())
+    String.format(s"%040x", digest)
+  }
+}

--- a/frontend/src/it/scala/bloop/CommunityBuild.scala
+++ b/frontend/src/it/scala/bloop/CommunityBuild.scala
@@ -132,6 +132,7 @@ abstract class CommunityBuild(val buildpressHomeDir: AbsolutePath) {
         resources = Nil,
         compileSetup = Config.CompileSetup.empty,
         genericClassesDir = dummyClassesDir,
+        isBestEffort = false,
         scalacOptions = Nil,
         javacOptions = Nil,
         sources = Nil,

--- a/frontend/src/main/scala/bloop/bsp/BloopBspDefinitions.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspDefinitions.scala
@@ -12,7 +12,8 @@ object BloopBspDefinitions {
       clientClassesRootDir: Option[Uri],
       semanticdbVersion: Option[String],
       supportedScalaVersions: Option[List[String]],
-      javaSemanticdbVersion: Option[String]
+      javaSemanticdbVersion: Option[String],
+      enableBestEffortMode: Option[Boolean]
   )
 
   object BloopExtraBuildParams {
@@ -21,7 +22,8 @@ object BloopBspDefinitions {
       clientClassesRootDir = None,
       semanticdbVersion = None,
       supportedScalaVersions = None,
-      javaSemanticdbVersion = None
+      javaSemanticdbVersion = None,
+      enableBestEffortMode = None
     )
 
     implicit val codec: JsonValueCodec[BloopExtraBuildParams] =

--- a/frontend/src/main/scala/bloop/data/WorkspaceSettings.scala
+++ b/frontend/src/main/scala/bloop/data/WorkspaceSettings.scala
@@ -47,6 +47,8 @@ import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
  * server before loading the state and presentings projects to the client.
  * @param traceSettings are the settings provided by the user that customize how
  * the bloop server should behave.
+ * @param enableBestEffortMode signifies whether the best-effort compilation mode
+ * is used
  */
 case class WorkspaceSettings(
     // Managed by bloop or build tool
@@ -55,7 +57,8 @@ case class WorkspaceSettings(
     supportedScalaVersions: Option[List[String]],
     // Managed by the user
     refreshProjectsCommand: Option[List[String]],
-    traceSettings: Option[TraceSettings]
+    traceSettings: Option[TraceSettings],
+    enableBestEffortMode: Option[Boolean]
 ) {
   def withSemanticdbSettings: Option[(WorkspaceSettings, SemanticdbSettings)] =
     if (semanticDBVersion.nonEmpty || javaSemanticDBVersion.nonEmpty) {
@@ -85,6 +88,7 @@ object WorkspaceSettings {
       Some(javaSemanticDBVersion),
       Some(scalaSemanticDBVersion),
       Some(supportedScalaVersions),
+      None,
       None,
       None
     )

--- a/frontend/src/main/scala/bloop/engine/BuildLoader.scala
+++ b/frontend/src/main/scala/bloop/engine/BuildLoader.scala
@@ -76,6 +76,7 @@ object BuildLoader {
               configDir,
               semanticdb.javaSemanticdbSettings,
               semanticdb.scalaSemanticdbSettings,
+              settings.enableBestEffortMode,
               logger
             ).map { transformedProjects =>
               transformedProjects.map {
@@ -106,6 +107,7 @@ object BuildLoader {
       configDir: AbsolutePath,
       javaSemanticSettings: Option[JavaSemanticdbSettings],
       scalaSemanticdbSettings: Option[ScalaSemanticdbSettings],
+      enableBestEffortMode: Option[Boolean],
       logger: Logger
   ): Task[List[(Project, Option[Project])]] = {
 
@@ -124,7 +126,14 @@ object BuildLoader {
             logger
           ) { (scalaPlugin: Option[AbsolutePath], javaPlugin: Option[AbsolutePath]) =>
             projects.map(p =>
-              Project.enableMetalsSettings(p, configDir, scalaPlugin, javaPlugin, logger) -> Some(p)
+              Project.enableMetalsSettings(
+                p,
+                configDir,
+                scalaPlugin,
+                javaPlugin,
+                enableBestEffortMode,
+                logger
+              ) -> Some(p)
             )
           }
         }
@@ -175,7 +184,14 @@ object BuildLoader {
             logger
           ) { (scalaPlugin: Option[AbsolutePath], javaPlugin: Option[AbsolutePath]) =>
             LoadedProject.ConfiguredProject(
-              Project.enableMetalsSettings(project, configDir, scalaPlugin, javaPlugin, logger),
+              Project.enableMetalsSettings(
+                project,
+                configDir,
+                scalaPlugin,
+                javaPlugin,
+                settings.enableBestEffortMode,
+                logger
+              ),
               project,
               settings
             )

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -173,6 +173,7 @@ object Interpreter {
         dag,
         createReporter,
         cmd.pipeline,
+        bestEffort = false,
         Promise[Unit](),
         CompileClientStore.NoStore,
         state.logger

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -365,7 +365,7 @@ object CompileTask {
     } else {
       // Denylist ensure final dir doesn't contain class files that don't map to source files
       val denylist = products.invalidatedCompileProducts.iterator.map(_.toPath).toSet
-      val config = ParallelOps.CopyConfiguration(5, CopyMode.NoReplace, denylist)
+      val config = ParallelOps.CopyConfiguration(5, CopyMode.NoReplace, denylist, Set.empty)
       val task = tracer.traceTaskVerbose("preparing new read-only classes directory") { _ =>
         ParallelOps.copyDirectories(config)(
           products.readOnlyClassesDir,

--- a/frontend/src/test/scala/bloop/BuildLoaderSpec.scala
+++ b/frontend/src/test/scala/bloop/BuildLoaderSpec.scala
@@ -306,7 +306,8 @@ object BuildLoaderSpec extends BaseSuite {
             traceEndAnnotation = Some("end"),
             enabled = Some(true)
           )
-        )
+        ),
+        None
       )
 
       val state1 = loadState(workspace1, Nil, logger, Some(settings1))

--- a/frontend/src/test/scala/bloop/DagSpec.scala
+++ b/frontend/src/test/scala/bloop/DagSpec.scala
@@ -28,7 +28,7 @@ class DagSpec {
   def dummyOrigin: Origin = TestUtil.syntheticOriginFor(dummyPath)
   def dummyProject(name: String, dependencies: List[String]): Project =
     Project(name, dummyPath, None, dependencies, Some(dummyInstance), Nil, Nil, compileOptions,
-      dummyPath, Nil, Nil, Nil, Nil, None, Nil, Nil, Config.TestOptions.empty, dummyPath, dummyPath,
+      dummyPath, isBestEffort = false, Nil, Nil, Nil, Nil, None, Nil, Nil, Config.TestOptions.empty, dummyPath, dummyPath,
       Project.defaultPlatform(logger, Nil, Nil), None, None, Nil, dummyOrigin)
   // format: ON
 

--- a/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
@@ -144,15 +144,16 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
     def compileTask(
         project: TestProject,
         originId: Option[String],
-        clearDiagnostics: Boolean = true
+        clearDiagnostics: Boolean = true,
+        arguments: Option[List[String]] = None
     ): Task[ManagedBspTestState] = {
       runAfterTargets(project) { target =>
         // Handle internal state before sending compile request
         if (clearDiagnostics) diagnostics.clear()
         currentCompileIteration.increment(1)
 
-        rpcRequest(BuildTarget.compile, bsp.CompileParams(List(target), originId, None)).flatMap {
-          r =>
+        rpcRequest(BuildTarget.compile, bsp.CompileParams(List(target), originId, arguments))
+          .flatMap { r =>
             // `headL` returns latest saved state from bsp because source is behavior subject
             Task
               .liftMonixTaskUncancellable(
@@ -168,7 +169,7 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
                   serverStates
                 )
               }
-        }
+          }
       }
     }
 
@@ -192,11 +193,12 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
         project: TestProject,
         originId: Option[String] = None,
         clearDiagnostics: Boolean = true,
-        timeout: Long = 30
+        timeout: Long = 30,
+        arguments: Option[List[String]] = None
     ): ManagedBspTestState = {
       // Use a default timeout of 30 seconds for every operation
       TestUtil.await(FiniteDuration(timeout, "s")) {
-        compileTask(project, originId, clearDiagnostics)
+        compileTask(project, originId, clearDiagnostics, arguments)
       }
     }
 

--- a/frontend/src/test/scala/bloop/bsp/BspIntellijClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspIntellijClientSpec.scala
@@ -59,7 +59,8 @@ class BspIntellijClientSpec(
         None,
         None,
         refreshProjectsCommand = Some(refreshProjectsCommand),
-        Some(TraceSettings.fromProperties(TraceProperties.default))
+        Some(TraceSettings.fromProperties(TraceProperties.default)),
+        None
       )
 
       WorkspaceSettings.writeToFile(configDir, workspaceSettings, logger)

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -22,6 +22,7 @@ import bloop.logging.RecordingLogger
 import bloop.task.Task
 import bloop.util.TestProject
 import bloop.util.TestUtil
+import bloop.Compiler
 
 object LocalBspMetalsClientSpec extends BspMetalsClientSpec(BspProtocol.Local)
 object TcpBspMetalsClientSpec extends BspMetalsClientSpec(BspProtocol.Tcp)
@@ -57,7 +58,8 @@ class BspMetalsClientSpec(
         clientClassesRootDir = None,
         semanticdbVersion = Some(semanticdbVersion),
         supportedScalaVersions = Some(List(testedScalaVersion)),
-        javaSemanticdbVersion = Some(javaSemanticdbVersion)
+        javaSemanticdbVersion = Some(javaSemanticdbVersion),
+        enableBestEffortMode = None
       )
 
       loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
@@ -113,7 +115,8 @@ class BspMetalsClientSpec(
         clientClassesRootDir = None,
         semanticdbVersion = Some(semanticdbVersion),
         supportedScalaVersions = Some(List(testedScalaVersion)),
-        javaSemanticdbVersion = Some(javaSemanticdbVersion)
+        javaSemanticdbVersion = Some(javaSemanticdbVersion),
+        enableBestEffortMode = None
       )
 
       loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
@@ -157,7 +160,8 @@ class BspMetalsClientSpec(
         clientClassesRootDir = None,
         semanticdbVersion = Some(semanticdbVersion),
         supportedScalaVersions = Some(List(testedScalaVersion)),
-        javaSemanticdbVersion = Some(javaSemanticdbVersion)
+        javaSemanticdbVersion = Some(javaSemanticdbVersion),
+        enableBestEffortMode = None
       )
 
       loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
@@ -187,7 +191,8 @@ class BspMetalsClientSpec(
         clientClassesRootDir = None,
         semanticdbVersion = Some(semanticdbVersion),
         supportedScalaVersions = Some(List(testedScalaVersion)),
-        javaSemanticdbVersion = Some(javaSemanticdbVersion)
+        javaSemanticdbVersion = Some(javaSemanticdbVersion),
+        enableBestEffortMode = None
       )
       val `A` = TestProject(workspace, "A", Nil)
       val projects = List(`A`)
@@ -240,7 +245,8 @@ class BspMetalsClientSpec(
             clientClassesRootDir = None,
             semanticdbVersion = Some(semanticdbVersion),
             supportedScalaVersions = Some(List(testedScalaVersion)),
-            javaSemanticdbVersion = Some(javaSemanticdbVersion)
+            javaSemanticdbVersion = Some(javaSemanticdbVersion),
+            enableBestEffortMode = None
           )
           val bspLogger = new BspClientLogger(logger)
           def bspCommand() = createBspCommand(configDir)
@@ -465,7 +471,8 @@ class BspMetalsClientSpec(
         clientClassesRootDir = None,
         semanticdbVersion = Some(semanticdbVersion),
         supportedScalaVersions = Some(List(testedScalaVersion)),
-        javaSemanticdbVersion = Some(javaSemanticdbVersion)
+        javaSemanticdbVersion = Some(javaSemanticdbVersion),
+        enableBestEffortMode = None
       )
       loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
         val compiledState = state.compile(`A`).toTestState
@@ -492,13 +499,110 @@ class BspMetalsClientSpec(
         clientClassesRootDir = None,
         semanticdbVersion = Some(semanticdbVersion),
         supportedScalaVersions = Some(List(testedScalaVersion)),
-        javaSemanticdbVersion = Some(javaSemanticdbVersion)
+        javaSemanticdbVersion = Some(javaSemanticdbVersion),
+        None
       )
       loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
         val compiledState = state.compile(`A`).toTestState
         assert(compiledState.status == ExitStatus.Ok)
         assertSemanticdbFileFor("Foo.scala", compiledState)
         assertSemanticdbFileFor("Bar.java", compiledState)
+      }
+    }
+  }
+
+  val bestEffortScalaVersion = "3.5.0-RC1"
+  test("best-effort: compile dependency of failing project and produce semanticdb and betasty") {
+    TestUtil.withinWorkspace { workspace =>
+      val `A` = TestProject(
+        workspace,
+        "A",
+        dummyBestEffortSources,
+        scalaVersion = Some(bestEffortScalaVersion)
+      )
+      val `B` = TestProject(
+        workspace,
+        "B",
+        dummyBestEffortDepSources,
+        directDependencies = List(`A`),
+        scalaVersion = Some(bestEffortScalaVersion)
+      )
+      val projects = List(`A`, `B`)
+      TestProject.populateWorkspace(workspace, projects)
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val extraParams = BloopExtraBuildParams(
+        ownsBuildFiles = None,
+        clientClassesRootDir = None,
+        semanticdbVersion = Some(semanticdbVersion),
+        supportedScalaVersions = Some(List(bestEffortScalaVersion)),
+        javaSemanticdbVersion = None,
+        enableBestEffortMode = Some(true)
+      )
+      loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
+        val compiledStateA = state.compile(`A`, arguments = Some(List("--best-effort"))).toTestState
+        assert(compiledStateA.status == ExitStatus.CompilationError)
+        assertSemanticdbFileFor("TypeError.scala", compiledStateA, "A")
+        assertBetastyFile("TypeError.betasty", compiledStateA, "A")
+        val compiledStateB = state.compile(`B`, arguments = Some(List("--best-effort"))).toTestState
+        assert(compiledStateB.status == ExitStatus.CompilationError)
+        assertSemanticdbFileFor("TypeErrorDependency.scala", compiledStateB, "B")
+        assertBetastyFile("TypeErrorDependency.betasty", compiledStateB, "B")
+
+        val projectB = compiledStateB.build.getProjectFor("B").get
+        compiledStateB.results.all(projectB) match {
+          case Compiler.Result.Failed(problemsPerPhase, crash, _, _, _) =>
+            assert(problemsPerPhase == List.empty) // No new errors should be found
+            assert(crash == None)
+          case result => fail(s"Result ${result} is not classified as failure")
+        }
+      }
+    }
+  }
+
+  test("best-effort: regain artifacts after disconnecting and reconnecting to the client") {
+    TestUtil.withinWorkspace { workspace =>
+      val `A` = TestProject(
+        workspace,
+        "A",
+        dummyBestEffortSources,
+        scalaVersion = Some(bestEffortScalaVersion)
+      )
+      val `B` = TestProject(
+        workspace,
+        "B",
+        dummyBestEffortDepSources,
+        directDependencies = List(`A`),
+        scalaVersion = Some(bestEffortScalaVersion)
+      )
+      val projects = List(`A`, `B`)
+      TestProject.populateWorkspace(workspace, projects)
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val extraParams = BloopExtraBuildParams(
+        ownsBuildFiles = None,
+        clientClassesRootDir = None,
+        semanticdbVersion = Some(semanticdbVersion),
+        supportedScalaVersions = Some(List(bestEffortScalaVersion)),
+        javaSemanticdbVersion = None,
+        enableBestEffortMode = Some(true)
+      )
+      loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
+        val compiledStateA = state.compile(`A`, arguments = Some(List("--best-effort"))).toTestState
+        val compiledStateB = state.compile(`B`, arguments = Some(List("--best-effort"))).toTestState
+      }
+      loadBspState(
+        workspace,
+        projects,
+        logger,
+        "Metals reconnected",
+        bloopExtraParams = extraParams
+      ) { state =>
+        val compiledStateA = state.compile(`A`, arguments = Some(List("--best-effort"))).toTestState
+        assertSemanticdbFileFor("TypeError.scala", compiledStateA, "A")
+        assertBetastyFile("TypeError.betasty", compiledStateA, "A")
+        val compiledStateB = state.compile(`B`, arguments = Some(List("--best-effort"))).toTestState
+        assertSemanticdbFileFor("TypeErrorDependency.scala", compiledStateB, "B")
+        assertBetastyFile("TypeErrorDependency.betasty", compiledStateB, "B")
+        state.findBuildTarget(`A`)
       }
     }
   }
@@ -516,7 +620,8 @@ class BspMetalsClientSpec(
         clientClassesRootDir = None,
         semanticdbVersion = Some(semanticdbVersion),
         supportedScalaVersions = Some(List(testedScalaVersion)),
-        javaSemanticdbVersion = Some(javaSemanticdbVersion)
+        javaSemanticdbVersion = Some(javaSemanticdbVersion),
+        None
       )
 
       loadBspBuildFromResources(projectName, workspace, logger, "Metals", extraParams) { build =>
@@ -578,6 +683,19 @@ class BspMetalsClientSpec(
 
   private val dummyFooScalaAndBarJavaSources = dummyFooScalaSources ++ dummyBarJavaSources
 
+  private val dummyBestEffortSources = List(
+    """/TypeError.scala
+      |object TypeError:
+      |  val num: Int = ""
+      |""".stripMargin
+  )
+  private val dummyBestEffortDepSources = List(
+    """/TypeErrorDependency.scala
+      |object TypeErrorDependency:
+      |  def num(): Int = TypeError.num
+      |""".stripMargin
+  )
+
   private def assertSemanticdbFileForProject(
       sourceFileName: String,
       state: TestState,
@@ -597,26 +715,39 @@ class BspMetalsClientSpec(
     classesDir.resolve(s"META-INF/semanticdb/src/$sourceFileName.semanticdb")
   }
 
-  private def semanticdbFile(sourceFileName: String, state: TestState) = {
-    val projectA = state.build.getProjectFor("A").get
+  private def semanticdbFile(sourceFileName: String, state: TestState, projectName: String) = {
+    val projectA = state.build.getProjectFor(projectName).get
     val classesDir = state.client.getUniqueClassesDirFor(projectA, forceGeneration = true)
     val sourcePath = if (sourceFileName.startsWith("/")) sourceFileName else s"/$sourceFileName"
-    classesDir.resolve(s"META-INF/semanticdb/A/src/$sourcePath.semanticdb")
+    classesDir.resolve(s"META-INF/semanticdb/$projectName/src/$sourcePath.semanticdb")
+  }
+
+  private def assertBetastyFile(
+      expectedBetastyRelativePath: String,
+      state: TestState,
+      projectName: String
+  ): Unit = {
+    val project = state.build.getProjectFor(projectName).get
+    val classesDir = state.client.getUniqueClassesDirFor(project, forceGeneration = true)
+    val beTastyFile = classesDir.resolve(s"META-INF/best-effort/$expectedBetastyRelativePath")
+    assertIsFile(beTastyFile)
   }
 
   private def assertSemanticdbFileFor(
       sourceFileName: String,
-      state: TestState
+      state: TestState,
+      projectName: String = "A"
   ): Unit = {
-    val file = semanticdbFile(sourceFileName, state)
+    val file = semanticdbFile(sourceFileName, state, projectName)
     assertIsFile(file)
   }
 
   private def assertNoSemanticdbFileFor(
       sourceFileName: String,
-      state: TestState
+      state: TestState,
+      projectName: String = "A"
   ): Unit = {
-    val file = semanticdbFile(sourceFileName, state)
+    val file = semanticdbFile(sourceFileName, state, projectName)
     assertNotFile(file)
   }
 

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -213,7 +213,8 @@ class BspProtocolSpec(
         Some(Uri(userClientClassesRootDir.toBspUri)),
         semanticdbVersion = None,
         supportedScalaVersions = None,
-        javaSemanticdbVersion = None
+        javaSemanticdbVersion = None,
+        enableBestEffortMode = None
       )
 
       // Start first client and query for scalac options which creates client classes dirs

--- a/frontend/src/test/scala/bloop/testing/BaseSuite.scala
+++ b/frontend/src/test/scala/bloop/testing/BaseSuite.scala
@@ -250,7 +250,7 @@ abstract class BaseSuite extends TestSuite with BloopHelpers {
   ): Unit = {
     if (errors > 0) {
       result match {
-        case Compiler.Result.Failed(problems, t, _, _) =>
+        case Compiler.Result.Failed(problems, t, _, _, _) =>
           val count = Problem.count(problems)
           if (count.errors == 0 && errors != 0) {
             // If there's an exception count it as one error

--- a/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
+++ b/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
@@ -83,7 +83,7 @@ trait BloopHelpers {
     val baseDir = sourceConfigDir.getParent
     val relativeConfigDir = RelativePath(sourceConfigDir.getFileName)
 
-    val config = ParallelOps.CopyConfiguration(5, CopyMode.ReplaceExisting, Set.empty)
+    val config = ParallelOps.CopyConfiguration(5, CopyMode.ReplaceExisting, Set.empty, Set.empty)
     val copyToNewWorkspace = ParallelOps.copyDirectories(config)(
       baseDir,
       workspace.underlying,
@@ -302,7 +302,8 @@ trait BloopHelpers {
             }
 
             val backupDir = ParallelOps.copyDirectories(
-              ParallelOps.CopyConfiguration(2, ParallelOps.CopyMode.ReplaceExisting, Set.empty)
+              ParallelOps
+                .CopyConfiguration(2, ParallelOps.CopyMode.ReplaceExisting, Set.empty, Set.empty)
             )(
               classesDir,
               newClassesDir,

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -409,6 +409,7 @@ object TestUtil {
       scalaInstance = scalaInstance,
       rawClasspath = classpath,
       resources = Nil,
+      isBestEffort = false,
       compileSetup = Config.CompileSetup.empty.copy(order = compileOrder),
       genericClassesDir = classes,
       scalacOptions = Nil,


### PR DESCRIPTION
## Related PRs
* dotty: https://github.com/lampepfl/dotty/pull/17582
* metals: https://github.com/scalameta/metals/pull/5219

## Explanation

This commit allows bloop to support the hopefully-upcoming Scala 3 best effort compilation for Metals, it being enabled with the other Metals options.

Best Effort is meant to be a set of Scala 3 compiler options that allow the errored, but typed programs, to be able to be serialized into a TASTy aligned format (Best Effort TASTy), and later to reuse those typed program trees in both the dependent projects, and in the presentation compiler.

~~Those best effort tasty files are always serialized to a seperate directory, which in this PR is managed by bloop.~~ It is worth noting that the best effort compilation may fail, similarly to the regular compilation.

~~The best effort directory is kept outside of the regular build directory, in `.bloop/project-id/scala-3/best-effort`. There, two directories are managed, `build` and `dep`. Whenever metals compiles a project the `build` directory is populated with best effort artifacts. Then, if the best effort compilation is successful, they are copied to the 'dep' directory, which is used for dependencies, metals presentation compiler etc. This way if a compilation fails, the artifacts from the previous compilation can still be kept. This is not completely dissimilar to how the regular compilation works here, with the difference being the more straightforward implementation, without any counters that monitor how many tasks are being executed with the `dep` directory concurrently.~~

There may be some unnecessary redundancies in this draft PR,~~ where sometimes information about best effort directories of a project is unnecessarily passed around~~. Also, I probably need to add some tests.