### PR TITLE
docs: Add release notes for 1.5.10

### DIFF
--- a/notes/v1.5.10.md
+++ b/notes/v1.5.10.md
@@ -1,0 +1,46 @@
+# bloop `v1.5.10`
+
+Bloop v1.5.10 is a bugfix release.
+
+## Installing Bloop
+
+For more details about installing Bloop, please see [Bloop's Installation Guide](https://scalacenter.github.io/bloop/setup))
+
+## Merged pull requests
+
+Here's a list of pull requests that were merged:
+
+- Build(deps): Update librarymanagement-ivy from 1.9.1 to 1.9.2 [#2135]
+- Build(deps): Update sbt, test-agent from 1.9.3 to 1.9.4 [#2136]
+- Improvement: Correctly download Scala 2 bridge for Scala 2.13.12 [#2133]
+- Build(deps): Update scalafmt-core from 3.7.11 to 3.7.12 [#2130]
+- Build(deps): Update zt-zip from 1.15 to 1.16 [#2131]
+- Build(deps): Update scala-debug-adapter from 3.1.3 to 3.1.4 [#2129]
+- Specify scip javac plugin targetroot exactly [#2128]
+- Bugfix: Fix infinite recursion [#2127]
+- Build(deps): Update zinc from 1.9.2 to 1.9.3 [#2123]
+- Build(deps): Update scalafmt-core from 3.7.10 to 3.7.11 [#2126]
+- Bugfix: Handle compiler position that is not a range [#2122]
+- Chore: Remove verbose option otherwise it's always verbose [#2121]
+- Feat: fallback to `source` and `javadoc` classifiers when exporting projects from sbt [#2118]
+
+
+[#2135]: https://github.com/scalacenter/bloop/pull/2135
+[#2136]: https://github.com/scalacenter/bloop/pull/2136
+[#2133]: https://github.com/scalacenter/bloop/pull/2133
+[#2130]: https://github.com/scalacenter/bloop/pull/2130
+[#2131]: https://github.com/scalacenter/bloop/pull/2131
+[#2129]: https://github.com/scalacenter/bloop/pull/2129
+[#2128]: https://github.com/scalacenter/bloop/pull/2128
+[#2127]: https://github.com/scalacenter/bloop/pull/2127
+[#2123]: https://github.com/scalacenter/bloop/pull/2123
+[#2126]: https://github.com/scalacenter/bloop/pull/2126
+[#2122]: https://github.com/scalacenter/bloop/pull/2122
+[#2121]: https://github.com/scalacenter/bloop/pull/2121
+[#2118]: https://github.com/scalacenter/bloop/pull/2118
+
+
+## Contributors
+
+According to `git shortlog -sn --no-merges v1.5.9..v1.5.10`, the following people have contributed to
+this `v1.5.10` release: scala-center-steward[bot], tgodzik, Kamil Podsiadlo, Arthur McGibbon, Tomasz Godzik.


### PR DESCRIPTION
I wanted to include the recent changes around the bridges before the next Metals release.