### PR TITLE
chore: Increase test maximum duration for ScalaJsToolchainSpec for 0.6

### DIFF
--- a/bridges/scalajs-0.6/src/test/scala/bloop/scalajs/ScalaJsToolchainSpec.scala
+++ b/bridges/scalajs-0.6/src/test/scala/bloop/scalajs/ScalaJsToolchainSpec.scala
@@ -81,7 +81,7 @@ class ScalaJsToolchainSpec {
     logger.getMessages.assertContain("Hello, world from DefaultApp!", atLevel = "info")
   }
 
-  private final val maxDuration = Duration.apply(45, TimeUnit.SECONDS)
+  private final val maxDuration = Duration.apply(90, TimeUnit.SECONDS)
   private implicit class RichLogs(logs: List[(String, String)]) {
     def assertContain(needle: String, atLevel: String): Unit = {
       def failMessage = s"""Logs did not contain `$needle` at level `$atLevel`. Logs were:


### PR DESCRIPTION
We did it previously for 1.x since the bridge compilation already might take up most of that time.