### PR TITLE
fix: empty environment variables are not handled in process forkers

### DIFF
--- a/frontend/src/main/scala/bloop/exec/JvmProcessForker.scala
+++ b/frontend/src/main/scala/bloop/exec/JvmProcessForker.scala
@@ -63,7 +63,7 @@ trait JvmProcessForker {
     val newEnv = envVars.foldLeft(opts.env) {
       case (properties, line) =>
         val eqIdx = line.indexOf("=")
-        if (eqIdx > 0 && eqIdx != line.length - 1) {
+        if (eqIdx > 0) {
           val key = line.substring(0, eqIdx)
           val value = line.substring(eqIdx + 1)
           properties.withProperty(key, value)

--- a/frontend/src/test/scala/bloop/ForkerSpec.scala
+++ b/frontend/src/test/scala/bloop/ForkerSpec.scala
@@ -115,13 +115,15 @@ class ForkerSpec {
     val envs =
       List(
         "FOO=bar",
-        "TEST=http://localhost:8086?test=1&foo=bar"
+        "TEST=http://localhost:8086?test=1&foo=bar",
+        "EMPTYVAR="
       )
     run(tmp, Array("print-env"), envs = envs) {
       case (exitCode, messages) =>
         assertEquals(0, exitCode.toLong)
         assert(messages.contains(("info", "FOO = bar")))
         assert(messages.contains(("info", "TEST = http://localhost:8086?test=1&foo=bar")))
+        assert(messages.contains(("info", "EMPTYVAR = ")))
     }
   }
 


### PR DESCRIPTION
During our transition from IntelliJ to Metals, we discovered that some environment variables from our usual dotenv file (specified with envFile in launch.json) were missing in the debuggee processes. It turns out that Bloop silently removes ones with empty values.
