### PR TITLE
chore: Mark 'restarted session does not contain JDI output' as flaky

### DIFF
--- a/frontend/src/test/scala/bloop/dap/DebugProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugProtocolSpec.scala
@@ -46,7 +46,7 @@ object DebugProtocolSpec extends DebugBspBaseSuite {
   }
 
   // when the session detaches from the JVM, the JDI once again writes to the standard output
-  test("restarted session does not contain JDI output") {
+  flakyTest("restarted session does not contain JDI output", 3) {
     TestUtil.withinWorkspace { workspace =>
       val main =
         """|/main/scala/Main.scala


### PR DESCRIPTION
It seems to be very fragile and we sometimes get additional things printed out.