### PR TITLE
bugfix: Compile only existing classes

### DIFF
--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopIncremental.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopIncremental.scala
@@ -115,6 +115,7 @@ object BloopIncremental {
       val doCompile = (srcs: Set[VirtualFile], changes: DependencyChanges) => {
         for {
           callback <- Task.now(callbackBuilder())
+          _ = incremental.log.debug(s"Compiling $srcs")
           _ <- compile(srcs, changes, callback, manager)
         } yield callback.get
       }


### PR DESCRIPTION
Previously, we would ask zinc to compile even a file that was removed and I think this was causing https://github.com/scalameta/metals/issues/6478

Now, we invalidated all changed sources, but only compile new ones.