### PR TITLE
 bugfix: Use last modified time instead of creation time for detecting orphaned directories

### DIFF
--- a/frontend/src/main/scala/bloop/data/ClientInfo.scala
+++ b/frontend/src/main/scala/bloop/data/ClientInfo.scala
@@ -292,7 +292,7 @@ object ClientInfo {
                   val dirName = clientDir.underlying.getFileName().toString
                   val attrs =
                     Files.readAttributes(clientDir.underlying, classOf[BasicFileAttributes])
-                  val isOldDir = attrs.creationTime.toInstant.isBefore(deletionThresholdInstant)
+                  val isOldDir = attrs.lastModifiedTime.toInstant.isBefore(deletionThresholdInstant)
                   val isAllowed = CliClientInfo.isStableDirName(dirName) ||
                     connectedBspClientIds.exists(clientId => dirName.endsWith(s"-$clientId"))
 

--- a/frontend/src/main/scala/bloop/engine/State.scala
+++ b/frontend/src/main/scala/bloop/engine/State.scala
@@ -67,7 +67,7 @@ object State {
     val opts = CommonOptions.default
     val cwd = opts.workingPath
     val clientInfo = ClientInfo.CliClientInfo(useStableCliDirs = true, () => true)
-    val results = ResultsCache.load(build, cwd, cleanOrphanedInternalDirs = false, logger)
+    val results = ResultsCache.load(build, cwd, cleanOrphanedInternalDirs = true, logger)
     State(
       build,
       results,

--- a/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
@@ -208,6 +208,9 @@ object ResultsCache {
                     fileName.startsWith(genericClassesName) &&
                       path != analysisClassesDir.underlying
                   if (isOrphan) {
+                    logger.debug(
+                      s"Discovered orphan directory $path"
+                    )(DebugFilter.All)
                     orphanInternalDirs.+=(path)
                   }
                 }

--- a/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
@@ -172,7 +172,7 @@ class BspCompileSpec(
     }
   }
 
-  testMac(
+  testNonWindows(
     "create orphan client classes directory and make sure loading a BSP session cleans it up"
   ) {
     TestUtil.withinWorkspace { workspace =>

--- a/shared/src/main/scala/bloop/logging/FlushingOutputStream.scala
+++ b/shared/src/main/scala/bloop/logging/FlushingOutputStream.scala
@@ -1,0 +1,16 @@
+package bloop.logging
+
+import java.io.ByteArrayOutputStream
+
+class FlushingOutputStream(write: String => Unit) extends ByteArrayOutputStream {
+
+  override def flush(): Unit = {
+    write(this.toByteArray().toString())
+  }
+
+  override def close(): Unit = {
+    flush();
+    super.close();
+  }
+
+}

--- a/shared/src/main/scala/bloop/logging/Logger.scala
+++ b/shared/src/main/scala/bloop/logging/Logger.scala
@@ -9,7 +9,10 @@ abstract class Logger extends xsbti.Logger with BaseSbtLogger {
 
   // Duplicate the standard output so that we get printlns from the compiler
   protected def redirectOutputToLogs(out: PrintStream) = {
-    System.setOut(new TeeOutputStream(out))
+    val baos = new FlushingOutputStream(info)
+    val tee = new TeeOutputStream(out)
+    tee.addListener(baos)
+    System.setOut(tee)
   }
 
   /** The name of the logger */


### PR DESCRIPTION
Somehow this was an issue on linux and JDK 17, but not sure why not others.
    
I also fixed getting stdout to get it redirected to the logger, my previous change did not fully fix it.