### PR TITLE
chore: Add release notes for Bloop 1.5.14

### DIFF
--- a/notes/v1.5.14.md
+++ b/notes/v1.5.14.md
@@ -1,0 +1,86 @@
+# bloop `v1.5.14`
+
+Bloop v1.5.14 is a bugfix release.
+
+## Installing Bloop
+
+For more details about installing Bloop, please see [Bloop's Installation Guide](https://scalacenter.github.io/bloop/setup))
+
+## Merged pull requests
+
+Here's a list of pull requests that were merged:
+
+- Build(deps): Update zt-zip from 1.16 to 1.17 [#2256]
+- Fix: incorrect directory in debug tests for scala-cli [#2254]
+- Build(deps): Update scala-debug-adapter from 3.1.5 to 3.1.6 [#2255]
+- Build(deps): Update bsp4s from 2.1.0-M7 to 2.1.1 [#2253]
+- Build(deps): Update tools from 0.4.16 to 0.4.17 [#2252]
+- Fixes misspelling runing -> running [#2247]
+- Build(deps): Update org.eclipse.jgit, ... from 5.13.2.202306221912-r to 5.13.3.202401111512-r [#2246]
+- Build(deps): Update brave from 5.17.1 to 5.18.1 [#2241]
+- Build(deps): Update sbt-mdoc from 2.5.1 to 2.5.2 [#2240]
+- Build(deps): Update brave from 5.17.0 to 5.17.1 [#2236]
+- Build(deps): Update zipkin-sender-urlconnection from 2.17.1 to 2.17.2 [#2237]
+- Build(deps): Update zinc from 1.9.5 to 1.9.6 [#2238]
+- Refactor: Further backports from bloop-core [#2233]
+- Bugfix: Print copying error together with stacktrace [#2232]
+- Build(deps): Update scalajs-linker, ... from 1.14.0 to 1.15.0 [#2234]
+- Refactor: Backport changes from bloop-core [#2224]
+- Build(deps): Update sbt-scalajs, scalajs-linker, ... from 1.14.0 to 1.15.0 [#2226]
+- Refactor: Remove Bloop4j as it seems not to be used at all [#2223]
+- Refactor: Remove forked parts of scala js envs [#2221]
+- Chore(deps): bump actions/download-artifact from 3 to 4 [#2229]
+- Chore(deps): bump actions/upload-artifact from 3 to 4 [#2228]
+- Build(deps): Update log4j-core from 2.22.0 to 2.22.1 [#2222]
+- Build(deps): Update zipkin-sender-urlconnection from 2.17.0 to 2.17.1 [#2220]
+- Build(deps): Update brave from 5.16.0 to 5.17.0 [#2219]
+- Don't show warning when using the correct version of JDK [#2218]
+- Build(deps): Update zipkin-sender-urlconnection from 2.16.5 to 2.17.0 [#2216]
+- Build(deps): Update sbt, test-agent from 1.9.7 to 1.9.8 [#2217]
+- Improvement: Change information about test framework to warn [#2214]
+- Build(deps): Update zipkin-sender-urlconnection from 2.16.4 to 2.16.5 [#2213]
+- Build(deps): Update jna, jna-platform from 5.13.0 to 5.14.0 [#2212]
+- Build(deps): Update log4j-core from 2.21.1 to 2.22.0 [#2208]
+- Build(deps): Update scalafmt-core from 3.7.15 to 3.7.17 [#2210]
+- Chore: Use the default download location for download action [#2207]
+
+
+[#2256]: https://github.com/scalacenter/bloop/pull/2256
+[#2254]: https://github.com/scalacenter/bloop/pull/2254
+[#2255]: https://github.com/scalacenter/bloop/pull/2255
+[#2253]: https://github.com/scalacenter/bloop/pull/2253
+[#2252]: https://github.com/scalacenter/bloop/pull/2252
+[#2247]: https://github.com/scalacenter/bloop/pull/2247
+[#2246]: https://github.com/scalacenter/bloop/pull/2246
+[#2241]: https://github.com/scalacenter/bloop/pull/2241
+[#2240]: https://github.com/scalacenter/bloop/pull/2240
+[#2236]: https://github.com/scalacenter/bloop/pull/2236
+[#2237]: https://github.com/scalacenter/bloop/pull/2237
+[#2238]: https://github.com/scalacenter/bloop/pull/2238
+[#2233]: https://github.com/scalacenter/bloop/pull/2233
+[#2232]: https://github.com/scalacenter/bloop/pull/2232
+[#2234]: https://github.com/scalacenter/bloop/pull/2234
+[#2224]: https://github.com/scalacenter/bloop/pull/2224
+[#2226]: https://github.com/scalacenter/bloop/pull/2226
+[#2223]: https://github.com/scalacenter/bloop/pull/2223
+[#2221]: https://github.com/scalacenter/bloop/pull/2221
+[#2229]: https://github.com/scalacenter/bloop/pull/2229
+[#2228]: https://github.com/scalacenter/bloop/pull/2228
+[#2222]: https://github.com/scalacenter/bloop/pull/2222
+[#2220]: https://github.com/scalacenter/bloop/pull/2220
+[#2219]: https://github.com/scalacenter/bloop/pull/2219
+[#2218]: https://github.com/scalacenter/bloop/pull/2218
+[#2216]: https://github.com/scalacenter/bloop/pull/2216
+[#2217]: https://github.com/scalacenter/bloop/pull/2217
+[#2214]: https://github.com/scalacenter/bloop/pull/2214
+[#2213]: https://github.com/scalacenter/bloop/pull/2213
+[#2212]: https://github.com/scalacenter/bloop/pull/2212
+[#2208]: https://github.com/scalacenter/bloop/pull/2208
+[#2210]: https://github.com/scalacenter/bloop/pull/2210
+[#2207]: https://github.com/scalacenter/bloop/pull/2207
+
+
+## Contributors
+
+According to `git shortlog -sn --no-merges v1.5.13..v1.5.14`, the following people have contributed to
+this `v1.5.14` release: scala-center-steward[bot], Tomasz Godzik, dependabot[bot], Katarzyna Marek, Marcus Rosti.


### PR DESCRIPTION
I want to release this one since we have a warning showing up that might be annoying for some people. The warning is about using too old JVM while in fact it's the same JVM version as required.