### PR TITLE
specify scip javac plugin targetroot exactly

### DIFF
--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -125,6 +125,13 @@ object CompileTask {
                 5
               )
           }
+          // get Bloop to replace the javac-classes-directory instead of the scip plugin so that no internal javac APIs are used.
+          val newJavacOptions = project.javacOptions.map(option =>
+            option.replaceAllLiterally(
+              "-targetroot:javac-classes-directory",
+              s"-targetroot:${newClassesDir}"
+            )
+          )
 
           val inputs = newScalacOptions.map { newScalacOptions =>
             CompileInputs(
@@ -136,7 +143,7 @@ object CompileTask {
               compileOut,
               project.out,
               newScalacOptions.toArray,
-              project.javacOptions.toArray,
+              newJavacOptions.toArray,
               project.compileJdkConfig.flatMap(_.javacBin),
               project.compileOrder,
               project.classpathOptions,


### PR DESCRIPTION
Currently Bloop uses `-targetroot:javac-classes-directory` to specify the `targetroot` dir for the `scip-java` plugin, which means  Bloop delegates to the plugin to work out the correct dir to place the semanticdb files in.

`scip-java` has to use the internal JDK API to perform the substitution which requires `--add-exports` and I see no way round that  - hence in this PR Bloop specifies the exact classes directory