### PR TITLE
Update sbt `bloopGenerate` docs to use `Value(None)`

### DIFF
--- a/docs/build-tools/sbt.md
+++ b/docs/build-tools/sbt.md
@@ -112,9 +112,9 @@ customize the result of the `bloopGenerate` task (which is scoped at the configu
 val foo = project
   .settings(
     // Bloop will not generate a target for the compile configuration of `foo`
-    bloopGenerate in Compile := None,
+    bloopGenerate in Compile := Value(None),
     // Bloop will not generate a target for the test configuration of `foo`
-    bloopGenerate in Test := None,
+    bloopGenerate in Test := Value(None),
   )
 ```
 


### PR DESCRIPTION
After #1973, you should use `Value(None)` instead of `None` but the docs haven't been updated.