### PR TITLE
improvement: Send debug logs to BSP client

### DIFF
--- a/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
+++ b/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
@@ -53,7 +53,15 @@ final class BspServerLogger private (
 
   override def ansiCodesSupported: Boolean = ansiSupported || underlying.ansiCodesSupported()
 
-  override private[logging] def printDebug(msg: String): Unit = underlying.printDebug(msg)
+  override private[logging] def printDebug(msg: String): Unit = {
+    if (isVerbose)
+      client.notify(
+        Build.logMessage,
+        bsp.LogMessageParams(bsp.MessageType.Log, None, originId, msg)
+      )
+    underlying.printDebug(msg)
+
+  }
   override def debug(msg: String)(implicit ctx: DebugFilter): Unit =
     if (debugFilter.isEnabledFor(ctx)) printDebug(msg)
 

--- a/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
@@ -36,7 +36,9 @@ class BspCompileSpec(
         assertExitStatus(state, ExitStatus.Ok)
       }
     }
-    val contentLogs = logger.debugs.flatMap(_.split("\n")).filter(_.startsWith("  --> content:"))
+    val contentLogs = logger.debugs
+      .flatMap(_.split("\n"))
+      .filter(msg => msg.startsWith("  --> content:") && !msg.contains("logMessage"))
     val allButInitializeRequest = contentLogs.filterNot(_.contains("""build/initialize""""))
     // Filter out the initialize request that contains platform-specific details
     assertNoDiff(

--- a/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspConnectionSpec.scala
@@ -90,7 +90,9 @@ class BspConnectionSpec(
   def checkConnectionIsInitialized(logger: RecordingLogger): Unit = {
     val contentLogs = logger.debugs.flatMap(_.split("\n")).filter(_.startsWith("  --> content:"))
     // Filter out the initialize request that contains platform-specific details
-    val allButInitializeRequest = contentLogs.filterNot(_.contains("""build/initialize""""))
+    val allButInitializeRequest = contentLogs.filterNot(msg =>
+      msg.contains("""build/initialize"""") || msg.contains("logMessage")
+    )
     assertNoDiff(
       allButInitializeRequest.mkString(lineSeparator),
       s"""|


### PR DESCRIPTION
Previously, we would only print the logs when using Bloop from CLI. We still will need to add `-verbose` to compile params to get this behaviour