### PR TITLE
Remove empty package directories after class invalidation.

### DIFF
--- a/backend/src/main/scala/bloop/BloopClassFileManager.scala
+++ b/backend/src/main/scala/bloop/BloopClassFileManager.scala
@@ -292,7 +292,7 @@ final class BloopClassFileManager(
         if tmp.exists
       } {
         if (!orig.getParentFile.exists) {
-          Files.createDirectory(orig.getParentFile.toPath())
+          Files.createDirectories(orig.getParentFile.toPath())
         }
         Files.move(tmp.toPath(), orig.toPath())
       }

--- a/backend/src/main/scala/bloop/BloopClassFileManager.scala
+++ b/backend/src/main/scala/bloop/BloopClassFileManager.scala
@@ -6,20 +6,19 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
-
 import scala.collection.mutable
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-
 import bloop.io.AbsolutePath
 import bloop.io.ParallelOps
 import bloop.io.ParallelOps.CopyMode
 import bloop.io.{Paths => BloopPaths}
 import bloop.task.Task
 import bloop.tracing.BraveTracer
-
 import xsbti.compile.ClassFileManager
+
+import scala.annotation.tailrec
 
 final class BloopClassFileManager(
     backupDir0: Path,
@@ -165,7 +164,38 @@ final class BloopClassFileManager(
       if f.exists()
     } f.delete()
 
+    pruneEmptyPackages(classes.toList, readOnlyClassesDir)
+
     allInvalidatedExtraCompileProducts.++=(invalidatedExtraCompileProducts)
+  }
+
+  private def pruneEmptyPackages(packages: List[File], contextDirPath: Path): Unit = {
+    def isEmptyDir(file: File): Boolean = {
+      val contents = file.list()
+      contents == null || contents.isEmpty
+    }
+    def isWithinContextDir(dir: File): Boolean = {
+      dir != null && dir.toPath.startsWith(contextDirPath)
+    }
+    @tailrec
+    def delete(packages: List[File]): Unit = {
+      packages match {
+        case Nil => ()
+        case dirs =>
+          for {
+            f <- dirs
+            if f != null && isEmptyDir(f)
+          } f.delete()
+          val parents =
+            for {
+              f <- dirs
+              parent = f.getParentFile
+              if isWithinContextDir(parent)
+            } yield parent
+          delete(parents)
+      }
+    }
+    delete(packages)
   }
 
   def generated(generatedClassFiles: Array[File]): Unit = {

--- a/frontend/src/test/scala/bloop/BaseCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/BaseCompileSpec.scala
@@ -2047,6 +2047,306 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
     }
   }
 
+  test("fail compilation when using wildcard import from empty package - after package rename") {
+    TestUtil.withinWorkspace { workspace =>
+      object Sources {
+        val `Sun.scala` =
+          """/main/scala/Z/A/Sun.scala
+            |package org.someorg.Z.A
+            |class Sun
+          """.stripMargin
+        val `Mercury.scala` =
+          """/main/scala/Z/A/Mercury.scala
+            |package org.someorg.Z.A
+            |class Mercury
+          """.stripMargin
+        val `Moon.scala` =
+          """/main/scala/B/Moon.scala
+            |package org.someorg.B
+            |
+            |import org.someorg.Z.A._
+            |object Moon {
+            |      val o = new Sun()
+            |      val o1 = new Mercury()
+            | }
+          """.stripMargin
+        val `Sun2.scala` =
+          """/main/scala/Z/A/Sun.scala
+            |package org.someorg.Z.C
+            |class Sun
+          """.stripMargin
+        val `Mercury2.scala` =
+          """/main/scala/Z/A/Mercury.scala
+            |package org.someorg.Z.C
+            |class Mercury
+          """.stripMargin
+        val `Moon2.scala` =
+          """/main/scala/B/Moon.scala
+            |package org.someorg.B
+            |
+            |import org.someorg.Z.A._
+            |import org.someorg.Z.C.{Sun, Mercury}
+            |object Moon {
+            |      val o = new Sun()
+            |      val o1 = new Mercury()
+            | }
+          """.stripMargin
+      }
+      val logger = new RecordingLogger(
+        debug = true,
+        ansiCodesSupported = false,
+        debugOut = Some(new PrintStream(System.out))
+      )
+
+      val `A` = TestProject(
+        workspace,
+        "a",
+        List(Sources.`Sun.scala`, Sources.`Mercury.scala`, Sources.`Moon.scala`)
+      )
+
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+
+      val firstState = state.compile(`A`)
+      assertExitStatus(firstState, ExitStatus.Ok)
+
+      writeFile(`A`.srcFor("/main/scala/Z/A/Sun.scala"), Sources.`Sun2.scala`)
+      writeFile(`A`.srcFor("/main/scala/Z/A/Mercury.scala"), Sources.`Mercury2.scala`)
+      writeFile(`A`.srcFor("/main/scala/B/Moon.scala"), Sources.`Moon2.scala`)
+
+      val secondState = firstState.compile(`A`)
+      assertExitStatus(secondState, ExitStatus.CompilationError)
+    }
+  }
+
+  test(
+    "fail compilation when using wildcard import from empty package if sub-packages are empty too"
+  ) {
+    TestUtil.withinWorkspace { workspace =>
+      object Sources {
+        val `Sun.scala` =
+          """/main/scala/Z/A/B/Sun.scala
+            |package org.someorg.Z.A.B
+            |class Sun
+          """.stripMargin
+        val `Mercury.scala` =
+          """/main/scala/Z/A/Mercury.scala
+            |package org.someorg.Z.A
+            |class Mercury
+          """.stripMargin
+        val `Moon.scala` =
+          """/main/scala/Y/Moon.scala
+            |package org.someorg.Y
+            |
+            |import org.someorg.Z.A.B._
+            |import org.someorg.Z.A._
+            |object Moon {
+            |      val o = new Sun()
+            |      val o1 = new Mercury()
+            | }
+          """.stripMargin
+        val `Sun2.scala` =
+          """/main/scala/Z/A/B/Sun.scala
+            |package org.someorg.Z.D.C
+            |class Sun
+          """.stripMargin
+        val `Mercury2.scala` =
+          """/main/scala/Z/A/Mercury.scala
+            |package org.someorg.Z.D
+            |class Mercury
+          """.stripMargin
+        val `Moon2.scala` =
+          """/main/scala/Y/Moon.scala
+            |package org.someorg.Y
+            |
+            |import org.someorg.Z.A.B._
+            |import org.someorg.Z.A._
+            |import org.someorg.Z.D.C.Sun
+            |import org.someorg.Z.D.Mercury
+            |object Moon {
+            |      val o = new Sun()
+            |      val o1 = new Mercury()
+            | }
+          """.stripMargin
+      }
+      val logger = new RecordingLogger(
+        debug = true,
+        ansiCodesSupported = false,
+        debugOut = Some(new PrintStream(System.out))
+      )
+
+      val `A` = TestProject(
+        workspace,
+        "a",
+        List(Sources.`Sun.scala`, Sources.`Mercury.scala`, Sources.`Moon.scala`)
+      )
+
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+
+      val firstState = state.compile(`A`)
+      assertExitStatus(firstState, ExitStatus.Ok)
+
+      writeFile(`A`.srcFor("/main/scala/Z/A/B/Sun.scala"), Sources.`Sun2.scala`)
+      writeFile(`A`.srcFor("/main/scala/Z/A/Mercury.scala"), Sources.`Mercury2.scala`)
+      writeFile(`A`.srcFor("/main/scala/Y/Moon.scala"), Sources.`Moon2.scala`)
+
+      val secondState = firstState.compile(`A`)
+      assertExitStatus(secondState, ExitStatus.CompilationError)
+    }
+  }
+
+  test(
+    "compilation succeed if using wildcard import from package where dependency was replaced with different one"
+  ) {
+    TestUtil.withinWorkspace { workspace =>
+      object Sources {
+        val `Sun.scala` =
+          """/main/scala/Z/A/B/Sun.scala
+            |package org.someorg.Z.A.B
+            |class Sun
+          """.stripMargin
+        val `Mercury.scala` =
+          """/main/scala/Z/A/Mercury.scala
+            |package org.someorg.Z.A
+            |class Mercury
+          """.stripMargin
+        val `Moon.scala` =
+          """/main/scala/Y/Moon.scala
+            |package org.someorg.Y
+            |
+            |import org.someorg.Z.A._
+            |import org.someorg.Z.A.B.Sun
+            |object Moon {
+            |      val o = new Sun()
+            |      val o1 = new Mercury()
+            | }
+          """.stripMargin
+        val `Sun2.scala` =
+          """/main/scala/Z/A/B/Sun.scala
+            |package org.someorg.Z.A
+            |class Sun
+          """.stripMargin
+        val `Mercury2.scala` =
+          """/main/scala/Z/A/Mercury.scala
+            |package org.someorg.Z.D
+            |class Mercury
+          """.stripMargin
+        val `Moon2.scala` =
+          """/main/scala/Y/Moon.scala
+            |package org.someorg.Y
+            |
+            |import org.someorg.Z.A._
+            |import org.someorg.Z.D.Mercury
+            |object Moon {
+            |      val o = new Sun()
+            |      val o1 = new Mercury()
+            | }
+          """.stripMargin
+      }
+      val logger = new RecordingLogger(
+        debug = true,
+        ansiCodesSupported = false,
+        debugOut = Some(new PrintStream(System.out))
+      )
+
+      val `A` = TestProject(
+        workspace,
+        "a",
+        List(Sources.`Sun.scala`, Sources.`Mercury.scala`, Sources.`Moon.scala`)
+      )
+
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+
+      val firstState = state.compile(`A`)
+      assertExitStatus(firstState, ExitStatus.Ok)
+
+      writeFile(`A`.srcFor("/main/scala/Z/A/B/Sun.scala"), Sources.`Sun2.scala`)
+      writeFile(`A`.srcFor("/main/scala/Z/A/Mercury.scala"), Sources.`Mercury2.scala`)
+      writeFile(`A`.srcFor("/main/scala/Y/Moon.scala"), Sources.`Moon2.scala`)
+
+      val secondState = firstState.compile(`A`)
+      assertExitStatus(secondState, ExitStatus.Ok)
+    }
+  }
+
+  test(
+    "pruning packages - whole package path is deleted if it is empty"
+  ) {
+    TestUtil.withinWorkspace { workspace =>
+      object Sources {
+        val `Sun.scala` =
+          """/main/scala/A/B/C/D/Sun.scala
+            |package org.someorg.A.B.C.D
+            |class Sun
+          """.stripMargin
+        val `Mercury.scala` =
+          """/main/scala/A/Mercury.scala
+            |package org.someorg.A
+            |class Mercury
+          """.stripMargin
+        val `Moon.scala` =
+          """/main/scala/Y/Moon.scala
+            |package org.someorg.Y
+            |
+            |import org.someorg.A._
+            |import org.someorg.A.B.C.D.Sun
+            |object Moon {
+            |      val o = new Sun()
+            |      val o1 = new Mercury()
+            | }
+          """.stripMargin
+        val `Sun2.scala` =
+          """/main/scala/A/B/C/D/Sun.scala
+            |package org.someorg.Z.B.C.D
+            |class Sun
+          """.stripMargin
+        val `Mercury2.scala` =
+          """/main/scala/A/Mercury.scala
+            |package org.someorg.Z
+            |class Mercury
+          """.stripMargin
+        val `Moon2.scala` =
+          """/main/scala/Y/Moon.scala
+            |package org.someorg.Y
+            |
+            |import org.someorg.A._
+            |import org.someorg.Z.B.C.D.Sun
+            |import org.someorg.Z.Mercury
+            |object Moon {
+            |      val o = new Sun()
+            |      val o1 = new Mercury()
+            | }
+          """.stripMargin
+      }
+      val logger = new RecordingLogger(
+        debug = true,
+        ansiCodesSupported = false,
+        debugOut = Some(new PrintStream(System.out))
+      )
+
+      val `A` = TestProject(
+        workspace,
+        "a",
+        List(Sources.`Sun.scala`, Sources.`Mercury.scala`, Sources.`Moon.scala`)
+      )
+
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+
+      val firstState = state.compile(`A`)
+      assertExitStatus(firstState, ExitStatus.Ok)
+
+      writeFile(`A`.srcFor("/main/scala/A/B/C/D/Sun.scala"), Sources.`Sun2.scala`)
+      writeFile(`A`.srcFor("/main/scala/A/Mercury.scala"), Sources.`Mercury2.scala`)
+      writeFile(`A`.srcFor("/main/scala/Y/Moon.scala"), Sources.`Moon2.scala`)
+
+      val secondState = firstState.compile(`A`)
+      assertExitStatus(secondState, ExitStatus.CompilationError)
+    }
+  }
+
   test("unsafe") {
     TestUtil.withinWorkspace { workspace =>
       val sources = List(

--- a/frontend/src/test/scala/bloop/BaseCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/BaseCompileSpec.scala
@@ -1,17 +1,17 @@
 package bloop
 
+import bloop.DeduplicationSpec.assertInvalidCompilationState
+
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
-
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
-
 import bloop.cli.CommonOptions
 import bloop.cli.ExitStatus
 import bloop.config.Config
@@ -2116,6 +2116,14 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
 
       val secondState = firstState.compile(`A`)
       assertExitStatus(secondState, ExitStatus.CompilationError)
+      assertInvalidCompilationState(
+        secondState,
+        projects,
+        existsAnalysisFile = true,
+        hasPreviousSuccessful = true,
+        hasSameContentsInClassesDir = true
+      )
+      assertExistingInternalClassesDir(secondState)(firstState, projects)
     }
   }
 
@@ -2193,6 +2201,14 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
 
       val secondState = firstState.compile(`A`)
       assertExitStatus(secondState, ExitStatus.CompilationError)
+      assertInvalidCompilationState(
+        secondState,
+        projects,
+        existsAnalysisFile = true,
+        hasPreviousSuccessful = true,
+        hasSameContentsInClassesDir = true
+      )
+      assertExistingInternalClassesDir(secondState)(firstState, projects)
     }
   }
 
@@ -2268,6 +2284,14 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
 
       val secondState = firstState.compile(`A`)
       assertExitStatus(secondState, ExitStatus.Ok)
+      assertInvalidCompilationState(
+        secondState,
+        projects,
+        existsAnalysisFile = true,
+        hasPreviousSuccessful = true,
+        hasSameContentsInClassesDir = true
+      )
+      assertNonExistingInternalClassesDir(secondState)(firstState, projects)
     }
   }
 
@@ -2344,6 +2368,14 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
 
       val secondState = firstState.compile(`A`)
       assertExitStatus(secondState, ExitStatus.CompilationError)
+      assertInvalidCompilationState(
+        secondState,
+        projects,
+        existsAnalysisFile = true,
+        hasPreviousSuccessful = true,
+        hasSameContentsInClassesDir = true
+      )
+      assertExistingInternalClassesDir(secondState)(firstState, projects)
     }
   }
 


### PR DESCRIPTION
## Background
This PR addresses an (#2647) issue where Bloop allows compilation to succeed incorrectly after package renaming, due to lingering empty directories left behind after class invalidation.

## Problem
When classes are invalidated (e.g., due to package renames or source changes), Zinc/Bloop correctly removes the class files, but the empty directories they lived in are left behind. These directories can cause wildcard imports to resolve even though the actual classes are no longer present, leading to confusing or incorrect compile results.

## Fix
This change enhances `BloopClassFileManager` to remove all empty directories recursively after class files are deleted. It walks up the directory tree from the location of each removed file, cleaning up any now-empty directories. This ensures that stale packages are fully removed from the class directory, avoiding false-positive resolutions by the compiler.

#### Possible Impact:
* Improves correctness of incremental compilation in scenarios involving package moves or deletions.
* Helps avoid silent failures caused by residual empty package directories.
* Should not affect builds where directories contain valid class files.

Fixes: #2647