### PR TITLE
Serve testClasses/mainClasses from compile gatekeeper after taskFinish

### DIFF
--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -11,6 +11,8 @@ import bloop.data.JdkConfig
 import bloop.data.Project
 import bloop.engine.Dag
 import bloop.engine.State
+import bloop.engine.caches.LastSuccessfulResult
+import bloop.engine.tasks.compilation.CompileGatekeeper
 import bloop.exec.Forker
 import bloop.exec.JvmProcessForker
 import bloop.io.AbsolutePath
@@ -254,6 +256,22 @@ object Tasks {
   }
 
   /**
+   * Returns the freshest successful result for `project`. Prefers the gatekeeper
+   * (updated before `taskFinish`) when it points at a usable classes directory,
+   * else the per-connection state. This lets read endpoints answer correctly
+   * right after a `taskFinish`, before the state has observed the new results.
+   */
+  private[bloop] def freshestSuccessfulResult(
+      state: State,
+      project: Project
+  ): LastSuccessfulResult =
+    CompileGatekeeper
+      .latestSuccessfulResult(project)
+      .filter(r => !r.isEmpty && r.classesDir.exists)
+      .orElse(state.results.lastSuccessfulResult(project))
+      .getOrElse(LastSuccessfulResult.empty(project))
+
+  /**
    * Finds the main classes in `project`.
    *
    * @param state   The current state of Bloop.
@@ -263,7 +281,7 @@ object Tasks {
   def findMainClasses(state: State, project: Project): List[String] = {
     import state.logger
 
-    state.results.lastSuccessfulResultOrEmpty(project).previous.analysis().toOption match {
+    freshestSuccessfulResult(state, project).previous.analysis().toOption match {
       case Some(analysis: Analysis) =>
         val mainClasses = analysis.infos.allInfos.values.flatMap(_.getMainClasses).toList
         logger.debug(s"Found ${mainClasses.size} main classes: ${mainClasses.mkString(", ")}.")(

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -395,7 +395,7 @@ object TestTask {
       case None => List.empty
       case Some(found) =>
         val frameworks = found.frameworks
-        val lastCompileResult = state.results.lastSuccessfulResultOrEmpty(project)
+        val lastCompileResult = Tasks.freshestSuccessfulResult(state, project)
         val analysis = lastCompileResult.previous.analysis().toOption.getOrElse {
           state.logger
             .debug(s"TestsFQCN was triggered, but no compilation detected for ${project.name}")(

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGatekeeper.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGatekeeper.scala
@@ -264,6 +264,15 @@ object CompileGatekeeper {
     ()
   }
 
+  /**
+   * Returns the most recent successful result for a project, if any. It is
+   * registered when a target finishes compiling, before its `taskFinish` is
+   * emitted, so read endpoints can consult it instead of the per-connection
+   * state (which only observes new results at the end of the compile request).
+   */
+  def latestSuccessfulResult(project: Project): Option[LastSuccessfulResult] =
+    Option(lastSuccessfulResults.get(project.uniqueId))
+
   // Expose clearing mechanism so that it can be invoked in the tests and community build runner
   private[bloop] def clearSuccessfulResults(): Unit = {
     lastSuccessfulResults.synchronized {

--- a/frontend/src/test/scala/bloop/RunSpec.scala
+++ b/frontend/src/test/scala/bloop/RunSpec.scala
@@ -17,8 +17,11 @@ import bloop.engine.Dag
 import bloop.engine.ExecutionContext
 import bloop.engine.Run
 import bloop.engine.State
+import bloop.engine.caches.ResultsCache
 import bloop.engine.tasks.Tasks
+import bloop.engine.tasks.compilation.CompileGatekeeper
 import bloop.io.AbsolutePath
+import bloop.io.Paths
 import bloop.logging.RecordingLogger
 import bloop.testing.BloopHelpers
 import bloop.util.TestProject
@@ -128,6 +131,51 @@ class RunSpec extends BloopHelpers {
       assertEquals(2, mainClasses.length.toLong)
       assertEquals(s"$packageName.$mainClassName0", mainClasses(0))
       assertEquals(s"$packageName.$mainClassName1", mainClasses(1))
+    }
+  }
+
+  @Test
+  def findsMainClassesViaGatekeeperWhenResultsCacheEmpty(): Unit = {
+    // Clients query mainClasses/testClasses right after a `taskFinish`, before the
+    // per-connection state observes the new results, so the lookup must fall back
+    // to the gatekeeper (which is updated earlier).
+    val projectName = "test-project"
+    val projectsStructure = Map(projectName -> Map("A.scala" -> ArtificialSources.RunnableClass0))
+    val expectedMainClass = s"$packageName.$mainClassName0"
+    checkAfterCleanCompilation(
+      projectsStructure,
+      noDependencies,
+      rootProjects = List(projectName),
+      jdkConfig = JdkConfig.default,
+      quiet = true
+    ) { state =>
+      val project = getProject(projectName, state)
+
+      // Sanity: the normal post-compile path resolves the main class.
+      val mainClasses = Tasks.findMainClasses(state, project)
+      assertEquals(1, mainClasses.length.toLong)
+      assertEquals(expectedMainClass, mainClasses(0))
+
+      // Race window: empty per-connection cache, but the gatekeeper already has it.
+      val racyState = state.copy(results = ResultsCache.emptyForTests)
+      assertTrue(
+        "Precondition: the racy state must have no cached successful result",
+        !TestUtil.hasPreviousResult(project, racyState)
+      )
+      val racyMainClasses = Tasks.findMainClasses(racyState, project)
+      assertEquals(1, racyMainClasses.length.toLong)
+      assertEquals(expectedMainClass, racyMainClasses(0))
+      // The shared helper also exposes the analysis used for test-class discovery.
+      assertTrue(
+        "Analysis must be available for test discovery in the race window",
+        Tasks.freshestSuccessfulResult(racyState, project).previous.analysis().isPresent
+      )
+
+      // Guard: a stale gatekeeper entry whose classes dir was deleted (e.g. by
+      // `cleanCache`) must be ignored.
+      val classesDir = CompileGatekeeper.latestSuccessfulResult(project).get.classesDir
+      Paths.delete(classesDir)
+      assertEquals(0, Tasks.findMainClasses(racyState, project).length.toLong)
     }
   }
 


### PR DESCRIPTION
Fixes #1067.

BSP clients send `buildTarget/testClasses` / `buildTarget/mainClasses` right after a per-target `taskFinish`, but sometimes get an empty result. These endpoints serve classes from the per-connection `state.results`, which is only refreshed at the compile request's terminal `saveState` - after `taskFinish` is emitted. So a client reacting to `taskFinish` reads a stale, empty cache.

## Note

This makes the race negligibly rare, not impossible - there's no enforced happens-before between gatekeeper registration and `taskFinish`. A hard guarantee would need sequencing in the compile engine, out of scope here.
