### PR TITLE
Fix recent regressions not allowing Metals to pass its tests 

### DIFF
--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -436,7 +436,7 @@ final class BloopBspServices(
     }
 
     val isPipeline = compileArgs.exists(_ == "--pipeline")
-    val isBestEffort = compileArgs.exists(_ == "--best-effort")
+    val bestEffortAllowed = compileArgs.exists(_ == "--best-effort")
     def compile(projects: List[Project]): Task[State] = {
       val config = ReporterConfig.defaultFormat.copy(reverseOrder = false)
 
@@ -486,7 +486,7 @@ final class BloopBspServices(
         dag,
         createReporter,
         isPipeline,
-        isBestEffort,
+        bestEffortAllowed,
         cancelCompilation,
         store,
         logger

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -173,7 +173,7 @@ object Interpreter {
         dag,
         createReporter,
         cmd.pipeline,
-        bestEffort = false,
+        bestEffortAllowed = false,
         Promise[Unit](),
         CompileClientStore.NoStore,
         state.logger

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -337,7 +337,7 @@ object TestTask {
         taskDefs.map {
           case TaskDefWithFramework(taskDef, _) =>
             selectedTests.get(taskDef.fullyQualifiedName()) match {
-              case None =>
+              case None | Some(Nil) =>
                 taskDef
               case Some(value) =>
                 new TaskDef(


### PR DESCRIPTION
Previously, if `--best-effort` option was set, every project would be compiled in the best effort mode, including those using scala 2. This first commit fixes the `CodeLensLspSuite` test. `DebugProtocolSuite` might have been broken by 7154823d8acdd3ceb05bd5000d62d869515851a7 (before that merge it works), <s>but I am still investigating that (or maybe the broken metals test should change?) </s>