### PR TITLE
improvement: Generate static fallback map if can't use complete deps …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -134,7 +134,8 @@ lazy val frontend: Project = project
       "nativeBridge04" -> (nativeBridge04Name + "_" + Keys.scalaBinaryVersion.value),
       "nativeBridge05" -> (nativeBridge05Name + "_" + Keys.scalaBinaryVersion.value),
       "jsBridge06" -> (jsBridge06Name + "_" + Keys.scalaBinaryVersion.value),
-      "jsBridge1" -> (jsBridge1Name + "_" + Keys.scalaBinaryVersion.value)
+      "jsBridge1" -> (jsBridge1Name + "_" + Keys.scalaBinaryVersion.value),
+      "lastSupportedSemanticdb" -> build.SemanticDbSupport.last
     ),
     (run / javaOptions) ++= jvmOptions,
     (Test / javaOptions) ++= jvmOptions,

--- a/frontend/src/main/scala/bloop/engine/caches/SemanticDBCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/SemanticDBCache.scala
@@ -21,6 +21,7 @@ import bloop.logging.Logger
 import sbt.internal.inc.BloopComponentCompiler
 import sbt.internal.inc.BloopComponentManager
 import sbt.internal.inc.IfMissing
+import bloop.internal.build.BuildInfo
 
 object SemanticDBCache {
   // to avoid resolving the same fallback semanticdb version multiple times
@@ -91,7 +92,9 @@ object SemanticDBCache {
         case _: Throwable => None
       }
 
-    Option(supportedFallbackSemanticdbVersions.get(scalaVersion)).orElse(version) match {
+    Option(supportedFallbackSemanticdbVersions.get(scalaVersion))
+      .orElse(version)
+      .orElse(BuildInfo.lastSupportedSemanticdb.get(scalaVersion)) match {
       case None =>
         Left(s"After retry no existing semanticdb version found for scala version $scalaVersion")
       case Some(semanticdbVersion) =>

--- a/project/SemanticDbSupport.scala
+++ b/project/SemanticDbSupport.scala
@@ -1,0 +1,35 @@
+package build
+
+import scala.jdk.CollectionConverters._
+
+object SemanticDbSupport {
+
+  private val Scala211Versions = getVersions(2, 11, 12 to 12)
+  private val last212 = Dependencies.Scala212Version.split('.').last.toInt
+  private val Scala212Versions = getVersions(2, 12, 9 to last212)
+  private val last213 = Dependencies.Scala213Version.split('.').last.toInt
+  private val Scala213Versions = getVersions(2, 13, 1 to last213)
+
+  private val AllScalaVersions =
+    Scala213Versions ++ Scala212Versions ++ Scala211Versions
+
+  val last: Map[String, String] = AllScalaVersions.flatMap { scalaVersion =>
+    coursierapi.Complete
+      .create()
+      .withScalaVersion(scalaVersion)
+      .withScalaBinaryVersion(scalaVersion.split('.').take(2).mkString("."))
+      .withInput(s"org.scalameta:semanticdb-scalac_$scalaVersion:")
+      .complete()
+      .getCompletions()
+      .asScala
+      .reverse
+      .headOption
+      .map(scalaVersion -> _)
+  }.toMap
+
+  // returns versions from newest to oldest
+  private def getVersions(major: Int, minor: Int, range: Range) = {
+    val desc = if (range.step > 0) range.reverse else range
+    desc.map { x => s"$major.$minor.$x" }
+  }
+}


### PR DESCRIPTION
…from coursier

This might happen with proxies or custom repositories. coursier complere really just works with Maven central