### PR TITLE
bugfix: Drop pipelining options coming from sbt

### DIFF
--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/use-pipelining/bar/src/test/scala/Bar.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/use-pipelining/bar/src/test/scala/Bar.scala
@@ -1,0 +1,1 @@
+trait BarTest

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/use-pipelining/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/use-pipelining/build.sbt
@@ -1,0 +1,39 @@
+import bloop.integrations.sbt.BloopDefaults
+
+ThisBuild / usePipelining := true
+ThisBuild / scalacOptions += "-Ydebug"
+val foo = project
+  .in(file(".") / "foo")
+
+val bar = project
+  .in(file(".") / "bar")
+  .dependsOn(foo)
+
+val checkBloopFiles = taskKey[Unit]("Check bloop file contents")
+
+def readConfigFor(projectName: String, allConfigs: Seq[File]): bloop.config.Config.File = {
+  val configFile = allConfigs
+    .find(_.toString.endsWith(s"$projectName.json"))
+    .getOrElse(sys.error(s"Missing $projectName.json"))
+  BloopDefaults.unsafeParseConfig(configFile.toPath)
+}
+
+checkBloopFiles in ThisBuild := {
+  import java.nio.file.Files
+  val bloopDir = Keys.baseDirectory.value./(".bloop")
+  val fooConfig = bloopDir./("foo.json")
+  val barConfig = bloopDir./("bar.json")
+
+  assert(Files.exists(fooConfig.toPath))
+  assert(Files.exists(barConfig.toPath))
+
+  val outputFileFoo = BloopDefaults.unsafeParseConfig(fooConfig.toPath)
+  val outputFileBar = BloopDefaults.unsafeParseConfig(barConfig.toPath)
+
+  val optsFoo = outputFileFoo.project.scala.get.options
+  assert(optsFoo == List("-Ydebug"), s"Expected `List(-Ydebug)` in scala options, got `$optsFoo`")
+
+  val optsBar = outputFileBar.project.scala.get.options
+  assert(optsBar == List("-Ydebug"), s"Expected `List(-Ydebug)` in scala options, got `$optsBar`")
+
+}

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/use-pipelining/foo/src/main/scala/Foo.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/use-pipelining/foo/src/main/scala/Foo.scala
@@ -1,0 +1,1 @@
+class Foo

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/use-pipelining/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/use-pipelining/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/use-pipelining/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/use-pipelining/test
@@ -1,0 +1,2 @@
+> bloopInstall
+> checkBloopFiles


### PR DESCRIPTION
Bloop will not be able to compile the project otherwise as the options containg paths from sbt.

Fixes https://github.com/scalameta/metals/issues/6999