### PR TITLE
bugfix: Don't log error to BloopLogger

### DIFF
--- a/frontend/src/main/scala/bloop/dap/DebuggeeLogger.scala
+++ b/frontend/src/main/scala/bloop/dap/DebuggeeLogger.scala
@@ -34,7 +34,6 @@ class DebuggeeLogger(listener: DebuggeeListener, underlying: Logger) extends Log
     new DebuggeeLogger(listener, underlying.withOriginId(originId))
 
   override def error(msg: String): Unit = {
-    underlying.error(msg)
     listener.err(msg)
   }
 


### PR DESCRIPTION
This produces error reports in Metals because it's treated as a server error.