### PR TITLE
improvement: Don't fail during copying

### DIFF
--- a/backend/src/main/scala/bloop/BloopClassFileManager.scala
+++ b/backend/src/main/scala/bloop/BloopClassFileManager.scala
@@ -221,7 +221,8 @@ final class BloopClassFileManager(
                 newClassesDir,
                 clientExternalClassesDir.underlying,
                 inputs.ioScheduler,
-                enableCancellation = false
+                enableCancellation = false,
+                inputs.logger
               )
               .map { walked =>
                 readOnlyCopyDenylist.++=(walked.target)
@@ -279,7 +280,8 @@ final class BloopClassFileManager(
                     Paths.get(readOnlyClassesDirPath),
                     clientExternalClassesDir.underlying,
                     inputs.ioScheduler,
-                    enableCancellation = false
+                    enableCancellation = false,
+                    inputs.logger
                   )
                   .map(_ => ())
               }

--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -434,7 +434,8 @@ object Compiler {
                   readOnlyClassesDir,
                   clientClassesDir.underlying,
                   compileInputs.ioScheduler,
-                  enableCancellation = false
+                  enableCancellation = false,
+                  compileInputs.logger
                 )
 
                 lastCopy.map { _ =>

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -363,7 +363,8 @@ object CompileTask {
           products.readOnlyClassesDir,
           products.newClassesDir,
           ExecutionContext.ioScheduler,
-          enableCancellation = false
+          enableCancellation = false,
+          logger
         )
       }
 

--- a/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
+++ b/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
@@ -28,6 +28,7 @@ import bloop.util.TestUtil
 
 import monix.execution.CancelableFuture
 import monix.execution.Scheduler
+import bloop.logging.NoopLogger
 
 trait BloopHelpers {
   def loadState(
@@ -87,7 +88,8 @@ trait BloopHelpers {
       baseDir,
       workspace.underlying,
       ExecutionContext.ioScheduler,
-      enableCancellation = false
+      enableCancellation = false,
+      logger
     )
 
     val loadFromNewWorkspace = copyToNewWorkspace.flatMap { _ =>
@@ -305,7 +307,8 @@ trait BloopHelpers {
               classesDir,
               newClassesDir,
               ExecutionContext.ioScheduler,
-              enableCancellation = false
+              enableCancellation = false,
+              NoopLogger
             )
 
             backupDir.map { _ =>


### PR DESCRIPTION
This might cause the compiler to never work again until restart. It seems that the reason might be that one of the files is locked, but this is highly difficult to reproduce.

Connected to https://github.com/scalacenter/bloop/issues/1989