### PR TITLE
bugfix: Don't add -release flag if target is already present

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -639,7 +639,9 @@ object Compiler {
     def existsReleaseSetting = scalacOptions.exists(opt =>
       opt.startsWith("-release") ||
         opt.startsWith("--release") ||
-        opt.startsWith("-java-output-version")
+        opt.startsWith("-java-output-version") ||
+        opt.startsWith("-Xtarget") ||
+        opt.startsWith("-target")
     )
     def sameHome = javacBin match {
       case Some(bin) => bin.getParent.getParent == JavaRuntime.home


### PR DESCRIPTION
The flags should not be used together and might cause unexpected issues