### PR TITLE
bugfix: Try to stop bloop if unable to run about

### DIFF
--- a/bloop-rifle/src/main/scala/bloop/rifle/BloopServer.scala
+++ b/bloop-rifle/src/main/scala/bloop/rifle/BloopServer.scala
@@ -100,7 +100,7 @@ object BloopServer {
       }
     val bloopVersionIsOk = bloopInfo.exists(_.bloopVersion == expectedBloopVersion)
     val bloopJvmIsOk = bloopInfo.exists(_.jvmVersion == expectedBloopJvmRelease)
-    val isOk = bloopVersionIsOk && bloopJvmIsOk
+    val isOk = bloopVersionIsOk && bloopJvmIsOk && bloopInfo.isRight
 
     if (!isOk) {
       logger.debug(s"Bloop daemon status: ${bloopInfo.fold(_.message, _.message)}")


### PR DESCRIPTION
This was raised on discord and it seems when we fail to parse the output of `about` everything will break.

This is because there is a server running and we will not restart it and the output of about command will again we wrong when we reask.

Now, we should try to exit it first in that case since msot likely the server is broken.