### PR TITLE
chore: Rename cli to bloop-cli

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -195,7 +195,7 @@ lazy val frontend: Project = project
   )
 
 lazy val cliSettings = Seq(
-  name := "cli",
+  name := "bloop-cli",
   scalaVersion := Dependencies.Scala213Version,
   (run / fork) := true,
   (Test / fork) := true,


### PR DESCRIPTION
I noticed that otherwise this gets published as ch.epfl.scala:cli_2.13:2.0.0 which is maybe too short a name and doesn't say what it is best.