### PR TITLE
Add support for absolute paths in Bloopgun error handling

### DIFF
--- a/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
@@ -503,10 +503,15 @@ class BloopgunCli(
         (exitServerStatus, usedExtraJvmOpts)
       } catch {
         case e: IOException =>
+          val javaBinaryName = if (Environment.isWindows) {
+            "java.exe"
+          } else {
+            "java"
+          }
           val javaExec = sys.env
             .get("JAVA_HOME")
             .orElse(sys.props.get("java.home"))
-            .map(Paths.get(_).resolve("bin/java"))
+            .map(Paths.get(_).resolve(s"bin/${javaBinaryName}"))
             .filter(_.toFile().isFile())
             .map(_.toString())
           val javaErrorMessage = "Cannot run program \".*java\"".r

--- a/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
@@ -513,7 +513,9 @@ class BloopgunCli(
           val errorCode = "error=2"
           javaExec match {
             case Some(java)
-                if javaErrorMessage.pattern.matcher(e.getMessage()).find() && e.getMessage.contains(errorCode) =>
+                if javaErrorMessage.pattern.matcher(e.getMessage()).find() && e.getMessage.contains(
+                  errorCode
+                ) =>
               logger.info(s"Java executable was not available on PATH, retrying with $java")
               val (cmd, usedExtraJvmOpts) =
                 cmdWithArgs(found, extraJvmOpts, List(java), globalSettings)

--- a/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
+++ b/bloopgun/src/main/scala/bloop/bloopgun/Bloopgun.scala
@@ -509,11 +509,11 @@ class BloopgunCli(
             .map(Paths.get(_).resolve("bin/java"))
             .filter(_.toFile().isFile())
             .map(_.toString())
-          val javaErrorMessage = "Cannot run program \"java\""
+          val javaErrorMessage = "Cannot run program \".*java\"".r
           val errorCode = "error=2"
           javaExec match {
             case Some(java)
-                if e.getMessage().contains(javaErrorMessage) && e.getMessage.contains(errorCode) =>
+                if javaErrorMessage.pattern.matcher(e.getMessage()).find() && e.getMessage.contains(errorCode) =>
               logger.info(s"Java executable was not available on PATH, retrying with $java")
               val (cmd, usedExtraJvmOpts) =
                 cmdWithArgs(found, extraJvmOpts, List(java), globalSettings)

--- a/launcher-test/src/test/scala/bloop/launcher/GlobalSettingsSpec.scala
+++ b/launcher-test/src/test/scala/bloop/launcher/GlobalSettingsSpec.scala
@@ -49,15 +49,11 @@ object GlobalSettingsSpec extends LauncherBaseSuite(BuildInfo.version, BuildInfo
     }
   }
 
-  test("fail to start server when bloop.json Java home is invalid") {
+  test("should start server even when bloop.json Java home is invalid") {
     // Create bloop.json with Java home pointing to non-existent path.
     val doesnotexist = "does-not-exist"
     runBspLauncherWithGlobalJsonSettings(s"""{"javaHome": "$doesnotexist"}""") { result =>
-      assert(result.status == Some(LauncherStatus.FailedToConnectToServer))
-      assertLogsContain(
-        List(doesnotexist, "Error when starting server"),
-        result.launcherLogs
-      )
+      assert(result.status == Some(LauncherStatus.SuccessfulRun))
     }
   }
 


### PR DESCRIPTION
On Windows with scala-cli I got something like:
```
java.io.IOException: Cannot run program "C:\Program Files\Microsoft\jdk-17.0.7.7-hotspot\bin\java" (in directory "d:\MojeProgramy\bloop-core"): CreateProcess error=2, Nie mo?na odnale?? okre?lonego pliku
```