### PR TITLE
refactor: don't send task start/end for no-op compilations

### DIFF
--- a/frontend/src/test/scala/bloop/DeduplicationSpec.scala
+++ b/frontend/src/test/scala/bloop/DeduplicationSpec.scala
@@ -111,10 +111,10 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
 
         assertNoDiff(
           firstCompiledState.lastDiagnostics(build.userProject),
-          """#1: task start 2
+          """#1: task start 1
             |  -> Msg: Compiling user (2 Scala sources)
             |  -> Data kind: compile-task
-            |#1: task finish 2
+            |#1: task finish 1
             |  -> errors 0, warnings 0
             |  -> Msg: Compiled 'user'
             |  -> Data kind: compile-report
@@ -153,14 +153,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
 
         assertNoDiff(
           firstCompiledState.lastDiagnostics(build.userProject),
-          """#2: task start 4
-            |  -> Msg: Start no-op compilation for user
-            |  -> Data kind: compile-task
-            |#2: task finish 4
-            |  -> errors 0, warnings 0
-            |  -> Msg: Compiled 'user'
-            |  -> Data kind: compile-report
-        """.stripMargin
+          "" // expect None here since it's a no-op which turns into ""
         )
 
         // Same check as before because no-op should not show any more input
@@ -233,10 +226,10 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
 
         assertNoDiff(
           firstCompiledState.lastDiagnostics(build.userProject),
-          """#1: task start 2
+          """#1: task start 1
             |  -> Msg: Compiling user (2 Scala sources)
             |  -> Data kind: compile-task
-            |#1: task finish 2
+            |#1: task finish 1
             |  -> errors 0, warnings 0
             |  -> Msg: Compiled 'user'
             |  -> Data kind: compile-report
@@ -326,10 +319,10 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
 
         assertNoDiff(
           secondCompiledState.lastDiagnostics(build.userProject),
-          """#2: task start 4
+          """#2: task start 2
             |  -> Msg: Compiling user (1 Scala source)
             |  -> Data kind: compile-task
-            |#2: task finish 4
+            |#2: task finish 2
             |  -> errors 0, warnings 0
             |  -> Msg: Compiled 'user'
             |  -> Data kind: compile-report
@@ -412,10 +405,10 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
         // First compilation should not report warning
         assertNoDiff(
           firstCompiledState.lastDiagnostics(build.userProject),
-          """#1: task start 2
+          """#1: task start 1
             |  -> Msg: Compiling user (2 Scala sources)
             |  -> Data kind: compile-task
-            |#1: task finish 2
+            |#1: task finish 1
             |  -> errors 0, warnings 0
             |  -> Msg: Compiled 'user'
             |  -> Data kind: compile-report
@@ -563,13 +556,13 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
         // We reproduce the same streaming side effects during compilation
         assertNoDiff(
           firstCompiledState.lastDiagnostics(`B`),
-          """#1: task start 2
+          """#1: task start 1
             |  -> Msg: Compiling b (1 Scala source)
             |  -> Data kind: compile-task
             |#1: b/src/B.scala
             |  -> List(Diagnostic(Range(Position(2,28),Position(2,28)),Some(Error),Some(_),Some(_),type mismatch;  found   : Int  required: String,None,None,Some({"actions":[]})))
             |  -> reset = true
-            |#1: task finish 2
+            |#1: task finish 1
             |  -> errors 1, warnings 0
             |  -> Msg: Compiled 'b'
             |  -> Data kind: compile-report
@@ -644,13 +637,13 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
 
         assertNoDiff(
           secondBspState.lastDiagnostics(`B`),
-          """#2: task start 4
+          """#2: task start 2
             |  -> Msg: Compiling b (1 Scala source)
             |  -> Data kind: compile-task
             |#2: b/src/B.scala
             |  -> List(Diagnostic(Range(Position(2,28),Position(2,28)),Some(Error),Some(_),Some(_),type mismatch;  found   : Int  required: String,None,None,Some({"actions":[]})))
             |  -> reset = true
-            |#2: task finish 4
+            |#2: task finish 2
             |  -> errors 1, warnings 0
             |  -> Msg: Compiled 'b'
             |  -> Data kind: compile-report
@@ -744,13 +737,13 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
 
         assertNoDiff(
           thirdBspState.lastDiagnostics(`B`),
-          """#3: task start 6
+          """#3: task start 3
             |  -> Msg: Compiling b (1 Scala source)
             |  -> Data kind: compile-task
             |#3: b/src/B.scala
             |  -> List()
             |  -> reset = true
-            |#3: task finish 6
+            |#3: task finish 3
             |  -> errors 0, warnings 0
             |  -> Msg: Compiled 'b'
             |  -> Data kind: compile-report
@@ -894,10 +887,10 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
           assertNoDiff(
             firstCompiledState.lastDiagnostics(`B`),
             s"""
-               |#1: task start 2
+               |#1: task start 1
                |  -> Msg: Compiling b (6 Scala sources)
                |  -> Data kind: compile-task
-               |#1: task finish 2
+               |#1: task finish 1
                |  -> errors 0, warnings 0
                |  -> Msg: Compiled 'b'
                |  -> Data kind: compile-report

--- a/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
@@ -83,13 +83,7 @@ class BspCompileSpec(
         assertSameExternalClassesDirs(compiledState, secondCompiledState, projects)
         assertNoDiff(
           secondCompiledState.lastDiagnostics(`A`),
-          """#2: task start 2
-            |  -> Msg: Start no-op compilation for a
-            |  -> Data kind: compile-task
-            |#2: task finish 2
-            |  -> errors 0, warnings 0
-            |  -> Msg: Compiled 'a'
-            |  -> Data kind: compile-report""".stripMargin
+          "" // no-op
         )
       }
     }
@@ -576,17 +570,10 @@ class BspCompileSpec(
         assertSameExternalClassesDirs(thirdCompiledState, compiledState, projects)
         assertNoDiff(
           thirdCompiledState.lastDiagnostics(`A`),
-          """#3: task start 3
-            |  -> Msg: Start no-op compilation for a
-            |  -> Data kind: compile-task
-            |#3: a/src/A.scala
+          """#3: a/src/A.scala
             |  -> List()
             |  -> reset = true
-            |#3: task finish 3
-            |  -> errors 0, warnings 0
-            |  -> Msg: Compiled 'a'
-            |  -> Data kind: compile-report
-            """.stripMargin
+            """.stripMargin // no-op so it only gives the compile-report
         )
 
         writeFile(`A`.srcFor("/A.scala"), Sources.`A3.scala`)
@@ -603,7 +590,7 @@ class BspCompileSpec(
         assertSameExternalClassesDirs(fourthCompiledState, compiledState, projects)
         assertNoDiff(
           fourthCompiledState.lastDiagnostics(`A`),
-          """#4: task start 4
+          """#4: task start 3
             |  -> Msg: Compiling a (1 Scala source)
             |  -> Data kind: compile-task
             |#4: a/src/A.scala
@@ -612,7 +599,7 @@ class BspCompileSpec(
             |#4: a/src/A.scala
             |  -> List(Diagnostic(Range(Position(0,0),Position(0,26)),Some(Warning),Some(_),Some(_),Unused import,None,None,Some({"actions":[]})))
             |  -> reset = false
-            |#4: task finish 4
+            |#4: task finish 3
             |  -> errors 1, warnings 1
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report
@@ -626,13 +613,13 @@ class BspCompileSpec(
         assertDifferentExternalClassesDirs(fifthCompiledState, compiledState, projects)
         assertNoDiff(
           fifthCompiledState.lastDiagnostics(`A`),
-          """#5: task start 5
+          """#5: task start 4
             |  -> Msg: Compiling a (1 Scala source)
             |  -> Data kind: compile-task
             |#5: a/src/A.scala
             |  -> List(Diagnostic(Range(Position(0,0),Position(0,26)),Some(Warning),Some(_),Some(_),Unused import,None,None,Some({"actions":[]})))
             |  -> reset = true
-            |#5: task finish 5
+            |#5: task finish 4
             |  -> errors 0, warnings 1
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report
@@ -652,17 +639,17 @@ class BspCompileSpec(
         assertSameExternalClassesDirs(sixthCompiledState, fifthCompiledState, projects)
         assertNoDiff(
           sixthCompiledState.lastDiagnostics(`A`),
-          """#6: task start 6
+          """#6: task start 5
             |  -> Msg: Compiling a (1 Scala source)
             |  -> Data kind: compile-task
             |#6: a/src/A.scala
             |  -> List()
             |  -> reset = true
-            |#6: task finish 6
+            |#6: task finish 5
             |  -> errors 0, warnings 0
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report
-            |#6: task start 6
+            |#6: task start 5
             |  -> Msg: Compiling a (1 Scala source)
             |  -> Data kind: compile-task
             |#6: a/src/A.scala
@@ -671,7 +658,7 @@ class BspCompileSpec(
             |#6: a/src/A.scala
             |  -> List(Diagnostic(Range(Position(1,0),Position(3,1)),Some(Error),Some(_),Some(_),object creation impossible, since value y in trait Base of type Int is not defined,None,None,Some({"actions":[]})))
             |  -> reset = false
-            |#6: task finish 6
+            |#6: task finish 5
             |  -> errors 1, warnings 1
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report
@@ -686,13 +673,13 @@ class BspCompileSpec(
 
         assertNoDiff(
           seventhCompiledState.lastDiagnostics(`A`),
-          """#7: task start 7
+          """#7: task start 6
             |  -> Msg: Compiling a (1 Scala source)
             |  -> Data kind: compile-task
             |#7: a/src/A.scala
             |  -> List(Diagnostic(Range(Position(0,0),Position(0,26)),Some(Warning),Some(_),Some(_),Unused import,None,None,Some({"actions":[]})))
             |  -> reset = true
-            |#7: task finish 7
+            |#7: task finish 6
             |  -> errors 0, warnings 0
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report
@@ -743,18 +730,12 @@ class BspCompileSpec(
         assertSameExternalClassesDirs(compiledState.toTestState, secondCliCompiledState, `A`)
 
         // BSP publishes warnings even if it's a no-op
+        // however it skips the task start/end
         assertNoDiff(
           compiledState.lastDiagnostics(`A`),
-          """#1: task start 1
-            |  -> Msg: Start no-op compilation for a
-            |  -> Data kind: compile-task
-            |#1: a/src/main/scala/App.scala
+          """#1: a/src/main/scala/App.scala
             |  -> List(Diagnostic(Range(Position(2,4),Position(2,4)),Some(Warning),Some(_),Some(_),a pure expression does nothing in statement position,None,None,Some({"actions":[]})))
-            |  -> reset = true
-            |#1: task finish 1
-            |  -> errors 0, warnings 0
-            |  -> Msg: Compiled 'a'
-            |  -> Data kind: compile-report""".stripMargin
+            |  -> reset = true""".stripMargin
         )
       }
     }
@@ -972,16 +953,9 @@ class BspCompileSpec(
 
         assertNoDiff(
           thirdCompiledState.lastDiagnostics(`A`),
-          """#3: task start 3
-            |  -> Msg: Start no-op compilation for a
-            |  -> Data kind: compile-task
-            |#3: a/src/main/scala/Bar.scala
+          """#3: a/src/main/scala/Bar.scala
             |  -> List()
-            |  -> reset = true
-            |#3: task finish 3
-            |  -> errors 0, warnings 0
-            |  -> Msg: Compiled 'a'
-            |  -> Data kind: compile-report""".stripMargin
+            |  -> reset = true""".stripMargin
         )
       }
     }
@@ -1083,14 +1057,7 @@ class BspCompileSpec(
 
         assertNoDiff(
           compiledState.lastDiagnostics(`B`),
-          """|#2: task start 4
-             |  -> Msg: Start no-op compilation for b
-             |  -> Data kind: compile-task
-             |#2: task finish 4
-             |  -> errors 0, warnings 0
-             |  -> Msg: Compiled 'b'
-             |  -> Data kind: compile-report
-             |""".stripMargin
+          "" // no-op
         )
 
         writeFile(`A`.srcFor("/Foo.scala"), Sources.`Foo3.scala`)
@@ -1100,7 +1067,7 @@ class BspCompileSpec(
         assertValidCompilationState(thirdCompiledState, projects)
         assertNoDiff(
           thirdCompiledState.lastDiagnostics(`A`),
-          """|#3: task start 5
+          """|#3: task start 4
              |  -> Msg: Compiling a (1 Scala source)
              |  -> Data kind: compile-task
              |#3: a/src/Foo.scala
@@ -1109,7 +1076,7 @@ class BspCompileSpec(
              |#3: a/src/Foo.scala
              |  -> List(Diagnostic(Range(Position(1,0),Position(1,7)),Some(Error),Some(_),Some(_),Unused import,None,None,Some({"actions":[]})))
              |  -> reset = false
-             |#3: task finish 5
+             |#3: task finish 4
              |  -> errors 2, warnings 0
              |  -> Msg: Compiled 'a'
              |  -> Data kind: compile-report
@@ -1118,13 +1085,13 @@ class BspCompileSpec(
 
         assertNoDiff(
           compiledState.lastDiagnostics(`B`),
-          """|#3: task start 6
+          """|#3: task start 5
              |  -> Msg: Compiling b (1 Scala source)
              |  -> Data kind: compile-task
              |#3: b/src/Buzz.scala
              |  -> List(Diagnostic(Range(Position(0,0),Position(0,7)),Some(Error),Some(_),Some(_),Unused import,None,None,Some({"actions":[]})))
              |  -> reset = true
-             |#3: task finish 6
+             |#3: task finish 5
              |  -> errors 1, warnings 0
              |  -> Msg: Compiled 'b'
              |  -> Data kind: compile-report

--- a/frontend/src/test/scala/bloop/bsp/BspSbtClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspSbtClientSpec.scala
@@ -155,6 +155,7 @@ class BspSbtClientSpec(
         assertValidCompilationState(newCompiledState, projects)
 
         assertNoDiff(
+          diagnosticsWithoutTaskIds(newCompiledState, `A`),
           s"""# task start 6
              |  -> Msg: Compiling a (1 Scala source)
              |  -> Data kind: compile-task
@@ -162,56 +163,34 @@ class BspSbtClientSpec(
              |  -> errors 0, warnings 0
              |  -> origin = $secondOriginId
              |  -> Msg: Compiled 'a'
-             |  -> Data kind: compile-report""".stripMargin,
-          diagnosticsWithoutTaskIds(newCompiledState, `A`)
+             |  -> Data kind: compile-report""".stripMargin
         )
 
         assertNoDiff(
+          diagnosticsWithoutTaskIds(newCompiledState, `B`),
+          "" // no-op
+        )
+
+        assertNoDiff(
+          diagnosticsWithoutTaskIds(newCompiledState, `C`),
           s"""# task start 7
-             |  -> Msg: Start no-op compilation for b
+             |  -> Msg: Compiling c (1 Scala source)
              |  -> Data kind: compile-task
              |# task finish 7
              |  -> errors 0, warnings 0
              |  -> origin = $secondOriginId
-             |  -> Msg: Compiled 'b'
-             |  -> Data kind: compile-report""".stripMargin,
-          diagnosticsWithoutTaskIds(newCompiledState, `B`)
-        )
-
-        assertNoDiff(
-          s"""# task start 8
-             |  -> Msg: Compiling c (1 Scala source)
-             |  -> Data kind: compile-task
-             |# task finish 8
-             |  -> errors 0, warnings 0
-             |  -> origin = $secondOriginId
              |  -> Msg: Compiled 'c'
-             |  -> Data kind: compile-report""".stripMargin,
-          diagnosticsWithoutTaskIds(newCompiledState, `C`)
+             |  -> Data kind: compile-report""".stripMargin
         )
 
         assertNoDiff(
-          s"""# task start 9
-             |  -> Msg: Start no-op compilation for d
-             |  -> Data kind: compile-task
-             |# task finish 9
-             |  -> errors 0, warnings 0
-             |  -> origin = $secondOriginId
-             |  -> Msg: Compiled 'd'
-             |  -> Data kind: compile-report""".stripMargin,
-          diagnosticsWithoutTaskIds(newCompiledState, `D`)
+          diagnosticsWithoutTaskIds(newCompiledState, `D`),
+          "" // no-op
         )
 
         assertNoDiff(
-          s"""# task start 10
-             |  -> Msg: Start no-op compilation for e
-             |  -> Data kind: compile-task
-             |# task finish 10
-             |  -> errors 0, warnings 0
-             |  -> origin = $secondOriginId
-             |  -> Msg: Compiled 'e'
-             |  -> Data kind: compile-report""".stripMargin,
-          diagnosticsWithoutTaskIds(newCompiledState, `E`)
+          diagnosticsWithoutTaskIds(newCompiledState, `E`),
+          "" // no-op
         )
 
         assertSameExternalClassesDirs(newCompiledState, initialStateBackup, List(`B`, `D`, `E`))
@@ -302,17 +281,9 @@ class BspSbtClientSpec(
 
         assertNoDiff(
           thirdCompiledState.lastDiagnostics(`A`),
-          """
-            |#3: task start 3
-            |  -> Msg: Start no-op compilation for a
-            |  -> Data kind: compile-task
-            |#3: a/src/main/scala/Foo.scala
+          """#3: a/src/main/scala/Foo.scala
             |  -> List()
-            |  -> reset = true
-            |#3: task finish 3
-            |  -> errors 0, warnings 0
-            |  -> Msg: Compiled 'a'
-            |  -> Data kind: compile-report """.stripMargin
+            |  -> reset = true""".stripMargin
         )
       }
     }


### PR DESCRIPTION
This might be a bit opinionated and I'm not 100% sure on the reason this was done in the first place, but this changes the current behavior around reporting start and end compilations for no-ops. This still retains the compile report if it was a no-op and also still checks the diagnostics and reports them, but skips the task start/end.

Originally this was added in a commit without any context... but there was a comment that said:

> // When no-op, we keep reporting the start and the end of compilation for consistency

However, I'm not really sure that consistency matters here. In reality this ends up creating a bunch of noise on the client side, especially when these tasks turn into LSP progress notifications that aren't useful for the user to see. You can see more context about this change in the issue reported [here](https://github.com/scalameta/metals/issues/6099) and also the discussion found
[here](https://github.com/build-server-protocol/build-server-protocol/discussions/654). It also seems that in some projects like scala-cli these are even [ignored](https://github.com/VirtusLab/scala-cli/blob/6b7a10007e4eefde717079255e0df38c027f788b/modules/build/src/main/scala/scala/build/ConsoleBloopBuildClient.scala#L109).