### PR TITLE
chore: Release notes for Bloop 1.5.8

### DIFF
--- a/notes/v1.5.8.md
+++ b/notes/v1.5.8.md
@@ -1,0 +1,32 @@
+# bloop `v1.5.8`
+
+Bloop v1.5.8 is a bugfix release.
+
+## Installing Bloop
+
+For more details about installing Bloop, please see [Bloop's Installation Guide](https://scalacenter.github.io/bloop/setup))
+
+## Merged pull requests
+
+Here's a list of pull requests that were merged:
+
+- Chore: Revert JGit to a version compatible with JDK 8 [#2101]
+- Docs: update overview.md with corrections [#2100]
+- Chore: Update coursier.json and run release on Java 8 for the time being [#2099]
+- Chore: Make source generator tests more resilient [#2085]
+- Build(deps): Update scalafmt-core from 3.7.5 to 3.7.6 [#2098]
+- Improvement: Try and find latest supported semanticdb version [#2097]
+
+
+[#2101]: https://github.com/scalacenter/bloop/pull/2101
+[#2100]: https://github.com/scalacenter/bloop/pull/2100
+[#2099]: https://github.com/scalacenter/bloop/pull/2099
+[#2085]: https://github.com/scalacenter/bloop/pull/2085
+[#2098]: https://github.com/scalacenter/bloop/pull/2098
+[#2097]: https://github.com/scalacenter/bloop/pull/2097
+
+
+## Contributors
+
+According to `git shortlog -sn --no-merges v1.5.7..v1.5.8`, the following people have contributed to
+this `v1.5.8` release: Tomasz Godzik, Chris Kipp, scala-center-steward[bot], tgodzik.


### PR DESCRIPTION
Quick follow up to have the last JDK 8 compatible version.