### PR TITLE
Report java error column

### DIFF
--- a/backend/src/main/scala/sbt/internal/inc/bloop/ZincInternals.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/ZincInternals.scala
@@ -24,7 +24,7 @@ object ZincInternals {
       rangePosition.orElse {
         for { line <- asIntPos(position.line()) } yield (
           line,
-          asIntPos(position.pointer()).getOrElse(0)
+          asIntPos(position.pointer()).orElse(asIntPos(position.offset())).getOrElse(0)
         )
       }
     }


### PR DESCRIPTION
Currently Bloop reports java errors as always being at the start of the line.  Now it includes the column as well.

I think this worked at one point but maybe got lost in the move away from the Zinc fork?

I don't know why Zinc reports the column of the error in the `offset` field instead of the `pointer` field as the code assumed - maybe it's an issue with Zinc?  Anyway - I don't see a problem in checking both fields.

I've tested this locally with Java code and Metals now underlines the correct error range.