### PR TITLE
Fix classpath options

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -319,6 +319,7 @@ object Compiler {
     val classpathOptions = compileInputs.classpathOptions
     val compilers = compileInputs.compilerCache.get(
       scalaInstance,
+      classpathOptions,
       compileInputs.javacBin,
       compileInputs.javacOptions.toList
     )

--- a/backend/src/main/scala/bloop/CompilerCache.scala
+++ b/backend/src/main/scala/bloop/CompilerCache.scala
@@ -35,12 +35,12 @@ import sbt.internal.util.LoggerWriter
 import xsbti.ComponentProvider
 import xsbti.VirtualFile
 import xsbti.compile.ClassFileManager
+import xsbti.compile.ClasspathOptions
 import xsbti.compile.Compilers
 import xsbti.compile.JavaCompiler
 import xsbti.compile.Output
 import xsbti.{Logger => XLogger}
 import xsbti.{Reporter => XReporter}
-import xsbti.compile.ClasspathOptions
 
 object CompilerCache {
   final case class JavacKey(javacBin: Option[AbsolutePath], allowLocal: Boolean)

--- a/backend/src/main/scala/bloop/util/JavaRuntime.scala
+++ b/backend/src/main/scala/bloop/util/JavaRuntime.scala
@@ -4,7 +4,9 @@ import javax.tools.JavaCompiler
 import javax.tools.ToolProvider
 
 import scala.annotation.nowarn
+import scala.collection.concurrent.TrieMap
 import scala.util.Failure
+import scala.util.Properties
 import scala.util.Try
 
 import bloop.io.AbsolutePath
@@ -13,8 +15,6 @@ import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigParseOptions
 import com.typesafe.config.ConfigSyntax
-import scala.collection.concurrent.TrieMap
-import scala.util.Properties
 
 sealed trait JavaRuntime
 object JavaRuntime {

--- a/backend/src/main/scala/sbt/internal/inc/BloopZincLibraryManagement.scala
+++ b/backend/src/main/scala/sbt/internal/inc/BloopZincLibraryManagement.scala
@@ -29,6 +29,7 @@ object BloopZincLibraryManagement {
       componentProvider: ComponentProvider,
       secondaryCacheDir: Option[File],
       compilerBridgeSource: ModuleID,
+      classpathOptions: ClasspathOptions,
       logger: _root_.bloop.logging.Logger
   ): AnalyzingCompiler = {
     val compilerBridgeProvider = BloopComponentCompiler.interfaceProvider(
@@ -40,7 +41,7 @@ object BloopZincLibraryManagement {
     new AnalyzingCompiler(
       scalaInstance,
       compilerBridgeProvider,
-      ClasspathOptionsUtil.boot(),
+      classpathOptions,
       _ => (),
       loader
     )

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -73,7 +73,7 @@ object Tasks {
         val loader = ClasspathUtil.makeLoader(pathEntries, instance)
         val compiler =
           state.compilerCache
-            .get(instance, javacBin, project.javacOptions)
+            .get(instance, project.classpathOptions, javacBin, project.javacOptions)
             .scalac
             .asInstanceOf[AnalyzingCompiler]
         val options = project.scalacOptions :+ "-Xnojline"

--- a/frontend/src/test/scala/bloop/BuildLoaderSpec.scala
+++ b/frontend/src/test/scala/bloop/BuildLoaderSpec.scala
@@ -9,13 +9,13 @@ import bloop.data.TraceSettings
 import bloop.data.WorkspaceSettings
 import bloop.engine.Build
 import bloop.internal.build.BuildInfo
+import bloop.internal.build.BuildTestInfo
 import bloop.io.AbsolutePath
 import bloop.logging.RecordingLogger
 import bloop.task.Task
 import bloop.testing.BaseSuite
 import bloop.tracing.TraceProperties
 import bloop.util.TestUtil
-import bloop.internal.build.BuildTestInfo
 
 object BuildLoaderSpec extends BaseSuite {
   val semanticdbVersion = BuildTestInfo.semanticdbVersion

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -13,6 +13,7 @@ import bloop.cli.ExitStatus
 import bloop.data.WorkspaceSettings
 import bloop.engine.ExecutionContext
 import bloop.internal.build.BuildInfo
+import bloop.internal.build.BuildTestInfo
 import bloop.io.AbsolutePath
 import bloop.io.Environment.LineSplitter
 import bloop.io.Environment.lineSeparator
@@ -21,7 +22,6 @@ import bloop.logging.RecordingLogger
 import bloop.task.Task
 import bloop.util.TestProject
 import bloop.util.TestUtil
-import bloop.internal.build.BuildTestInfo
 
 object LocalBspMetalsClientSpec extends BspMetalsClientSpec(BspProtocol.Local)
 object TcpBspMetalsClientSpec extends BspMetalsClientSpec(BspProtocol.Tcp)

--- a/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
+++ b/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
@@ -21,6 +21,7 @@ import bloop.io.ParallelOps
 import bloop.io.ParallelOps.CopyMode
 import bloop.io.RelativePath
 import bloop.logging.Logger
+import bloop.logging.NoopLogger
 import bloop.logging.RecordingLogger
 import bloop.task.Task
 import bloop.util.TestProject
@@ -28,7 +29,6 @@ import bloop.util.TestUtil
 
 import monix.execution.CancelableFuture
 import monix.execution.Scheduler
-import bloop.logging.NoopLogger
 
 trait BloopHelpers {
   def loadState(

--- a/frontend/src/test/scala/bloop/testing/ProjectBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/testing/ProjectBaseSuite.scala
@@ -2,11 +2,12 @@ package bloop.testing
 
 import java.nio.file.Files
 
+import scala.concurrent.duration.Duration
+
 import bloop.io.AbsolutePath
 import bloop.io.Paths
 import bloop.logging.RecordingLogger
 import bloop.task.Task
-import scala.concurrent.duration.Duration
 
 class ProjectBaseSuite(buildName: String) extends BaseSuite {
   val workspace: AbsolutePath = AbsolutePath(Files.createTempDirectory(s"workspace-${buildName}"))

--- a/shared/src/main/scala/bloop/io/AbsolutePath.scala
+++ b/shared/src/main/scala/bloop/io/AbsolutePath.scala
@@ -7,7 +7,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.{Paths => NioPaths}
 import java.util.stream.Collectors
-import collection.JavaConverters._
+
+import scala.collection.JavaConverters._
 
 final class AbsolutePath private (val underlying: Path) extends AnyVal {
   def syntax: String = toString

--- a/shared/src/main/scala/bloop/logging/Logger.scala
+++ b/shared/src/main/scala/bloop/logging/Logger.scala
@@ -1,6 +1,7 @@
 package bloop.logging
 
 import java.util.function.Supplier
+
 import bloop.io.Environment
 
 abstract class Logger extends xsbti.Logger with BaseSbtLogger {


### PR DESCRIPTION
Fix #2268 

We should cache the `ScalaInstance` to reuse classloaders as much as possible but we should take into account the `ClasspathOptions` of a project when we create the `ScalaCompiler`.

Tested on Dotty: compilation :heavy_check_mark: auto-completion :heavy_check_mark: 