### PR TITLE
Fix issue with BE compilations incorrectly reusing successful artifacts

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -394,11 +394,19 @@ object Compiler {
               BestEffortProducts(previousCompilationResults, previousHash, _)
             )
           ) if isBestEffortMode =>
+        // We filter out certain directories from classpath, as:
+        // * we do not want to hash readOnlyClassesDir, as that contains classfiles unrelated to
+        // best effort compilation
+        // * newClassesDir on the classpath of the previous successful best effort compilation
+        // is also different from newClassesDir of the current compilation.
         val newHash = BestEffortUtils.hashResult(
           previousCompilationResults.newClassesDir,
           compileInputs.sources,
           compileInputs.classpath,
-          List(compileOut.internalReadOnlyClassesDir, compileOut.internalNewClassesDir)
+          ignoredClasspathDirectories = List(
+            compileOut.internalReadOnlyClassesDir,
+            compileOut.internalNewClassesDir
+          )
         )
 
         if (newHash == previousHash) {

--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -397,7 +397,8 @@ object Compiler {
         val newHash = BestEffortUtils.hashResult(
           previousCompilationResults.newClassesDir,
           compileInputs.sources,
-          compileInputs.classpath
+          compileInputs.classpath,
+          List(compileOut.internalReadOnlyClassesDir, compileOut.internalNewClassesDir)
         )
 
         if (newHash == previousHash) {
@@ -1036,7 +1037,8 @@ object Compiler {
         BestEffortUtils.hashResult(
           products.newClassesDir,
           compileInputs.sources,
-          compileInputs.classpath
+          compileInputs.classpath,
+          List(compileOut.internalReadOnlyClassesDir, compileOut.internalNewClassesDir)
         )
       else ""
     val failedProblems = findFailedProblems(reporter, errorCause)

--- a/backend/src/main/scala/bloop/util/BestEffortUtils.scala
+++ b/backend/src/main/scala/bloop/util/BestEffortUtils.scala
@@ -29,7 +29,7 @@ object BestEffortUtils {
       outputDir: Path,
       sources: Array[AbsolutePath],
       classpath: Array[AbsolutePath],
-      ignoredClasspathDirectory: List[AbsolutePath]
+      ignoredClasspathDirectories: List[AbsolutePath]
   ): String = {
     val md = MessageDigest.getInstance("SHA-1")
 
@@ -50,21 +50,19 @@ object BestEffortUtils {
         md.update(Files.readAllBytes(underlying))
       }
     }
-
     md.update("<classpath>".getBytes())
     classpath.map(_.underlying).foreach { classpathFile =>
       if (
-        !Files.exists(classpathFile) || ignoredClasspathDirectory
-          .exists(_.underlying == classpathFile)
+        !Files.exists(classpathFile)
+        || ignoredClasspathDirectories.exists(_.underlying == classpathFile)
+        || outputDir == classpathFile
       ) ()
       else if (Files.isRegularFile(classpathFile)) {
         md.update(Files.readAllBytes(classpathFile))
       } else if (Files.isDirectory(classpathFile)) {
-        if (outputDir != classpathFile) {
-          Files.walk(classpathFile).iterator().asScala.foreach { file =>
-            if (Files.isRegularFile(file)) {
-              md.update(Files.readAllBytes(file))
-            }
+        Files.walk(classpathFile).iterator().asScala.foreach { file =>
+          if (Files.isRegularFile(file)) {
+            md.update(Files.readAllBytes(file))
           }
         }
       }

--- a/backend/src/main/scala/bloop/util/BestEffortUtils.scala
+++ b/backend/src/main/scala/bloop/util/BestEffortUtils.scala
@@ -28,7 +28,8 @@ object BestEffortUtils {
   def hashResult(
       outputDir: Path,
       sources: Array[AbsolutePath],
-      classpath: Array[AbsolutePath]
+      classpath: Array[AbsolutePath],
+      ignoredClasspathDirectory: List[AbsolutePath]
   ): String = {
     val md = MessageDigest.getInstance("SHA-1")
 
@@ -52,7 +53,10 @@ object BestEffortUtils {
 
     md.update("<classpath>".getBytes())
     classpath.map(_.underlying).foreach { classpathFile =>
-      if (!Files.exists(classpathFile)) ()
+      if (
+        !Files.exists(classpathFile) || ignoredClasspathDirectory
+          .exists(_.underlying == classpathFile)
+      ) ()
       else if (Files.isRegularFile(classpathFile)) {
         md.update(Files.readAllBytes(classpathFile))
       } else if (Files.isDirectory(classpathFile)) {

--- a/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/CompileTask.scala
@@ -192,8 +192,11 @@ object CompileTask {
                   inputs.reporter.reset()
                   val emptyResult =
                     PreviousResult.of(Optional.empty[CompileAnalysis], Optional.empty[MiniSetup])
+                  val nonIncrementalClasspath =
+                    inputs.classpath.filter(_ != inputs.out.internalReadOnlyClassesDir)
                   val newInputs = inputs.copy(
                     sources = inputs.sources,
+                    classpath = nonIncrementalClasspath,
                     previousCompilerResult = result,
                     previousResult = emptyResult
                   )


### PR DESCRIPTION
Also fixes an issue with best effort compilation not being properly cached, if recompiled from successful compilations.

@tgodzik About the main issue fixed here, I misdiagnosed that issue yesterday (I mentioned a race condition, not what was happening - the issue is consistent, the way I tried to reproduce it with adding and removing a class in another class was not), but thankfully, it's a simple fix.

About the second thing raised [here](https://github.com/scalameta/metals/issues/6628#issuecomment-2497836757), that sounds like an actual race condition I'm not sure is exclusive to best effort (like you mentioned) and one I'm not sure I would be able to fix quickly, but it seems to me like a later recompilation would fix that.