### PR TITLE
feat: fallback to `source` and `javadoc` classifiers when exporting projects from sbt

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -144,6 +144,7 @@ object BloopDefaults {
       Option(System.getProperty("bloop.export-jar-classifiers"))
         .orElse(Option(System.getenv("BLOOP_EXPORT_JAR_CLASSIFIERS")))
         .map(_.split(",").toSet)
+        .orElse(Some(Set("sources")))
     },
     BloopKeys.bloopInstall := bloopInstall.value,
     BloopKeys.bloopAggregateSourceDependencies := true,

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -144,7 +144,7 @@ object BloopDefaults {
       Option(System.getProperty("bloop.export-jar-classifiers"))
         .orElse(Option(System.getenv("BLOOP_EXPORT_JAR_CLASSIFIERS")))
         .map(_.split(",").toSet)
-        .orElse(Some(Set("sources")))
+        .orElse(Some(Set("sources", "javadoc")))
     },
     BloopKeys.bloopInstall := bloopInstall.value,
     BloopKeys.bloopAggregateSourceDependencies := true,


### PR DESCRIPTION
As a power user I often use `bloopInstall` from already opened sbt session as it is much faster than `Metals: Import Build` (warm JVM with sbt, etc.). However, there is one main advantage that `Metals: Import Build` has - it runs sbt with `-Dbloop.export-jar-classifiers=sources`.

Even though it is possible to configure bloop's sbt plugin to download sources, by [tweaking build.sbt](https://scalacenter.github.io/bloop/docs/build-tools/sbt#download-dependencies-sources) I don't consider it as a viable option because:
- not everybody uses metals, hence bloop which is default build server
- not everybody uses bloop as their default build server

Not having sources for dependencies results in really bad UX in Metals, as they can't e.g. go to the definition of given class. They instead fail silently, or go to the completely different class which happens to have the same symbol name.

I do understand that this may lead to slightly longer downloading times, but I think it's better to sacrifice a bit of time once, rather than UX every time when there are no sources.