### PR TITLE
Implement BSP buildTarget/outputPaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ support many different workflows and allow bespoke integrations.
 | ❓Questions? Unsure if bloop is useful for your use case? Ask right away in our [Discord channel](https://discord.gg/KWF9zMhJWS)! |
 
 [discord]: https://discord.gg/KWF9zMhJWS
-[contributing]: https://scalacenter.github.io/bloop/docs/developer-documentation/
+[contributing]: https://scalacenter.github.io/bloop/docs/contributing-guide
 [coc]: https://www.scala-lang.org/conduct/

--- a/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
@@ -349,6 +349,19 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
       TestUtil.await(FiniteDuration(5, "s"))(resourcesTask)
     }
 
+    def requestOutputPaths(project: TestProject): bsp.OutputPathsResult = {
+      val outputPathsTask = {
+        client0
+          .request(endpoints.BuildTarget.outputPaths, bsp.OutputPathsParams(List(project.bspId)))
+          .map {
+            case RpcFailure(_, error) => fail(s"Received error ${error}")
+            case RpcSuccess(resources, _) => resources
+          }
+      }
+
+      TestUtil.await(FiniteDuration(5, "s"))(outputPathsTask)
+    }
+
     def requestDependencyModules(project: TestProject): bsp.DependencyModulesResult = {
       val dependencyModulesTask = {
         client0

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -510,6 +510,37 @@ class BspProtocolSpec(
     }
   }
 
+  test("outputPaths request works") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      loadBspBuildFromResources("cross-test-build-scalajs-0.6", workspace, logger) { build =>
+        val mainProject = build.projectFor("test-project")
+        val testProject = build.projectFor("test-project-test")
+        val mainJsProject = build.projectFor("test-projectJS")
+        val testJsProject = build.projectFor("test-projectJS-test")
+        val rootMain = build.projectFor("cross-test-build-scalajs-0-6")
+        val rootTest = build.projectFor("cross-test-build-scalajs-0-6-test")
+
+        def checkOutputPaths(project: TestProject): Unit = {
+          val outputPathsResult = build.state.requestOutputPaths(project)
+          assert(outputPathsResult.items.size == 1)
+          val outputPathsItem = outputPathsResult.items.head
+          assert(outputPathsItem.target == project.bspId)
+          val outputPaths = outputPathsItem.outputPaths.map(_.uri.toPath)
+          val expectedOutputPaths = List(project.config.out.toAbsolutePath())
+          assert(outputPaths == expectedOutputPaths)
+        }
+
+        checkOutputPaths(mainProject)
+        checkOutputPaths(testProject)
+        checkOutputPaths(mainJsProject)
+        checkOutputPaths(testJsProject)
+        checkOutputPaths(rootMain)
+        checkOutputPaths(rootTest)
+      }
+    }
+  }
+
   test("dependency modules request works") {
     TestUtil.withinWorkspace { workspace =>
       val logger = new RecordingLogger(ansiCodesSupported = false)

--- a/frontend/src/test/scala/bloop/bsp/TestConstants.scala
+++ b/frontend/src/test/scala/bloop/bsp/TestConstants.scala
@@ -18,6 +18,7 @@ object TestConstants {
         "dependencySourcesProvider": true,
         "dependencyModulesProvider": true,
         "resourcesProvider": true,
+        "outputPathsProvider":true,
         "buildTargetChangedProvider": false,
         "jvmRunEnvironmentProvider": true,
         "jvmTestEnvironmentProvider": true,


### PR DESCRIPTION
This fixes build-server-protocol/build-server-protocol#205 when importing from bloop by reporting the `target/` folder of each project as an outputPath.

In my case I am using it with bloop-maven-plugin.