### PR TITLE
Bump `coursier` to 2.1.25-M19

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val lmVersion = "1.11.5"
   val configDirsVersion = "26"
   val caseAppVersion = "2.0.6"
-  val coursierVersion = "2.1.24"
+  val coursierVersion = "2.1.25-M19"
   val sourcecodeVersion = "0.4.4"
   val sbtTestInterfaceVersion = "1.0"
   val sbtTestAgentVersion = "1.11.6"


### PR DESCRIPTION
https://github.com/coursier/coursier/releases/tag/v2.1.25-M19

It's rather likely that this will help to unblock:
- https://github.com/VirtusLab/scala-cli/pull/3884