### PR TITLE
Update scala-debug-adpater to 4.x and add support for hot code replace

### DIFF
--- a/backend/src/main/scala/bloop/ClientClassesObserver.scala
+++ b/backend/src/main/scala/bloop/ClientClassesObserver.scala
@@ -1,0 +1,65 @@
+package bloop
+
+import java.io.File
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.jdk.CollectionConverters._
+
+import bloop.io.AbsolutePath
+import bloop.task.Task
+
+import monix.reactive.Observable
+import monix.reactive.subjects.PublishSubject
+import sbt.internal.inc.PlainVirtualFileConverter
+import xsbti.VirtualFileRef
+import xsbti.compile.CompileAnalysis
+import xsbti.compile.analysis.Stamp
+
+/**
+ * Each time a new compile analysis is produced for a given client, it is given to
+ * the [[ClientClassObserver]] which computes the list of classes that changed or got created.
+ *
+ * A client can subscribe to the observer to get notified of classes to update.
+ * It is used by DAP to hot reload classes in the debuggee process.
+ *
+ * @param clientClassesDir the class directory for the client
+ */
+private[bloop] class ClientClassesObserver(val classesDir: AbsolutePath) {
+  private val converter = PlainVirtualFileConverter.converter
+  private val previousAnalysis: AtomicReference[CompileAnalysis] = new AtomicReference()
+  private val classesSubject: PublishSubject[Seq[String]] = PublishSubject()
+
+  def observable: Observable[Seq[String]] = classesSubject
+
+  def nextAnalysis(analysis: CompileAnalysis): Task[Unit] = {
+    val prev = previousAnalysis.getAndSet(analysis)
+    if (prev != null && classesSubject.size > 0) {
+      Task {
+        val previousStamps = prev.readStamps.getAllProductStamps
+        analysis.readStamps.getAllProductStamps.asScala.iterator.collect {
+          case (vf, stamp) if isClassFile(vf) && isNewer(stamp, previousStamps.get(vf)) =>
+            getFullyQualifiedClassName(vf)
+        }.toSeq
+      }
+        .flatMap { classesToUpdate =>
+          Task.fromFuture(classesSubject.onNext(classesToUpdate)).map(_ => ())
+        }
+    } else Task.unit
+  }
+
+  private def isClassFile(vf: VirtualFileRef): Boolean = vf.id.endsWith(".class")
+
+  private def isNewer(current: Stamp, previous: Stamp): Boolean =
+    previous == null || {
+      val currentHash = current.getHash
+      val previousHash = previous.getHash
+      currentHash.isPresent &&
+      (!previousHash.isPresent || currentHash.get != previousHash.get)
+    }
+
+  private def getFullyQualifiedClassName(vf: VirtualFileRef): String = {
+    val path = converter.toPath(vf)
+    val relativePath = classesDir.underlying.relativize(path)
+    relativePath.toString.replace(File.separator, ".").stripSuffix(".class")
+  }
+}

--- a/backend/src/main/scala/bloop/CompileBackgroundTasks.scala
+++ b/backend/src/main/scala/bloop/CompileBackgroundTasks.scala
@@ -8,7 +8,7 @@ import bloop.tracing.BraveTracer
 
 abstract class CompileBackgroundTasks {
   def trigger(
-      clientClassesDir: AbsolutePath,
+      clientClassesObserver: ClientClassesObserver,
       clientReporter: Reporter,
       clientTracer: BraveTracer,
       clientLogger: Logger
@@ -20,7 +20,7 @@ object CompileBackgroundTasks {
   val empty: CompileBackgroundTasks = {
     new CompileBackgroundTasks {
       def trigger(
-          clientClassesDir: AbsolutePath,
+          clientClassesObserver: ClientClassesObserver,
           clientReporter: Reporter,
           clientTracer: BraveTracer,
           clientLogger: Logger

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -647,7 +647,7 @@ final class BloopBspServices(
             BloopDebuggeeRunner.forTestSuite(projects, testClasses, state, ioScheduler)
           })
         case Some(bsp.DebugSessionParamsDataKind.ScalaAttachRemote) =>
-          Right(BloopDebuggeeRunner.forAttachRemote(state, ioScheduler, projects))
+          Right(BloopDebuggeeRunner.forAttachRemote(projects, state, ioScheduler))
         case dataKind => Left(Response.invalidRequest(s"Unsupported data kind: $dataKind"))
       }
     }

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -603,10 +603,7 @@ final class BloopBspServices(
       params: bsp.DebugSessionParams
   ): BspEndpointResponse[bsp.DebugSessionAddress] = {
 
-    def inferDebuggee(
-        projects: Seq[Project],
-        state: State
-    ): BspResponse[Debuggee] = {
+    def inferDebuggee(projects: Seq[Project], state: State): BspResponse[Debuggee] = {
       def convert[A: JsonValueCodec](
           f: A => Either[String, Debuggee]
       ): Either[Response.Error, Debuggee] = {

--- a/frontend/src/main/scala/bloop/dap/BloopDebugToolsResolver.scala
+++ b/frontend/src/main/scala/bloop/dap/BloopDebugToolsResolver.scala
@@ -34,13 +34,12 @@ class BloopDebugToolsResolver(logger: Logger) extends DebugToolsResolver {
     }
   }
 
-  override def resolveUnpickler(scalaVersion: ScalaVersion): Try[ClassLoader] = {
-    getOrTryUpdate(stepFilterCache, scalaVersion) {
-      val unpicklerModule = s"${BuildInfo.unpicklerName}_${scalaVersion.binaryVersion}"
-      val stepFilter = Artifact(BuildInfo.organization, unpicklerModule, BuildInfo.version)
-      val tastyCore = Artifact("org.scala-lang", "tasty-core_3", scalaVersion.value)
+  override def resolveDecoder(scalaVersion: ScalaVersion): Try[ClassLoader] = {
+    getOrTryUpdate(decoderCache, scalaVersion) {
+      val decoderModule = s"${BuildInfo.decoderName}_${scalaVersion.binaryVersion}"
+      val artifact = Artifact(BuildInfo.organization, decoderModule, BuildInfo.version)
       DependencyResolution
-        .resolveWithErrors(List(stepFilter, tastyCore), logger)
+        .resolveWithErrors(List(artifact), logger)
         .map(jars => toClassLoader(jars, true))
         .toTry
     }
@@ -66,5 +65,5 @@ class BloopDebugToolsResolver(logger: Logger) extends DebugToolsResolver {
 
 object BloopDebugToolsResolver {
   private val expressionCompilerCache: mutable.Map[ScalaVersion, ClassLoader] = mutable.Map.empty
-  private val stepFilterCache: mutable.Map[ScalaVersion, ClassLoader] = mutable.Map.empty
+  private val decoderCache: mutable.Map[ScalaVersion, ClassLoader] = mutable.Map.empty
 }

--- a/frontend/src/main/scala/bloop/dap/BloopDebugToolsResolver.scala
+++ b/frontend/src/main/scala/bloop/dap/BloopDebugToolsResolver.scala
@@ -34,10 +34,10 @@ class BloopDebugToolsResolver(logger: Logger) extends DebugToolsResolver {
     }
   }
 
-  override def resolveStepFilter(scalaVersion: ScalaVersion): Try[ClassLoader] = {
+  override def resolveUnpickler(scalaVersion: ScalaVersion): Try[ClassLoader] = {
     getOrTryUpdate(stepFilterCache, scalaVersion) {
-      val stepFilterModule = s"${BuildInfo.scala3StepFilterName}_${scalaVersion.binaryVersion}"
-      val stepFilter = Artifact(BuildInfo.organization, stepFilterModule, BuildInfo.version)
+      val unpicklerModule = s"${BuildInfo.unpicklerName}_${scalaVersion.binaryVersion}"
+      val stepFilter = Artifact(BuildInfo.organization, unpicklerModule, BuildInfo.version)
       val tastyCore = Artifact("org.scala-lang", "tasty-core_3", scalaVersion.value)
       DependencyResolution
         .resolveWithErrors(List(stepFilter, tastyCore), logger)

--- a/frontend/src/main/scala/bloop/dap/DapCancellableFuture.scala
+++ b/frontend/src/main/scala/bloop/dap/DapCancellableFuture.scala
@@ -3,6 +3,8 @@ package bloop.dap
 import scala.concurrent.Future
 import scala.concurrent.Promise
 
+import ch.epfl.scala.debugadapter.CancelableFuture
+
 import bloop.task.Task
 
 import monix.execution.Cancelable
@@ -15,10 +17,7 @@ private class DapCancellableFuture(future: Future[Unit], cancelable: Cancelable)
 }
 
 object DapCancellableFuture {
-  def runAsync(
-      task: Task[Unit],
-      ioScheduler: Scheduler
-  ): ch.epfl.scala.debugadapter.CancelableFuture[Unit] = {
+  def runAsync(task: Task[Unit])(implicit ioScheduler: Scheduler): CancelableFuture[Unit] = {
     val promise = Promise[Unit]()
     val cancelable = task
       .doOnFinish {

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -28,6 +28,7 @@ import bloop.util.JavaRuntime
 import scalaz.Cord
 import xsbti.compile.ClasspathOptions
 import xsbti.compile.CompileOrder
+import io.reactivex.subjects.PublishSubject
 
 final case class Project(
     name: String,
@@ -55,6 +56,8 @@ final case class Project(
     tags: List[String],
     origin: Origin
 ) {
+
+  val classObserver = PublishSubject.create[Seq[String]]()
 
   /** The bsp uri associated with this project. */
   val bspUri: Bsp.Uri = Bsp.Uri(ProjectUris.toURI(baseDirectory, name))

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -28,7 +28,6 @@ import bloop.util.JavaRuntime
 import scalaz.Cord
 import xsbti.compile.ClasspathOptions
 import xsbti.compile.CompileOrder
-import io.reactivex.subjects.PublishSubject
 
 final case class Project(
     name: String,
@@ -56,8 +55,6 @@ final case class Project(
     tags: List[String],
     origin: Origin
 ) {
-
-  val classObserver = PublishSubject.create[Seq[String]]()
 
   /** The bsp uri associated with this project. */
   val bspUri: Bsp.Uri = Bsp.Uri(ProjectUris.toURI(baseDirectory, name))

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -36,10 +36,6 @@ import bloop.tracing.BraveTracer
 import monix.execution.CancelableFuture
 import monix.reactive.MulticastStrategy
 import monix.reactive.Observable
-import xsbti.compile.analysis.ReadStamps
-import xsbti.compile.analysis.Stamp
-import xsbti.VirtualFileRef
-import scala.jdk.CollectionConverters._
 
 object CompileTask {
   private implicit val logContext: DebugFilter = DebugFilter.Compilation
@@ -102,7 +98,6 @@ object CompileTask {
           compileProjectTracer.terminate()
           Task.now(earlyResultBundle)
         case Right(CompileSourcesAndInstance(sources, instance, _)) =>
-          val externalUserClassesDir = bundle.clientClassesDir
           val readOnlyClassesDir = lastSuccessful.classesDir
           val newClassesDir = compileOut.internalNewClassesDir
           val classpath = bundle.dependenciesData.buildFullCompileClasspathFor(
@@ -177,7 +172,7 @@ object CompileTask {
                 val postCompilationTasks =
                   backgroundTasks
                     .trigger(
-                      externalUserClassesDir,
+                      bundle.clientClassesObserver,
                       reporter.underlying,
                       compileProjectTracer,
                       logger
@@ -223,52 +218,6 @@ object CompileTask {
       }
     }
 
-    def registerUpdatedClasses(res: FinalNormalCompileResult, project: Project) = {
-      res.result.fromCompiler match {
-        case s: Success =>
-          val currentAnalysis =
-            Option(s.products.resultForFutureCompilationRuns.analysis().orElse(null))
-          val previous = res.result.previous
-          val previousAnalysis =
-            if (previous.isEmpty) None
-            else Option(previous.get.previous.analysis().orElse(null))
-
-          (currentAnalysis, previousAnalysis) match {
-            case (None, _) | (_, None) => ()
-            case (Some(curr), Some(prev)) =>
-              val currentStamps = curr.readStamps
-              val previousStamps = prev.readStamps
-              val newClasses = getNewClasses(currentStamps, previousStamps)
-              project.classObserver.onNext(newClasses)
-          }
-        case _ => ()
-      }
-    }
-
-    def getNewClasses(currentStamps: ReadStamps, previousStamps: ReadStamps): Seq[String] = {
-      def isNewer(current: Stamp, previous: Stamp) = {
-        if (previous == null) true
-        else {
-          val newHash = current.getHash
-          val oldHash = previous.getHash
-          newHash.isPresent && (!oldHash.isPresent || newHash.get != oldHash.get)
-        }
-      }
-
-      object ClassFile {
-        def unapply(vf: VirtualFileRef): Option[String] = {
-          val fqcn = vf.name
-          if (fqcn.toString.endsWith(".class")) Some(fqcn.stripSuffix(".class"))
-          else None
-        }
-      }
-
-      val oldStamps = previousStamps.getAllProductStamps
-      currentStamps.getAllProductStamps.asScala.collect {
-        case (file @ ClassFile(fqcn), stamp) if isNewer(stamp, oldStamps.get(file)) => fqcn
-      }.toSeq
-    }
-
     def setup(inputs: CompileDefinitions.BundleInputs): Task[CompileBundle] = {
       // Create a multicast observable stream to allow multiple mirrors of loggers
       val (observer, obs) = {
@@ -297,14 +246,14 @@ object CompileTask {
       val o = state.commonOptions
       val cancel = cancelCompilation
       val logger = ObservedLogger(rawLogger, observer)
-      val dir = state.client.getUniqueClassesDirFor(inputs.project, forceGeneration = true)
+      val clientClassesObserver = state.client.getClassesObserverFor(inputs.project)
       val underlying = createReporter(ReporterInputs(inputs.project, cwd, rawLogger))
       val reporter = new ObservedReporter(logger, underlying)
       val sourceGeneratorCache = state.sourceGeneratorCache
       CompileBundle.computeFrom(
         inputs,
         sourceGeneratorCache,
-        dir,
+        clientClassesObserver,
         reporter,
         last,
         prev,
@@ -338,11 +287,6 @@ object CompileTask {
         val newState: State = {
           val stateWithResults = state.copy(results = state.results.addFinalResults(results))
           if (failures.isEmpty) {
-            results.foreach {
-              case res: FinalNormalCompileResult =>
-                registerUpdatedClasses(res, res.project)
-              case _ => ()
-            }
             stateWithResults.copy(status = ExitStatus.Ok)
           } else {
             results.foreach {
@@ -374,9 +318,12 @@ object CompileTask {
         runIOTasksInParallel(cleanUpTasksToRunInBackground)
 
         val runningTasksRequiredForCorrectness = Task.sequence {
-          results.collect {
+          results.flatMap {
             case FinalNormalCompileResult(_, result) =>
-              Task.fromFuture(result.runningBackgroundTasks)
+              val tasksAtEndOfBuildCompilation =
+                Task.fromFuture(result.runningBackgroundTasks)
+              List(tasksAtEndOfBuildCompilation)
+            case _ => Nil
           }
         }
 

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
@@ -23,6 +23,7 @@ import bloop.tracing.BraveTracer
 
 import monix.reactive.Observable
 import sbt.internal.inc.PlainVirtualFileConverter
+import bloop.ClientClassesObserver
 
 sealed trait CompileBundle
 
@@ -75,7 +76,7 @@ case object CancelledCompileBundle extends CompileBundle
  */
 final case class SuccessfulCompileBundle(
     project: Project,
-    clientClassesDir: AbsolutePath,
+    clientClassesObserver: ClientClassesObserver,
     dependenciesData: CompileDependenciesData,
     javaSources: List[AbsolutePath],
     scalaSources: List[AbsolutePath],
@@ -95,7 +96,7 @@ final case class SuccessfulCompileBundle(
       project.out,
       project.analysisOut,
       project.genericClassesDir,
-      clientClassesDir,
+      clientClassesObserver.classesDir,
       readOnlyClassesDir
     )
   }
@@ -152,7 +153,7 @@ object CompileBundle {
   def computeFrom(
       inputs: CompileDefinitions.BundleInputs,
       sourceGeneratorCache: SourceGeneratorCache,
-      clientExternalClassesDir: AbsolutePath,
+      clientClassesObserver: ClientClassesObserver,
       reporter: ObservedReporter,
       lastSuccessful: LastSuccessfulResult,
       lastResult: Compiler.Result,
@@ -228,7 +229,7 @@ object CompileBundle {
 
           new SuccessfulCompileBundle(
             project,
-            clientExternalClassesDir,
+            clientClassesObserver,
             compileDependenciesData,
             javaSources,
             scalaSources,

--- a/frontend/src/test/scala/bloop/dap/DebugAdapterConnection.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugAdapterConnection.scala
@@ -16,6 +16,7 @@ import com.microsoft.java.debug.core.protocol.Events
 import com.microsoft.java.debug.core.protocol.Requests._
 import com.microsoft.java.debug.core.protocol.Responses.ContinueResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.EvaluateResponseBody
+import com.microsoft.java.debug.core.protocol.Responses.RedefineClassesResponse
 import com.microsoft.java.debug.core.protocol.Responses.ScopesResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.SetBreakpointsResponseBody
 import com.microsoft.java.debug.core.protocol.Responses.StackTraceResponseBody
@@ -117,6 +118,11 @@ private[dap] final class DebugAdapterConnection(
     arguments.hostName = hostName
     arguments.port = port
     adapter.request(Attach, arguments)
+  }
+
+  def redefineClasses(): Task[RedefineClassesResponse] = {
+    val args = new RedefineClassesArguments()
+    adapter.request(RedefineClasses, args)
   }
 
   def close(): Unit = {

--- a/frontend/src/test/scala/bloop/dap/DebugAdapterConnection.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugAdapterConnection.scala
@@ -14,13 +14,7 @@ import bloop.task.Task
 
 import com.microsoft.java.debug.core.protocol.Events
 import com.microsoft.java.debug.core.protocol.Requests._
-import com.microsoft.java.debug.core.protocol.Responses.ContinueResponseBody
-import com.microsoft.java.debug.core.protocol.Responses.EvaluateResponseBody
-import com.microsoft.java.debug.core.protocol.Responses.RedefineClassesResponse
-import com.microsoft.java.debug.core.protocol.Responses.ScopesResponseBody
-import com.microsoft.java.debug.core.protocol.Responses.SetBreakpointsResponseBody
-import com.microsoft.java.debug.core.protocol.Responses.StackTraceResponseBody
-import com.microsoft.java.debug.core.protocol.Responses.VariablesResponseBody
+import com.microsoft.java.debug.core.protocol.Responses._
 import com.microsoft.java.debug.core.protocol.Types.Capabilities
 import monix.execution.Cancelable
 import monix.execution.Scheduler

--- a/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
@@ -1,11 +1,11 @@
 package bloop.dap
 
+import java.io.Closeable
 import java.net.ConnectException
 import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.util.NoSuchElementException
 import java.util.concurrent.TimeUnit.MILLISECONDS
-import java.util.concurrent.TimeUnit.SECONDS
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -14,15 +14,19 @@ import scala.concurrent.Promise
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
 import ch.epfl.scala.bsp
 import ch.epfl.scala.bsp.ScalaMainClass
 import ch.epfl.scala.debugadapter._
 
+import bloop.Cli
 import bloop.ScalaInstance
+import bloop.cli.CommonOptions
 import bloop.cli.ExitStatus
 import bloop.data.Platform
 import bloop.data.Project
+import bloop.engine.NoPool
 import bloop.engine.State
 import bloop.engine.tasks.RunMode
 import bloop.engine.tasks.Tasks
@@ -30,6 +34,7 @@ import bloop.internal.build
 import bloop.internal.build.BuildTestInfo
 import bloop.io.AbsolutePath
 import bloop.io.Environment.lineSeparator
+import bloop.logging.BspClientLogger
 import bloop.logging.Logger
 import bloop.logging.LoggerAction
 import bloop.logging.LoggerAction.LogInfoMessage
@@ -48,84 +53,11 @@ import coursierapi.Dependency
 import coursierapi.Fetch
 import monix.execution.Ack
 import monix.reactive.Observer
-import io.reactivex.Observable
 
 object DebugServerSpec extends DebugBspBaseSuite {
   private val ServerNotListening = new IllegalStateException("Server is not accepting connections")
   private val Success: ExitStatus = ExitStatus.Ok
   private val resolver = new BloopDebugToolsResolver(NoopLogger)
-
-  testTask("Performs Hot Code Replace", FiniteDuration(16, SECONDS)) {
-    val source2 =
-      """|/example/Main.scala
-         |package example
-         |class A {
-         |  def m() = {
-         |    println("B")
-         |  }
-         |}
-         |""".stripMargin
-    TestUtil.withinWorkspace { workspace =>
-      val source =
-        """|/Main.scala
-           |import example.A
-           |object Main {
-           |  def main(args: Array[String]): Unit = {
-           |    println("A")
-           |    new A().m()
-           |  }
-           |}
-           |""".stripMargin
-      val Asource =
-        """|/example/A.scala
-           |package example
-           |class A {
-           |  def m() = {
-           |    println("A")
-           |  }
-           |}
-           |""".stripMargin
-
-      val logger = new RecordingLogger(ansiCodesSupported = false)
-      val projectDep = TestProject(workspace, "a", List(Asource))
-      val mainProject = TestProject(workspace, "r", List(source), List(projectDep))
-
-      loadBspStateWithTask(workspace, List(mainProject, projectDep), logger) { state =>
-        val testState = state.compile(mainProject).toTestState
-        val buildProject = testState.getProjectFor(mainProject)
-        def srcFor(srcName: String) =
-          buildProject.sources.map(_.resolve(s"$srcName")).find(_.exists).get
-        val `A.scala` = srcFor("../../a/src/example/A.scala")
-        val breakpoints = breakpointsArgs(srcFor("Main.scala"), 5)
-
-        val runner = mainRunner(mainProject, state)
-
-        startDebugServer(runner) { server =>
-          for {
-            client <- server.startConnection
-            _ <- client.initialize()
-            _ <- client.launch(noDebug = false)
-            _ <- client.initialized
-            bps <- client.setBreakpoints(breakpoints)
-            _ = assert(bps.breakpoints.forall(_.verified))
-            _ <- client.configurationDone()
-            stopped <- client.stopped
-            _ = writeFile(`A.scala`, source2)
-            _ = state.compile(mainProject)
-            _ <- client.redefineClasses()
-            _ <- client.continue(stopped.threadId)
-            _ <- client.exited
-            _ <- client.terminated
-            _ <- Task.fromFuture(client.closedPromise.future)
-            output <- client.takeCurrentOutput
-          } yield {
-            assert(client.socket.isClosed)
-            assertNoDiff(output, "A\nB")
-          }
-        }
-      }
-    }
-  }
 
   testTask("cancelling server closes server connection", FiniteDuration(10, SECONDS)) {
     startDebugServer(Task.now(Success)) { server =>
@@ -1037,6 +969,87 @@ object DebugServerSpec extends DebugBspBaseSuite {
     }
   }
 
+  testTask("hot code replace", 30.seconds) {
+    val mainSource =
+      """|/Main.scala
+         |object Main {
+         |  def main(args: Array[String]): Unit = {
+         |    val a = new example.A
+         |    a.m()
+         |  }
+         |}
+         |""".stripMargin
+    val originalSource =
+      """|/example/A.scala
+         |package example
+         |class A {
+         |  def m() = {
+         |    println("A")
+         |  }
+         |}
+         |""".stripMargin
+    val modifiedSource =
+      """|/example/A.scala
+         |package example
+         |class A {
+         |  def m() = {
+         |    println("B")
+         |  }
+         |}
+         |""".stripMargin
+    val logger = new RecordingLogger(ansiCodesSupported = false)
+    TestUtil.withinWorkspace { workspace =>
+      val dependency = TestProject(workspace, "a", List(originalSource))
+      val mainProject = TestProject(workspace, "main", List(mainSource), List(dependency))
+      val configDir = TestProject.populateWorkspace(workspace, List(mainProject, dependency))
+
+      def cliCompile(project: TestProject) = {
+        val compileArgs = Array("compile", project.config.name, "--config-dir", configDir.syntax)
+        val compileAction = Cli.parse(compileArgs, CommonOptions.default)
+        Task.eval(Cli.run(compileAction, NoPool)).executeAsync
+      }
+
+      def bspCommand() = createBspCommand(configDir)
+      val state = TestUtil.loadTestProject(configDir.underlying, logger)
+      openBspConnection(state, bspCommand, configDir, new BspClientLogger(logger))
+        .withinSession { state =>
+          val testState = state.compile(mainProject).toTestState
+          val `A.scala` = testState
+            .getProjectFor(dependency)
+            .sources
+            .map(_.resolve("example/A.scala"))
+            .find(_.exists)
+            .get
+
+          val runner = mainRunner(mainProject, state)
+          startDebugServer(runner) { server =>
+            for {
+              client <- server.startConnection
+              _ <- client.initialize()
+              _ <- client.launch(noDebug = false)
+              _ <- client.initialized
+              response <- client.setBreakpoints(breakpointsArgs(`A.scala`, 4))
+              _ = assert(response.breakpoints.forall(_.verified))
+              _ <- client.configurationDone()
+              stopped <- client.stopped
+              _ = writeFile(`A.scala`, modifiedSource)
+              _ <- cliCompile(mainProject) // another client trigger a compilation
+              _ = state.compile(mainProject) // noop
+              _ <- client.redefineClasses()
+              _ <- client.continue(stopped.threadId)
+              _ <- client.exited
+              _ <- client.terminated
+              _ <- Task.fromFuture(client.closedPromise.future)
+              output <- client.takeCurrentOutput
+            } yield {
+              assert(client.socket.isClosed)
+              assertNoDiff(output, "B")
+            }
+          }
+        }
+    }
+  }
+
   private def startRemoteProcess(buildProject: Project, testState: TestState): Task[Int] = {
     val attachPort = Promise[Int]()
 
@@ -1169,13 +1182,14 @@ object DebugServerSpec extends DebugBspBaseSuite {
       override def modules: Seq[Module] = Seq.empty
       override def libraries: Seq[Library] = Seq.empty
       override def unmanagedEntries: Seq[UnmanagedEntry] = Seq.empty
-      override val classesToUpdate = Observable.empty[Seq[String]]
       override def javaRuntime: Option[JavaRuntime] = None
       def name: String = "MockRunner"
       def run(listener: DebuggeeListener): CancelableFuture[Unit] = {
-        DapCancellableFuture.runAsync(task.map(_ => ()), defaultScheduler)
+        DapCancellableFuture.runAsync(task.map(_ => ()))(defaultScheduler)
       }
       def scalaVersion: ScalaVersion = ScalaVersion("2.12.17")
+
+      override def observeClassUpdates(onClassUpdate: Seq[String] => Unit): Closeable = () => ()
     }
 
     startDebugServer(
@@ -1188,7 +1202,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
 
   def startDebugServer(
       debuggee: Debuggee,
-      gracePeriod: Duration = Duration(5, SECONDS)
+      gracePeriod: Duration = 5.seconds
   )(f: TestServer => Task[Unit]): Task[Unit] = {
     val logger = new RecordingLogger(ansiCodesSupported = false)
     val dapLogger = new DebugServerLogger(logger)
@@ -1215,7 +1229,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
     override def close(): Unit = {
       cancel()
       val allClientsClosed = clients.map(c => Task.fromFuture(c.closedPromise.future))
-      TestUtil.await(10, SECONDS)(Task.sequence(allClientsClosed)); ()
+      TestUtil.await(10.seconds)(Task.sequence(allClientsClosed)); ()
     }
 
     def startConnection: Task[DebugAdapterConnection] = Task {

--- a/frontend/src/test/scala/bloop/dap/DebugTestEndpoints.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugTestEndpoints.scala
@@ -4,12 +4,7 @@ import bloop.dap.DebugTestProtocol._
 
 import com.microsoft.java.debug.core.protocol.Events
 import com.microsoft.java.debug.core.protocol.Requests._
-import com.microsoft.java.debug.core.protocol.Responses.ContinueResponseBody
-import com.microsoft.java.debug.core.protocol.Responses.EvaluateResponseBody
-import com.microsoft.java.debug.core.protocol.Responses.ScopesResponseBody
-import com.microsoft.java.debug.core.protocol.Responses.SetBreakpointsResponseBody
-import com.microsoft.java.debug.core.protocol.Responses.StackTraceResponseBody
-import com.microsoft.java.debug.core.protocol.Responses.VariablesResponseBody
+import com.microsoft.java.debug.core.protocol.Responses._
 import com.microsoft.java.debug.core.protocol.Types
 
 private[dap] object DebugTestEndpoints {
@@ -24,6 +19,8 @@ private[dap] object DebugTestEndpoints {
   val Variables = new Request[VariablesArguments, VariablesResponseBody]("variables")
   val Evaluate = new Request[EvaluateArguments, EvaluateResponseBody]("evaluate")
   val Continue = new Request[ContinueArguments, ContinueResponseBody]("continue")
+  val RedefineClasses =
+    new Request[RedefineClassesArguments, RedefineClassesResponse]("redefineClasses")
   val ConfigurationDone = new Request[Unit, Unit]("configurationDone")
 
   val Exited = new Event[Events.ExitedEvent]("exited")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,7 +45,7 @@ object Dependencies {
   val asmVersion = "9.6"
   val snailgunVersion = "0.4.0"
   val ztExecVersion = "1.12"
-  val debugAdapterVersion = "3.1.6"
+  val debugAdapterVersion = "4.0.0"
   val bloopConfigVersion = "1.5.5"
   val semanticdbVersion = "4.7.8"
   val zinc = "org.scala-sbt" %% "zinc" % zincVersion
@@ -60,7 +60,7 @@ object Dependencies {
   val scalazCore = "org.scalaz" %% "scalaz-core" % scalazVersion
   val coursierInterface = "io.get-coursier" % "interface" % "1.0.19"
   val coursierInterfaceSubs = "io.get-coursier" % "interface-svm-subs" % "1.0.19"
-  val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.2"
+  val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0"
   val shapeless = "com.chuusai" %% "shapeless" % shapelessVersion
   val caseApp = "com.github.alexarchambault" %% "case-app" % caseAppVersion
   val sourcecode = "com.lihaoyi" %% "sourcecode" % sourcecodeVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,7 +45,7 @@ object Dependencies {
   val asmVersion = "9.6"
   val snailgunVersion = "0.4.0"
   val ztExecVersion = "1.12"
-  val debugAdapterVersion = "4.0.0"
+  val debugAdapterVersion = "4.0.1"
   val bloopConfigVersion = "1.5.5"
   val semanticdbVersion = "4.7.8"
   val zinc = "org.scala-sbt" %% "zinc" % zincVersion


### PR DESCRIPTION
The new 4.x version of the scala-debug-adpater brings:
- pretty stack traces
- runtime evaluator (scalameta-based evaluation on runtime values)
- hot code replace

See the [release notes](https://github.com/scalacenter/scala-debug-adapter/releases/tag/v4.0.0) for more information.

For the hot code replace we need Bloop to call the `onClassUpdate` callback each time some classes change or new classes are created. This PR implements it by introducing the `ClientClassesObserver`. It compares the new `CompileAnalysis` with the previous one to know which classes need to be reloaded and then it calls the `onClassUpdate` callback.