### PR TITLE
refactor: Further backports from bloop-core

### DIFF
--- a/frontend/src/main/resources/logback.xml
+++ b/frontend/src/main/resources/logback.xml
@@ -1,5 +1,7 @@
 <configuration>
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>
@@ -8,7 +10,7 @@
         </layout>
     </appender>
 
-    <root level="info">
+    <root level="error">
         <appender-ref ref="CONSOLE"/>
     </root>
 

--- a/frontend/src/main/scala/bloop/Server.scala
+++ b/frontend/src/main/scala/bloop/Server.scala
@@ -63,17 +63,7 @@ object Server {
 
   def nailMain(ngContext: NGContext): Unit = {
     val server = ngContext.getNGServer
-    import java.util.concurrent.ForkJoinPool
-
-    ForkJoinPool
-      .commonPool()
-      .submit(new Runnable {
-        override def run(): Unit = {
-          server.shutdown(false)
-        }
-      })
-
-    ()
+    server.shutdown(false)
   }
 
   private def run(server: NGServer): Unit = {


### PR DESCRIPTION
Some overall minor changes. Looks that next we will have to port the socket changes, which require JVM 17. We should be fine to do it, with maybe bloop-rifle needing a release output flag.