### PR TITLE
bugfix: Never set empty Scala JS version from sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -336,6 +336,7 @@ val integrations = file("integrations")
 lazy val sbtBloop: Project = project
   .enablePlugins(ScriptedPlugin)
   .disablePlugins(ScalafixPlugin)
+  .enablePlugins(BuildInfoPlugin)
   .in(integrations / "sbt-bloop")
   .settings(
     scriptedBufferLog := false,
@@ -347,7 +348,11 @@ lazy val sbtBloop: Project = project
     sbtPlugin := true,
     sbtVersion := SbtVersion,
     target := (file("integrations") / "sbt-bloop" / "target" / SbtVersion).getAbsoluteFile,
-    libraryDependencies += Dependencies.bloopConfig
+    libraryDependencies += Dependencies.bloopConfig,
+    buildInfoPackage := "bloop.integrations.sbt",
+    buildInfoKeys := List[BuildInfoKey](
+      "latestScalaJsVersion" -> Dependencies.scalaJs1Version
+    )
   )
 
 lazy val buildpressConfig = (project in file("buildpress-config"))


### PR DESCRIPTION
Previously, we were always expecting scala JS plugin to find the correct version of Scala JS, however I think for Scala 3 it's not a plugin, which is causing the version field to be empty. Now, we look for the scala-js library instead and default to the latest known scala js version.

@sjrd would this be a correct assumption?