### PR TITLE
bugfix: Print copying error together with stacktrace

### DIFF
--- a/backend/src/main/scala/bloop/io/ParallelOps.scala
+++ b/backend/src/main/scala/bloop/io/ParallelOps.scala
@@ -173,7 +173,7 @@ object ParallelOps {
           ()
         } catch {
           case NonFatal(t) =>
-            logger.report(
+            logger.error(
               s"Unexpected error when copying $originFile to $targetFile, you might need to restart the build server.",
               t
             )

--- a/backend/src/main/scala/bloop/logging/BloopLogger.scala
+++ b/backend/src/main/scala/bloop/logging/BloopLogger.scala
@@ -146,13 +146,6 @@ object BloopLogger {
   def default(name: String): BloopLogger =
     at(name, System.out, System.err, false, DebugFilter.All)
 
-  def prettyPrintException(t: Throwable): String = {
-    val sw = new java.io.StringWriter()
-    val pw = new java.io.PrintWriter(sw)
-    t.printStackTrace(pw)
-    sw.toString()
-  }
-
   private lazy val colorsRegex = "\u001b\\[[0-9;]*m".r
 
   /**

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -60,9 +60,9 @@ import bloop.internal.build.BuildInfo
 import bloop.io.AbsolutePath
 import bloop.io.Environment.lineSeparator
 import bloop.io.RelativePath
-import bloop.logging.BloopLogger
 import bloop.logging.BspServerLogger
 import bloop.logging.DebugFilter
+import bloop.logging.Logger
 import bloop.reporter.BspProjectReporter
 import bloop.reporter.ProblemPerPhase
 import bloop.reporter.ReporterConfig
@@ -559,7 +559,7 @@ final class BloopBspServices(
           Tasks.clean(state, projectsToClean, includeDeps = false).materialize.map {
             case Success(state) => (state, Right(bsp.CleanCacheResult(None, cleaned = true)))
             case Failure(exception) =>
-              val t = BloopLogger.prettyPrintException(exception)
+              val t = Logger.prettyPrintException(exception)
               val msg = s"Unexpected error when cleaning build targets!${lineSeparator}$t"
               state -> Right(bsp.CleanCacheResult(Some(msg), cleaned = false))
           }

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -22,7 +22,6 @@ import bloop.engine.tasks.compilation._
 import bloop.io.ParallelOps
 import bloop.io.ParallelOps.CopyMode
 import bloop.io.{Paths => BloopPaths}
-import bloop.logging.BloopLogger
 import bloop.logging.DebugFilter
 import bloop.logging.Logger
 import bloop.logging.LoggerAction
@@ -293,7 +292,7 @@ object CompileTask {
           } else {
             results.foreach {
               case FinalNormalCompileResult.HasException(project, err) =>
-                val errMsg = err.fold(identity, BloopLogger.prettyPrintException)
+                val errMsg = err.fold(identity, Logger.prettyPrintException)
                 rawLogger.error(s"Unexpected error when compiling ${project.name}: $errMsg")
               case _ => () // Do nothing when the final compilation result is not an actual error
             }

--- a/frontend/src/main/scala/bloop/testing/TestInternals.scala
+++ b/frontend/src/main/scala/bloop/testing/TestInternals.scala
@@ -340,7 +340,7 @@ object TestInternals {
     } catch {
       case _: ClassNotFoundException => None
       case NonFatal(t) =>
-        logger.report(s"Initialisation of test framework $fqn failed", t)
+        logger.error(s"Initialisation of test framework $fqn failed", t)
         None
     }
   }

--- a/shared/src/main/scala/bloop/logging/Logger.scala
+++ b/shared/src/main/scala/bloop/logging/Logger.scala
@@ -1,6 +1,7 @@
 package bloop.logging
 
 import java.util.function.Supplier
+import bloop.io.Environment
 
 abstract class Logger extends xsbti.Logger with BaseSbtLogger {
 
@@ -31,7 +32,12 @@ abstract class Logger extends xsbti.Logger with BaseSbtLogger {
   override def info(msg: Supplier[String]): Unit = info(msg.get)
   override def trace(exception: Supplier[Throwable]): Unit = trace(exception.get())
 
-  def report(msg: String, t: Throwable): Unit = { error(msg); trace(t) }
+  def error(msg: String, t: Throwable): Unit = {
+    error(
+      msg + Environment.lineSeparator + Logger.prettyPrintException(t)
+    )
+  }
+
   def handleCompilationEvent(): Unit = ()
 
   /** Display a message as a warning to user using `showMessage` in BSP-based loggers and `warn` otherwise. */
@@ -47,4 +53,13 @@ abstract class Logger extends xsbti.Logger with BaseSbtLogger {
 private[logging] trait BaseSbtLogger extends sbt.testing.Logger {
   private[logging] def printDebug(line: String): Unit
   override def debug(msg: String): Unit = printDebug(msg)
+}
+
+object Logger {
+  def prettyPrintException(t: Throwable): String = {
+    val sw = new java.io.StringWriter()
+    val pw = new java.io.PrintWriter(sw)
+    t.printStackTrace(pw)
+    sw.toString()
+  }
 }


### PR DESCRIPTION
It seems we don't get that properly forwarded to Bloop otherwise.