### PR TITLE
docs: Add release notes for Bloop v2.0.6

### DIFF
--- a/notes/v2.0.6.md
+++ b/notes/v2.0.6.md
@@ -1,0 +1,72 @@
+# bloop `v2.0.6`
+
+Bloop v2.0.6 is a bugfix release.
+
+## Installing Bloop
+
+For more details about installing Bloop, please see
+[Bloop's Installation Guide](https://scalacenter.github.io/bloop/setup))
+
+## Merged pull requests
+
+Here's a list of pull requests that were merged:
+
+- Build(deps): Update coursier, coursier-jvm from 2.1.20 to 2.1.21 [#2533]
+- Build(deps): Update sbt-mdoc from 2.6.1 to 2.6.2 [#2534]
+- Bugfix: Drop pipelining options coming from sbt [#2527]
+- Build(deps): Update interface from 1.0.25 to 1.0.26 [#2530]
+- Build(deps): Update dependency from 0.3.1 to 0.3.2 [#2529]
+- Build(deps): Update coursier, coursier-jvm from 2.1.19 to 2.1.20 [#2528]
+- Fix issue with BE compilations incorrectly reusing successful artifacts
+  [#2520]
+- Build(deps): Update munit from 1.0.2 to 1.0.3 [#2525]
+- Build(deps): Update sbt, scripted-plugin, test-agent from 1.10.5 to 1.10.6
+  [#2523]
+- Build(deps): Update zinc from 1.10.4 to 1.10.5 [#2524]
+- Build(deps): Update librarymanagement-ivy from 1.10.2 to 1.10.3 [#2522]
+- Build(deps): Update interface from 1.0.24 to 1.0.25 [#2521]
+- Build(deps): Update coursier, coursier-jvm from 2.1.18 to 2.1.19 [#2518]
+- Bugfix: Catch fatal errors when persisting zinc analysis [#2516]
+- Bugfix: Fix compilation error and make sure cli module is compiled [#2512]
+- Build(deps): Update interface from 1.0.23 to 1.0.24 [#2511]
+- Build(deps): Update coursier, coursier-jvm from 2.1.17 to 2.1.18 [#2510]
+- Build(deps): Update tools from 0.5.5 to 0.5.6 [#2509]
+- Build(deps): Update expecty from 0.16.0 to 0.17.0 [#2507]
+- Build(deps): Update dependency from 0.2.5 to 0.3.1 [#2508]
+- Build(deps): Update dependency from 0.2.4 to 0.2.5 [#2504]
+- Build(deps): Update interface from 1.0.22 to 1.0.23 [#2505]
+- Build(deps): Update coursier, coursier-jvm from 2.1.16 to 2.1.17 [#2502]
+- Build(deps): Update sbt-buildinfo from 0.13.0 to 0.13.1 [#2503]
+- Build(deps): Update coursier, coursier-jvm from 2.1.15 to 2.1.16 [#2501]
+
+[#2533]: https://github.com/scalacenter/bloop/pull/2533
+[#2534]: https://github.com/scalacenter/bloop/pull/2534
+[#2527]: https://github.com/scalacenter/bloop/pull/2527
+[#2530]: https://github.com/scalacenter/bloop/pull/2530
+[#2529]: https://github.com/scalacenter/bloop/pull/2529
+[#2528]: https://github.com/scalacenter/bloop/pull/2528
+[#2520]: https://github.com/scalacenter/bloop/pull/2520
+[#2525]: https://github.com/scalacenter/bloop/pull/2525
+[#2523]: https://github.com/scalacenter/bloop/pull/2523
+[#2524]: https://github.com/scalacenter/bloop/pull/2524
+[#2522]: https://github.com/scalacenter/bloop/pull/2522
+[#2521]: https://github.com/scalacenter/bloop/pull/2521
+[#2518]: https://github.com/scalacenter/bloop/pull/2518
+[#2516]: https://github.com/scalacenter/bloop/pull/2516
+[#2512]: https://github.com/scalacenter/bloop/pull/2512
+[#2511]: https://github.com/scalacenter/bloop/pull/2511
+[#2510]: https://github.com/scalacenter/bloop/pull/2510
+[#2509]: https://github.com/scalacenter/bloop/pull/2509
+[#2507]: https://github.com/scalacenter/bloop/pull/2507
+[#2508]: https://github.com/scalacenter/bloop/pull/2508
+[#2504]: https://github.com/scalacenter/bloop/pull/2504
+[#2505]: https://github.com/scalacenter/bloop/pull/2505
+[#2502]: https://github.com/scalacenter/bloop/pull/2502
+[#2503]: https://github.com/scalacenter/bloop/pull/2503
+[#2501]: https://github.com/scalacenter/bloop/pull/2501
+
+## Contributors
+
+According to `git shortlog -sn --no-merges v2.0.5..v2.0.6`, the following people
+have contributed to this `v2.0.6` release: scala-center-steward[bot], Tomasz
+Godzik, Jan Chyb.


### PR DESCRIPTION
I am thinking of a new Metals release, so I would include the recent fixes