### PR TITLE
bugfix: Don't deduplicate all options when using Metals

### DIFF
--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -454,10 +454,10 @@ object Project {
       // engine so that semanticdb files are replicated in those directories
       val hasSemanticDB = hasScalaSemanticDBEnabledInCompilerOptions(options)
       val pluginOption = if (hasSemanticDB) Nil else List(s"-Xplugin:$pluginPath")
-      val baseOptions = s"-P:semanticdb:sourceroot:$workspaceDir" :: options.filterNot(
-        isScalaSemanticdbSourceRoot
+      val baseOptions = s"-P:semanticdb:sourceroot:$workspaceDir" :: options.filterNot(opt =>
+        isScalaSemanticdbSourceRoot(opt) || baseSemanticdbOptions.contains(opt)
       )
-      (baseOptions ++ baseSemanticdbOptions ++ pluginOption).distinct
+      baseOptions ++ baseSemanticdbOptions ++ pluginOption
     }
 
     def enableDottySemanticdb(options: List[String]) = {


### PR DESCRIPTION
PReviously, we would use `.distinct` on all project scalac options which would remove values for different options if the happened to be the same. Now, we only deduplicate semanticdb options.

Fixes https://github.com/scalameta/metals/issues/5400