### PR TITLE
bugfix: Don't use fullclasspath in sbt plugin

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -788,7 +788,8 @@ object BloopDefaults {
         val isForkedExecution = (Keys.fork in configuration in forkScopedTask).value
         val workingDir = if (isForkedExecution) Keys.baseDirectory.value else rootBaseDirectory
         val extraJavaOptions = List(s"-Duser.dir=${workingDir.getAbsolutePath}")
-        lazy val runtimeClasspath =  (Runtime / Keys.fullClasspath).value.map(_.data.toPath()).toList
+        lazy val runtimeClasspath =  BloopKeys.bloopProductDirectories.value.head.toPath() +:
+          (emulateRuntimeDependencyClasspath).value.map(_.toPath.toAbsolutePath).toList
         lazy val javaRuntimeHome = (Runtime / Keys.javaHome).value.map(_.toPath())
         lazy val javaRuntimeOptions = (Runtime / Keys.javaOptions).value
         val config = Config.JvmConfig(Some(javaHome.toPath), (extraJavaOptions ++ javaOptions).toList)
@@ -1206,6 +1207,12 @@ object BloopDefaults {
   def emulateDependencyClasspath: Def.Initialize[Task[Seq[File]]] = Def.task {
     val internalClasspath = BloopKeys.bloopInternalClasspath.value.map(_._2)
     val externalClasspath = Keys.externalDependencyClasspath.value.map(_.data)
+    internalClasspath ++ externalClasspath
+  }
+
+  def emulateRuntimeDependencyClasspath: Def.Initialize[Task[Seq[File]]] = Def.task {
+    val internalClasspath = (Runtime / BloopKeys.bloopInternalClasspath).value.map(_._2)
+    val externalClasspath = (Runtime / Keys.externalDependencyClasspath).value.map(_.data)
     internalClasspath ++ externalClasspath
   }
 

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/non-compiling/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/non-compiling/build.sbt
@@ -1,0 +1,26 @@
+import bloop.integrations.sbt.BloopDefaults
+
+name := "non-compiling"
+
+val bloopConfigFile = settingKey[File]("Config file to test")
+ThisBuild / bloopConfigFile := {
+  val bloopDir = Keys.baseDirectory.value./(".bloop")
+  val config = bloopDir./("non-compiling.json")
+  config
+}
+
+val bloopTestConfigFile = settingKey[File]("Test config file to test")
+ThisBuild / bloopTestConfigFile := {
+  val bloopDir = Keys.baseDirectory.value./(".bloop")
+  val config = bloopDir./("non-compiling-test.json")
+  config
+}
+
+val checkBloopFiles = taskKey[Unit]("Check bloop file contents")
+ThisBuild / checkBloopFiles := {
+  val configContents = BloopDefaults.unsafeParseConfig(bloopConfigFile.value.toPath)
+  assert(configContents.project.platform.isDefined)
+
+  val configTestContents = BloopDefaults.unsafeParseConfig(bloopTestConfigFile.value.toPath)
+  assert(configTestContents.project.platform.isDefined)
+}

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/non-compiling/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/non-compiling/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/non-compiling/src/main/scala/Obj.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/non-compiling/src/main/scala/Obj.scala
@@ -1,0 +1,3 @@
+object Obj {
+  val a: Int = ""
+}

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/non-compiling/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/non-compiling/test
@@ -1,0 +1,3 @@
+> bloopGenerate
+> test:bloopGenerate
+> checkBloopFiles


### PR DESCRIPTION
Previously, I used fullclasspath for getting the runtime classpath, but I forgot this causes sbt to always compile on bloopInstaall.

Now, I changed to use the same mechanism we use for compile classpath and added a test to make sure this doesn't show up again.