### PR TITLE
feature: Automatically add -release option when needed

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -604,6 +604,53 @@ object Compiler {
       }
   }
 
+  /**
+   * Bloop runs Scala compilation in the same process as the main server,
+   * so the compilation process will use the same JDK that Bloop is using.
+   * That's why we must ensure that produce class files will be compliant with expected JDK version
+   * and compilation errors will show up when using wrong JDK API.
+   */
+  private def adjustScalacReleaseOptions(
+      scalacOptions: Array[String],
+      javacBin: Option[AbsolutePath],
+      logger: Logger
+  ): Array[String] = {
+    def existsReleaseSetting = scalacOptions.exists(opt =>
+      opt.startsWith("-release") ||
+        opt.startsWith("--release") ||
+        opt.startsWith("-java-output-version")
+    )
+    def sameHome = javacBin match {
+      case Some(bin) => bin.getParent.getParent == JavaRuntime.home
+      case None => false
+    }
+
+    javacBin.flatMap(binary =>
+      // <JAVA_HOME>/bin/java
+      JavaRuntime.getJavaVersionFromJavaHome(binary.getParent.getParent)
+    ) match {
+      case None => scalacOptions
+      case Some(_) if existsReleaseSetting || sameHome => scalacOptions
+      case Some(version) =>
+        try {
+          val numVer = if (version.startsWith("1.8")) 8 else version.takeWhile(_.isDigit).toInt
+          val bloopNumVer = JavaRuntime.version.takeWhile(_.isDigit).toInt
+          if (bloopNumVer > numVer) {
+            scalacOptions ++ List("-release", numVer.toString())
+          } else {
+            logger.warn(
+              s"Bloop is runing with ${JavaRuntime.version} but your code requires $version to compile, " +
+                "this might cause some compilation issues when using JDK API unsupported by the Bloop's current JVM version"
+            )
+            scalacOptions
+          }
+        } catch {
+          case NonFatal(_) =>
+            scalacOptions
+        }
+    }
+  }
+
   private def getCompilationOptions(
       inputs: CompileInputs,
       logger: Logger,
@@ -612,46 +659,18 @@ object Compiler {
     // Sources are all files
     val sources = inputs.sources.map(path => converter.toVirtualFile(path.underlying))
     val classpath = inputs.classpath.map(path => converter.toVirtualFile(path.underlying))
-    def existsReleaseSetting = inputs.scalacOptions.exists(opt =>
-      opt.startsWith("-release") ||
-        opt.startsWith("--release") ||
-        opt.startsWith("-java-output-version")
-    )
-    def sameHome = inputs.javacBin match {
-      case Some(bin) => bin.getParent.getParent == JavaRuntime.home
-      case None => false
-    }
 
-    val scalacOptions = inputs.javacBin.flatMap(binary =>
-      // <JAVA_HOME>/bin/java
-      JavaRuntime.getJavaVersionFromJavaHome(binary.getParent.getParent)
-    ) match {
-      case None => inputs.scalacOptions
-      case Some(_) if existsReleaseSetting || sameHome => inputs.scalacOptions
-      case Some(version) =>
-        try {
-          val numVer = if (version.startsWith("1.8")) 8 else version.takeWhile(_.isDigit).toInt
-          val bloopNumVer = JavaRuntime.version.takeWhile(_.isDigit).toInt
-          if (bloopNumVer > numVer) {
-            inputs.scalacOptions ++ List("-release", numVer.toString())
-          } else {
-            logger.warn(
-              s"Bloop is runing with ${JavaRuntime.version} but your code requires $version to compile, " +
-                "this might cause some compilation issues when using JDK API unsupported by the Bloop's current JVM version"
-            )
-            inputs.scalacOptions
-          }
-        } catch {
-          case NonFatal(_) =>
-            inputs.scalacOptions
-        }
-    }
+    val scalacOptions = adjustScalacReleaseOptions(
+      scalacOptions = inputs.scalacOptions,
+      javacBin = inputs.javacBin,
+      logger = logger
+    )
 
     val optionsWithoutFatalWarnings = scalacOptions.filter(_ != "-Xfatal-warnings")
-    val isFatalWarningsEnabled = scalacOptions.length != optionsWithoutFatalWarnings.length
+    val areFatalWarningsEnabled = scalacOptions.length != optionsWithoutFatalWarnings.length
 
     // Enable fatal warnings in the reporter if they are enabled in the build
-    if (isFatalWarningsEnabled)
+    if (areFatalWarningsEnabled)
       inputs.reporter.enableFatalWarnings()
 
     CompileOptions

--- a/backend/src/main/scala/bloop/util/JavaRuntime.scala
+++ b/backend/src/main/scala/bloop/util/JavaRuntime.scala
@@ -14,6 +14,7 @@ import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigParseOptions
 import com.typesafe.config.ConfigSyntax
 import scala.collection.concurrent.TrieMap
+import scala.util.Properties
 
 sealed trait JavaRuntime
 object JavaRuntime {
@@ -74,7 +75,8 @@ object JavaRuntime {
    * appropriately.
    */
   def javacBinaryFromJavaHome(home: AbsolutePath): Option[AbsolutePath] = {
-    def toJavaBinary(home: AbsolutePath) = home.resolve("bin").resolve("javac")
+    val binaryName = if (Properties.isWin) "javac.exe" else "javac"
+    def toJavaBinary(home: AbsolutePath) = home.resolve("bin").resolve(binaryName)
     if (!home.exists) None
     else {
       Option(toJavaBinary(home))

--- a/frontend/src/test/scala/bloop/JavaVersionSpec.scala
+++ b/frontend/src/test/scala/bloop/JavaVersionSpec.scala
@@ -37,7 +37,7 @@ object JavaVersionSpec extends bloop.testing.BaseSuite {
               |     value repeat is not a member of String
               |     L2:   val output = "La ".repeat(2) + "Land";
               |                              ^
-              |a/src/main/scala/Foo.scala: L2 [E1]
+              |$targetFoo: L2 [E1]
               |Failed to compile 'a'
               |""".stripMargin
         )

--- a/frontend/src/test/scala/bloop/JavaVersionSpec.scala
+++ b/frontend/src/test/scala/bloop/JavaVersionSpec.scala
@@ -1,0 +1,66 @@
+package bloop
+
+import bloop.cli.ExitStatus
+import bloop.config.Config
+import bloop.logging.RecordingLogger
+import bloop.util.TestProject
+import bloop.util.TestUtil
+
+object JavaVersionSpec extends bloop.testing.BaseSuite {
+
+  private val jvmManager = coursierapi.JvmManager.create()
+
+  def checkFlag(scalacOpts: List[String], jdkVersion: String = "8") = {
+    val javaHome = jvmManager.get(jdkVersion).toPath()
+    val jvmConfig = Some(Config.JvmConfig(Some(javaHome), Nil))
+    TestUtil.withinWorkspace { workspace =>
+      val sources = List(
+        """/main/scala/Foo.scala
+          |class Foo{
+          |  val output = "La ".repeat(2) + "Land";
+          |}
+          """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` =
+        TestProject(workspace, "a", sources, jvmConfig = jvmConfig, scalacOptions = scalacOpts)
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.compile(`A`)
+      if (jdkVersion == "8") {
+        assertExitStatus(compiledState, ExitStatus.CompilationError)
+        val targetFoo = TestUtil.universalPath("a/src/main/scala/Foo.scala")
+        assertNoDiff(
+          logger.renderErrors(),
+          s"""|[E1] $targetFoo:2:22
+              |     value repeat is not a member of String
+              |     L2:   val output = "La ".repeat(2) + "Land";
+              |                              ^
+              |a/src/main/scala/Foo.scala: L2 [E1]
+              |Failed to compile 'a'
+              |""".stripMargin
+        )
+      } else {
+        assertExitStatus(compiledState, ExitStatus.Ok)
+      }
+    }
+  }
+
+  test("flag-is-added-correctly") {
+    checkFlag(Nil)
+  }
+
+  test("flag-is-not-added-correctly") {
+    checkFlag(List("-release", "8"))
+    checkFlag(List("-release:8"))
+  }
+
+  test("compiles-with-11") {
+    checkFlag(Nil, jdkVersion = "11")
+  }
+
+  test("compiles-with-17") {
+    checkFlag(Nil, jdkVersion = "17")
+  }
+}


### PR DESCRIPTION
Previously, if we compiled with a Bloop running an newer JDK we would not see any errors even when using methods belonging to a newer JDK. Now, we automatically add -release flag, which makes sure that we will fail any compilation that should not pass with an older JDK (if specified in configuration)

This is needed for incorporating the forks.