### PR TITLE
improvement: Try and find latest supported semanticdb version

### DIFF
--- a/frontend/src/main/scala/bloop/engine/caches/SemanticDBCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/SemanticDBCache.scala
@@ -2,21 +2,30 @@ package bloop.engine.caches
 
 import java.nio.file.Path
 
+import scala.collection.JavaConverters._
+import scala.concurrent.Await
+import scala.concurrent.duration.FiniteDuration
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
 import bloop.DependencyResolution
 import bloop.SemanticDBCacheLock
+import bloop.engine.ExecutionContext
 import bloop.io.AbsolutePath
 import bloop.io.Paths
 import bloop.logging.Logger
+import bloop.task.Task
 
 import sbt.internal.inc.BloopComponentCompiler
 import sbt.internal.inc.BloopComponentManager
 import sbt.internal.inc.IfMissing
+import java.util.concurrent.ConcurrentHashMap
+import scala.concurrent.Future
 
 object SemanticDBCache {
+  // to avoid resolving the same fallback semanticdb version multiple times
+  private val supportedFallbackSemanticdbVersions = new ConcurrentHashMap[String, String]()
   private def fetchPlugin(
       artifact: DependencyResolution.Artifact,
       logger: Logger
@@ -57,6 +66,41 @@ object SemanticDBCache {
     }
   }
 
+  private def fallbackSemanticdbFetch(
+      scalaVersion: String,
+      artifact: DependencyResolution.Artifact,
+      logger: Logger
+  ): Either[String, AbsolutePath] = {
+    // if scala version is no longer supported find the latest supported semanticdb version
+    def versionFuture =
+      Future {
+        coursierapi.Complete
+          .create()
+          .withScalaVersion(scalaVersion)
+          .withScalaBinaryVersion(scalaVersion.split('.').take(2).mkString("."))
+          .withInput(s"org.scalameta:semanticdb-scalac_$scalaVersion:")
+          .complete()
+          .getCompletions()
+          .asScala
+          .lastOption
+      }(ExecutionContext.ioScheduler)
+
+    def version =
+      try
+        Await.result(versionFuture, FiniteDuration(10, "s"))
+      catch {
+        case _: Throwable => None
+      }
+
+    Option(supportedFallbackSemanticdbVersions.get(scalaVersion)).orElse(version) match {
+      case None =>
+        Left(s"After retry no existing semanticdb version found for scala version $scalaVersion")
+      case Some(semanticdbVersion) =>
+        supportedFallbackSemanticdbVersions.put(scalaVersion, semanticdbVersion)
+        fetchPlugin(artifact.copy(version = semanticdbVersion), logger)
+    }
+  }
+
   @volatile private var latestResolvedScalaSemanticDB: Path = null
   def fetchScalaPlugin(
       scalaVersion: String,
@@ -77,7 +121,16 @@ object SemanticDBCache {
           latestResolvedPlugin
         }
       }
-    } else fetchPlugin(artifact, logger)
+    } else {
+      fetchPlugin(artifact, logger) match {
+        case Right(plugin) => Right(plugin)
+        case Left(error) =>
+          fallbackSemanticdbFetch(scalaVersion, artifact, logger) match {
+            case Left(newError) => Left(error + "\n" + newError)
+            case Right(plugin) => Right(plugin)
+          }
+      }
+    }
   }
 
   @volatile private var latestResolvedJavaSemanticDB: Path = null

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -87,32 +87,6 @@ class BspMetalsClientSpec(
     }
   }
 
-  test("do not initialize metals client and save settings with unsupported scala version") {
-    TestUtil.withinWorkspace { workspace =>
-      val `A` = TestProject(workspace, "A", Nil, scalaVersion = Some("2.12.4"))
-      val projects = List(`A`)
-      val configDir = TestProject.populateWorkspace(workspace, projects)
-      val logger = new RecordingLogger(ansiCodesSupported = false)
-      val extraParams = BloopExtraBuildParams(
-        ownsBuildFiles = None,
-        clientClassesRootDir = None,
-        semanticdbVersion = Some(semanticdbVersion), // Doesn't support 2.12.4
-        supportedScalaVersions = Some(List(testedScalaVersion)),
-        javaSemanticdbVersion = Some(javaSemanticdbVersion)
-      )
-
-      loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
-        assertNoDiffInSettingsFile(
-          configDir,
-          expectedConfig
-        )
-        // Expect only range positions to be added, semanticdb is not supported
-        assertScalacOptions(state, `A`, "-Yrangepos")
-        assertNoDiff(logger.warnings.mkString(lineSeparator), "")
-      }
-    }
-  }
-
   test("initialize metals client in workspace with already enabled semanticdb") {
     TestUtil.withinWorkspace { workspace =>
       val pluginPath = s"-Xplugin:path-to-plugin/$semanticdbJar"
@@ -315,6 +289,40 @@ class BspMetalsClientSpec(
 
       val `A` =
         TestProject(workspace, "A", dummyFooScalaAndBarJavaSources, javacOptions = JavacOptions.A)
+      val projects = List(`A`)
+      val configDir = TestProject.populateWorkspace(workspace, projects)
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      WorkspaceSettings.writeToFile(
+        configDir,
+        WorkspaceSettings
+          .fromSemanticdbSettings("0.5.7", semanticdbVersion, List(testedScalaVersion)),
+        logger
+      )
+      loadBspState(workspace, projects, logger) { state =>
+        val compiledState = state.compile(`A`).toTestState
+        assert(compiledState.status == ExitStatus.Ok)
+        assertSemanticdbFileFor("Foo.scala", compiledState)
+        assertSemanticdbFileFor("Bar.java", compiledState)
+      }
+    }
+  }
+
+  test("compile with old semanticDB") {
+    TestUtil.withinWorkspace { workspace =>
+      object JavacOptions {
+        // This will cause to use the forked javac compiler, since addong any `-J` property causes it
+        val A = List("-J-Xms48m")
+      }
+
+      val `A` =
+        TestProject(
+          workspace,
+          "A",
+          dummyFooScalaAndBarJavaSources,
+          javacOptions = JavacOptions.A,
+          // this Scala version is not supported in the newest semanticdb
+          scalaVersion = Some("2.12.8")
+        )
       val projects = List(`A`)
       val configDir = TestProject.populateWorkspace(workspace, projects)
       val logger = new RecordingLogger(ansiCodesSupported = false)


### PR DESCRIPTION
Previously, we wouldn't produce semanticdb files for older version of Scala since we wouldn't find the correct artifact if we stopped publishing for a particular version.

Now, we try and find the latest version that still supported that Scala version.

This is similar to the change we did in Metals in regards to the presentation compiler interface, where we would fetch old mtags for unsupported scala version and this way always support a particular version.

Will do a similar thing for our Metals sbt plugin if it makes sense.