### PR TITLE
improvement: Don't fail on hashing, but use a random hash

### DIFF
--- a/backend/src/main/scala/sbt/internal/inc/bloop/BloopZincCompiler.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/BloopZincCompiler.scala
@@ -247,7 +247,7 @@ object BloopZincCompiler {
       skip: Boolean = false,
       incrementalCompilerOptions: IncOptions,
       extra: List[(String, String)]
-  ): Task[CompileConfiguration] = Task.now {
+  )(implicit logger: ObservedLogger[_]): Task[CompileConfiguration] = Task.now {
     // Remove directories from classpath hashes, we're only interested in jars
     val jarClasspathHashes = BloopLookup.filterOutDirsFromHashedClasspath(classpathHashes)
     val compileSetup = MiniSetup.of(
@@ -284,7 +284,7 @@ object BloopZincCompiler {
       earlyOutput = None,
       // deals with pipelining, not supported yet
       earlyAnalysisStore = None,
-      stamper = BloopStamps.initial
+      stamper = BloopStamps.initial(logger)
     )
   }
 }

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopIncremental.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopIncremental.scala
@@ -48,7 +48,7 @@ object BloopIncremental {
       }
     }
 
-    val current = BloopStamps.initial
+    val current = BloopStamps.initial(log)
     val externalAPI = getExternalAPI(lookup)
     val previous = previous0 match { case a: Analysis => a }
     val previousRelations = previous.relations


### PR DESCRIPTION
Previously, when hashing would fail the whole compilation would also fail and while this seems incredibly rare let's try to guard ourselves here.

Connected to https://github.com/scalacenter/bloop/issues/2053

It's the safest option, we could also try another stamp in this case, but I think there is something wrong with that jar