### PR TITLE
chore: Unignore tests that were ignored for JDK 11

### DIFF
--- a/frontend/src/test/scala/bloop/testing/ProjectBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/testing/ProjectBaseSuite.scala
@@ -15,26 +15,24 @@ class ProjectBaseSuite(buildName: String) extends BaseSuite {
     loadBuildFromResources(buildName, workspace, logger)
   }
 
-  def testProject(name: String, runOnlyOnJava8: Boolean)(
+  def testProject(name: String, ignoreTest: Boolean = false)(
       fun: (TestBuild, RecordingLogger) => Any
   ): Unit = {
     val newLogger = new RecordingLogger(ansiCodesSupported = false)
     val newBuild = build.withLogger(newLogger)
-    if (runOnlyOnJava8) testOnlyOnJava8(name)(fun(newBuild, newLogger))
+    if (ignoreTest) ignore(name)(fun(newBuild, newLogger))
     else test(name)(fun(newBuild, newLogger))
   }
 
   def testProjectTask(
       name: String,
-      runOnlyOnJava8: Boolean,
       maxDuration: Duration = Duration("60s")
   )(
       fun: (TestBuild, RecordingLogger) => Task[Unit]
   ): Unit = {
     val newLogger = new RecordingLogger(ansiCodesSupported = false)
     val newBuild = build.withLogger(newLogger)
-    if (runOnlyOnJava8) testOnlyOnJava8(name)(fun(newBuild, newLogger))
-    else testTask(name, maxDuration)(fun(newBuild, newLogger))
+    testTask(name, maxDuration)(fun(newBuild, newLogger))
   }
 
   override def test(name: String)(fun: => Any): Unit = {


### PR DESCRIPTION
Since we only run on JDK 11 currently, those tests wouldn't run ever.

I only left the Scala JS tests ignored since there were some issues around that and we need to rework Scala JS integration at some point anyway.