### PR TITLE
Best-effort: fix issue with frequent file saves leading to leftover errors

### DIFF
--- a/backend/src/main/scala/bloop/util/BestEffortUtils.scala
+++ b/backend/src/main/scala/bloop/util/BestEffortUtils.scala
@@ -13,35 +13,21 @@ object BestEffortUtils {
 
   case class BestEffortProducts(
       compileProducts: bloop.CompileProducts,
-      hash: String,
+      hash: BestEffortHash,
       recompile: Boolean
   )
 
-  /* Hashes results of a projects compilation, to mimic how it would have been handled in zinc.
-   * Returns SHA-1 of a project.
-   *
-   * Since currently for best-effort compilation we are unable to use neither incremental compilation,
-   * nor the data supplied by zinc (like the compilation analysis files, which are not able to be generated
-   * since the compiler is able to skip the necessary phases for now), this custom implementation
-   * is meant to keep the best-effort projects from being unnecessarily recompiled.
-   */
-  def hashResult(
+  sealed trait BestEffortHash
+  case class NonEmptyBestEffortHash(inputHash: String, outputHash: String) extends BestEffortHash
+  case object EmptyBestEffortHash extends BestEffortHash
+
+  def hashInput(
       outputDir: Path,
       sources: Array[AbsolutePath],
       classpath: Array[AbsolutePath],
       ignoredClasspathDirectories: List[AbsolutePath]
   ): String = {
     val md = MessageDigest.getInstance("SHA-1")
-
-    md.update("<outputs>".getBytes())
-    if (Files.exists(outputDir)) {
-      Files.walk(outputDir).iterator().asScala.foreach { path =>
-        if (Files.isRegularFile(path)) {
-          md.update(path.toString.getBytes())
-          md.update(Files.readAllBytes(path))
-        }
-      }
-    }
 
     md.update("<inputs>".getBytes())
     sources.foreach { sourceFilePath =>
@@ -71,4 +57,44 @@ object BestEffortUtils {
     val digest = new BigInteger(1, md.digest())
     String.format(s"%040x", digest)
   }
+
+  def hashOutput(
+      outputDir: Path
+  ): String = {
+    val md = MessageDigest.getInstance("SHA-1")
+
+    md.update("<outputs>".getBytes())
+    if (Files.exists(outputDir)) {
+      Files.walk(outputDir).iterator().asScala.foreach { path =>
+        if (Files.isRegularFile(path)) {
+          md.update(path.toString.getBytes())
+          md.update(Files.readAllBytes(path))
+        }
+      }
+    }
+
+    val digest = new BigInteger(1, md.digest())
+    String.format(s"%040x", digest)
+  }
+
+  /* Hashes results of a projects compilation, to mimic how it would have been handled in zinc.
+   * Returns a pair of SHA-1 of an input and output of a project.
+   *
+   * Since currently for best-effort compilation we are unable to use neither incremental compilation,
+   * nor the data supplied by zinc (like the compilation analysis files, which are not able to be generated
+   * since the compiler is able to skip the necessary phases for now), this custom implementation
+   * is meant to keep the best-effort projects from being unnecessarily recompiled.
+   *
+   */
+  def hashAll(
+      outputDir: Path,
+      sources: Array[AbsolutePath],
+      classpath: Array[AbsolutePath],
+      ignoredClasspathDirectories: List[AbsolutePath]
+  ) =
+    NonEmptyBestEffortHash(
+      hashInput(outputDir, sources, classpath, ignoredClasspathDirectories),
+      hashOutput(outputDir)
+    )
+
 }


### PR DESCRIPTION
This was caused by the custom hashing mechanism used for best effort compilations where we would needlessly hash the inputs twice - once before compilation (to see if it is necessary), and once after (to save the results). If a file was resaved during the compilation, by the end of it the hash input would be outdated and unreleted to the hash output, so bloop would cease recompilations until next change in the source file, leading to incoherent, leftover errors.

So now, we decouple the output hashing from the input hashing, and only hash the outputs after the compilation, and inputs always before the compilation. In theory, this could cause an unnecessary recompilation if a file is re-saved after reading inputs, but before compiling, leading to a needless compilation, but this is the case where too much is better then not enough.

I am no longer able to reproduce the leftover autosave errors (https://github.com/scalameta/metals/issues/6628#issuecomment-2543169442) after the changes here. Outside of that I am unsure if there is a good way to test it here, so for now I did not add any unit tests.