### PR TITLE
improvement: Respect bspEnabled when generating bloop config files

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -220,7 +220,9 @@ object BloopDefaults {
       BloopKeys.bloopProductDirectories := List(BloopKeys.bloopClassDirectory.value),
       BloopKeys.bloopClassDirectory := generateBloopProductDirectories.value,
       BloopKeys.bloopInternalClasspath := bloopInternalDependencyClasspath.value,
-      BloopKeys.bloopGenerate := bloopGenerate.value,
+      BloopKeys.bloopGenerate := {
+        if (Keys.bspEnabled.value) bloopGenerate.value else Value(None)
+      },
       BloopKeys.bloopPostGenerate := bloopPostGenerate.value,
       BloopKeys.bloopMainClass := None,
       BloopKeys.bloopMainClass in Keys.run := BloopKeys.bloopMainClass.value

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/bsp-enabled/bar/src/test/scala/Bar.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/bsp-enabled/bar/src/test/scala/Bar.scala
@@ -1,0 +1,1 @@
+trait BarTest

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/bsp-enabled/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/bsp-enabled/build.sbt
@@ -1,0 +1,24 @@
+val foo = project
+  .in(file(".") / "foo")
+
+val bar = project
+  .in(file(".") / "bar")
+  .settings(
+    bspEnabled := false
+  )
+  .dependsOn(foo)
+
+val checkBloopFiles = taskKey[Unit]("Check bloop file contents")
+checkBloopFiles in ThisBuild := {
+  import java.nio.file.Files
+  val bloopDir = Keys.baseDirectory.value./(".bloop")
+  val fooConfig = bloopDir./("foo.json")
+  val barConfig = bloopDir./("bar.json")
+  val barTestConfig = bloopDir./("bar-test.json")
+  val fooTestConfig = bloopDir./("foo-test.json")
+
+  assert(Files.exists(fooConfig.toPath))
+  assert(Files.exists(fooTestConfig.toPath))
+  assert(!Files.exists(barConfig.toPath))
+  assert(!Files.exists(barTestConfig.toPath))
+}

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/bsp-enabled/foo/src/main/scala/Foo.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/bsp-enabled/foo/src/main/scala/Foo.scala
@@ -1,0 +1,1 @@
+class Foo

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/bsp-enabled/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/bsp-enabled/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/bsp-enabled/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/bsp-enabled/test
@@ -1,0 +1,2 @@
+> bloopInstall
+> checkBloopFiles

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/non-compiling/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/non-compiling/build.sbt
@@ -1,18 +1,19 @@
 import bloop.integrations.sbt.BloopDefaults
 
-name := "non-compiling"
+val nonCompiling = project
+  .in(file("."))
 
 val bloopConfigFile = settingKey[File]("Config file to test")
 ThisBuild / bloopConfigFile := {
   val bloopDir = Keys.baseDirectory.value./(".bloop")
-  val config = bloopDir./("non-compiling.json")
+  val config = bloopDir./("nonCompiling.json")
   config
 }
 
 val bloopTestConfigFile = settingKey[File]("Test config file to test")
 ThisBuild / bloopTestConfigFile := {
   val bloopDir = Keys.baseDirectory.value./(".bloop")
-  val config = bloopDir./("non-compiling-test.json")
+  val config = bloopDir./("nonCompiling-test.json")
   config
 }
 

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/runtime-dependency/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/runtime-dependency/build.sbt
@@ -1,27 +1,29 @@
 import bloop.integrations.sbt.BloopDefaults
 
-name := "runtime-dependency"
-
-libraryDependencies +=
-  "ch.qos.logback" % "logback-classic" % "1.2.7" % Runtime
+val runtimeDependency = project
+  .in(file("."))
+  .settings(
+    libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.7" % Runtime
+  )
 
 val bloopConfigFile = settingKey[File]("Config file to test")
 ThisBuild / bloopConfigFile := {
   val bloopDir = Keys.baseDirectory.value./(".bloop")
-  val config = bloopDir./("runtime-dependency.json")
+  val config = bloopDir./("runtimeDependency.json")
   config
 }
 
 val bloopTestConfigFile = settingKey[File]("Test config file to test")
 ThisBuild / bloopTestConfigFile := {
   val bloopDir = Keys.baseDirectory.value./(".bloop")
-  val config = bloopDir./("runtime-dependency-test.json")
+  val config = bloopDir./("runtimeDependency-test.json")
   config
 }
 
 val checkBloopFiles = taskKey[Unit]("Check bloop file contents")
 ThisBuild / checkBloopFiles := {
   val configContents = BloopDefaults.unsafeParseConfig(bloopConfigFile.value.toPath)
+
   assert(configContents.project.platform.isDefined)
   val platformJvm =
     configContents.project.platform.get.asInstanceOf[bloop.config.Config.Platform.Jvm]
@@ -29,10 +31,10 @@ ThisBuild / checkBloopFiles := {
   val expectedRuntimeClasspath = Some(
     List(
       "classes",
-      "logback-core-1.2.7.jar",
       "scala-library.jar",
-      "slf4j-api-1.7.32.jar",
-      "logback-classic-1.2.7.jar"
+      "logback-classic-1.2.7.jar",
+      "logback-core-1.2.7.jar",
+      "slf4j-api-1.7.32.jar"
     )
   )
   assert(obtainedRuntimeClasspath == expectedRuntimeClasspath)
@@ -46,14 +48,13 @@ ThisBuild / checkBloopFiles := {
   assert(testPlatformJvm.classpath.isEmpty)
 
   val obtainedTestClasspath = configTestContents.project.classpath.map(_.getFileName.toString)
-  println(obtainedTestClasspath)
   val expectedTestClasspath =
     List(
       "classes",
-      "logback-core-1.2.7.jar",
       "scala-library.jar",
-      "slf4j-api-1.7.32.jar",
-      "logback-classic-1.2.7.jar"
+      "logback-classic-1.2.7.jar",
+      "logback-core-1.2.7.jar",
+      "slf4j-api-1.7.32.jar"
     )
 
   assert(obtainedTestClasspath == expectedTestClasspath)

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/build.sbt
@@ -7,6 +7,6 @@ val jsProject = project
       val lines = IO.read(config).replaceAll("\\s", "")
       assert(lines.contains(s""""platform":{"name":"$expected""""))
       assert(lines.contains(s""""mode":"debug""""))
-      assert(lines.contains(s""""version":"0.6.28""""))
+      assert(lines.contains(s""""version":"1.5.1""""))
     }
   )

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.1")

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/working-dir/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/working-dir/build.sbt
@@ -49,16 +49,17 @@ checkBloopFiles in ThisBuild := {
     config.project.platform.get.asInstanceOf[bloop.config.Config.Platform.Jvm].config.options
   }
 
+  val userDir = sys.props.get("user.dir").getOrElse("working-dir")
   assert(
     readJvmOptions(fooConfig)
-      .exists(opt => opt.startsWith("-Duser.dir") && opt.endsWith("working-dir")),
-    "foo working directory ends with working-dir"
+      .exists(opt => opt.startsWith("-Duser.dir") && opt.endsWith(userDir)),
+    s"foo working directory ends with $userDir"
   )
 
   assert(
     readJvmOptions(fooTestConfig)
-      .exists(opt => opt.startsWith("-Duser.dir") && opt.endsWith("working-dir")),
-    "foo test working directory ends with working-dir"
+      .exists(opt => opt.startsWith("-Duser.dir") && opt.endsWith(userDir)),
+    s"foo test working directory ends with $userDir"
   )
 
   assert(
@@ -75,13 +76,13 @@ checkBloopFiles in ThisBuild := {
 
   assert(
     readJvmOptions(bazConfig)
-      .exists(opt => opt.startsWith("-Duser.dir") && opt.endsWith("working-dir")),
-    "baz working directory ends with working-dir"
+      .exists(opt => opt.startsWith("-Duser.dir") && opt.endsWith(userDir)),
+    s"baz working directory ends with $userDir"
   )
 
   assert(
     readJvmOptions(bazTestConfig)
-      .exists(opt => opt.startsWith("-Duser.dir") && opt.endsWith("working-dir")),
-    "baz test working directory ends with working-dir"
+      .exists(opt => opt.startsWith("-Duser.dir") && opt.endsWith(userDir)),
+    s"baz test working directory ends with $userDir"
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val Scala212Version = "2.12.20"
   val Scala213Version = "2.13.14"
 
-  val SbtVersion = "1.3.3"
+  val SbtVersion = "1.5.8"
 
   // Keep in sync in BloopComponentCompiler
   val zincVersion = "1.10.2"


### PR DESCRIPTION
I noticed we have to work around it in a number of places and might be useful in the scala3 repo for example.

We didn't do it previously to keep the sbt version as low as possible, but it should be fine for users of older sbt to use older plugins (will be done automatically in Metals)