### PR TITLE
bugfix: Redownload artifacts if missing

### DIFF
--- a/backend/src/main/scala/bloop/DependencyResolution.scala
+++ b/backend/src/main/scala/bloop/DependencyResolution.scala
@@ -16,7 +16,12 @@ object DependencyResolution {
    * @param module       The module's name.
    * @param version      The module's version.
    */
-  case class Artifact(organization: String, module: String, version: String)
+  case class Artifact(
+      organization: String,
+      module: String,
+      version: String,
+      classifier: Option[String] = None
+  )
 
   /**
    * Resolve the specified modules and get all the files. By default, the local Ivy
@@ -59,8 +64,13 @@ object DependencyResolution {
       import artifact._
       logger.debug(s"Resolving $organization:$module:$version")(DebugFilter.All)
       val baseDep = coursierapi.Dependency.of(organization, module, version)
-      if (resolveSources) baseDep.withClassifier("sources")
-      else baseDep
+      classifier match {
+        case Some(c) => baseDep.withClassifier(c)
+        case None =>
+          if (resolveSources) baseDep.withClassifier("sources")
+          else baseDep
+      }
+
     }
     resolveDependenciesWithErrors(dependencies, resolveSources, additionalRepositories)
   }

--- a/frontend/src/test/resources/simple-build/a/src/main/scala/A.scala
+++ b/frontend/src/test/resources/simple-build/a/src/main/scala/A.scala
@@ -1,1 +1,5 @@
-trait A
+trait A {
+  def hello(implicit file: sourcecode.File, line: sourcecode.Line): Unit = {
+    println(s"Hello from ${file.value}:${line.value}")
+  }
+}

--- a/frontend/src/test/resources/simple-build/build.sbt
+++ b/frontend/src/test/resources/simple-build/build.sbt
@@ -1,5 +1,7 @@
 bloopExportJarClassifiers in Global := Some(Set("sources"))
 bloopConfigDir in Global := baseDirectory.value / "bloop-config"
 
-val a = project
+val a = project.settings(
+  libraryDependencies += "com.lihaoyi" %% "sourcecode" % "0.4.2"
+)
 val b = project.dependsOn(a)

--- a/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspProtocolSpec.scala
@@ -323,6 +323,31 @@ class BspProtocolSpec(
     }
   }
 
+  test("find test classes") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      loadBspBuildFromResources("simple-build", workspace, logger) { build =>
+        val project = build.projectFor("a")
+        val compiledState = build.state.compile(project, timeout = 120)
+
+        compiledState.state.build.loadedProjects.foreach { project =>
+          assert(compiledState.status == ExitStatus.Ok)
+          project.project.resolution.toIterable.flatMap(_.modules).flatMap(_.artifacts).foreach {
+            artifact =>
+              if (artifact.path.toString.contains("sourcecode")) {
+                artifact.path.toFile().delete()
+              }
+          }
+        }
+      }
+      loadBspBuildFromResources("simple-build", workspace, logger) { build =>
+        val project = build.projectFor("a")
+        val compiledState = build.state.compile(project, timeout = 120)
+        assert(compiledState.status == ExitStatus.Ok)
+      }
+    }
+  }
+
   test("build targets request works on complicated build") {
     TestUtil.withinWorkspace { workspace =>
       val logger = new RecordingLogger(ansiCodesSupported = false)


### PR DESCRIPTION
Fixes https://github.com/scalacenter/bloop/issues/821

This might cause loading configuration a bit, but that should not be an issue compared to potential user trouble when the artifacts are missing.

The alternative is to only react to missing main scala jars, which would indicate that a cache was cleaned, but not if it was deleted only partly