### PR TITLE
bugfix: Make absolute path from relative plugin paths

### DIFF
--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/wartremover/bar/src/test/scala/Bar.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/wartremover/bar/src/test/scala/Bar.scala
@@ -1,0 +1,1 @@
+trait BarTest

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/wartremover/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/wartremover/build.sbt
@@ -1,0 +1,21 @@
+import java.nio.file.Paths
+import bloop.integrations.sbt.BloopDefaults
+
+val foo = project
+  .in(file(".") / "foo")
+  .settings(
+    wartremoverWarnings := Warts.all
+  )
+
+val checkBloopFiles = taskKey[Unit]("Check bloop file contents")
+checkBloopFiles in ThisBuild := {
+  import java.nio.file.Files
+  val bloopDir = Keys.baseDirectory.value./(".bloop")
+  val fooConfigFile = bloopDir./("foo.json")
+
+  val fooConfig = BloopDefaults.unsafeParseConfig(fooConfigFile.toPath)
+
+  val pluginPath =
+    fooConfig.project.scala.get.options.find(_.startsWith("-Xplugin")).get.stripPrefix("-Xplugin:")
+  assert(Paths.get(pluginPath).toFile.exists())
+}

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/wartremover/foo/src/main/scala/Foo.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/wartremover/foo/src/main/scala/Foo.scala
@@ -1,0 +1,1 @@
+class Foo

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/wartremover/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/wartremover/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))
+
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.1.8")

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/wartremover/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/wartremover/test
@@ -1,0 +1,2 @@
+> bloopInstall
+> checkBloopFiles


### PR DESCRIPTION
Otherwise this doesn't work, looks like Bloop and sbt's working dir have a mismatch?

Fixes https://github.com/scalacenter/bloop/issues/1421 finally