### PR TITLE
Report the cause of run and test execution failures

### DIFF
--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -81,15 +81,18 @@ object TestTask {
   ): Task[Int] = {
     import state.logger
     val isTest = isTestProject(project)
-    def handleEmptyTestFrameworks: Task[Int] = {
+    // Report a problem as an error for test projects (failing the run) or a warning otherwise.
+    def reportMissing(reason: String): Task[Int] = {
       if (isTest) {
-        logger.error(s"Missing configured test frameworks in ${project.name}")
+        logger.error(reason)
         Task.now(1)
       } else {
-        logger.warn(s"Missing configured test frameworks in ${project.name}")
+        logger.warn(reason)
         Task.now(0)
       }
     }
+    def handleEmptyTestFrameworks: Task[Int] =
+      reportMissing(s"Missing configured test frameworks in ${project.name}")
 
     val lastCompilerResult = state.results.latestResult(project)
     val lastSuccessful = state.results.lastSuccessfulResultOrEmpty(project)
@@ -99,92 +102,145 @@ object TestTask {
         logger.warn(s"Skipping test for ${project.name} because compiler result is empty")
         Task.now(0)
       } else {
-        if (isTest) {
-          logger.error(s"Missing compilation to test ${project.name}")
-          Task.now(1)
-        } else {
-          logger.warn(s"Missing compilation to test ${project.name}")
-          Task.now(0)
-        }
+        reportMissing(s"Missing compilation to test ${project.name}")
       }
     } else {
-      TestTask.discoverTestFrameworks(project, state, mode).flatMap {
-        case None => handleEmptyTestFrameworks
-        case Some(found) if found.frameworks.isEmpty => handleEmptyTestFrameworks
-        case Some(found) =>
-          val configuredFrameworks = found.frameworks
-          logger.debug(s"Found test frameworks: ${configuredFrameworks.map(_.name).mkString(", ")}")
-          val suites =
-            discoverTestSuites(
+      TestTask
+        .discoverTestFrameworks(project, state, mode)
+        .map(found => Right(found): Either[Int, Option[DiscoveredTestFrameworks]])
+        .onErrorRecover {
+          // A discovery failure (e.g. node/JSDOM unavailable) is reported here so the cause is
+          // visible without `--verbose`; returning a non-zero code avoids the misleading
+          // "Missing configured test frameworks" path below.
+          case NonFatal(t) =>
+            logger.error(
+              Feedback
+                .printException(s"Failed to discover test frameworks for '${project.name}'", t)
+            )
+            logger.trace(t)
+            Left(ExitStatus.TestExecutionError.code)
+        }
+        .flatMap {
+          case Left(code) => Task.now(code)
+          case Right(None) => handleEmptyTestFrameworks
+          case Right(Some(found)) if found.frameworks.isEmpty => handleEmptyTestFrameworks
+          case Right(Some(found)) =>
+            runDiscoveredSuites(
               state,
               project,
-              configuredFrameworks,
+              cwd,
               compileAnalysis,
+              rawTestOptions,
               testFilter,
-              testClasses
+              testClasses,
+              handler,
+              found
             )
-          val discoveredFrameworks = suites.iterator.filterNot(_._2.isEmpty).map(_._1).toList
-          val (userJvmOptions, userTestOptions) = rawTestOptions.partition(_.startsWith("-J"))
-          val jvmOptions = userJvmOptions.map(_.stripPrefix("-J")) ++ testClasses.jvmOptions
-          val envOptions = testClasses.environmentVariables
-          val frameworkArgs = considerFrameworkArgs(discoveredFrameworks, userTestOptions, logger)
-          val args = project.testOptions.arguments ++ frameworkArgs
-          logger.debug(s"Running test suites with arguments: $args")
-          logger.debug(s"Running ForkMain with jvm opts: $jvmOptions")
-          logger.debug(s"Running ForkMain with env variables: $envOptions")
+        }
+    }
+  }
 
-          found match {
-            case DiscoveredTestFrameworks.Jvm(_, forker, loader) =>
-              val opts = state.commonOptions
-              // FORMAT: OFF
-              TestInternals.execute(cwd, forker, loader, suites, args, jvmOptions, envOptions, handler, logger, opts)
-              // FORMAT: ON
-            case DiscoveredTestFrameworks.Js(_, closeResources) =>
-              val cancelled: AtomicBoolean = AtomicBoolean(false)
-              def cancel(): Unit = {
-                if (!cancelled.getAndSet(true)) {
-                  closeResources()
-                }
-              }
+  /**
+   * Runs the suites for the already-discovered `found` frameworks, dispatching to the JVM or
+   * Scala.js runner depending on the project's platform.
+   */
+  private def runDiscoveredSuites(
+      state: State,
+      project: Project,
+      cwd: AbsolutePath,
+      compileAnalysis: CompileAnalysis,
+      rawTestOptions: List[String],
+      testFilter: String => Boolean,
+      testClasses: bsp.ScalaTestSuites,
+      handler: LoggingEventHandler,
+      found: DiscoveredTestFrameworks
+  ): Task[Int] = {
+    import state.logger
+    val configuredFrameworks = found.frameworks
+    logger.debug(s"Found test frameworks: ${configuredFrameworks.map(_.name).mkString(", ")}")
+    val suites =
+      discoverTestSuites(
+        state,
+        project,
+        configuredFrameworks,
+        compileAnalysis,
+        testFilter,
+        testClasses
+      )
+    val discoveredFrameworks = suites.iterator.filterNot(_._2.isEmpty).map(_._1).toList
+    val (userJvmOptions, userTestOptions) = rawTestOptions.partition(_.startsWith("-J"))
+    val jvmOptions = userJvmOptions.map(_.stripPrefix("-J")) ++ testClasses.jvmOptions
+    val envOptions = testClasses.environmentVariables
+    val frameworkArgs = considerFrameworkArgs(discoveredFrameworks, userTestOptions, logger)
+    val args = project.testOptions.arguments ++ frameworkArgs
+    logger.debug(s"Running test suites with arguments: $args")
+    logger.debug(s"Running ForkMain with jvm opts: $jvmOptions")
+    logger.debug(s"Running ForkMain with env variables: $envOptions")
 
-              def reportTestException(t: Throwable): scala.util.Try[Int] = {
-                logger.error(Feedback.printException("Unexpected test-related exception", t))
-                logger.trace(t)
-                scala.util.Success(ExitStatus.TestExecutionError.code)
-              }
+    found match {
+      case DiscoveredTestFrameworks.Jvm(_, forker, loader) =>
+        val opts = state.commonOptions
+        // FORMAT: OFF
+        TestInternals.execute(cwd, forker, loader, suites, args, jvmOptions, envOptions, handler, logger, opts)
+        // FORMAT: ON
+      case DiscoveredTestFrameworks.Js(_, closeResources) =>
+        runJsTestSuites(suites, args, handler, closeResources, logger)
+    }
+  }
 
-              val checkCancelled = () => cancelled.get
-              TestInternals
-                .runJsTestsInProcess(suites, args, handler, checkCancelled, logger)
-                .materialize
-                .doOnCancel(Task(cancel()))
-                .map {
-                  case s @ scala.util.Success(_) => closeResources(); s
-                  case scala.util.Failure(e) =>
-                    e match {
-                      case NonFatal(t) =>
-                        if (!checkCancelled()) {
-                          closeResources()
-                          reportTestException(t)
-                        } else {
-                          t.getCause match {
-                            // Swallow the ISE because we know it happens when cancelling
-                            case _: IllegalStateException =>
-                              logger.debug("Test server has been successfully closed.")
-                              scala.util.Success(0)
-                            // Swallow the IAE because we know it happens when cancelling
-                            case _: IllegalArgumentException =>
-                              logger.debug("Test server has been successfully closed.")
-                              scala.util.Success(0)
-                            case _ => reportTestException(t)
-                          }
-                        }
-                    }
-                }
-                .dematerialize
-          }
+  /**
+   * Runs the Scala.js test suites in-process, making sure the underlying test server is always
+   * closed and that cancellation-induced exceptions are not reported as failures.
+   */
+  private def runJsTestSuites(
+      suites: Map[Framework, List[TaskDef]],
+      args: List[Config.TestArgument],
+      handler: LoggingEventHandler,
+      closeResources: ScalaJsToolchain.CloseResources,
+      logger: Logger
+  ): Task[Int] = {
+    val cancelled: AtomicBoolean = AtomicBoolean(false)
+    def cancel(): Unit = {
+      if (!cancelled.getAndSet(true)) {
+        closeResources()
       }
     }
+
+    def reportTestException(t: Throwable): scala.util.Try[Int] = {
+      logger.error(Feedback.printException("Unexpected test-related exception", t))
+      logger.trace(t)
+      scala.util.Success(ExitStatus.TestExecutionError.code)
+    }
+
+    val checkCancelled = () => cancelled.get
+    TestInternals
+      .runJsTestsInProcess(suites, args, handler, checkCancelled, logger)
+      .materialize
+      .doOnCancel(Task(cancel()))
+      .map {
+        case s @ scala.util.Success(_) => closeResources(); s
+        case scala.util.Failure(e) =>
+          e match {
+            case NonFatal(t) =>
+              if (!checkCancelled()) {
+                closeResources()
+                reportTestException(t)
+              } else {
+                t.getCause match {
+                  // Swallow the ISE because we know it happens when cancelling
+                  case _: IllegalStateException =>
+                    logger.debug("Test server has been successfully closed.")
+                    scala.util.Success(0)
+                  // Swallow the IAE because we know it happens when cancelling
+                  case _: IllegalArgumentException =>
+                    logger.debug("Test server has been successfully closed.")
+                    scala.util.Success(0)
+                  case _ => reportTestException(t)
+                }
+              }
+          }
+      }
+      .dematerialize
   }
 
   /**

--- a/frontend/src/main/scala/bloop/engine/tasks/toolchains/ScalaJsToolchain.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/toolchains/ScalaJsToolchain.scala
@@ -104,9 +104,15 @@ final class ScalaJsToolchain private (bridgeClassLoader: ClassLoader) {
     val bridgeClazz = bridgeClassLoader.loadClass("bloop.scalajs.JsBridge")
     val method = bridgeClazz.getMethod("discoverTestFrameworks", paramTypesTestFrameworks: _*)
     val node = config.nodePath.map(_.toAbsolutePath.toString).getOrElse("node")
-    val (frameworks, closeResources) = method
-      .invoke(null, frameworkNames, node, linkedFile.underlying, baseDir, logger, config, env)
-      .asInstanceOf[(List[sbt.testing.Framework], ScalaJsToolchain.CloseResources)]
+    val (frameworks, closeResources) =
+      try {
+        method
+          .invoke(null, frameworkNames, node, linkedFile.underlying, baseDir, logger, config, env)
+          .asInstanceOf[(List[sbt.testing.Framework], ScalaJsToolchain.CloseResources)]
+      } catch {
+        // Unwrap the reflective wrapper so callers see the real cause, mirroring `link`
+        case e: InvocationTargetException => throw e.getCause
+      }
 
     DiscoveredTestFrameworks.Js(frameworks, closeResources)
   }

--- a/frontend/src/main/scala/bloop/exec/Forker.scala
+++ b/frontend/src/main/scala/bloop/exec/Forker.scala
@@ -95,8 +95,18 @@ object Forker {
             }
           } catch {
             case t: IOException =>
-              logger.debug(s"Error from input gobbler: ${t.getMessage}")
-              logger.trace(t)
+              // A broken/closed pipe is expected once the child stops reading stdin;
+              // anything else is a genuine input-forwarding failure worth surfacing.
+              val benign = shutdownInput ||
+                Option(t.getMessage).exists { m =>
+                  m.contains("Broken pipe") || m.contains("Stream closed")
+                }
+              if (benign) {
+                logger.debug(s"Error from input gobbler: ${t.getMessage}")
+                logger.trace(t)
+              } else {
+                logger.error("Error forwarding standard input to the forked process", t)
+              }
               // Rethrow so that Monix cancels future scheduling of the same task
               throw t
           }
@@ -180,13 +190,21 @@ object Forker {
       }
     }
 
-    def readOutput(stream: InputStream, f: String => Unit): Thread = {
-      val thread = new Thread {
+    def readOutput(streamName: String, stream: InputStream, f: String => Unit): Thread = {
+      val thread = new Thread(s"bloop-forker-$streamName") {
         override def run(): Unit = {
           // use scala.sys.process implementation
           try {
             BasicIO.processFully(f)(stream)
-          } catch { case NonFatal(_) => }
+          } catch {
+            // Reader threads are interrupted on completion/cancellation; only surface
+            // failures that are not part of a normal teardown so genuine I/O errors
+            // are no longer swallowed silently.
+            case _: java.io.InterruptedIOException => ()
+            case NonFatal(t) =>
+              if (!isInterrupted)
+                logger.error(s"Error reading $streamName from the forked process", t)
+          }
         }
       }
       thread.setDaemon(true)
@@ -205,8 +223,8 @@ object Forker {
       val writeIn = writeToStdIn(ps.getOutputStream)
       val outReaders =
         List(
-          readOutput(ps.getInputStream(), logger.info),
-          readOutput(ps.getErrorStream(), logger.error)
+          readOutput("stdout", ps.getInputStream(), logger.info),
+          readOutput("stderr", ps.getErrorStream(), logger.error)
         )
       awaitCompletion(writeIn, outReaders, ps)
         .doOnCancel(cancelTask(writeIn, outReaders, ps))
@@ -214,14 +232,14 @@ object Forker {
           case error =>
             writeIn.cancel()
             outReaders.foreach(_.interrupt())
-            logger.error(error.getMessage)
+            logger.error(s"Failed to run '${cmd.mkString(" ")}'", error)
             Forker.EXIT_ERROR
         }
     }
 
     task.onErrorRecover {
       case e =>
-        logger.error(e.getMessage)
+        logger.error(s"Failed to run '${cmd.mkString(" ")}'", e)
         Forker.EXIT_ERROR
     }
   }

--- a/frontend/src/test/scala/bloop/ForkerSpec.scala
+++ b/frontend/src/test/scala/bloop/ForkerSpec.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration.Duration
 
+import bloop.cli.CommonOptions
 import bloop.cli.ExitStatus
 import bloop.data.JdkConfig
 import bloop.exec.Forker
@@ -190,6 +191,23 @@ class ForkerSpec {
         assertEquals(ExitStatus.RunError, exitStatus)
         assert(messages.exists(expected), s"Could not find expected error messages in $messages")
     }
+  }
+
+  @Test
+  def runReportsMissingExecutable(): Unit = TestUtil.withinWorkspace { tmp =>
+    val logger = new RecordingLogger
+    val missing = "bloop-nonexistent-binary-xyz"
+    val wait = Duration.apply(25, TimeUnit.SECONDS)
+    val exitCode = TestUtil.await(wait)(
+      Forker.run(tmp, List(missing), logger, CommonOptions.default)
+    )
+    val messages = logger.getMessages()
+    assertEquals(ExitStatus.RunError, Forker.exitStatus(exitCode))
+    val expected: ((String, String)) => Boolean = {
+      case ("error", msg) => msg.contains("Failed to run") && msg.contains(missing)
+      case _ => false
+    }
+    assert(messages.exists(expected), s"Could not find expected error message in $messages")
   }
 
   @Test


### PR DESCRIPTION
Fixes #981

## What changed

**Scala.js test-framework discovery (the main remaining gap)**
- `ScalaJsToolchain.discoverTestFrameworks` now unwraps the reflective `InvocationTargetException` and rethrows the real cause, mirroring what `link` already does.
- `TestTask.runTestSuites` reports a discovery failure **once** via `logger.error` (always visible, no `--verbose` needed) and returns a non-zero `TestExecutionError`, instead of letting the failure surface as a verbose-only stack trace.

  | | Before | After |
  |---|---|---|
  | CLI | `Caught java.lang.reflect.InvocationTargetException` (cause hidden unless `--verbose`) | `Failed to discover test frameworks for '<project>': '<cause>'` |
  | BSP | `Failed test execution: null` | the real cause is reported |

  It also no longer prints the misleading `Missing configured test frameworks` on a genuine discovery failure.

**Run path (`Forker`)**
- Start/run failures are reported with the failing command and the throwable (null-safe overload) instead of a bare, possibly-`null` message: `Failed to run '<cmd>'`.
- The output-reader threads no longer **silently** discard exceptions, and the stdin-forwarding thread distinguishes a benign broken/closed pipe (debug) from a genuine I/O failure (error) — so real failures surface while normal teardown stays quiet.

**Cleanup**
- Split the overlong `TestTask.runTestSuites` into focused helpers (`runDiscoveredSuites`, `runJsTestSuites`) and de-duplicated the missing-frameworks/compilation reporting.
