### PR TITLE
bugfix: Make sure proper runtime classpath is used when debugging

### DIFF
--- a/frontend/src/main/scala/bloop/dap/BloopDebuggee.scala
+++ b/frontend/src/main/scala/bloop/dap/BloopDebuggee.scala
@@ -155,7 +155,7 @@ object BloopDebuggeeRunner {
                 modules,
                 libraries,
                 unmanagedEntries,
-                jvm.config,
+                jvm.runtimeConfig.getOrElse(jvm.config),
                 state,
                 ioScheduler,
                 project.scalaInstance.map(_.version)
@@ -184,8 +184,8 @@ object BloopDebuggeeRunner {
         val modules = getModules(dag, state.client)
         val libraries = getLibraries(dag)
         val unmanagedEntries = getUnmanagedEntries(project, dag, state.client, modules ++ libraries)
-        val Platform.Jvm(config, _, _, _, _, _) = project.platform
-        val javaRuntime = JavaRuntime(config.javaHome.underlying)
+        val Platform.Jvm(config, _, _, runtimeConfig, _, _) = project.platform
+        val javaRuntime = JavaRuntime(runtimeConfig.getOrElse(config).javaHome.underlying)
         Right(
           new TestSuiteDebugAdapter(
             projects,
@@ -229,8 +229,8 @@ object BloopDebuggeeRunner {
         val libraries = getLibraries(dag)
         val modules = getModules(dag, state.client)
         val unmanagedEntries = getUnmanagedEntries(project, dag, state.client, modules ++ libraries)
-        val Platform.Jvm(config, _, _, _, _, _) = project.platform
-        val javaRuntime = JavaRuntime(config.javaHome.underlying)
+        val Platform.Jvm(config, _, _, runtimeConfig, _, _) = project.platform
+        val javaRuntime = JavaRuntime(runtimeConfig.getOrElse(config).javaHome.underlying)
         new AttachRemoteDebugAdapter(
           modules,
           libraries,

--- a/frontend/src/test/scala/bloop/util/TestProject.scala
+++ b/frontend/src/test/scala/bloop/util/TestProject.scala
@@ -107,6 +107,7 @@ abstract class BaseTestProject {
       scalaVersion: Option[String] = None,
       resources: List[String] = Nil,
       runtimeResources: Option[List[String]] = None,
+      runtimeClasspath: Option[List[Path]] = None,
       jvmConfig: Option[Config.JvmConfig] = None,
       runtimeJvmConfig: Option[Config.JvmConfig] = None,
       order: Config.CompileOrder = Config.Mixed,
@@ -136,7 +137,7 @@ abstract class BaseTestProject {
       mkScalaInstance(finalScalaOrg, finalScalaCompiler, scalaVersion, jars.toList, NoopLogger)
 
     val allJars = instance.allJars.map(AbsolutePath.apply)
-    val (compileClasspath, runtimeClasspath) = {
+    val (compileClasspath, runtimeClasspathForStrict) = {
       val transitiveClasspath =
         (directDependencies.flatMap(classpathDeps) ++ allJars ++ jars).map(_.underlying)
       val directClasspath =
@@ -170,7 +171,7 @@ abstract class BaseTestProject {
       javaConfig,
       None,
       runtimeJvmConfig,
-      Some(runtimeClasspath),
+      runtimeClasspath.orElse(Some(runtimeClasspathForStrict)),
       runtimeResourcesList
     )
 


### PR DESCRIPTION
Previously, we would use the default config, which would not always be correct. Now, we use runtime config with a fallback to normal platform config.