### PR TITLE
chore: Print better errors when bloopInstall failed

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -1147,7 +1147,22 @@ object BloopDefaults {
       )
       .map(fail =>
         if (fail.nonEmpty) {
-          logger.error(s"Couldn't run bloopGenerate. Cause: ${fail.mkString("\n")}")
+          val messages = fail.flatMap { incomplete =>
+            incomplete.directCause.zip(incomplete.message)
+          }
+
+          if (messages.nonEmpty) {
+            logger.error(s"Couldn't run bloopGenerate. The issue might be caused by:")
+            messages.foreach {
+              case (t, message) =>
+                logger.error(message)
+                logger.trace(t)
+            }
+          } else {
+            logger.error(
+              s"Couldn't run bloopGenerate. The issue could be caused by failing to compile the project."
+            )
+          }
           throw fail.head
         }
       )


### PR DESCRIPTION
Previously, we would get soemthing like:

```
Cause: Incomplete(node=Some(Task(_)), tpe=Error, msg=None, causes=List(Incomplete(node=Some(Task(_)), tpe=Error, msg=None, causes=List(Incomplete(node=Some(Task(_)), tpe=Error, msg=None, causes=List(Incomplete(node=Some(Task((taskDefinitionKey: ScopedKey(Scope(Select(ProjectRef(file:/tmp/sbt_14ffb38d/no-compile-incremental/,no-compile-incremental)), Select(ConfigKey(runtime)), Zero, Zero),fullClasspath)))), tpe=Error, msg=None, causes=List(Incomplete(node=Some(Task(_)), tpe=Error, msg=None, causes=List(Incomplete(node=Some(Task((taskDefinitionKey: ScopedKey(Scope(Select(ProjectRef(file:/tmp/sbt_14ffb38d/no-compile-incremental/,no-compile-incremental)), Select(ConfigKey(runtime)), Zero, Zero),dependencyClasspath)))), tpe=Error, msg=None, causes=List(Incomplete(node=Some(Task(_)), tpe=Error
```

which doesn't contain any useful information.

Now, I change to print errors if we have any direct causes of the failure, which would come from bloop task itself.