### PR TITLE
improvement: Automatically include semanticdbjar for tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -163,6 +163,8 @@ lazy val frontend: Project = project
       Dependencies.scalaDebugAdapter,
       Dependencies.bloopConfig
     ),
+    // needed for tests and to be automatically updated
+    Test / libraryDependencies += Dependencies.semanticdb intransitive (),
     dependencyOverrides += Dependencies.shapeless,
     scalafixSettings,
     testSettings,

--- a/frontend/src/test/scala/bloop/BuildLoaderSpec.scala
+++ b/frontend/src/test/scala/bloop/BuildLoaderSpec.scala
@@ -15,10 +15,11 @@ import bloop.task.Task
 import bloop.testing.BaseSuite
 import bloop.tracing.TraceProperties
 import bloop.util.TestUtil
+import bloop.internal.build.BuildTestInfo
 
 object BuildLoaderSpec extends BaseSuite {
-  val semanticdbVersion = "4.6.0"
-  val semanticdbVersion2 = "4.5.13"
+  val semanticdbVersion = BuildTestInfo.semanticdbVersion
+  val oldSemanticdbVersion = "4.5.13"
 
   testLoad("don't reload if nothing changes") { (testBuild, logger) =>
     testBuild.state.build.checkForChange(None, logger).map {
@@ -64,7 +65,7 @@ object BuildLoaderSpec extends BaseSuite {
     val newSettings =
       WorkspaceSettings.fromSemanticdbSettings(
         "0.2.0",
-        semanticdbVersion2,
+        oldSemanticdbVersion,
         List(BuildInfo.scalaVersion)
       )
     testBuild.state.build.checkForChange(Some(newSettings), logger).map {
@@ -82,7 +83,7 @@ object BuildLoaderSpec extends BaseSuite {
     val newSettings =
       WorkspaceSettings.fromSemanticdbSettings(
         "0.1.0",
-        semanticdbVersion2,
+        oldSemanticdbVersion,
         List(BuildInfo.scalaVersion)
       )
     testBuild.state.build.checkForChange(Some(newSettings), logger).map {
@@ -141,7 +142,7 @@ object BuildLoaderSpec extends BaseSuite {
       val newSettings =
         WorkspaceSettings.fromSemanticdbSettings(
           "0.2.0",
-          semanticdbVersion2,
+          oldSemanticdbVersion,
           List(BuildInfo.scalaVersion)
         )
       testBuild.state.build.checkForChange(Some(newSettings), logger).map {

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -21,6 +21,7 @@ import bloop.logging.RecordingLogger
 import bloop.task.Task
 import bloop.util.TestProject
 import bloop.util.TestUtil
+import bloop.internal.build.BuildTestInfo
 
 object LocalBspMetalsClientSpec extends BspMetalsClientSpec(BspProtocol.Local)
 object TcpBspMetalsClientSpec extends BspMetalsClientSpec(BspProtocol.Tcp)
@@ -29,13 +30,10 @@ class BspMetalsClientSpec(
     override val protocol: BspProtocol
 ) extends BspBaseSuite {
   private val testedScalaVersion = BuildInfo.scalaVersion
-  require(
-    testedScalaVersion == "2.12.17",
-    "Updating scala version requires updating semanticDB plugin"
-  )
-  private val semanticdbVersion = "4.6.0"
+  private val semanticdbVersion = BuildTestInfo.semanticdbVersion
   private val javaSemanticdbVersion = "0.5.7"
-  private val semanticdbJar = "semanticdb-scalac_2.12.17-4.6.0.jar"
+
+  private val semanticdbJar = s"semanticdb-scalac_$testedScalaVersion-$semanticdbVersion.jar"
 
   private val expectedConfig =
     s"""|{
@@ -117,7 +115,7 @@ class BspMetalsClientSpec(
 
   test("initialize metals client in workspace with already enabled semanticdb") {
     TestUtil.withinWorkspace { workspace =>
-      val pluginPath = s"-Xplugin:path-to-plugin/semanticdb-scalac_2.12.17-4.6.0.jar"
+      val pluginPath = s"-Xplugin:path-to-plugin/$semanticdbJar"
       val defaultScalacOptions = List(
         "-P:semanticdb:failures:warning",
         s"-P:semanticdb:sourceroot:$workspace",
@@ -167,7 +165,7 @@ class BspMetalsClientSpec(
         "-P:semanticdb:failures:warning",
         "-P:semanticdb:synthetics:on",
         "-Xplugin-require:semanticdb",
-        s"-Xplugin:path-to-plugin/semanticdb-scalac_2.12.17-4.6.0.jar",
+        s"-Xplugin:path-to-plugin/$semanticdbJar",
         "-Yrangepos"
       )
       val `A` = TestProject(

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -360,6 +360,7 @@ object BuildImplementation {
 
           List(
             "sampleSourceGenerator" -> sampleSourceGenerator,
+            "semanticdbVersion" -> Dependencies.semanticdbVersion,
             junitTestJars,
             BuildKeys.bloopCoursierJson,
             (ThisBuild / Keys.baseDirectory)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,12 +1,13 @@
 package build
 
 import sbt.librarymanagement.syntax.stringToOrganization
+import sbt.librarymanagement.CrossVersion
 import sbt.Provided
 
 object Dependencies {
   val Scala211Version = "2.11.12"
-  val Scala212Version = "2.12.17"
-  val Scala213Version = "2.13.8"
+  val Scala212Version = "2.12.18"
+  val Scala213Version = "2.13.11"
 
   val SbtVersion = "1.3.3"
 
@@ -46,7 +47,7 @@ object Dependencies {
   val ztExecVersion = "1.12"
   val debugAdapterVersion = "3.1.3"
   val bloopConfigVersion = "1.5.5"
-
+  val semanticdbVersion = "4.7.8"
   val zinc = "org.scala-sbt" %% "zinc" % zincVersion
   val bsp4s = "ch.epfl.scala" %% "bsp4s" % bspVersion
   val bsp4j = "ch.epfl.scala" % "bsp4j" % bspVersion
@@ -95,6 +96,7 @@ object Dependencies {
   val scalaJsSbtTestAdapter1 =
     "org.scala-js" %% "scalajs-sbt-test-adapter" % scalaJs1Version % Provided
   val scalaJsLogging1 = "org.scala-js" %% "scalajs-logging" % "1.1.1" % Provided
+  val semanticdb = "org.scalameta" % "semanticdb" % semanticdbVersion cross CrossVersion.full
 
   val xxHashLibrary = "net.jpountz.lz4" % "lz4" % xxHashVersion
   val zt = "org.zeroturnaround" % "zt-zip" % ztVersion


### PR DESCRIPTION
Previously, we would use a commited semanticdb jar for tests in frontend, however this caused two issues:

- semanticdb would be always out of date
- scala version updates would require also bumping semanticdb manually and fetching the jar

Now, we use the latest semanticdb plugin always, which should work properly.