### PR TITLE
chore: Add release notes and fix release process

### DIFF
--- a/notes/v1.5.9.md
+++ b/notes/v1.5.9.md
@@ -1,0 +1,48 @@
+# bloop `v1.5.9`
+
+Bloop v1.5.9 is a bugfix release.
+
+## Installing Bloop
+
+For more details about installing Bloop, please see [Bloop's Installation Guide](https://scalacenter.github.io/bloop/setup))
+
+## Merged pull requests
+
+Here's a list of pull requests that were merged:
+
+- Chore: Update scalafmt bostrap [#2119]
+- Build(deps): Update scalafmt-core from 3.7.9 to 3.7.10 [#2117]
+- Bugfix: Handle NoClassDefFoundError coming from the compiler [#2114]
+- Improvement: Don't fail during copying [#2115]
+- Build(deps): Update scalafmt-core from 3.7.8 to 3.7.9 [#2116]
+- Build(deps): Update sbt, test-agent from 1.9.1 to 1.9.2 [#2109]
+- Chore(deps): bump semver from 5.7.1 to 5.7.2 in /website [#2111]
+- Build(deps): Update scalafmt-core from 3.7.7 to 3.7.8 [#2110]
+- Bugfix: Don't try to discover test frameworks if none exist [#2107]
+- Refactor(test): bump maxDuration in js tests [#1981]
+- Improvement: Send debug logs to BSP client [#2105]
+- Build(deps): Update sbt-scalajs-crossproject from 1.3.1 to 1.3.2 [#2106]
+- Bugfix: Don't deduplicate all options when using Metals [#2104]
+- Build(deps): Update scalafmt-core from 3.7.6 to 3.7.7 [#2103]
+
+
+[#2119]: https://github.com/scalacenter/bloop/pull/2119
+[#2117]: https://github.com/scalacenter/bloop/pull/2117
+[#2114]: https://github.com/scalacenter/bloop/pull/2114
+[#2115]: https://github.com/scalacenter/bloop/pull/2115
+[#2116]: https://github.com/scalacenter/bloop/pull/2116
+[#2109]: https://github.com/scalacenter/bloop/pull/2109
+[#2111]: https://github.com/scalacenter/bloop/pull/2111
+[#2110]: https://github.com/scalacenter/bloop/pull/2110
+[#2107]: https://github.com/scalacenter/bloop/pull/2107
+[#1981]: https://github.com/scalacenter/bloop/pull/1981
+[#2105]: https://github.com/scalacenter/bloop/pull/2105
+[#2106]: https://github.com/scalacenter/bloop/pull/2106
+[#2104]: https://github.com/scalacenter/bloop/pull/2104
+[#2103]: https://github.com/scalacenter/bloop/pull/2103
+
+
+## Contributors
+
+According to `git shortlog -sn --no-merges v1.5.8..v1.5.9`, the following people have contributed to
+this `v1.5.9` release: Tomasz Godzik, scala-center-steward[bot], Chris Kipp, dependabot[bot].

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -103,9 +103,12 @@ object BuildKeys {
       val baseDir = (ThisBuild / Keys.baseDirectory).value
       val releaseTargetDir = Keys.target.value / "ghrelease-assets"
 
-      val originBloopWindowsBinary = Keys.target.value / "graalvm-binaries" / "bloop-windows"
-      val originBloopLinuxBinary = Keys.target.value / "graalvm-binaries" / "bloop-linux"
-      val originBloopMacosBinary = Keys.target.value / "graalvm-binaries" / "bloop-macos"
+      val originBloopWindowsBinary =
+        Keys.target.value / "graalvm-binaries" / "bloop-artifacts" / "bloop-windows"
+      val originBloopLinuxBinary =
+        Keys.target.value / "graalvm-binaries" / "bloop-artifacts" / "bloop-linux"
+      val originBloopMacosBinary =
+        Keys.target.value / "graalvm-binaries" / "bloop-artifacts" / "bloop-macos"
       val targetBloopLinuxBinary = releaseTargetDir / "bloop-x86_64-pc-linux"
       val targetBloopWindowsBinary = releaseTargetDir / "bloop-x86_64-pc-win32.exe"
       val targetBloopMacosBinary = releaseTargetDir / "bloop-x86_64-apple-darwin"


### PR DESCRIPTION
Not sure if it possible that mv semantics changed, but locally this needs the additional directory in the path.

The failure is here https://github.com/scalacenter/bloop/actions/runs/5466710338/jobs/9953460172