### PR TITLE
bugfix: Check modification time with milisecond precision

### DIFF
--- a/frontend/src/test/scala/bloop/BaseCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/BaseCompileSpec.scala
@@ -227,7 +227,7 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
     }
   }
 
-  test("compile build incrementally sourcing from an analysis file") {
+  test("incremental-noop") {
     TestUtil.withinWorkspace { workspace =>
       object Sources {
         val `A.scala` =


### PR DESCRIPTION
I haven't managed to add a sensible tests, since it's not possible to add a check for last modfied. But when checking locally I noticed that we always copy file because of how different APIs seem to deal with precision. Milisecond precision should be good enough

Related to https://github.com/scalacenter/bloop/pull/1776