### PR TITLE
refactor: Remove cancelPromise, which was used mostly for logging

### DIFF
--- a/backend/src/main/scala/sbt/internal/inc/bloop/BloopZincCompiler.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/BloopZincCompiler.scala
@@ -56,7 +56,6 @@ object BloopZincCompiler {
       logger: ObservedLogger[_],
       uniqueInputs: UniqueCompileInputs,
       manager: ClassFileManager,
-      cancelPromise: Promise[Unit],
       tracer: BraveTracer,
       classpathOptions: ClasspathOptions
   ): Task[CompileResult] = {
@@ -90,7 +89,6 @@ object BloopZincCompiler {
         incrementalCompilerOptions,
         extraOptions,
         manager,
-        cancelPromise,
         tracer
       )(logger)
     }
@@ -117,7 +115,6 @@ object BloopZincCompiler {
       incrementalOptions: IncOptions,
       extra: List[(String, String)],
       manager: ClassFileManager,
-      cancelPromise: Promise[Unit],
       tracer: BraveTracer
   )(implicit logger: ObservedLogger[_]): Task[CompileResult] = {
     val prev = previousAnalysis match {
@@ -137,7 +134,7 @@ object BloopZincCompiler {
         val analysis = invalidateAnalysisFromSetup(config.currentSetup, previousSetup, setOfSources, prev, manager, logger)
 
         // Scala needs the explicit type signature to infer the function type arguments
-        val compile: (Set[VirtualFile], DependencyChanges, AnalysisCallback, ClassFileManager) => Task[Unit] = compiler.compile(_, _, _, _, cancelPromise)
+        val compile: (Set[VirtualFile], DependencyChanges, AnalysisCallback, ClassFileManager) => Task[Unit] = compiler.compile(_, _, _, _)
         BloopIncremental
           .compile(
             setOfSources,

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopHighLevelCompiler.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopHighLevelCompiler.scala
@@ -63,8 +63,7 @@ final class BloopHighLevelCompiler(
       sourcesToCompile: Set[VirtualFile],
       changes: DependencyChanges,
       callback: AnalysisCallback,
-      classfileManager: ClassFileManager,
-      cancelPromise: Promise[Unit]
+      classfileManager: ClassFileManager
   ): Task[Unit] = {
     def timed[T](label: String)(t: => T): T = {
       tracer.trace(label) { _ =>
@@ -140,12 +139,7 @@ final class BloopHighLevelCompiler(
             case NonFatal(t) =>
               // If scala compilation happens, complete the java promise so that it doesn't block
               JavaCompleted.tryFailure(t)
-
-              t match {
-                case _: NullPointerException if cancelPromise.isCompleted =>
-                  throw new InterfaceCompileCancelled(Array(), "Caught NPE when compilation was cancelled!")
-                case t => throw t
-              }
+              throw t
           }
         }
 


### PR DESCRIPTION
I am trying to remove some cancelation logic, which doesn't seem 100% neccessary or try to handle it differently. This might help in migrating off monix.

Here, I think we mostly used the cancelation for logging purposes, which is not really something users care a lot.