### PR TITLE
Support WebAssembly: Correctly detect Scala.js 1.x scalaJSLinkerConfig#...

### DIFF
--- a/bridges/scalajs-1/src/main/scala/bloop/scalajs/JsBridge.scala
+++ b/bridges/scalajs-1/src/main/scala/bloop/scalajs/JsBridge.scala
@@ -81,6 +81,7 @@ object JsBridge {
         .withModuleKind(scalaJSModuleKind)
         .withSourceMap(config.emitSourceMaps)
         .withMinify(isFullLinkJS)
+        .withExperimentalUseWebAssembly(config.useWebAssembly)
 
       (config.kind, scalaJSModuleKindSplitStyle) match {
         case (ModuleKindJS.ESModule, Some(value)) =>

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -620,8 +620,16 @@ object Interpreter {
                     None
                   )
                   .flatMap { state =>
+                    // TODO: We should use `jsEnvInput` to obtain the JS files to run
+                    // (or even use https://github.com/scala-js/scala-js-js-envs to run ideally),
+                    // https://github.com/scala-js/scala-js/blob/6a145af4dc575340a40b80459d1bf15184c3a2da/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala#L252-L255
+                    // and get command line options from `jsEnv` tasks for Node.js options.
+                    // https://github.com/scala-js/scala-js/blob/6a145af4dc575340a40b80459d1bf15184c3a2da/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala#L238-L240
+                    // For now, we just filter .js files (so we don't include sourcemap, .wasm files, and __loader.js generated for Wasm), and run them.
+                    val files = targetDirectory.list
+                      .map(_.toString())
+                      .filter(name => name.endsWith(".js") && !name.endsWith("__loader.js"))
                     // We use node to run the program (is this a special case?)
-                    val files = targetDirectory.list.map(_.toString())
                     val args = ("node" +: files ::: cmd.args).toArray
                     if (!state.status.isOk) Task.now(state)
                     else Tasks.runNativeOrJs(state, cwd, args)

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/ScalaJsKeys.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/ScalaJsKeys.scala
@@ -2,6 +2,8 @@ package bloop.integrations.sbt
 
 object ScalaJsKeys {
   import sbt.{SettingKey, settingKey}
+
+  @deprecated("Use bloopScalaJSSourceMap instead.")
   val scalaJSEmitSourceMaps: SettingKey[Boolean] =
     settingKey("Proxy for Scala.js definition of `scalaJSEmitSourceMaps`")
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,7 +43,7 @@ object Dependencies {
   val asmVersion = "9.8"
   val ztExecVersion = "1.12"
   val debugAdapterVersion = "4.2.8"
-  val bloopConfigVersion = "2.3.2"
+  val bloopConfigVersion = "2.3.3"
   val semanticdbVersion = "4.9.9"
   val millVersion = "0.12.7"
   val zinc = "org.scala-sbt" %% "zinc" % zincVersion


### PR DESCRIPTION
This PR supports `useExperimentalWebAssembly` option in Scala.js (based on https://github.com/scalacenter/bloop-config/pull/129).

---

Also, fixes https://github.com/scalacenter/bloop/issues/1309

The sbt-bloop integration was failing to detect the
`scalaJSModuleKind` for projects using Scala.js 1.x. This was
because the previous implementation relied on old API
that have changed in Scala.js 1.x, through reflection.
This commit updates the `findOutScalaJsModuleKind`
to use the new Scala.js 1.x linker interface APIs
through reflection.

Now, sbt-bloop loses Scala.js ~0.6 supports in detecting `moduleKind`,
but I guess it's no problem since Scala.js is already 1.21 (?)

Note that:
As commented in https://github.com/scalacenter/bloop/issues/1308#issuecomment-645263171
current implementation isn't ideal. It should statically depend on `scalajs-linker-interface` instead of dynamically accessing those APIs.

> It can statically depend on a version of scalajs-linker-interface, but should load the correct scalajs-linker depending on the scalaJSVersion used by the project. Problems with the current scheme include:
> issues like this one will keep popping up every time there is a new version of Scala.js
> if the project uses an older version of Scala.js, the linker used by bloop will be different than the one used by sbt/Maven/the original build tool, resulting in different produced .js files depending on whether bloop is used or not
