### PR TITLE
Replace usages of `java.io.File` with `java.nio.file.Path` in `bloop-rifle`

### DIFF
--- a/bloop-rifle/src/main/scala/bloop/rifle/BloopRifle.scala
+++ b/bloop-rifle/src/main/scala/bloop/rifle/BloopRifle.scala
@@ -75,7 +75,7 @@ object BloopRifle {
           config.address,
           bloopJava,
           config.javaOpts,
-          cp.map(_.toPath),
+          cp,
           config.workingDir,
           scheduler,
           config.startCheckPeriod,

--- a/bloop-rifle/src/main/scala/bloop/rifle/BloopRifleConfig.scala
+++ b/bloop-rifle/src/main/scala/bloop/rifle/BloopRifleConfig.scala
@@ -127,9 +127,9 @@ object BloopRifleConfig {
 
   @deprecated(message = "Use default which accepts java.nio.file.Path parameters")
   def default(
-    address: Address,
-    bloopClassPath: String => Either[Throwable, Seq[File]],
-    workingDir: File
+      address: Address,
+      bloopClassPath: String => Either[Throwable, Seq[File]],
+      workingDir: File
   ): BloopRifleConfig =
     default(
       address = address,

--- a/bloop-rifle/src/main/scala/bloop/rifle/BloopRifleConfig.scala
+++ b/bloop-rifle/src/main/scala/bloop/rifle/BloopRifleConfig.scala
@@ -4,7 +4,6 @@ import bloop.rifle.internal.BuildInfo
 
 import java.io.{File, InputStream, OutputStream}
 import java.nio.file.Path
-
 import scala.concurrent.duration._
 import scala.util.Try
 
@@ -12,8 +11,8 @@ final case class BloopRifleConfig(
     address: BloopRifleConfig.Address,
     javaPath: String,
     javaOpts: Seq[String],
-    classPath: String => Either[Throwable, Seq[File]],
-    workingDir: File,
+    classPath: String => Either[Throwable, Seq[Path]],
+    workingDir: Path,
     bspSocketOrPort: Option[() => BspConnectionAddress],
     bspStdin: Option[InputStream],
     bspStdout: Option[OutputStream],
@@ -126,10 +125,22 @@ object BloopRifleConfig {
     .collect { case d: FiniteDuration => d }
     .getOrElse(Duration.Zero)
 
+  @deprecated(message = "Use default which accepts java.nio.file.Path parameters")
+  def default(
+    address: Address,
+    bloopClassPath: String => Either[Throwable, Seq[File]],
+    workingDir: File
+  ): BloopRifleConfig =
+    default(
+      address = address,
+      bloopClassPath = s => bloopClassPath(s).map(_.map(_.toPath)),
+      workingDir = workingDir.toPath
+    )
+
   def default(
       address: Address,
-      bloopClassPath: String => Either[Throwable, Seq[File]],
-      workingDir: File
+      bloopClassPath: String => Either[Throwable, Seq[Path]],
+      workingDir: Path
   ): BloopRifleConfig =
     BloopRifleConfig(
       address = address,

--- a/bloop-rifle/src/main/scala/bloop/rifle/BloopServer.scala
+++ b/bloop-rifle/src/main/scala/bloop/rifle/BloopServer.scala
@@ -7,7 +7,7 @@ import bloop.rifle.bloop4j.BloopExtraBuildParams
 import bloop.rifle.internal.BuildInfo
 import org.eclipse.lsp4j.jsonrpc
 
-import java.io.{File, IOException}
+import java.io.IOException
 import java.net.{ConnectException, Socket}
 import java.nio.file.{Files, Path, Paths}
 import java.util.concurrent.{Future => JFuture, ScheduledExecutorService, TimeoutException}
@@ -67,7 +67,7 @@ object BloopServer {
       startServerChecksPool: ScheduledExecutorService,
       logger: BloopRifleLogger
   ): BloopRifle.BloopServerRuntimeInfo = {
-    val workdir = new File(".").getCanonicalFile.toPath
+    val workdir = Path.of(".").toAbsolutePath.normalize()
     def startBloop(bloopVersion: String, bloopJava: String) = {
       val fut = BloopRifle.startServer(
         config,

--- a/bloop-rifle/src/main/scala/bloop/rifle/BspConnectionAddress.scala
+++ b/bloop-rifle/src/main/scala/bloop/rifle/BspConnectionAddress.scala
@@ -1,10 +1,10 @@
 package bloop.rifle
 
-import java.io.File
+import java.nio.file.Path
 
 sealed abstract class BspConnectionAddress extends Product with Serializable
 
 object BspConnectionAddress {
   final case class Tcp(host: String, port: Int) extends BspConnectionAddress
-  final case class UnixDomainSocket(path: File) extends BspConnectionAddress
+  final case class UnixDomainSocket(path: Path) extends BspConnectionAddress
 }

--- a/bloop-rifle/src/main/scala/bloop/rifle/internal/Operations.scala
+++ b/bloop-rifle/src/main/scala/bloop/rifle/internal/Operations.scala
@@ -113,24 +113,44 @@ object Operations {
 
   /**
    * Starts a new bloop server.
-   *
-   * @param host
-   * @param port
-   * @param javaPath
-   * @param classPath
-   * @param scheduler
-   * @param waitInterval
-   * @param timeout
-   * @param logger
-   * @return
-   *   A future, that gets completed when the server is done starting (and can thus be used).
+   * @return A future, which gets completed when the server is done starting (and can thus be used).
+   */
+  @deprecated(message = "Use startServer which accepts a java.nio.file.Path for workingDir")
+  def startServer(
+    address: BloopRifleConfig.Address,
+    javaPath: String,
+    javaOpts: Seq[String],
+    classPath: Seq[Path],
+    workingDir: File,
+    scheduler: ScheduledExecutorService,
+    waitInterval: FiniteDuration,
+    timeout: Duration,
+    logger: BloopRifleLogger,
+    bloopServerSupportsFileTruncating: Boolean
+  ): Future[Unit] =
+    startServer(
+      address = address,
+      javaPath = javaPath,
+      javaOpts = javaOpts,
+      classPath = classPath,
+      workingDir = workingDir.toPath,
+      scheduler = scheduler,
+      waitInterval = waitInterval,
+      timeout = timeout,
+      logger = logger,
+      bloopServerSupportsFileTruncating = bloopServerSupportsFileTruncating
+    )
+
+  /**
+   * Starts a new bloop server.
+   * @return A future, which gets completed when the server is done starting (and can thus be used).
    */
   def startServer(
       address: BloopRifleConfig.Address,
       javaPath: String,
       javaOpts: Seq[String],
       classPath: Seq[Path],
-      workingDir: File,
+      workingDir: Path,
       scheduler: ScheduledExecutorService,
       waitInterval: FiniteDuration,
       timeout: Duration,
@@ -245,8 +265,8 @@ object Operations {
         (b, () => ())
     }
 
-    workingDir.mkdirs()
-    b.directory(workingDir)
+    Files.createDirectories(workingDir)
+    b.directory(workingDir.toFile)
     b.redirectInput(ProcessBuilder.Redirect.PIPE)
     val p = b.start()
     p.getOutputStream.close()

--- a/bloop-rifle/src/main/scala/bloop/rifle/internal/Operations.scala
+++ b/bloop-rifle/src/main/scala/bloop/rifle/internal/Operations.scala
@@ -117,16 +117,16 @@ object Operations {
    */
   @deprecated(message = "Use startServer which accepts a java.nio.file.Path for workingDir")
   def startServer(
-    address: BloopRifleConfig.Address,
-    javaPath: String,
-    javaOpts: Seq[String],
-    classPath: Seq[Path],
-    workingDir: File,
-    scheduler: ScheduledExecutorService,
-    waitInterval: FiniteDuration,
-    timeout: Duration,
-    logger: BloopRifleLogger,
-    bloopServerSupportsFileTruncating: Boolean
+      address: BloopRifleConfig.Address,
+      javaPath: String,
+      javaOpts: Seq[String],
+      classPath: Seq[Path],
+      workingDir: File,
+      scheduler: ScheduledExecutorService,
+      waitInterval: FiniteDuration,
+      timeout: Duration,
+      logger: BloopRifleLogger,
+      bloopServerSupportsFileTruncating: Boolean
   ): Future[Unit] =
     startServer(
       address = address,

--- a/bloop-rifle/src/main/scala/bloop/rifle/internal/Operations.scala
+++ b/bloop-rifle/src/main/scala/bloop/rifle/internal/Operations.scala
@@ -379,7 +379,7 @@ object Operations {
       case t: BspConnectionAddress.Tcp =>
         Array("--protocol", "tcp", "--host", t.host, "--port", t.port.toString)
       case s: BspConnectionAddress.UnixDomainSocket =>
-        Array("--protocol", "local", "--socket", s.path.getAbsolutePath)
+        Array("--protocol", "local", "--socket", s.path.toAbsolutePath.toString)
     }
     val runnable: Runnable = logger.runnable(threadName) { () =>
       val maybeRetCode = Try {
@@ -414,7 +414,7 @@ object Operations {
       def address = bspSocketOrPort match {
         case t: BspConnectionAddress.Tcp => s"${t.host}:${t.port}"
         case s: BspConnectionAddress.UnixDomainSocket =>
-          "local:" + s.path.toURI.toASCIIString.stripPrefix("file:")
+          "local:" + s.path.toUri.toASCIIString.stripPrefix("file:")
       }
       def openSocket(period: FiniteDuration, timeout: FiniteDuration) = bspSocketOrPort match {
         case t: BspConnectionAddress.Tcp =>
@@ -426,14 +426,14 @@ object Operations {
           var socket: SocketChannel = null
           while (socket == null && count < maxCount && closed.value.isEmpty) {
             logger.debug {
-              if (socketFile.exists())
+              if (Files.exists(socketFile))
                 s"BSP connection $socketFile found but not open, waiting $period"
               else
                 s"BSP connection at $socketFile not found, waiting $period"
             }
             Thread.sleep(period.toMillis)
-            if (socketFile.exists()) {
-              val addr = UnixDomainSocketAddress.of(socketFile.toPath)
+            if (Files.exists(socketFile)) {
+              val addr = UnixDomainSocketAddress.of(socketFile)
               socket = SocketChannel.open(StandardProtocolFamily.UNIX)
               socket.connect(addr)
               socket.finishConnect()


### PR DESCRIPTION
Related to #2566.

The Scala Plugin for IntelliJ IDEA depends on `bloop-rifle` for managing the bloop BSP server instance. We're in the process of migrating code which uses `java.io.File` to use `java.nio.file.Path` instead.

The changes in this PR are **binary incompatible** as `case class` definitions are being changed. From what I can see, there is no `mima` set up in this repository.

`BloopRifleConfig` has already been changed previously in https://github.com/scalacenter/bloop/commit/4c8fcde4. I guess this happened with a major version bump?

Thanks in advance.