### PR TITLE
chore: Use the default download location for download action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,10 +263,7 @@ jobs:
           git config --global user.email "bloop@vican.me"
           git config --global push.default simple
           ls -al bloop-artifacts
-          mkdir -p frontend/target
-          mv bloop-artifacts frontend/target/graalvm-binaries
-          ls -al frontend/target/graalvm-binaries
-          readlink -f frontend/target/graalvm-binaries
+          readlink -f bloop-artifacts
           sbt ci-release
         shell: bash
 

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -104,11 +104,11 @@ object BuildKeys {
       val releaseTargetDir = Keys.target.value / "ghrelease-assets"
 
       val originBloopWindowsBinary =
-        Keys.target.value / "graalvm-binaries" / "bloop-windows"
+        baseDir / "bloop-artifacts" / "bloop-windows"
       val originBloopLinuxBinary =
-        Keys.target.value / "graalvm-binaries" / "bloop-linux"
+        baseDir / "bloop-artifacts" / "bloop-linux"
       val originBloopMacosBinary =
-        Keys.target.value / "graalvm-binaries" / "bloop-macos"
+        baseDir / "bloop-artifacts" / "bloop-macos"
       val targetBloopLinuxBinary = releaseTargetDir / "bloop-x86_64-pc-linux"
       val targetBloopWindowsBinary = releaseTargetDir / "bloop-x86_64-pc-win32.exe"
       val targetBloopMacosBinary = releaseTargetDir / "bloop-x86_64-apple-darwin"


### PR DESCRIPTION
Looks like maybe target is being cleaned which is why we can publish properly later on. Tested it locally and seems to work ok.