### PR TITLE
improvement: Change information about test framework to warn

### DIFF
--- a/bridges/scalajs-1/src/main/scala/bloop/scalajs/JsBridge.scala
+++ b/bridges/scalajs-1/src/main/scala/bloop/scalajs/JsBridge.scala
@@ -169,7 +169,7 @@ object JsBridge {
       val result = adapter.loadFrameworks(frameworkNames).flatMap(_.toList)
       (result, () => adapter.close())
     } else {
-      logger.error(
+      logger.warn(
         s"Cannot discover test frameworks, missing node_modules in test project, expected them at $nodeModules"
       )
       (Nil, () => ())


### PR DESCRIPTION
Previously, this would be set to error, which would mean Metals would show it to the users more prominently. Now, we change it to warn, which means it's still present, but since this might be actually be related to non compiled code, it's prominence is reduced,

Fixes https://github.com/scalacenter/bloop/issues/2211