### PR TITLE
refactor: Keep daemon socket used by Scala Cli

### DIFF
--- a/cli/src/main/scala/bloop/cli/Directories.scala
+++ b/cli/src/main/scala/bloop/cli/Directories.scala
@@ -37,7 +37,7 @@ object Directories {
       else
         GetWinDirs.powerShellBased
 
-    OsLocations(ProjectDirectories.from(null, null, "bloop", getWinDirs))
+    OsLocations(ProjectDirectories.from(null, null, "ScalaCli", getWinDirs))
   }
 
   def under(dir: os.Path): Directories =


### PR DESCRIPTION
This way at least Scala CLI will be able to restart the old server without an issue and not start a totally new one. For Bloop core unfortunately people might need to stop it manually