### PR TITLE
fix: erase scrollback when clearing the screen

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -139,7 +139,7 @@ object Interpreter {
         }
 
         if (!bloop.util.CrossPlatform.isWindows)
-          state.logger.info("\u001b[H\u001b[2J")
+          state.logger.info(bloop.util.Console.clearCommand)
 
         // Force the first execution before relying on the file watching task
         fg(state).flatMap(newState => watcher.watch(newState, fg))

--- a/frontend/src/main/scala/bloop/io/SourceWatcher.scala
+++ b/frontend/src/main/scala/bloop/io/SourceWatcher.scala
@@ -42,7 +42,7 @@ final class SourceWatcher private (
     def runAction(state: State, events: Seq[DirectoryChangeEvent]): Task[State] = {
       // Windows is not supported for now
       if (!bloop.util.CrossPlatform.isWindows)
-        logger.info("\u001b[H\u001b[2J") // Clean terminal before acting on the event action
+        logger.info(bloop.util.Console.clearCommand)
       events.foreach(e => logger.debug(s"A ${e.eventType()} in ${e.path()} has triggered an event"))
       action(state)
     }

--- a/frontend/src/main/scala/bloop/util/Console.scala
+++ b/frontend/src/main/scala/bloop/util/Console.scala
@@ -1,0 +1,10 @@
+package bloop.util
+
+object Console {
+  private val escape = "\u001b["
+  private val cursorHome = "H"
+  private val eraseScreen = "2J"
+  private val eraseScrollbar = "3J"
+
+  val clearCommand: String = escape + cursorHome + escape + eraseScreen + escape + eraseScrollbar
+}


### PR DESCRIPTION
If during watch mode, one would scroll terminal a bit and then make changes, terminal won't be cleared fully. This results in degarded experience. This PR fixes it. 

The missing erase scrollback was inspired by https://github.com/watchexec/clearscreen/blob/main/src/lib.rs#L524, which is used by cargo watch's `clear` command.