### PR TITLE
bugfix: Use the default CompileReport

### DIFF
--- a/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
+++ b/frontend/src/main/scala/bloop/logging/BspServerLogger.scala
@@ -8,7 +8,6 @@ import scala.collection.JavaConverters._
 import ch.epfl.scala.bsp
 import ch.epfl.scala.bsp.BuildTargetIdentifier
 import ch.epfl.scala.bsp.DiagnosticSeverity
-import ch.epfl.scala.bsp.Uri
 import ch.epfl.scala.bsp.endpoints.Build
 
 import bloop.bsp.BloopLanguageClient
@@ -349,16 +348,13 @@ final class BspServerLogger private (
     val errors = event.problems.count(_.severity == Severity.Error)
     val warnings = event.problems.count(_.severity == Severity.Warn)
     val encoded = writeToArray(
-      BspServerLogger.BloopCompileReport(
+      bsp.CompileReport(
         bsp.BuildTargetIdentifier(event.projectUri),
         originId,
         errors,
         warnings,
         None,
-        Some(event.isNoOp),
-        Some(event.isLastCycle),
-        event.clientDir.map(path => bsp.Uri(path.toBspUri)),
-        event.analysisOut.map(path => bsp.Uri(path.toBspUri))
+        Some(event.isNoOp)
       )
     )
 
@@ -390,27 +386,4 @@ object BspServerLogger {
     new BspServerLogger(name, state.logger, client, taskIdCounter, ansiCodesSupported, None)
   }
 
-  /**
-   * A modified version of `bsp.CompileReport` with optional bloop fields.
-   *
-   * We should consider upstreaming many of these fields as they are usually
-   * very useful for clients.
-   */
-  final case class BloopCompileReport(
-      target: BuildTargetIdentifier,
-      originId: Option[String],
-      errors: Int,
-      warnings: Int,
-      time: Option[Long],
-      // ++ bloop ++
-      isNoOp: Option[Boolean],
-      isLastCycle: Option[Boolean],
-      clientDir: Option[Uri],
-      analysisOut: Option[Uri]
-  )
-
-  object BloopCompileReport {
-    implicit val codec: JsonValueCodec[BloopCompileReport] =
-      JsonCodecMaker.makeWithRequiredCollectionFields
-  }
 }

--- a/frontend/src/main/scala/bloop/reporter/BspProjectReporter.scala
+++ b/frontend/src/main/scala/bloop/reporter/BspProjectReporter.scala
@@ -14,7 +14,6 @@ import bloop.logging.CompilationEvent
 
 import monix.execution.atomic.AtomicInt
 import xsbti.VirtualFile
-import bloop.UniqueCompileInputs
 import bloop.util.HashedSource
 
 final class BspProjectReporter(

--- a/frontend/src/test/scala/bloop/DeduplicationSpec.scala
+++ b/frontend/src/test/scala/bloop/DeduplicationSpec.scala
@@ -115,7 +115,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
             |  -> Msg: Compiling user (2 Scala sources)
             |  -> Data kind: compile-task
             |#1: task finish 1
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop false
             |  -> Msg: Compiled 'user'
             |  -> Data kind: compile-report
         """.stripMargin
@@ -230,7 +230,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
             |  -> Msg: Compiling user (2 Scala sources)
             |  -> Data kind: compile-task
             |#1: task finish 1
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop false
             |  -> Msg: Compiled 'user'
             |  -> Data kind: compile-report
         """.stripMargin
@@ -323,7 +323,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
             |  -> Msg: Compiling user (1 Scala source)
             |  -> Data kind: compile-task
             |#2: task finish 2
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop false
             |  -> Msg: Compiled 'user'
             |  -> Data kind: compile-report
         """.stripMargin
@@ -409,7 +409,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
             |  -> Msg: Compiling user (2 Scala sources)
             |  -> Data kind: compile-task
             |#1: task finish 1
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop false
             |  -> Msg: Compiled 'user'
             |  -> Data kind: compile-report
         """.stripMargin
@@ -563,7 +563,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
             |  -> List(Diagnostic(Range(Position(2,28),Position(2,28)),Some(Error),Some(_),Some(_),type mismatch;  found   : Int  required: String,None,None,Some({"actions":[]})))
             |  -> reset = true
             |#1: task finish 1
-            |  -> errors 1, warnings 0
+            |  -> errors 1, warnings 0, noop false
             |  -> Msg: Compiled 'b'
             |  -> Data kind: compile-report
         """.stripMargin
@@ -644,7 +644,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
             |  -> List(Diagnostic(Range(Position(2,28),Position(2,28)),Some(Error),Some(_),Some(_),type mismatch;  found   : Int  required: String,None,None,Some({"actions":[]})))
             |  -> reset = true
             |#2: task finish 2
-            |  -> errors 1, warnings 0
+            |  -> errors 1, warnings 0, noop false
             |  -> Msg: Compiled 'b'
             |  -> Data kind: compile-report
         """.stripMargin
@@ -744,7 +744,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
             |  -> List()
             |  -> reset = true
             |#3: task finish 3
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop false
             |  -> Msg: Compiled 'b'
             |  -> Data kind: compile-report
         """.stripMargin
@@ -891,7 +891,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
                |  -> Msg: Compiling b (6 Scala sources)
                |  -> Data kind: compile-task
                |#1: task finish 1
-               |  -> errors 0, warnings 0
+               |  -> errors 0, warnings 0, noop false
                |  -> Msg: Compiled 'b'
                |  -> Data kind: compile-report
            """.stripMargin
@@ -1093,7 +1093,7 @@ object DeduplicationSpec extends bloop.bsp.BspBaseSuite {
             |  -> Msg: Compiling user (32 Scala sources)
             |  -> Data kind: compile-task
             |#1: task finish 2
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop false
             |  -> Msg: Compiled 'user'
             |  -> Data kind: compile-report
         """.stripMargin

--- a/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspClientTest.scala
@@ -300,7 +300,9 @@ trait BspClientTest {
                 (builder: StringBuilder) => {
                   builder.synchronized {
                     builder.++=(s"#${compileIteration()}: task finish ${taskFinish.taskId.id}\n")
-                    builder.++=(s"  -> errors ${report.errors}, warnings ${report.warnings}\n")
+                    builder.++=(
+                      s"  -> errors ${report.errors}, warnings ${report.warnings}, noop ${report.noOp.getOrElse(false)}\n"
+                    )
                     report.originId.foreach(originId => builder.++=(s"  -> origin = $originId\n"))
                     taskFinish.message.foreach(msg => builder.++=(s"  -> Msg: ${msg}\n"))
                     taskFinish.dataKind.foreach(msg => builder.++=(s"  -> Data kind: ${msg}\n"))

--- a/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspCompileSpec.scala
@@ -71,7 +71,7 @@ class BspCompileSpec(
             |  -> Msg: Compiling a (1 Scala source)
             |  -> Data kind: compile-task
             |#1: task finish 1
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report""".stripMargin,
           compiledState.lastDiagnostics(`A`)
@@ -109,7 +109,7 @@ class BspCompileSpec(
             |  -> Msg: Compiling a (1 Scala source)
             |  -> Data kind: compile-task
             |#1: task finish 1
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report""".stripMargin,
           compiledState.lastDiagnostics(`A`)
@@ -126,7 +126,7 @@ class BspCompileSpec(
             |  -> Msg: Compiling a (1 Scala source)
             |  -> Data kind: compile-task
             |#2: task finish 2
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report""".stripMargin,
           compiledState.lastDiagnostics(`A`)
@@ -162,7 +162,7 @@ class BspCompileSpec(
              |  -> reset = true
              |  -> origin = test-origin
              |#1: task finish 1
-             |  -> errors 0, warnings 1
+             |  -> errors 0, warnings 1, noop false
              |  -> origin = test-origin
              |  -> Msg: Compiled 'a'
              |  -> Data kind: compile-report
@@ -275,7 +275,7 @@ class BspCompileSpec(
             |  -> Msg: Compiling a (1 Scala source)
             |  -> Data kind: compile-task
             |#1: task finish 1
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report""".stripMargin
         )
@@ -286,7 +286,7 @@ class BspCompileSpec(
             |  -> Msg: Compiling b (1 Scala source)
             |  -> Data kind: compile-task
             |#1: task finish 2
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop false
             |  -> Msg: Compiled 'b'
             |  -> Data kind: compile-report""".stripMargin
         )
@@ -316,7 +316,7 @@ class BspCompileSpec(
             |  -> List(Diagnostic(Range(Position(2,28),Position(2,28)),Some(Error),Some(_),Some(_),type mismatch;  found   : Int  required: String,None,None,Some({"actions":[]})))
             |  -> reset = true
             |#2: task finish 3
-            |  -> errors 1, warnings 0
+            |  -> errors 1, warnings 0, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report """.stripMargin
         )
@@ -605,7 +605,7 @@ class BspCompileSpec(
             |  -> Msg: Compiling a (2 Scala sources)
             |  -> Data kind: compile-task
             |#1: task finish 1
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report
             """.stripMargin
@@ -632,7 +632,7 @@ class BspCompileSpec(
             |  -> List(Diagnostic(Range(Position(2,6),Position(2,6)),Some(Error),Some(_),Some(_),x is already defined as value x,None,None,Some({"actions":[]})))
             |  -> reset = true
             |#2: task finish 2
-            |  -> errors 1, warnings 0
+            |  -> errors 1, warnings 0, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report
             """.stripMargin
@@ -652,7 +652,7 @@ class BspCompileSpec(
             |  -> Msg: Start no-op compilation for a
             |  -> Data kind: compile-task
             |#3: task finish 3
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop true
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report
             """.stripMargin // no-op so it only gives the compile-report
@@ -682,7 +682,7 @@ class BspCompileSpec(
             |  -> List(Diagnostic(Range(Position(0,0),Position(0,26)),Some(Warning),Some(_),Some(_),Unused import,None,None,Some({"actions":[]})))
             |  -> reset = false
             |#4: task finish 4
-            |  -> errors 1, warnings 1
+            |  -> errors 1, warnings 1, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report
             """.stripMargin
@@ -702,7 +702,7 @@ class BspCompileSpec(
             |  -> List(Diagnostic(Range(Position(0,0),Position(0,26)),Some(Warning),Some(_),Some(_),Unused import,None,None,Some({"actions":[]})))
             |  -> reset = true
             |#5: task finish 5
-            |  -> errors 0, warnings 1
+            |  -> errors 0, warnings 1, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report
             """.stripMargin
@@ -728,7 +728,7 @@ class BspCompileSpec(
             |  -> List()
             |  -> reset = true
             |#6: task finish 6
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report
             |#6: task start 6
@@ -741,7 +741,7 @@ class BspCompileSpec(
             |  -> List(Diagnostic(Range(Position(1,0),Position(3,1)),Some(Error),Some(_),Some(_),object creation impossible, since value y in trait Base of type Int is not defined,None,None,Some({"actions":[]})))
             |  -> reset = false
             |#6: task finish 6
-            |  -> errors 1, warnings 1
+            |  -> errors 1, warnings 1, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report
             """.stripMargin
@@ -762,7 +762,7 @@ class BspCompileSpec(
             |  -> List(Diagnostic(Range(Position(0,0),Position(0,26)),Some(Warning),Some(_),Some(_),Unused import,None,None,Some({"actions":[]})))
             |  -> reset = true
             |#7: task finish 7
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report
             """.stripMargin
@@ -873,7 +873,7 @@ class BspCompileSpec(
              |  -> Msg: Start no-op compilation for a
              |  -> Data kind: compile-task
              |#1: task finish 1
-             |  -> errors 0, warnings 0
+             |  -> errors 0, warnings 0, noop true
              |  -> Msg: Compiled 'a'
              |  -> Data kind: compile-report
              |""".stripMargin
@@ -935,7 +935,7 @@ class BspCompileSpec(
             |  -> List(Diagnostic(Range(Position(2,4),Position(2,4)),Some(Warning),Some(_),Some(_),a pure expression does nothing in statement position,None,None,Some({"actions":[]})))
             |  -> reset = true
             |#1: task finish 1
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report""".stripMargin
         )
@@ -957,7 +957,7 @@ class BspCompileSpec(
              |  -> List()
              |  -> reset = true
              |#2: task finish 2
-             |  -> errors 0, warnings 0
+             |  -> errors 0, warnings 0, noop false
              |  -> Msg: Compiled 'a'
              |  -> Data kind: compile-report
              |""".stripMargin
@@ -1101,7 +1101,7 @@ class BspCompileSpec(
             |  -> List(Diagnostic(Range(Position(1,28),Position(1,28)),Some(Error),Some(_),Some(_),type mismatch;  found   : Int  required: String,None,None,Some({"actions":[]})))
             |  -> reset = true
             |#1: task finish 1
-            |  -> errors 1, warnings 0
+            |  -> errors 1, warnings 0, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report""".stripMargin
         )
@@ -1136,7 +1136,7 @@ class BspCompileSpec(
             |  -> List()
             |  -> reset = true
             |#2: task finish 2
-            |  -> errors 1, warnings 0
+            |  -> errors 1, warnings 0, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report""".stripMargin
         )
@@ -1167,7 +1167,7 @@ class BspCompileSpec(
              |  -> Msg: Start no-op compilation for a
              |  -> Data kind: compile-task
              |#3: task finish 3
-             |  -> errors 0, warnings 0
+             |  -> errors 0, warnings 0, noop true
              |  -> Msg: Compiled 'a'
              |  -> Data kind: compile-report""".stripMargin
         )
@@ -1233,7 +1233,7 @@ class BspCompileSpec(
                |  -> List(Diagnostic(Range(Position(0,0),Position(0,7)),Some(Error),Some(_),Some(_),Unused import,None,None,Some({"actions":[]})))
                |  -> reset = true
                |#1: task finish 1
-               |  -> errors 1, warnings 0
+               |  -> errors 1, warnings 0, noop false
                |  -> Msg: Compiled 'a'
                |  -> Data kind: compile-report
                |""".stripMargin
@@ -1245,7 +1245,7 @@ class BspCompileSpec(
                |  -> Msg: Compiling b (1 Scala source)
                |  -> Data kind: compile-task
                |#1: task finish 2
-               |  -> errors 0, warnings 0
+               |  -> errors 0, warnings 0, noop false
                |  -> Msg: Compiled 'b'
                |  -> Data kind: compile-report
                |""".stripMargin
@@ -1264,7 +1264,7 @@ class BspCompileSpec(
                |  -> List()
                |  -> reset = true
                |#2: task finish 3
-               |  -> errors 0, warnings 0
+               |  -> errors 0, warnings 0, noop false
                |  -> Msg: Compiled 'a'
                |  -> Data kind: compile-report
                |""".stripMargin
@@ -1292,7 +1292,7 @@ class BspCompileSpec(
                |  -> List(Diagnostic(Range(Position(1,0),Position(1,7)),Some(Error),Some(_),Some(_),Unused import,None,None,Some({"actions":[]})))
                |  -> reset = false
                |#3: task finish 4
-               |  -> errors 2, warnings 0
+               |  -> errors 2, warnings 0, noop false
                |  -> Msg: Compiled 'a'
                |  -> Data kind: compile-report
                |""".stripMargin
@@ -1307,7 +1307,7 @@ class BspCompileSpec(
                |  -> List(Diagnostic(Range(Position(0,0),Position(0,7)),Some(Error),Some(_),Some(_),Unused import,None,None,Some({"actions":[]})))
                |  -> reset = true
                |#3: task finish 5
-               |  -> errors 1, warnings 0
+               |  -> errors 1, warnings 0, noop false
                |  -> Msg: Compiled 'b'
                |  -> Data kind: compile-report
                |""".stripMargin
@@ -1420,6 +1420,257 @@ class BspCompileSpec(
         assert(secondResult.status == ExitStatus.Ok)
       }
       runTest(2000)
+    }
+  }
+
+  test("task notifications are sent when compiling project with dependency") {
+    TestUtil.withinWorkspace { workspace =>
+      val sourcesA = List(
+        """/main/scala/Foo.scala
+          |class Foo {
+          |  def foo(s: String): String = s
+          |}
+        """.stripMargin
+      )
+
+      val sourcesB = List(
+        """/main/scala/Bar.scala
+          |object Bar {
+          |  def bar(s: String): String = (new Foo()).foo(s)
+          |}
+        """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", sourcesA)
+      val `B` = TestProject(workspace, "b", sourcesB, List(`A`))
+      val projects = List(`A`, `B`)
+
+      loadBspState(workspace, projects, logger) { state =>
+        // When we compile B, which depends on A, both should get task notifications
+        val compiledState = state.compile(`B`)
+        assertExitStatus(compiledState, ExitStatus.Ok)
+        assertValidCompilationState(compiledState, projects)
+
+        // Verify A gets task start and task finish notifications
+        assertNoDiff(
+          compiledState.lastDiagnostics(`A`),
+          """#1: task start 1
+            |  -> Msg: Compiling a (1 Scala source)
+            |  -> Data kind: compile-task
+            |#1: task finish 1
+            |  -> errors 0, warnings 0, noop false
+            |  -> Msg: Compiled 'a'
+            |  -> Data kind: compile-report""".stripMargin
+        )
+
+        // Verify B gets task start and task finish notifications with different task IDs
+        assertNoDiff(
+          compiledState.lastDiagnostics(`B`),
+          """#1: task start 2
+            |  -> Msg: Compiling b (1 Scala source)
+            |  -> Data kind: compile-task
+            |#1: task finish 2
+            |  -> errors 0, warnings 0, noop false
+            |  -> Msg: Compiled 'b'
+            |  -> Data kind: compile-report""".stripMargin
+        )
+
+      }
+    }
+  }
+
+  test("task notifications are sent when compiling dependency chain A -> B -> C") {
+    TestUtil.withinWorkspace { workspace =>
+      val sourcesA = List(
+        """/main/scala/A.scala
+          |class A {
+          |  def methodA(): String = "A"
+          |}
+        """.stripMargin
+      )
+
+      val sourcesB = List(
+        """/main/scala/B.scala
+          |class B {
+          |  def methodB(): String = (new A()).methodA() + "B"
+          |}
+        """.stripMargin
+      )
+
+      val sourcesC = List(
+        """/main/scala/C.scala
+          |object C {
+          |  def methodC(): String = (new B()).methodB() + "C"
+          |}
+        """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", sourcesA)
+      val `B` = TestProject(workspace, "b", sourcesB, List(`A`))
+      val `C` = TestProject(workspace, "c", sourcesC, List(`B`))
+      val projects = List(`A`, `B`, `C`)
+
+      loadBspState(workspace, projects, logger) { state =>
+        // When we compile C, which depends on B -> A, all three should get task notifications
+        val compiledState = state.compile(`C`)
+        assertExitStatus(compiledState, ExitStatus.Ok)
+        assertValidCompilationState(compiledState, projects)
+
+        // Verify A gets task notifications (task id 1)
+        assertNoDiff(
+          compiledState.lastDiagnostics(`A`),
+          """#1: task start 1
+            |  -> Msg: Compiling a (1 Scala source)
+            |  -> Data kind: compile-task
+            |#1: task finish 1
+            |  -> errors 0, warnings 0, noop false
+            |  -> Msg: Compiled 'a'
+            |  -> Data kind: compile-report""".stripMargin
+        )
+
+        // Verify B gets task notifications (task id 2)
+        assertNoDiff(
+          compiledState.lastDiagnostics(`B`),
+          """#1: task start 2
+            |  -> Msg: Compiling b (1 Scala source)
+            |  -> Data kind: compile-task
+            |#1: task finish 2
+            |  -> errors 0, warnings 0, noop false
+            |  -> Msg: Compiled 'b'
+            |  -> Data kind: compile-report""".stripMargin
+        )
+
+        // Verify C gets task notifications (task id 3)
+        assertNoDiff(
+          compiledState.lastDiagnostics(`C`),
+          """#1: task start 3
+            |  -> Msg: Compiling c (1 Scala source)
+            |  -> Data kind: compile-task
+            |#1: task finish 3
+            |  -> errors 0, warnings 0, noop false
+            |  -> Msg: Compiled 'c'
+            |  -> Data kind: compile-report""".stripMargin
+        )
+      }
+    }
+  }
+
+  test("send-noop") {
+    TestUtil.withinWorkspace { workspace =>
+      val sourcesA = List(
+        """/main/scala/Foo.scala
+          |class Foo
+        """.stripMargin
+      )
+
+      val sourcesB = List(
+        """/main/scala/Bar.scala
+          |class Bar
+        """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", sourcesA)
+      val `B` = TestProject(workspace, "b", sourcesB, List(`A`))
+      val projects = List(`A`, `B`)
+
+      loadBspState(workspace, projects, logger) { state =>
+        // First compilation
+        val compiledState = state.compile(`B`)
+        assertExitStatus(compiledState, ExitStatus.Ok)
+        assertValidCompilationState(compiledState, projects)
+
+        // Second compilation (no-op) - should not send task notifications for either project
+        val secondCompiledState = compiledState.compile(`B`)
+        assertExitStatus(secondCompiledState, ExitStatus.Ok)
+        assertValidCompilationState(secondCompiledState, projects)
+
+        // Verify noop task notifications for A
+        assertNoDiff(
+          secondCompiledState.lastDiagnostics(`A`),
+          ""
+        )
+
+        // Verify noop task notifications for B
+        assertNoDiff(
+          secondCompiledState.lastDiagnostics(`B`),
+          ""
+        )
+
+      }
+    }
+  }
+
+  test("task notifications sent when only dependency needs recompilation") {
+    TestUtil.withinWorkspace { workspace =>
+      val sourcesA = List(
+        """/main/scala/Foo.scala
+          |class Foo {
+          |  def foo(): String = "original"
+          |}
+        """.stripMargin
+      )
+
+      val sourcesB = List(
+        """/main/scala/Bar.scala
+          |class Bar {
+          |  def bar(): String = (new Foo()).foo()
+          |}
+        """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", sourcesA)
+      val `B` = TestProject(workspace, "b", sourcesB, List(`A`))
+      val projects = List(`A`, `B`)
+
+      loadBspState(workspace, projects, logger) { state =>
+        // First compilation
+        val compiledState = state.compile(`B`)
+        assertExitStatus(compiledState, ExitStatus.Ok)
+        assertValidCompilationState(compiledState, projects)
+
+        // Modify only A
+        writeFile(
+          `A`.srcFor("/main/scala/Foo.scala"),
+          """/main/scala/Foo.scala
+            |class Foo {
+            |  def foo(): String = "modified"
+            |}
+          """.stripMargin
+        )
+
+        // Compile B again - should trigger recompilation of A and B
+        val secondCompiledState = compiledState.compile(`B`)
+        assertExitStatus(secondCompiledState, ExitStatus.Ok)
+        assertValidCompilationState(secondCompiledState, projects)
+
+        // Verify A gets task notifications (modified and recompiled)
+        assertNoDiff(
+          secondCompiledState.lastDiagnostics(`A`),
+          """#2: task start 3
+            |  -> Msg: Compiling a (1 Scala source)
+            |  -> Data kind: compile-task
+            |#2: task finish 3
+            |  -> errors 0, warnings 0, noop false
+            |  -> Msg: Compiled 'a'
+            |  -> Data kind: compile-report""".stripMargin
+        )
+
+        // Verify B gets task notifications (needs recompilation due to A change)
+        assertNoDiff(
+          secondCompiledState.lastDiagnostics(`B`),
+          """#2: task start 4
+            |  -> Msg: Compiling b (1 Scala source)
+            |  -> Data kind: compile-task
+            |#2: task finish 4
+            |  -> errors 0, warnings 0, noop false
+            |  -> Msg: Compiled 'b'
+            |  -> Data kind: compile-report""".stripMargin
+        )
+      }
     }
   }
 

--- a/frontend/src/test/scala/bloop/bsp/BspSbtClientSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspSbtClientSpec.scala
@@ -75,7 +75,7 @@ class BspSbtClientSpec(
              |  -> Msg: Compiling a (1 Scala source)
              |  -> Data kind: compile-task
              |# task finish 1
-             |  -> errors 0, warnings 0
+             |  -> errors 0, warnings 0, noop false
              |  -> origin = $firstOriginId
              |  -> Msg: Compiled 'a'
              |  -> Data kind: compile-report""".stripMargin,
@@ -87,7 +87,7 @@ class BspSbtClientSpec(
              |  -> Msg: Compiling b (1 Scala source)
              |  -> Data kind: compile-task
              |# task finish 2
-             |  -> errors 0, warnings 0
+             |  -> errors 0, warnings 0, noop false
              |  -> origin = $firstOriginId
              |  -> Msg: Compiled 'b'
              |  -> Data kind: compile-report""".stripMargin,
@@ -99,7 +99,7 @@ class BspSbtClientSpec(
              |  -> Msg: Compiling c (1 Scala source)
              |  -> Data kind: compile-task
              |# task finish 3
-             |  -> errors 0, warnings 0
+             |  -> errors 0, warnings 0, noop false
              |  -> origin = $firstOriginId
              |  -> Msg: Compiled 'c'
              |  -> Data kind: compile-report""".stripMargin,
@@ -111,7 +111,7 @@ class BspSbtClientSpec(
              |  -> Msg: Compiling d (1 Scala source)
              |  -> Data kind: compile-task
              |# task finish 4
-             |  -> errors 0, warnings 0
+             |  -> errors 0, warnings 0, noop false
              |  -> origin = $firstOriginId
              |  -> Msg: Compiled 'd'
              |  -> Data kind: compile-report""".stripMargin,
@@ -123,7 +123,7 @@ class BspSbtClientSpec(
              |  -> Msg: Compiling e (1 Scala source)
              |  -> Data kind: compile-task
              |# task finish 5
-             |  -> errors 0, warnings 0
+             |  -> errors 0, warnings 0, noop false
              |  -> origin = $firstOriginId
              |  -> Msg: Compiled 'e'
              |  -> Data kind: compile-report""".stripMargin,
@@ -160,7 +160,7 @@ class BspSbtClientSpec(
              |  -> Msg: Compiling a (1 Scala source)
              |  -> Data kind: compile-task
              |# task finish 6
-             |  -> errors 0, warnings 0
+             |  -> errors 0, warnings 0, noop false
              |  -> origin = $secondOriginId
              |  -> Msg: Compiled 'a'
              |  -> Data kind: compile-report""".stripMargin
@@ -177,7 +177,7 @@ class BspSbtClientSpec(
              |  -> Msg: Compiling c (1 Scala source)
              |  -> Data kind: compile-task
              |# task finish 7
-             |  -> errors 0, warnings 0
+             |  -> errors 0, warnings 0, noop false
              |  -> origin = $secondOriginId
              |  -> Msg: Compiled 'c'
              |  -> Data kind: compile-report""".stripMargin
@@ -238,7 +238,7 @@ class BspSbtClientSpec(
             |  -> Msg: Compiling a (1 Scala source)
             |  -> Data kind: compile-task
             |#1: task finish 1
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report""".stripMargin
         )
@@ -267,7 +267,7 @@ class BspSbtClientSpec(
             |  -> List(Diagnostic(Range(Position(1,3),Position(1,3)),Some(Error),Some(_),Some(_),';' expected but 'def' found.,None,None,Some({"actions":[]})))
             |  -> reset = true
             |#2: task finish 2
-            |  -> errors 1, warnings 0
+            |  -> errors 1, warnings 0, noop false
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report """.stripMargin
         )
@@ -288,7 +288,7 @@ class BspSbtClientSpec(
             |  -> Msg: Start no-op compilation for a
             |  -> Data kind: compile-task
             |#3: task finish 3
-            |  -> errors 0, warnings 0
+            |  -> errors 0, warnings 0, noop true
             |  -> Msg: Compiled 'a'
             |  -> Data kind: compile-report""".stripMargin
         )


### PR DESCRIPTION
Looks like noop was never actually being sent or this broke at some point.

It's important to note that currently noop task finish will not be sent when nothing changed since the last compile request. I don't remember why that was done, but we can send those noop responses.

On the other hand, maybe that should just be part of the final CompilationReport