### PR TITLE
bugfix: Fix sbt integration tests

### DIFF
--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/cross-compile-test-configurations/test
@@ -6,5 +6,6 @@
 > checkBloopFile
 $ copy-file changes/export-jars.sbt export-jars.sbt
 > reload
+> updateClassifiers
 > bloopInstall
 > checkSourceAndDocs


### PR DESCRIPTION
Looks like a bug that was present long time ago in sbt. I think it might be related to https://github.com/sbt/sbt/issues/5501

Running update manually fixes things.