### PR TITLE
chore: Add release notes for Bloop 1.5.7 release

### DIFF
--- a/notes/v1.5.7.md
+++ b/notes/v1.5.7.md
@@ -1,0 +1,246 @@
+# bloop `v1.5.7`
+
+Bloop v1.5.7 is a bugfix release.
+
+## Installing Bloop
+
+For more details about installing Bloop, please see [Bloop's Installation Guide](https://scalacenter.github.io/bloop/setup)). Some of the highlight of this release are the numerous improvements to debugging support.
+
+## Merged pull requests
+
+Here's a list of pull requests that were merged:
+
+- Build(deps): Update sbt, test-agent from 1.8.3 to 1.9.1 [#2091]
+- Build(deps): Update zinc from 1.8.1 to 1.9.2 [#2092]
+- Build(deps): Update scalafmt-core from 3.7.4 to 3.7.5 [#2094]
+- Bugfix: Don't accept files other than .class or .jar as binary deps [#2060]
+- Build(deps): Update zinc from 1.8.1 to 1.9.1 [#2064]
+- Bugfix: Include semanticdb plugin path in java options processorpath [#2072]
+- Build(deps): Update librarymanagement-ivy from 1.9.0 to 1.9.1 [#2090]
+- Chore: Remove nailgun module and NailgunSpec, which is no longer rele… [#2087]
+- Chore: Remove unused python check [#2086]
+- Improvement: Add main classes to JvmEnvironmentItem [#2083]
+- Build(deps): Update scalajs-linker, ... from 1.13.1 to 1.13.2 [#2088]
+- Build(deps): Update sbt-scalajs, scalajs-linker, ... from 1.13.1 to 1.13.2 [#2084]
+- Improvement: Automatically include semanticdbjar for tests [#2081]
+- Build(deps): Update commons-codec from 1.15 to 1.16.0 [#2082]
+- Build(deps): Update sbt-dynver from 4.1.1 to 5.0.1 [#2078]
+- Build(deps): Update org.eclipse.jgit, ... from 6.5.0.202303070854-r to 6.6.0.202305301015-r [#2075]
+- Build(deps): Update tools from 0.4.12 to 0.4.14 [#2069]
+- Build(deps): Update interface, interface-svm-subs from 1.0.16 to 1.0.18 [#2077]
+- Build(deps): Update librarymanagement-ivy from 1.8.0 to 1.9.0 [#2062]
+- Update the developer documentation. [#2067]
+- Build(deps): Update sbt-scalafix from 0.10.4 to 0.11.0 [#2065]
+- Build(deps): Update scalafmt-core from 3.7.3 to 3.7.4 [#2061]
+- Improvement: Don't fail on hashing, but use a random hash [#2058]
+- Bugfix: Remove backup directory after compilation [#2057]
+- Report java error column [#2055]
+- Build(deps): Update scala-debug-adapter from 3.1.2 to 3.1.3 [#2054]
+- Build(deps): Update scala-debug-adapter from 3.1.1 to 3.1.2 [#2052]
+- Build(deps): Update sbt, test-agent from 1.8.2 to 1.8.3 [#2050]
+- Build(deps): Update zinc from 1.8.0 to 1.8.1 [#2051]
+- Build(deps): Update zipkin-sender-urlconnection from 2.16.3 to 2.16.4 [#2042]
+- Build(deps): Update scala-debug-adapter from 3.0.9 to 3.1.1 [#2047]
+- Build(deps): Update brave from 5.15.1 to 5.16.0 [#2048]
+- Build(deps): Update interface, interface-svm-subs from 1.0.15 to 1.0.16 [#2045]
+- Build(deps): Update sbt-ci-release from 1.5.11 to 1.5.12 [#2044]
+- Fix some links in gradle docs [#2043]
+- Build(deps): Update sbt-scalajs-crossproject from 1.3.0 to 1.3.1 [#2040]
+- Build(deps): Update brave from 5.15.0 to 5.15.1 [#2038]
+- Build(deps): Update scalajs-linker, ... from 1.13.0 to 1.13.1 [#2037]
+- Bugfix: Properly clean up orphan directories for internal classes [#2032]
+- Build(deps): Update sbt-scalajs, scalajs-linker, ... from 1.13.0 to 1.13.1 [#2035]
+- Build(deps): Update interface, interface-svm-subs from 1.0.14 to 1.0.15 [#2034]
+- Build(deps): Update sbt-scalajs-crossproject from 1.2.0 to 1.3.0 [#2033]
+- Build(deps): Update scala-debug-adapter from 3.0.5 to 3.0.9 [#2011]
+- Build(deps): Update interface, interface-svm-subs from 1.0.13 to 1.0.14 [#2028]
+- Fix timeout in DebugProtocolTests [#2029]
+- Build(deps): Update scalafmt-core from 3.7.2 to 3.7.3 [#2026]
+- Build(deps): Update tools from 0.4.11 to 0.4.12 [#2023]
+- Build(deps): Update asm, asm-util from 9.4 to 9.5 [#2025]
+- Build(deps): Update slf4j-nop from 2.0.6 to 2.0.7 [#2021]
+- Build(deps): Update tools from 0.4.10 to 0.4.11 [#2020]
+- Fix: do not expose mutable env properties in State [#2016]
+- Build(deps): Update sbt-native-packager from 1.9.15 to 1.9.16 [#2012]
+- Build(deps): Update log4j-core from 2.19.0 to 2.20.0 [#2013]
+- Build(deps): Update scala-debug-adapter from 3.0.5 to 3.0.7 [#2002]
+- Build(deps): Update org.eclipse.jgit, ... from 6.4.0.202211300538-r to 6.5.0.202303070854-r [#2014]
+- Build(deps): Update scalafmt-core from 3.7.1 to 3.7.2 [#2015]
+- Build(deps): bump actions/checkout from 2 to 3 [#2010]
+- Build(deps): Update sbt-native-packager from 1.9.14 to 1.9.15 [#2005]
+- Build(deps): Update sbt-native-packager from 1.9.13 to 1.9.14 [#2004]
+- Bugfix: Catch and log StackOverflowError [#2001]
+- Build(deps): Update brave from 5.14.1 to 5.15.0 [#2003]
+- Build(deps): Update tools from 0.4.9 to 0.4.10 [#1999]
+- Build(deps): Update sbt-mdoc from 2.3.6 to 2.3.7 [#2000]
+- Build(deps): Update scalajs-linker, ... from 1.12.0 to 1.13.0 [#1998]
+- Build(deps): Update sbt-scalajs, scalajs-linker, ... from 1.12.0 to 1.13.0 [#1997]
+- Refactor: take care of a bunch of warnings [#1995]
+- Fix: ensure valid scalajs-logging version in ScalaJsToolchain [#1994]
+- Build(deps): Update scalafmt-core from 3.7.0 to 3.7.1 [#1993]
+- Build(deps): Update scalafmt-core from 3.6.1 to 3.7.0 [#1988]
+- Build(deps): Update sbt-native-packager from 1.9.12 to 1.9.13 [#1987]
+- Improvement: Use diagnostic related information from the compiler [#1986]
+- Build(deps): Update sbt-native-packager from 1.9.11 to 1.9.12 [#1985]
+- Build(deps): Update jna, jna-platform from 5.12.1 to 5.13.0 [#1984]
+- Build(deps): Update interface, interface-svm-subs from 1.0.12 to 1.0.13 [#1982]
+- Throw error from bloopGenerate task [#1973]
+- Small test improvements [#1980]
+- Chore: remove twitterIntegrationProjects [#1979]
+- Build(deps): Update sbt, test-agent from 1.8.1 to 1.8.2 [#1978]
+- Build(deps): bump json5 from 1.0.1 to 1.0.2 in /website [#1977]
+- Build(deps): Update sbt, test-agent from 1.8.0 to 1.8.1 [#1976]
+- Refactor(build): clean up the plugins file [#1975]
+- Build(deps): Update zt-zip from 1.13 to 1.15 [#1974]
+- Chore(ci): try to bump node to lts [#1972]
+- Refactor(build): get rid of build warnings and unused things [#1968]
+- Chore: remove the gitter icon in the readme [#1967]
+- Build(deps): Update org.eclipse.jgit, ... from 5.13.1.202206130422-r to 6.4.0.202211300538-r [#1912]
+- Refactor(ci): update graal release infrastructure [#1966]
+- Fix(ci): ensure release sbt version is the same as the build [#1965]
+- Refactor(ci): migrate to sbt-ci-release [#1962]
+- Correct typo in sbt.md [#1959]
+- Build(deps): Update slf4j-nop from 1.7.36 to 2.0.6 [#1950]
+- Build(deps): Update interface, interface-svm-subs from 1.0.6 to 1.0.12 [#1957]
+- Refactor: stop shading launcher and bloopgun [#1961]
+- Chore(deps): bump scalaz to 7.3.7 [#1963]
+- Fix: update jvmOpts to not mention bloop-sbt-already-installed [#1960]
+- Refactor: rework/rethink the meta meta build stuff [#1956]
+- Refactor(build): a bit of build cleanup [#1955]
+- Refactor: get rid of leftover integration utils [#1954]
+- Refactor: migrate Gradle integration out of Bloop [#1951]
+- Refactor: move the Maven plugin out of Bloop [#1948]
+- Build(deps): Update classgraph from 4.8.151 to 4.8.152 [#1949]
+- Build(deps): Update scalajs-linker, ... from 1.3.1 to 1.12.0 [#1919]
+- Build(deps): Update scalajs-env-nodejs, ... from 1.1.1 to 1.4.0 [#1917]
+- Bugfix: Use the project working directory for running [#1947]
+- Build(deps): Update asm, asm-util from 7.3.1 to 9.4 [#1945]
+- Build(deps): Update zt-exec from 1.11 to 1.12 [#1933]
+- Fix: revert sbt-jmh update [#1946]
+- Build(deps): Update asm, asm-util from 7.0 to 7.3.1 [#1914]
+- Build(deps): bump express from 4.17.1 to 4.18.2 in /website [#1942]
+- Build(deps): bump qs from 6.5.2 to 6.5.3 in /website [#1941]
+- Build(deps): Update sbt-git from 2.0.0 to 2.0.1 [#1936]
+- Build(deps): Update sbt-scalajs from 1.6.0 to 1.12.0 [#1916]
+- Build(deps): Update scala-library from 2.12.15 to 2.12.17 [#1920]
+
+
+[#2091]: https://github.com/scalacenter/bloop/pull/2091
+[#2092]: https://github.com/scalacenter/bloop/pull/2092
+[#2094]: https://github.com/scalacenter/bloop/pull/2094
+[#2060]: https://github.com/scalacenter/bloop/pull/2060
+[#2064]: https://github.com/scalacenter/bloop/pull/2064
+[#2072]: https://github.com/scalacenter/bloop/pull/2072
+[#2090]: https://github.com/scalacenter/bloop/pull/2090
+[#2087]: https://github.com/scalacenter/bloop/pull/2087
+[#2086]: https://github.com/scalacenter/bloop/pull/2086
+[#2083]: https://github.com/scalacenter/bloop/pull/2083
+[#2088]: https://github.com/scalacenter/bloop/pull/2088
+[#2084]: https://github.com/scalacenter/bloop/pull/2084
+[#2081]: https://github.com/scalacenter/bloop/pull/2081
+[#2082]: https://github.com/scalacenter/bloop/pull/2082
+[#2078]: https://github.com/scalacenter/bloop/pull/2078
+[#2075]: https://github.com/scalacenter/bloop/pull/2075
+[#2069]: https://github.com/scalacenter/bloop/pull/2069
+[#2077]: https://github.com/scalacenter/bloop/pull/2077
+[#2062]: https://github.com/scalacenter/bloop/pull/2062
+[#2067]: https://github.com/scalacenter/bloop/pull/2067
+[#2065]: https://github.com/scalacenter/bloop/pull/2065
+[#2061]: https://github.com/scalacenter/bloop/pull/2061
+[#2058]: https://github.com/scalacenter/bloop/pull/2058
+[#2057]: https://github.com/scalacenter/bloop/pull/2057
+[#2055]: https://github.com/scalacenter/bloop/pull/2055
+[#2054]: https://github.com/scalacenter/bloop/pull/2054
+[#2052]: https://github.com/scalacenter/bloop/pull/2052
+[#2050]: https://github.com/scalacenter/bloop/pull/2050
+[#2051]: https://github.com/scalacenter/bloop/pull/2051
+[#2042]: https://github.com/scalacenter/bloop/pull/2042
+[#2047]: https://github.com/scalacenter/bloop/pull/2047
+[#2048]: https://github.com/scalacenter/bloop/pull/2048
+[#2045]: https://github.com/scalacenter/bloop/pull/2045
+[#2044]: https://github.com/scalacenter/bloop/pull/2044
+[#2043]: https://github.com/scalacenter/bloop/pull/2043
+[#2040]: https://github.com/scalacenter/bloop/pull/2040
+[#2038]: https://github.com/scalacenter/bloop/pull/2038
+[#2037]: https://github.com/scalacenter/bloop/pull/2037
+[#2032]: https://github.com/scalacenter/bloop/pull/2032
+[#2035]: https://github.com/scalacenter/bloop/pull/2035
+[#2034]: https://github.com/scalacenter/bloop/pull/2034
+[#2033]: https://github.com/scalacenter/bloop/pull/2033
+[#2011]: https://github.com/scalacenter/bloop/pull/2011
+[#2028]: https://github.com/scalacenter/bloop/pull/2028
+[#2029]: https://github.com/scalacenter/bloop/pull/2029
+[#2026]: https://github.com/scalacenter/bloop/pull/2026
+[#2023]: https://github.com/scalacenter/bloop/pull/2023
+[#2025]: https://github.com/scalacenter/bloop/pull/2025
+[#2021]: https://github.com/scalacenter/bloop/pull/2021
+[#2020]: https://github.com/scalacenter/bloop/pull/2020
+[#2016]: https://github.com/scalacenter/bloop/pull/2016
+[#2012]: https://github.com/scalacenter/bloop/pull/2012
+[#2013]: https://github.com/scalacenter/bloop/pull/2013
+[#2002]: https://github.com/scalacenter/bloop/pull/2002
+[#2014]: https://github.com/scalacenter/bloop/pull/2014
+[#2015]: https://github.com/scalacenter/bloop/pull/2015
+[#2010]: https://github.com/scalacenter/bloop/pull/2010
+[#2005]: https://github.com/scalacenter/bloop/pull/2005
+[#2004]: https://github.com/scalacenter/bloop/pull/2004
+[#2001]: https://github.com/scalacenter/bloop/pull/2001
+[#2003]: https://github.com/scalacenter/bloop/pull/2003
+[#1999]: https://github.com/scalacenter/bloop/pull/1999
+[#2000]: https://github.com/scalacenter/bloop/pull/2000
+[#1998]: https://github.com/scalacenter/bloop/pull/1998
+[#1997]: https://github.com/scalacenter/bloop/pull/1997
+[#1995]: https://github.com/scalacenter/bloop/pull/1995
+[#1994]: https://github.com/scalacenter/bloop/pull/1994
+[#1993]: https://github.com/scalacenter/bloop/pull/1993
+[#1988]: https://github.com/scalacenter/bloop/pull/1988
+[#1987]: https://github.com/scalacenter/bloop/pull/1987
+[#1986]: https://github.com/scalacenter/bloop/pull/1986
+[#1985]: https://github.com/scalacenter/bloop/pull/1985
+[#1984]: https://github.com/scalacenter/bloop/pull/1984
+[#1982]: https://github.com/scalacenter/bloop/pull/1982
+[#1973]: https://github.com/scalacenter/bloop/pull/1973
+[#1980]: https://github.com/scalacenter/bloop/pull/1980
+[#1979]: https://github.com/scalacenter/bloop/pull/1979
+[#1978]: https://github.com/scalacenter/bloop/pull/1978
+[#1977]: https://github.com/scalacenter/bloop/pull/1977
+[#1976]: https://github.com/scalacenter/bloop/pull/1976
+[#1975]: https://github.com/scalacenter/bloop/pull/1975
+[#1974]: https://github.com/scalacenter/bloop/pull/1974
+[#1972]: https://github.com/scalacenter/bloop/pull/1972
+[#1968]: https://github.com/scalacenter/bloop/pull/1968
+[#1967]: https://github.com/scalacenter/bloop/pull/1967
+[#1912]: https://github.com/scalacenter/bloop/pull/1912
+[#1966]: https://github.com/scalacenter/bloop/pull/1966
+[#1965]: https://github.com/scalacenter/bloop/pull/1965
+[#1962]: https://github.com/scalacenter/bloop/pull/1962
+[#1959]: https://github.com/scalacenter/bloop/pull/1959
+[#1950]: https://github.com/scalacenter/bloop/pull/1950
+[#1957]: https://github.com/scalacenter/bloop/pull/1957
+[#1961]: https://github.com/scalacenter/bloop/pull/1961
+[#1963]: https://github.com/scalacenter/bloop/pull/1963
+[#1960]: https://github.com/scalacenter/bloop/pull/1960
+[#1956]: https://github.com/scalacenter/bloop/pull/1956
+[#1955]: https://github.com/scalacenter/bloop/pull/1955
+[#1954]: https://github.com/scalacenter/bloop/pull/1954
+[#1951]: https://github.com/scalacenter/bloop/pull/1951
+[#1948]: https://github.com/scalacenter/bloop/pull/1948
+[#1949]: https://github.com/scalacenter/bloop/pull/1949
+[#1919]: https://github.com/scalacenter/bloop/pull/1919
+[#1917]: https://github.com/scalacenter/bloop/pull/1917
+[#1947]: https://github.com/scalacenter/bloop/pull/1947
+[#1945]: https://github.com/scalacenter/bloop/pull/1945
+[#1933]: https://github.com/scalacenter/bloop/pull/1933
+[#1946]: https://github.com/scalacenter/bloop/pull/1946
+[#1914]: https://github.com/scalacenter/bloop/pull/1914
+[#1942]: https://github.com/scalacenter/bloop/pull/1942
+[#1941]: https://github.com/scalacenter/bloop/pull/1941
+[#1936]: https://github.com/scalacenter/bloop/pull/1936
+[#1916]: https://github.com/scalacenter/bloop/pull/1916
+[#1920]: https://github.com/scalacenter/bloop/pull/1920
+
+
+## Contributors
+
+According to `git shortlog -sn --no-merges v1.5.6..v1.5.7`, the following people have contributed to
+this `v1.5.7` release: scala-center-steward[bot], Chris Kipp, Tomasz Godzik, Gerson Sosa, dependabot[bot], Adrien Piquerez, Arthur McGibbon, Dmytro Tsyliuryk, Gngr, Kamil Podsiadło, Rory Graves, Thanh Le, Łukasz Wroński.


### PR DESCRIPTION
I figured we haven't had a release for a while and a lot of the improvements of Scala debug adapter are not being used.