### PR TITLE
bugfix: add class compatibility with java 8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import build.BuildImplementation.BuildDefaults
-import build.BuildImplementation.jvmOptions
+import build.BuildImplementation.{jvmOptions, javacOpts}
 import build.Dependencies
 import build.Dependencies.{Scala211Version, Scala212Version, SbtVersion}
 
@@ -208,6 +208,7 @@ lazy val frontend: Project = project
 lazy val cliSettings = Seq(
   name := "bloop-cli",
   scalaVersion := Dependencies.Scala213Version,
+  javacOptions ++= javacOpts,
   (run / fork) := true,
   (Test / fork) := true,
   (Test / parallelExecution) := false,

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -272,6 +272,9 @@ object BuildImplementation {
   final val jvmOptions =
     "-Xmx3g" :: "-Xms1g" :: "-XX:ReservedCodeCacheSize=512m" :: "-XX:MaxInlineLevel=20" :: Nil
 
+  final val javacOpts =
+    "-source" :: "1.8" :: "-target" :: "1.8" :: Nil
+
   object BuildDefaults {
     def exportProjectsInTestResources(
         baseDir: File,


### PR DESCRIPTION
JniGetWinDirs.java ends up being compiled jdk17 (class file version 61.0) causing issues for jdk8 windows users.

This change adds source and target compatibility for bloop-cli with java 8.

JniGetWinDirs seems to have to been recently added as of 2.0.0