### PR TITLE
bugfix: Handle compiler position that is not a range

### DIFF
--- a/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
+++ b/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
@@ -161,10 +161,10 @@ final class BspServerLogger private (
   private def toExistingBspPosition(pos: xsbti.Position): Option[bsp.Range] = {
     def asIntPos(opt: Optional[Integer]) = InterfaceUtil.toOption(opt).map(_.toInt)
     for {
-      startLine <- asIntPos(pos.startLine())
-      startColumn <- asIntPos(pos.startColumn())
-      endLine <- asIntPos(pos.endLine())
-      endColumn <- asIntPos(pos.endColumn())
+      startLine <- asIntPos(pos.startLine()).orElse(asIntPos(pos.line()))
+      startColumn <- asIntPos(pos.startColumn()).orElse(asIntPos(pos.pointer()))
+      endLine = asIntPos(pos.endLine()).getOrElse(startLine)
+      endColumn = asIntPos(pos.endColumn()).getOrElse(startColumn)
     } yield bsp.Range(
       bsp.Position(startLine - 1, startColumn),
       bsp.Position(endLine - 1, endColumn)


### PR DESCRIPTION
I was experimenting with @lrytz with code actions for Scala 2 and manged it working this way. There will need to be some more changes, but this ones we can already merge.

![bridge-scala-test-1689949673344](https://github.com/scalacenter/bloop/assets/3807253/090a847b-563d-4fc0-81ae-3d925b3968a0)
