### PR TITLE
Remove betasty directory on successful compilation backgroundTasks

### DIFF
--- a/backend/src/main/scala/bloop/BloopClassFileManager.scala
+++ b/backend/src/main/scala/bloop/BloopClassFileManager.scala
@@ -219,36 +219,20 @@ final class BloopClassFileManager(
           clientTracer.traceTaskVerbose("copy new products to external classes dir") { _ =>
             val config =
               ParallelOps.CopyConfiguration(5, CopyMode.ReplaceExisting, Set.empty, Set.empty)
-            val clientExternalBestEffortDir =
-              clientExternalClassesDir.underlying.resolve("META-INF/best-effort")
 
-            // Deletes all previous best-effort artifacts to get rid of all of the outdated ones.
-            // Since best effort compilation is not affected by incremental compilation,
-            // all relevant files are always produced by the compiler. Because of this,
-            // we can always delete all previous files and copy newly created ones
-            // without losing anything in the process.
-            val deleteClientExternalBestEffortDir =
-              Task {
-                if (Files.exists(clientExternalBestEffortDir)) {
-                  BloopPaths.delete(AbsolutePath(clientExternalBestEffortDir))
-                }
+            ParallelOps
+              .copyDirectories(config)(
+                newClassesDir,
+                clientExternalClassesDir.underlying,
+                inputs.ioScheduler,
+                enableCancellation = false,
+                inputs.logger
+              )
+              .map { walked =>
+                readOnlyCopyDenylist.++=(walked.target)
                 ()
-              }.memoize
-
-            deleteClientExternalBestEffortDir *>
-              ParallelOps
-                .copyDirectories(config)(
-                  newClassesDir,
-                  clientExternalClassesDir.underlying,
-                  inputs.ioScheduler,
-                  enableCancellation = false,
-                  inputs.logger
-                )
-                .map { walked =>
-                  readOnlyCopyDenylist.++=(walked.target)
-                  ()
-                }
-                .flatMap(_ => deleteAfterCompilation)
+              }
+              .flatMap(_ => deleteAfterCompilation)
           }
         }
       )

--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -1016,12 +1016,9 @@ object Compiler {
               BloopClassFileManager.supportedCompileProducts.filter(_ != ".betasty") :+ ".class"
             Files
               .walk(clientClassesDir.underlying)
-              .filter(path =>
-                Files.isRegularFile(path) && deletedCompileProducts.exists(
-                  path.toString.endsWith(_)
-                )
-              )
-              .forEach(path => if (Files.exists(path)) Files.delete(path))
+              .filter(path => Files.isRegularFile(path))
+              .filter(path => deletedCompileProducts.exists(path.toString.endsWith(_)))
+              .forEach(Files.delete(_))
           }.map(_ => ())
         }
 

--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -1,6 +1,8 @@
 package bloop
 
 import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Optional
@@ -742,9 +744,13 @@ object Compiler {
               Result.Failed(failedProblems, None, elapsed, backgroundTasks, None)
             case t: Throwable =>
               t.printStackTrace()
+              val sw = new StringWriter()
+              t.printStackTrace(new PrintWriter(sw))
+              logger.info(sw.toString())
               val backgroundTasks =
                 toBackgroundTasks(backgroundTasksForFailedCompilation.toList)
-              Result.Failed(Nil, Some(t), elapsed, backgroundTasks, None)
+              val failedProblems = findFailedProblems(reporter, None)
+              Result.Failed(failedProblems, Some(t), elapsed, backgroundTasks, None)
           }
       }
   }

--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -5,6 +5,7 @@ import java.io.PrintWriter
 import java.io.StringWriter
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.Optional
 import java.util.concurrent.Executor
 

--- a/backend/src/main/scala/bloop/util/BestEffortUtils.scala
+++ b/backend/src/main/scala/bloop/util/BestEffortUtils.scala
@@ -1,11 +1,12 @@
 package bloop.util
 
-import java.security.MessageDigest
-
 import java.math.BigInteger
 import java.nio.file.Files
-import scala.collection.JavaConverters._
 import java.nio.file.Path
+import java.security.MessageDigest
+
+import scala.collection.JavaConverters._
+
 import bloop.io.AbsolutePath
 
 object BestEffortUtils {

--- a/backend/src/main/scala/bloop/util/BestEffortUtils.scala
+++ b/backend/src/main/scala/bloop/util/BestEffortUtils.scala
@@ -10,7 +10,11 @@ import bloop.io.AbsolutePath
 
 object BestEffortUtils {
 
-  case class BestEffortProducts(compileProducts: bloop.CompileProducts, hash: String)
+  case class BestEffortProducts(
+      compileProducts: bloop.CompileProducts,
+      hash: String,
+      recompile: Boolean
+  )
 
   /* Hashes results of a projects compilation, to mimic how it would have been handled in zinc.
    * Returns SHA-1 of a project.

--- a/backend/src/main/scala/sbt/internal/inc/bloop/BloopZincCompiler.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/BloopZincCompiler.scala
@@ -58,7 +58,8 @@ object BloopZincCompiler {
       manager: ClassFileManager,
       cancelPromise: Promise[Unit],
       tracer: BraveTracer,
-      classpathOptions: ClasspathOptions
+      classpathOptions: ClasspathOptions,
+      withPreviousResult: Boolean
   ): Task[CompileResult] = {
     val config = in.options()
     val setup = in.setup()
@@ -81,8 +82,8 @@ object BloopZincCompiler {
         scalacOptions,
         javacOptions,
         classpathOptions,
-        in.previousResult.analysis.toOption,
-        in.previousResult.setup.toOption,
+        if (withPreviousResult) in.previousResult.analysis.toOption else None,
+        if (withPreviousResult) in.previousResult.setup.toOption else None,
         perClasspathEntryLookup,
         reporter,
         order,

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -178,7 +178,8 @@ object CompileTask {
           waitOnReadClassesDir.flatMap { _ =>
             // Only when the task is finished, we kickstart the compilation
             def compile(inputs: CompileInputs) = {
-              val firstResult = Compiler.compile(inputs, isBestEffort, isBestEffortDep, true)
+              val firstResult =
+                Compiler.compile(inputs, isBestEffort, isBestEffortDep, firstCompilation = true)
               firstResult.flatMap {
                 case result @ Compiler.Result.Failed(
                       _,
@@ -196,7 +197,12 @@ object CompileTask {
                     previousCompilerResult = result,
                     previousResult = emptyResult
                   )
-                  Compiler.compile(newInputs, isBestEffort, isBestEffortDep, false)
+                  Compiler.compile(
+                    newInputs,
+                    isBestEffort,
+                    isBestEffortDep,
+                    firstCompilation = false
+                  )
                 case result => Task(result)
               }
             }

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -1,5 +1,7 @@
 package bloop.engine.tasks
 
+import java.util.Optional
+
 import scala.collection.mutable
 import scala.concurrent.Promise
 
@@ -8,8 +10,8 @@ import bloop.CompileInputs
 import bloop.CompileOutPaths
 import bloop.CompileProducts
 import bloop.Compiler
-import bloop.Compiler.Result.Success
 import bloop.Compiler.Result.Failed
+import bloop.Compiler.Result.Success
 import bloop.cli.ExitStatus
 import bloop.data.Project
 import bloop.data.WorkspaceSettings
@@ -20,10 +22,10 @@ import bloop.engine.State
 import bloop.engine.caches.LastSuccessfulResult
 import bloop.engine.tasks.compilation.FinalCompileResult
 import bloop.engine.tasks.compilation._
+import bloop.io.AbsolutePath
 import bloop.io.ParallelOps
 import bloop.io.ParallelOps.CopyMode
 import bloop.io.{Paths => BloopPaths}
-import bloop.io.AbsolutePath
 import bloop.logging.DebugFilter
 import bloop.logging.Logger
 import bloop.logging.LoggerAction
@@ -39,11 +41,9 @@ import bloop.util.BestEffortUtils.BestEffortProducts
 import monix.execution.CancelableFuture
 import monix.reactive.MulticastStrategy
 import monix.reactive.Observable
-import sbt.internal.inc.BloopComponentCompiler
-import xsbti.compile.PreviousResult
-import java.util.Optional
-import xsbti.compile.MiniSetup
 import xsbti.compile.CompileAnalysis
+import xsbti.compile.MiniSetup
+import xsbti.compile.PreviousResult
 
 object CompileTask {
   private implicit val logContext: DebugFilter = DebugFilter.Compilation

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
@@ -27,9 +27,9 @@ import bloop.logging.DebugFilter
 import bloop.logging.LoggerAction
 import bloop.reporter.ReporterAction
 import bloop.task.Task
+import bloop.util.BestEffortUtils.BestEffortProducts
 import bloop.util.JavaCompat.EnrichOptional
 import bloop.util.SystemProperties
-import bloop.util.BestEffortUtils.BestEffortProducts
 
 import xsbti.compile.PreviousResult
 

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGraph.scala
@@ -453,7 +453,7 @@ object CompileGraph {
                           .+=(newProducts.readOnlyClassesDir.toFile -> newResult)
                       case (p, ResultBundle(f: Compiler.Result.Failed, _, _, _)) =>
                         f.bestEffortProducts.foreach {
-                          case BestEffortProducts(products, _) =>
+                          case BestEffortProducts(products, _, _) =>
                             dependentProducts += (p -> Right(products))
                         }
                       case _ => ()

--- a/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspMetalsClientSpec.scala
@@ -665,8 +665,9 @@ class BspMetalsClientSpec(
       )
       loadBspState(workspace, projects, logger, "Metals", bloopExtraParams = extraParams) { state =>
         val compiledState = state.compile(`A`, arguments = Some(List("--best-effort"))).toTestState
-        assertBetastyFile("A.betasty", compiledState, "A")
-        assertBetastyFile("B.betasty", compiledState, "A")
+        // we remove betasty from successful compilations
+        assertNoBetastyFile("A.betasty", compiledState, "A")
+        assertNoBetastyFile("B.betasty", compiledState, "A")
         assertCompilationFile("A.class", compiledState, "A")
         updateProject(updatedFile1WithError)
         val compiledState2 = state.compile(`A`, arguments = Some(List("--best-effort"))).toTestState
@@ -677,8 +678,8 @@ class BspMetalsClientSpec(
         updateProject(updatedFile2WithoutError)
         val compiledState3 = state.compile(`A`, arguments = Some(List("--best-effort"))).toTestState
         assertNoBetastyFile("A.betasty", compiledState3, "A")
-        assertBetastyFile("B.betasty", compiledState3, "A")
-        assertBetastyFile("C.betasty", compiledState3, "A")
+        assertNoBetastyFile("B.betasty", compiledState3, "A")
+        assertNoBetastyFile("C.betasty", compiledState3, "A")
         assertCompilationFile("B.class", compiledState, "A")
         updateProject(updatedFile3WithError)
         val compiledState4 = state.compile(`A`, arguments = Some(List("--best-effort"))).toTestState


### PR DESCRIPTION
Fix to https://github.com/scalameta/metals/issues/6628
Usually it was fine to always put betasty files at the end of the classpath, but in the reproduction for some reason despite the code being correct, those files were still being used, which resulted in an incoherent state in bloop (we obtained only betasty files on what was being considered non-best effort compilation). This lead to trying to apply incremental compilation there, producing singular betasty files, and losing information about symbols from other files, producing errors.

The fix is very simple, but so far I have been unable to properly add any tests for it, as the `backgroundTasks` do not seem to be run in the tests suites.