### PR TITLE
chore: Change frameworks not supported message to warn

### DIFF
--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -249,7 +249,7 @@ object TestTask {
         }
 
       case _: Platform.Native =>
-        logger.error("Detecting test frameworks in Scala Native projects is not yet supported")
+        logger.warn("Detecting test frameworks in Scala Native projects is not yet supported")
         Task.now(None)
     }
   }


### PR DESCRIPTION
Previously, we would show an error whenever a native project was loaded, since we can't currently run tests for native. However, this will pop up currently in Metals as a server error, while it's more of a warning. There is nothing the user can do about it. Now, we report this as a warning.