### PR TITLE
Best-effort: Move betasty directory cleaning into the compilation thread

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -542,13 +542,8 @@ object Compiler {
           // .betasty files are always produced with -Ybest-effort, even when
           // the compilation is successful.
           // We might want to change this in the compiler itself...
-          def deleteBestEffortDir() =
-            if (isBestEffortMode)
-              Task(
-                BloopPaths
-                  .delete(compileOut.internalNewClassesDir.resolve("META-INF/best-effort"))
-              )
-            else Task {}
+          if (isBestEffortMode)
+            BloopPaths.delete(compileOut.internalNewClassesDir.resolve("META-INF/best-effort"))
 
           val isNoOp = previousAnalysis.contains(analysis)
           if (isNoOp) {
@@ -582,8 +577,7 @@ object Compiler {
                   Task
                     .gatherUnordered(
                       List(
-                        deleteClientExternalBestEffortDirTask(clientClassesDir),
-                        deleteBestEffortDir()
+                        deleteClientExternalBestEffortDirTask(clientClassesDir)
                       )
                     )
                     .flatMap { _ =>
@@ -679,7 +673,6 @@ object Compiler {
                   Task
                     .gatherUnordered(
                       List(
-                        deleteBestEffortDir(),
                         deleteClientExternalBestEffortDirTask(clientClassesDir)
                       )
                     )


### PR DESCRIPTION
Previously it was done in backgroundTasks, which could cause issues when combined with the hashing mechanism, itself in the main thread (blocking on compilation thread). This race condition could cause the iterator on the files to throw an error, and downstream compilations would switch to the best effort mode, even if the compilation should be successful.