### PR TITLE
Add support for BSP TestParamsData kinds

### DIFF
--- a/frontend/src/test/scala/bloop/bsp/BspTestSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspTestSpec.scala
@@ -7,6 +7,13 @@ import bloop.io.AbsolutePath
 import bloop.logging.RecordingLogger
 import bloop.util.TestProject
 import bloop.util.TestUtil
+import com.github.plokhotnyuk.jsoniter_scala.core.writeToArray
+import jsonrpc4s.RawJson
+import ch.epfl.scala.bsp.ScalaTestParams
+import ch.epfl.scala.bsp.ScalaTestClassesItem
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+import ch.epfl.scala.bsp.ScalaTestSuites
+import ch.epfl.scala.bsp.ScalaTestSuiteSelection
 
 object TcpBspTestSpec extends BspTestSpec(BspProtocol.Tcp)
 object LocalBspTestSpec extends BspTestSpec(BspProtocol.Local)
@@ -31,6 +38,286 @@ class BspTestSpec(override val protocol: BspProtocol) extends BspBaseSuite {
       loadBspState(workspace, List(A), logger) { state =>
         val testResult: ManagedBspTestState = state.test(A)
         assertExitStatus(testResult, ExitStatus.Ok)
+      }
+    }
+  }
+
+  test("Test only when datakind is scala-test succeeds in testing only one test suite") {
+    TestUtil.withinWorkspace { workspace =>
+      val sources = List(
+        """/FooTest.scala
+          |class FooTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(false)
+          |}
+          """.stripMargin,
+        """/BarTest.scala
+          |class BarTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(true)
+          |}
+          """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+
+      val A = TestProject(workspace, "a", sources, enableTests = true, jars = junitJars)
+      loadBspState(workspace, List(A), logger) { state =>
+        val cls =
+          state.testClasses(A)
+
+        val classes =
+          Some(
+            List(
+              ScalaTestClassesItem(cls.items.head.target, cls.items.head.framework, List("BarTest"))
+            )
+          )
+
+        val data = RawJson(writeToArray(ScalaTestParams(classes, None)))
+
+        val testResult: ManagedBspTestState =
+          state.test(A, dataKind = Some("scala-test"), data = Some(data))
+        assertExitStatus(testResult, ExitStatus.Ok)
+      }
+    }
+  }
+
+  test("Test only when datakind is scala-test fails in testing only one test suite") {
+    TestUtil.withinWorkspace { workspace =>
+      val sources = List(
+        """/FooTest.scala
+          |class FooTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(true)
+          |}
+          """.stripMargin,
+        """/BarTest.scala
+          |class BarTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(false)
+          |}
+          """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+
+      val A = TestProject(workspace, "a", sources, enableTests = true, jars = junitJars)
+      loadBspState(workspace, List(A), logger) { state =>
+        val cls =
+          state.testClasses(A)
+
+        val classes =
+          Some(
+            List(
+              ScalaTestClassesItem(cls.items.head.target, cls.items.head.framework, List("BarTest"))
+            )
+          )
+
+        val data = RawJson(writeToArray(ScalaTestParams(classes, None)))
+
+        val testResult: ManagedBspTestState =
+          state.test(A, dataKind = Some("scala-test"), data = Some(data))
+        assertExitStatus(testResult, ExitStatus.TestExecutionError)
+      }
+    }
+  }
+
+  test("Test only when datakind is scala-test-suites succeeds in testing only one test suite") {
+    TestUtil.withinWorkspace { workspace =>
+      val sources = List(
+        """/FooTest.scala
+          |class FooTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(false)
+          |}
+          """.stripMargin,
+        """/BarTest.scala
+          |class BarTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(true)
+          |}
+          """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+
+      val A = TestProject(workspace, "a", sources, enableTests = true, jars = junitJars)
+      loadBspState(workspace, List(A), logger) { state =>
+        val classes = writeToArray(List("BarTest"))(JsonCodecMaker.make[List[String]])
+        val data = RawJson(classes)
+
+        val testResult: ManagedBspTestState =
+          state.test(A, dataKind = Some("scala-test-suites"), data = Some(data))
+        assertExitStatus(testResult, ExitStatus.Ok)
+      }
+    }
+  }
+
+  test("Test only when datakind is scala-test-suites fails in testing only one test suite") {
+    TestUtil.withinWorkspace { workspace =>
+      val sources = List(
+        """/FooTest.scala
+          |class FooTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(true)
+          |}
+          """.stripMargin,
+        """/BarTest.scala
+          |class BarTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(false)
+          |}
+          """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+
+      val A = TestProject(workspace, "a", sources, enableTests = true, jars = junitJars)
+      loadBspState(workspace, List(A), logger) { state =>
+        val classes = writeToArray(List("BarTest"))(JsonCodecMaker.make[List[String]])
+        val data = RawJson(classes)
+
+        val testResult: ManagedBspTestState =
+          state.test(A, dataKind = Some("scala-test-suites"), data = Some(data))
+        assertExitStatus(testResult, ExitStatus.TestExecutionError)
+      }
+    }
+  }
+
+  test(
+    "Test only when datakind is scala-test-suites-selection succeeds in testing only one test suite"
+  ) {
+    TestUtil.withinWorkspace { workspace =>
+      val sources = List(
+        """/FooTest.scala
+          |class FooTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(false)
+          |}
+          """.stripMargin,
+        """/BarTest.scala
+          |class BarTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(true)
+          |}
+          """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+
+      val A = TestProject(workspace, "a", sources, enableTests = true, jars = junitJars)
+
+      loadBspState(workspace, List(A), logger) { state =>
+        val testSuites = ScalaTestSuites(
+          List(ScalaTestSuiteSelection("BarTest", Nil)),
+          Nil,
+          Nil
+        )
+        val data = RawJson(writeToArray(testSuites))
+
+        val testResult: ManagedBspTestState =
+          state.test(A, dataKind = Some("scala-test-suites-selection"), data = Some(data))
+        assertExitStatus(testResult, ExitStatus.Ok)
+      }
+    }
+  }
+
+  test(
+    "Test only when datakind is scala-test-suites-selection fails in testing only one test suite"
+  ) {
+    TestUtil.withinWorkspace { workspace =>
+      val sources = List(
+        """/FooTest.scala
+          |class FooTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(true)
+          |}
+          """.stripMargin,
+        """/BarTest.scala
+          |class BarTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(false)
+          |}
+          """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+
+      val A = TestProject(workspace, "a", sources, enableTests = true, jars = junitJars)
+
+      loadBspState(workspace, List(A), logger) { state =>
+        val testSuites = ScalaTestSuites(
+          List(ScalaTestSuiteSelection("BarTest", Nil)),
+          Nil,
+          Nil
+        )
+        val data = RawJson(writeToArray(testSuites))
+
+        val testResult: ManagedBspTestState =
+          state.test(A, dataKind = Some("scala-test-suites-selection"), data = Some(data))
+        assertExitStatus(testResult, ExitStatus.TestExecutionError)
+      }
+    }
+  }
+
+  test(
+    "Test only when datakind is scala-test-suites-selection succeeds in testing only one test suite with specific test"
+  ) {
+    TestUtil.withinWorkspace { workspace =>
+      val sources = List(
+        """/FooTest.scala
+          |class FooTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(false)
+          |}
+          """.stripMargin,
+        """/BarTest.scala
+          |class BarTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(false)
+          |  @org.junit.Test def bar(): Unit = org.junit.Assert.assertTrue(true)
+          |}
+          """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+
+      val A = TestProject(workspace, "a", sources, enableTests = true, jars = junitJars)
+
+      loadBspState(workspace, List(A), logger) { state =>
+        val testSuites = ScalaTestSuites(
+          List(ScalaTestSuiteSelection("BarTest", List("bar"))),
+          Nil,
+          Nil
+        )
+        val data = RawJson(writeToArray(testSuites))
+
+        val testResult: ManagedBspTestState =
+          state.test(A, dataKind = Some("scala-test-suites-selection"), data = Some(data))
+        assertExitStatus(testResult, ExitStatus.Ok)
+      }
+    }
+  }
+
+  test(
+    "Test only when datakind is scala-test-suites-selection fails in testing only one test suite with specific test"
+  ) {
+    TestUtil.withinWorkspace { workspace =>
+      val sources = List(
+        """/FooTest.scala
+          |class FooTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(false)
+          |}
+          """.stripMargin,
+        """/BarTest.scala
+          |class BarTest {
+          |  @org.junit.Test def foo(): Unit = org.junit.Assert.assertTrue(true)
+          |  @org.junit.Test def bar(): Unit = org.junit.Assert.assertTrue(false)
+          |}
+          """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+
+      val A = TestProject(workspace, "a", sources, enableTests = true, jars = junitJars)
+
+      loadBspState(workspace, List(A), logger) { state =>
+        val testSuites = ScalaTestSuites(
+          List(ScalaTestSuiteSelection("BarTest", List("bar"))),
+          Nil,
+          Nil
+        )
+        val data = RawJson(writeToArray(testSuites))
+
+        val testResult: ManagedBspTestState =
+          state.test(A, dataKind = Some("scala-test-suites-selection"), data = Some(data))
+        assertExitStatus(testResult, ExitStatus.TestExecutionError)
       }
     }
   }


### PR DESCRIPTION
Adds support for TestParamsData kinds as defined in the scala extension of BSP. This allows clients to specify which test classes / tests to run

Relevant bsp documentation:  https://build-server-protocol.github.io/docs/extensions/scala#testparamsdata-kinds

Fixed a bug? in the TestTask.discoverTestSuites where it did not filter on which test should should
run when explicitly passing list of test classes (fully qualified)

Included tests for running specific test suites, and tests within suites