### PR TITLE
chore: Remove unused python check

### DIFF
--- a/launcher-test/src/test/scala/bloop/launcher/LauncherSpec.scala
+++ b/launcher-test/src/test/scala/bloop/launcher/LauncherSpec.scala
@@ -27,19 +27,6 @@ class LauncherSpec(bloopVersion: String)
     assert(parentDir.underlying == Environment.homeDirectory.getParent)
   }
 
-  test("check that python is in the classpath") {
-    // Python must always be in the classpath in order to run these tests, if this fails install it
-    assert(shellWithPython.isPythonInClasspath)
-  }
-
-  ignore("fail for bloop version not supporting launcher") {
-    setUpLauncher(shellWithPython) { run =>
-      val args = Array("1.0.0")
-      val status = run.launcher.cli(args)
-      assert(status == LauncherStatus.FailedToInstallBloop)
-    }
-  }
-
   test("when bloop is uninstalled, resolve bloop, start and connect to server via BSP") {
     val result = runBspLauncherWithEnvironment(Array(bloopVersion), shellWithPython)
     val expectedLogs = List(


### PR DESCRIPTION
The tests work on my machine despite not having python on path, so most likely this is no longer valid as the launcher uses snailgun.