### PR TITLE
improvement: Correctly download Scala 2 bridge for Scala 2.13.12

### DIFF
--- a/backend/src/main/scala/bloop/ScalaInstance.scala
+++ b/backend/src/main/scala/bloop/ScalaInstance.scala
@@ -17,6 +17,8 @@ import bloop.internal.build.BloopScalaInfo
 import bloop.logging.DebugFilter
 import bloop.logging.Logger
 
+import coursierapi.Repository
+
 final class ScalaInstance private (
     val organization: String,
     val name: String,
@@ -195,12 +197,14 @@ object ScalaInstance {
       scalaOrg: String,
       scalaName: String,
       scalaVersion: String,
-      logger: Logger
+      logger: Logger,
+      additionalRepositories: List[Repository] = Nil
   ): ScalaInstance = {
     def resolveInstance: ScalaInstance = {
       val allPaths = DependencyResolution.resolve(
         List(DependencyResolution.Artifact(scalaOrg, scalaName, scalaVersion)),
-        logger
+        logger,
+        additionalRepos = additionalRepositories
       )
       val allJars = allPaths.collect {
         case path if path.underlying.toString.endsWith(".jar") => path.underlying.toFile

--- a/frontend/src/test/scala/bloop/ScalaVersionsSpec.scala
+++ b/frontend/src/test/scala/bloop/ScalaVersionsSpec.scala
@@ -10,6 +10,8 @@ import bloop.task.Task
 import bloop.util.TestProject
 import bloop.util.TestUtil
 
+import coursierapi.MavenRepository
+
 object ScalaVersionsSpec extends bloop.testing.BaseSuite {
   var loggers: List[RecordingLogger] = Nil
 
@@ -22,7 +24,15 @@ object ScalaVersionsSpec extends bloop.testing.BaseSuite {
 
       def jarsForScalaVersion(version: String, logger: RecordingLogger) = {
         ScalaInstance
-          .resolve(compilerOrg, compilerArtifact, version, logger)
+          .resolve(
+            compilerOrg,
+            compilerArtifact,
+            version,
+            logger,
+            List(
+              MavenRepository.of("https://scala-ci.typesafe.com/artifactory/scala-integration/")
+            )
+          )
           .allJars
           .map(AbsolutePath(_))
       }
@@ -71,7 +81,8 @@ object ScalaVersionsSpec extends bloop.testing.BaseSuite {
     "2.12.17",
     "2.13.10",
     "3.1.3",
-    "3.2.1"
+    "3.2.1",
+    "2.13.12-bin-86f40c2"
   )
 
   val allVersions = if (TestUtil.isJdk8) jdk8OnlyVersions ++ scalaVersions else scalaVersions


### PR DESCRIPTION
In preparation for the new Scala 2.13.12 release