### PR TITLE
Revert "build(deps): Update sbt, test-agent from 1.9.8 to 1.9.9"

### DIFF
--- a/frontend/src/test/resources/compiler-plugin-allowlist/project/build.properties
+++ b/frontend/src/test/resources/compiler-plugin-allowlist/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.9.9
+sbt.version=1.9.8
 

--- a/frontend/src/test/resources/cross-test-build-scala-native-0.4/project/build.properties
+++ b/frontend/src/test/resources/cross-test-build-scala-native-0.4/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.9.9
+sbt.version=1.9.8
 

--- a/frontend/src/test/resources/cross-test-build-scalajs-0.6/project/build.properties
+++ b/frontend/src/test/resources/cross-test-build-scalajs-0.6/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.9.8

--- a/frontend/src/test/resources/cross-test-build-scalajs-1.0/project/build.properties
+++ b/frontend/src/test/resources/cross-test-build-scalajs-1.0/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.9.8

--- a/frontend/src/test/resources/cross-test-build-scalajs-1.x/project/build.properties
+++ b/frontend/src/test/resources/cross-test-build-scalajs-1.x/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.9.8

--- a/frontend/src/test/resources/custom-test-framework/project/build.properties
+++ b/frontend/src/test/resources/custom-test-framework/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.9.8

--- a/frontend/src/test/resources/no-test-frameworks/project/project/build.properties
+++ b/frontend/src/test/resources/no-test-frameworks/project/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.9.8

--- a/frontend/src/test/resources/scala-seed-project/project/build.properties
+++ b/frontend/src/test/resources/scala-seed-project/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.9.8

--- a/frontend/src/test/resources/simple-build/project/build.properties
+++ b/frontend/src/test/resources/simple-build/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.9.8

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val caseAppVersion = "2.0.6"
   val sourcecodeVersion = "0.3.1"
   val sbtTestInterfaceVersion = "1.0"
-  val sbtTestAgentVersion = "1.9.9"
+  val sbtTestAgentVersion = "1.9.8"
   val junitVersion = "0.13.3"
   val directoryWatcherVersion = "0.8.0+6-f651bd93"
   val monixVersion = "3.2.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.9.8


### PR DESCRIPTION
This reverts commit 0032c7fa743db98adb14e9430592eb7143948250.

Looks like native image executable is not being found since that version 