### PR TITLE
docs: Add Bloop 2.0.2 release notes

### DIFF
--- a/notes/v2.0.2.md
+++ b/notes/v2.0.2.md
@@ -1,0 +1,48 @@
+# bloop `v2.0.2`
+
+Bloop v2.0.2 is a bugfix release.
+
+## Installing Bloop
+
+For more details about installing Bloop, please see
+[Bloop's Installation Guide](https://scalacenter.github.io/bloop/setup))
+
+## Merged pull requests
+
+Here's a list of pull requests that were merged:
+
+- Build(deps): Update coursier, coursier-jvm from 2.1.12 to 2.1.13 [#2440]
+- Build(deps): Update github-api from 1.325 to 1.326 [#2443]
+- Build(deps): Update interface from 1.0.20 to 1.0.21 [#2441]
+- Build(deps): Update svm from 24.0.2 to 24.1.0 [#2442]
+- Bugfix: Don't republish old errors on successful compilation [#2427]
+- Docs: Add release notes for Bloop 2.0.1 [#2434]
+- Build(deps): Update sbt-mdoc from 2.5.4 to 2.6.0 [#2439]
+- Build(deps): Update sbt, test-agent, zinc from 1.10.1 to 1.10.2 [#2438]
+- Build(deps): Update github-api from 1.324 to 1.325 [#2436]
+- Build(deps): Update munit from 1.0.1 to 1.0.2 [#2437]
+- Chore(deps): bump express from 4.19.2 to 4.21.0 in /website [#2433]
+- Build(deps): Update coursier, coursier-jvm from 2.1.11 to 2.1.12 [#2431]
+- Build(deps): Update os-lib from 0.10.6 to 0.10.7 [#2430]
+- Build(deps): Update interface from 1.0.19 to 1.0.20 [#2432]
+
+[#2440]: https://github.com/scalacenter/bloop/pull/2440
+[#2443]: https://github.com/scalacenter/bloop/pull/2443
+[#2441]: https://github.com/scalacenter/bloop/pull/2441
+[#2442]: https://github.com/scalacenter/bloop/pull/2442
+[#2427]: https://github.com/scalacenter/bloop/pull/2427
+[#2434]: https://github.com/scalacenter/bloop/pull/2434
+[#2439]: https://github.com/scalacenter/bloop/pull/2439
+[#2438]: https://github.com/scalacenter/bloop/pull/2438
+[#2436]: https://github.com/scalacenter/bloop/pull/2436
+[#2437]: https://github.com/scalacenter/bloop/pull/2437
+[#2433]: https://github.com/scalacenter/bloop/pull/2433
+[#2431]: https://github.com/scalacenter/bloop/pull/2431
+[#2430]: https://github.com/scalacenter/bloop/pull/2430
+[#2432]: https://github.com/scalacenter/bloop/pull/2432
+
+## Contributors
+
+According to `git shortlog -sn --no-merges v2.0.1..v2.0.2`, the following people
+have contributed to this `v2.0.2` release: scala-center-steward[bot], Tomasz
+Godzik, dependabot[bot].


### PR DESCRIPTION
I broke coursier.json since I needed to update it manually. I can't update it since sha will be different, so instead I need to do another release.