### PR TITLE
bugfix: Don't try to discover test frameworks if none exist

### DIFF
--- a/bridges/scalajs-1/src/main/scala/bloop/scalajs/jsenv/NodeJsEnv.scala
+++ b/bridges/scalajs-1/src/main/scala/bloop/scalajs/jsenv/NodeJsEnv.scala
@@ -124,6 +124,7 @@ final class NodeJSEnv(logger: Logger, config: NodeJSConfig) extends JSEnv {
   }
 
   private def internalStart(input: Seq[Input], runConfig: RunConfig): JSRun = {
+    runConfig.logger.debug("Using input file: " + (input.mkString(",")))
     NodeJSEnv.internalStart(logger, config, env)(NodeJSEnv.write(input), runConfig)
   }
 
@@ -290,7 +291,10 @@ object NodeJSEnv {
       import scala.concurrent.ExecutionContext.Implicits.global
 
       private val isClosed = AtomicBoolean(false)
-      override def future: Future[Unit] = cancellable.map(_ => ())
+      override def future: Future[Unit] = cancellable.map { results =>
+        logger.debug(s"Finished with results: ${results}")
+        ()
+      }
       override def close(): Unit = {
         // Make sure we only destroy the process once, the test adapter can call this several times!
         if (!isClosed.getAndSet(true)) {


### PR DESCRIPTION
Previously, even if node_modules wouldn't exist we would run test discovery, which requires the node_modules and the scripts it contains. Now, we show an error in such a case. This seems to have hanged the node process causing no tests to be discovered.

I am not sure how to properly test it yet, but I need to dig into the JS part at some point since from earlier discussions with Sebastien the bridges might be problematic.