### PR TITLE
improvement: trim spaces when filtering the only tests that should be run

### DIFF
--- a/frontend/src/main/scala/bloop/testing/TestInternals.scala
+++ b/frontend/src/main/scala/bloop/testing/TestInternals.scala
@@ -79,7 +79,7 @@ object TestInternals {
    * @return A function that determines whether a test should be run given its FQCN.
    */
   def parseFilters(filters: List[String]): String => Boolean = {
-    val (exclusionFilters, inclusionFilters) = filters.partition(_.startsWith("-"))
+    val (exclusionFilters, inclusionFilters) = filters.map(_.trim).partition(_.startsWith("-"))
     val inc = inclusionFilters.map(toPattern)
     val exc = exclusionFilters.map(f => toPattern(f.tail))
 

--- a/frontend/src/test/scala/bloop/TestFilterSpec.scala
+++ b/frontend/src/test/scala/bloop/TestFilterSpec.scala
@@ -89,4 +89,15 @@ class TestFilterSpec {
     assertTrue("The filter should match.", filter(input1))
     assertFalse("The filter shouldn't match.", filter(input2))
   }
+
+  @Test
+  def testFilterShouldTrimWhiteSpace: Unit = {
+    val input0 = "foo.hello.world"
+    val input1 = "foo.something.world"
+    // Space at the ends should be ignored
+    val patterns = " foo.hello.world" :: "foo.something.world " :: Nil
+    val filter = TestInternals.parseFilters(patterns)
+    assertTrue("The filter should match.", filter(input0))
+    assertTrue("The filter should match.", filter(input1))
+  }
 }


### PR DESCRIPTION
Often, when copying the failed test path from Jenkins CI or Gradle Enterprise webpage, the path copied might contain leading or trailing space(s). Pasting the failed test path into the `-o` switch requires carefully removing the space from both ends.  

Example:
` bloop test project-it -o ' a.b.c.Test' --config-dir=../.bloop`
This command would not run the test `a.b.c.Test`

This PR fixes the annoyance by trimming the path before matching the pattern. 
