### PR TITLE
chore: Add full error stack trace

### DIFF
--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -22,6 +22,7 @@ import bloop.engine.tasks.compilation._
 import bloop.io.ParallelOps
 import bloop.io.ParallelOps.CopyMode
 import bloop.io.{Paths => BloopPaths}
+import bloop.logging.BloopLogger
 import bloop.logging.DebugFilter
 import bloop.logging.Logger
 import bloop.logging.LoggerAction
@@ -292,9 +293,8 @@ object CompileTask {
           } else {
             results.foreach {
               case FinalNormalCompileResult.HasException(project, err) =>
-                val errMsg = err.fold(identity, _.getMessage)
-                rawLogger.error(s"Unexpected error when compiling ${project.name}: '$errMsg'")
-                err.foreach(rawLogger.trace(_))
+                val errMsg = err.fold(identity, BloopLogger.prettyPrintException)
+                rawLogger.error(s"Unexpected error when compiling ${project.name}: $errMsg")
               case _ => () // Do nothing when the final compilation result is not an actual error
             }
 


### PR DESCRIPTION
Previously, we would just print the error message, but since this error is usually complex, we always need a full stack trace. Now, we just print the full stack trace. This means metals will also get the full exception in those cases without the need to configure anything.