### PR TITLE
bugfix: Only delete directories if nothing is running

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -435,7 +435,6 @@ object Compiler {
               // new compilation artifacts coming from scalac, which we will not
               // have in this case and it's going to remain empty.
               val firstTask = Task { BloopPaths.delete(AbsolutePath(newClassesDir)) }
-
               // Then we copy previous best effort artifacts to a clientDir from the
               // cached compilation result.
               // This is useful if e.g. the client restarted after the last compilation

--- a/frontend/src/main/scala/bloop/engine/caches/LastSuccessfulResult.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/LastSuccessfulResult.scala
@@ -9,7 +9,6 @@ import bloop.data.Project
 import bloop.io.AbsolutePath
 import bloop.task.Task
 
-import monix.execution.atomic.AtomicInt
 import xsbti.compile.CompileAnalysis
 import xsbti.compile.MiniSetup
 import xsbti.compile.PreviousResult
@@ -18,7 +17,6 @@ case class LastSuccessfulResult(
     noClassPathAndSources: Boolean,
     previous: PreviousResult,
     classesDir: AbsolutePath,
-    counterForClassesDir: AtomicInt,
     populatingProducts: Task[Unit]
 ) {
   def isEmpty: Boolean = {
@@ -43,7 +41,6 @@ object LastSuccessfulResult {
       noClassPathAndSources = true,
       EmptyPreviousResult,
       emptyClassesDir,
-      AtomicInt(0),
       Task.now(())
     )
   }
@@ -57,7 +54,6 @@ object LastSuccessfulResult {
       noClassPathAndSources = inputs.sources.size == 0 && inputs.classpath.size == 0,
       products.resultForFutureCompilationRuns,
       AbsolutePath(products.newClassesDir),
-      AtomicInt(0),
       backgroundIO
     )
   }

--- a/frontend/src/test/scala/bloop/BaseCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/BaseCompileSpec.scala
@@ -280,7 +280,7 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
       }
 
       val logger = new RecordingLogger(ansiCodesSupported = false)
-      val `A` = TestProject(workspace, "a", List(Sources.`A.scala`), scalaVersion = Some("3.1.1"))
+      val `A` = TestProject(workspace, "a", List(Sources.`A.scala`), scalaVersion = Some("3.3.7"))
       val projects = List(`A`)
       val state = loadState(workspace, projects, logger)
       val compiledState = state.compile(`A`)


### PR DESCRIPTION
Previously, we would sometimes delete directories when another compilation was running concurrently. Now, we only delete at the end if no other compilation is running.

Should fix https://github.com/scalacenter/bloop/issues/2779

@jackkoenig It took longer than I wanted, since I tried adding tests for this. However, it seems that the tests pass even I remove the old deletion mechanism, which seems impossible. Testing manually confirms that this works, but I think I might need some additional testing suite at some point to simulate better actual client such as Metals. Since, this already took longer than I wanted, I'll merge this and you can confirm if there are any issues with this new approach.