### PR TITLE
chore: don't use javadoc classifier as default for bloopInstall

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -144,7 +144,7 @@ object BloopDefaults {
       Option(System.getProperty("bloop.export-jar-classifiers"))
         .orElse(Option(System.getenv("BLOOP_EXPORT_JAR_CLASSIFIERS")))
         .map(_.split(",").toSet)
-        .orElse(Some(Set("sources", "javadoc")))
+        .orElse(Some(Set("sources")))
     },
     BloopKeys.bloopInstall := bloopInstall.value,
     BloopKeys.bloopAggregateSourceDependencies := true,


### PR DESCRIPTION
improvement over https://github.com/scalacenter/bloop/pull/2118, `javadoc` is not necessary and causes too much stuff to be downloaded