### PR TITLE
Fix reporting after deduplicating compilations

### DIFF
--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
@@ -197,7 +197,7 @@ object CompileGraph {
                 case a: ReporterAction.ProcessEndCompilation =>
                   a.code match {
                     case BspStatusCode.Cancelled | BspStatusCode.Error =>
-                      reporter.processEndCompilation(previousSuccessfulProblems, a.code, None, None)
+                      reporter.processEndCompilation(previousProblems, a.code, None, None)
                       reporter.reportEndCompilation()
                     case _ =>
                       /*
@@ -207,7 +207,7 @@ object CompileGraph {
                        * can use `taskFinish` notifications as a signal to process them.
                        */
                       reporter.processEndCompilation(
-                        previousSuccessfulProblems,
+                        previousProblems,
                         a.code,
                         Some(clientClassesObserver.classesDir),
                         Some(bundle.out.analysisOut)


### PR DESCRIPTION
Previously in some cases when deduplicating bloop would report the `previousSuccessfulProblems` in which case bsp clients like metals could have their diagnostics overwritten with outdated ones (so here we use `previousProblems` instead).