### PR TITLE
Support JUnit 5 (Jupiter) tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,8 @@ lazy val frontend: Project = project
       "jsBridge06" -> (jsBridge06Name + "_" + Keys.scalaBinaryVersion.value),
       "jsBridge1" -> (jsBridge1Name + "_" + Keys.scalaBinaryVersion.value),
       "lastSupportedSemanticdb" -> build.SemanticDbSupport.last,
-      "millVersion" -> Dependencies.millVersion
+      "millVersion" -> Dependencies.millVersion,
+      "jupiterInterfaceVersion" -> Dependencies.jupiterInterfaceVersion
     ),
     (run / javaOptions) ++= jvmOptions,
     (Test / javaOptions) ++= jvmOptions,
@@ -159,7 +160,8 @@ lazy val frontend: Project = project
       Dependencies.scalaDebugAdapter,
       Dependencies.bloopConfig,
       Dependencies.logback,
-      Dependencies.libdaemonjvm
+      Dependencies.libdaemonjvm,
+      Dependencies.jupiterInterface
     ),
     // needed for tests and to be automatically updated
     Test / libraryDependencies += Dependencies.semanticdb intransitive (),

--- a/docs/assets/bloop-schema.json
+++ b/docs/assets/bloop-schema.json
@@ -636,7 +636,8 @@
                 "examples": [
                   "org.scalacheck.ScalaCheckFramework",
                   "org.scalatest.tools.Framework",
-                  "org.scalatest.tools.ScalaTestFramework"
+                  "org.scalatest.tools.ScalaTestFramework",
+                  "com.github.sbt.junit.jupiter.api.JupiterFramework"
                 ]
               }
             },

--- a/docs/server.md
+++ b/docs/server.md
@@ -11,6 +11,12 @@ Bloop's build server is a long-running process designed to provide the fastest
 compilation possible to users. As such, users are responsible for managing its
 lifecycle and minimizing the amount of times it's restarted.
 
+<blockquote class="grab-attention">
+Discovering and running <b>JUnit 5</b> (Jupiter) tests requires the build server to run on
+<b>JDK 17 or newer</b>, because Bloop discovers them with the JUnit Platform launcher (which targets
+Java 17). The native CLI is unaffected. On older JVMs JUnit 5 discovery is skipped with a warning.
+</blockquote>
+
 ## Start the build server
 
 At the end of the day, the build server is an artifact in Maven Central.

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -24,6 +24,7 @@ import bloop.io.ByteHasher
 import bloop.logging.DebugFilter
 import bloop.logging.Logger
 import bloop.task.Task
+import bloop.testing.JUnit5FrameworkDependency
 import bloop.testing.TestNGFrameworkDependency
 import bloop.util.JavaRuntime
 
@@ -306,9 +307,14 @@ object Project {
             .getOrElse(compileClasspath)
 
           // adjust for testng
-          if (testFrameworks.contains(Config.TestFramework.TestNG))
-            TestNGFrameworkDependency.maybeAddTestNGFrameworkDependency(classpath, logger)
-          else classpath
+          val withTestNG =
+            if (testFrameworks.contains(Config.TestFramework.TestNG))
+              TestNGFrameworkDependency.maybeAddTestNGFrameworkDependency(classpath, logger)
+            else classpath
+          // adjust for junit 5: add the test-interface adapter if the project uses junit-jupiter
+          // but lacks the adapter. Triggered from the classpath (not the configured frameworks)
+          // because config generators may not export the Jupiter framework.
+          JUnit5FrameworkDependency.maybeAddJUnit5FrameworkDependency(withTestNG, logger)
         }
         val runtimeResources = platform.resources
           .map(_.map(AbsolutePath.apply))

--- a/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/TestTask.scala
@@ -114,6 +114,10 @@ object TestTask {
         case Some(found) =>
           val configuredFrameworks = found.frameworks
           logger.debug(s"Found test frameworks: ${configuredFrameworks.map(_.name).mkString(", ")}")
+          val jvmTestLoader = found match {
+            case DiscoveredTestFrameworks.Jvm(_, _, loader) => Some(loader)
+            case _: DiscoveredTestFrameworks.Js => None
+          }
           val suites =
             discoverTestSuites(
               state,
@@ -121,7 +125,8 @@ object TestTask {
               configuredFrameworks,
               compileAnalysis,
               testFilter,
-              testClasses
+              testClasses,
+              jvmTestLoader
             )
           val discoveredFrameworks = suites.iterator.filterNot(_._2.isEmpty).map(_._1).toList
           val (userJvmOptions, userTestOptions) = rawTestOptions.partition(_.startsWith("-J"))
@@ -208,9 +213,23 @@ object TestTask {
         val classpath = project.fullRuntimeClasspath(dag, state.client)
         val forker = JvmProcessForker(env, classpath, mode)
         val testLoader = forker.newClassLoader(Some(TestInternals.filteredLoader))
-        val frameworks = project.testFrameworks.flatMap(f =>
+        val configuredFrameworks = project.testFrameworks.flatMap(f =>
           TestInternals.loadFramework(testLoader, f.names, logger)
         )
+        // The JUnit 5 adapter may be on the classpath without being declared in the bloop config
+        // (e.g. config generators that don't export it). Load it so its tests are still discovered.
+        val frameworks =
+          if (configuredFrameworks.exists(TestInternals.isJupiterFramework)) configuredFrameworks
+          else if (
+            classpath.exists(_.underlying.getFileName.toString.startsWith("jupiter-interface"))
+          )
+            configuredFrameworks ++
+              TestInternals.loadFramework(
+                testLoader,
+                List(TestInternals.JupiterFrameworkClass),
+                logger
+              )
+          else configuredFrameworks
         Task.now(Some(DiscoveredTestFrameworks.Jvm(frameworks, forker, testLoader)))
 
       case Platform.Js(config, toolchain, userMainClass) =>
@@ -293,10 +312,11 @@ object TestTask {
       frameworks: List[Framework],
       analysis: CompileAnalysis,
       testFilter: String => Boolean,
-      testClasses: bsp.ScalaTestSuites
+      testClasses: bsp.ScalaTestSuites,
+      classLoader: Option[ClassLoader] = None
   ): Map[Framework, List[TaskDef]] = {
     import state.logger
-    val tests = discoverTests(analysis, frameworks)
+    val tests = discoverAllTests(state, project, frameworks, analysis, classLoader)
     val excluded = project.testOptions.excludes.toSet
     val ungroupedTests = tests.toList.flatMap {
       case (framework, tasks) => tasks.map(taskDef => TaskDefWithFramework(taskDef, framework))
@@ -343,7 +363,7 @@ object TestTask {
                 new TaskDef(
                   taskDef.fullyQualifiedName(),
                   taskDef.fingerprint(),
-                  false,
+                  taskDef.explicitlySpecified(),
                   value.map(test => new TestSelector(test)).toList.toArray
                 )
             }
@@ -381,6 +401,41 @@ object TestTask {
   }
 
   /**
+   * Discovers tests for all frameworks, combining sbt fingerprint discovery with the JUnit
+   * Platform discovery needed for JUnit 5 (Jupiter). Jupiter tests cannot be found by the
+   * fingerprint path (the adapter reports a fake fingerprint on purpose), so when a Jupiter
+   * framework is present and the project is a JVM project we run `JupiterTestCollector` against
+   * the project's compiled classes and merge its TaskDefs in. `classLoader` is only used as the
+   * "this is a JVM project" signal; discovery itself runs against Bloop's bundled Platform stack.
+   */
+  private[bloop] def discoverAllTests(
+      state: State,
+      project: Project,
+      frameworks: List[Framework],
+      analysis: CompileAnalysis,
+      classLoader: Option[ClassLoader]
+  ): Map[Framework, List[TaskDef]] = {
+    val fingerprintTests = discoverTests(analysis, frameworks)
+    (classLoader, frameworks.find(TestInternals.isJupiterFramework)) match {
+      case (Some(_), Some(jupiter)) =>
+        val classDirectory =
+          state.client.getUniqueClassesDirFor(project, forceGeneration = true).underlying
+        val dag = state.build.getDagFor(project)
+        val runtimeClasspath =
+          project.fullRuntimeClasspath(dag, state.client).map(_.underlying.toUri.toURL)
+        val jupiterTests =
+          TestInternals.discoverJUnit5Tests(classDirectory, runtimeClasspath, state.logger)
+        if (jupiterTests.isEmpty) fingerprintTests
+        else
+          fingerprintTests.updated(
+            jupiter,
+            fingerprintTests.getOrElse(jupiter, Nil) ++ jupiterTests
+          )
+      case _ => fingerprintTests
+    }
+  }
+
+  /**
    * Finds the fully qualified names of the test names discovered in a project.
    *
    * @param state   The current state of Bloop.
@@ -395,6 +450,10 @@ object TestTask {
       case None => List.empty
       case Some(found) =>
         val frameworks = found.frameworks
+        val jvmTestLoader = found match {
+          case DiscoveredTestFrameworks.Jvm(_, _, loader) => Some(loader)
+          case _: DiscoveredTestFrameworks.Js => None
+        }
         val lastCompileResult = state.results.lastSuccessfulResultOrEmpty(project)
         val analysis = lastCompileResult.previous.analysis().toOption.getOrElse {
           state.logger
@@ -403,7 +462,7 @@ object TestTask {
             )
           Analysis.empty
         }
-        val tests = discoverTests(analysis, frameworks)
+        val tests = discoverAllTests(state, project, frameworks, analysis, jvmTestLoader)
         tests.map {
           case (framework, tasks) =>
             TestFrameworkWithClasses(framework.name, tasks.map(_.fullyQualifiedName))

--- a/frontend/src/main/scala/bloop/testing/JUnit5FrameworkDependency.scala
+++ b/frontend/src/main/scala/bloop/testing/JUnit5FrameworkDependency.scala
@@ -1,0 +1,92 @@
+package bloop.testing
+
+import bloop.DependencyResolution
+import bloop.internal.build.BuildInfo
+import bloop.io.AbsolutePath
+import bloop.logging.DebugFilter
+import bloop.logging.Logger
+
+/**
+ * JUnit 5 needs the sbt test-interface adapter (`com.github.sbt.junit:jupiter-interface`,
+ * which also provides the `JupiterFramework` and the JUnit Platform launcher) on the test
+ * classpath to discover and run tests. Projects depending on `junit-jupiter` directly (e.g.
+ * Maven/Gradle builds) usually don't have that adapter, so Bloop adds it here.
+ */
+object JUnit5FrameworkDependency {
+  private val junitJupiterPattern = raw"junit-jupiter-.*\.jar".r
+  private val jupiterInterfacePattern = raw"jupiter-interface-.*\.jar".r
+
+  /**
+   * If the project uses JUnit 5 (`junit-jupiter-*` on the classpath) but the adapter
+   * (`jupiter-interface-*`) is missing, resolve it and append the parts that aren't already on
+   * the classpath. The user's own `junit-jupiter` engine/api versions are left untouched so they
+   * stay authoritative; only the adapter (and the platform launcher, if absent) are added.
+   */
+  def maybeAddJUnit5FrameworkDependency(
+      rawClasspath: List[AbsolutePath],
+      logger: Logger
+  ): List[AbsolutePath] = {
+    var junitJupiterDependency = false
+    var jupiterInterfaceDependency = false
+    rawClasspath.foreach { jar =>
+      if (jar.isFile) {
+        jar.underlying.getFileName().toString() match {
+          case junitJupiterPattern() => junitJupiterDependency = true
+          case jupiterInterfacePattern() => jupiterInterfaceDependency = true
+          case _ =>
+        }
+      }
+    }
+
+    if (junitJupiterDependency && !jupiterInterfaceDependency) {
+      getJUnit5FrameworkDependency(logger) match {
+        case None => rawClasspath
+        case Some(resolved) =>
+          val present =
+            rawClasspath.iterator
+              .map(p => artifactBaseName(p.underlying.getFileName.toString))
+              .toSet
+          val additions =
+            resolved.filterNot(p => present(artifactBaseName(p.underlying.getFileName.toString)))
+          logger.debug(
+            s"Adding JUnit 5 adapter jars: ${additions.map(_.underlying.getFileName).mkString(", ")}"
+          )(DebugFilter.Test)
+          val hasLauncher =
+            present("junit-platform-launcher") ||
+              additions.exists(
+                _.underlying.getFileName.toString.startsWith("junit-platform-launcher")
+              )
+          if (!hasLauncher)
+            logger.warn(
+              "JUnit 5 detected but no junit-platform-launcher on the classpath; tests may not run."
+            )
+          rawClasspath ++ additions
+      }
+    } else rawClasspath
+  }
+
+  /** Strip the trailing `-<version>` from a jar file name, e.g. `jupiter-interface-0.19.0.jar`. */
+  private def artifactBaseName(jarFileName: String): String =
+    jarFileName
+      .stripSuffix(".jar")
+      .split('-')
+      .reverse
+      .dropWhile(_.headOption.exists(_.isDigit))
+      .reverse
+      .mkString("-")
+
+  private def getJUnit5FrameworkDependency(logger: Logger): Option[Array[AbsolutePath]] = {
+    val jupiterInterface =
+      DependencyResolution.Artifact(
+        "com.github.sbt.junit",
+        "jupiter-interface",
+        BuildInfo.jupiterInterfaceVersion
+      )
+    DependencyResolution.resolveWithErrors(List(jupiterInterface), logger) match {
+      case Left(error) =>
+        logger.warn(s"Failed to resolve JUnit 5 jupiter-interface dependency: $error")
+        None
+      case Right(value) => Some(value)
+    }
+  }
+}

--- a/frontend/src/main/scala/bloop/testing/TestInternals.scala
+++ b/frontend/src/main/scala/bloop/testing/TestInternals.scala
@@ -1,11 +1,15 @@
 package bloop.testing
 
+import java.net.URL
+import java.nio.file.Path
 import java.util.regex.Pattern
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.control.NonFatal
 
 import ch.epfl.scala.debugadapter.testing.TestSuiteEvent
+import com.github.sbt.junit.jupiter.api.JupiterTestCollector
 
 import bloop.DependencyResolution
 import bloop.cli.CommonOptions
@@ -19,6 +23,7 @@ import bloop.io.AbsolutePath
 import bloop.logging.DebugFilter
 import bloop.logging.Logger
 import bloop.task.Task
+import bloop.util.JavaRuntime
 
 import monix.execution.atomic.AtomicBoolean
 import org.scalatools.testing.{Framework => OldFramework}
@@ -67,6 +72,20 @@ object TestInternals {
     )
     new FilteredLoader(getClass.getClassLoader, filter)
   }
+
+  /** Implementation class of the sbt test-interface adapter for JUnit 5 (Jupiter). */
+  final val JupiterFrameworkClass = "com.github.sbt.junit.jupiter.api.JupiterFramework"
+
+  /** Minimum Java version of the Bloop server JVM required to run JUnit 5 discovery. */
+  private final val JUnit5MinJavaVersion = 17
+
+  /**
+   * Whether `framework` is the JUnit 5 (Jupiter) adapter. Its fingerprint reports a fake
+   * annotation name on purpose, so fingerprint-based discovery never matches Jupiter tests;
+   * they must be discovered with `discoverJUnit5Tests` instead.
+   */
+  def isJupiterFramework(framework: Framework): Boolean =
+    framework.getClass.getName == JupiterFrameworkClass || framework.name() == "Jupiter"
 
   /**
    * Parses `filters` to produce a filtering function for the tests.
@@ -290,6 +309,92 @@ object TestInternals {
   ): Runner = {
     val args = args0.toArray.flatMap(_.args)
     framework.runner(args, Array.empty, testClassLoader)
+  }
+
+  /** Jars that make up the JUnit Platform / Jupiter stack, which Bloop bundles itself. */
+  private def isBundledJupiterJar(url: URL): Boolean = {
+    val name = url.getPath.split('/').lastOption.getOrElse("")
+    name.startsWith("junit-platform-") || name.startsWith("junit-jupiter-") ||
+    name.startsWith("junit-vintage-") || name.startsWith("jupiter-interface-") ||
+    name.startsWith("opentest4j-") || name.startsWith("apiguardian-api-")
+  }
+
+  /** Major version of the JVM Bloop itself is running on (handles both "17.0.x" and "1.8.0"). */
+  private def currentJavaMajorVersion: Int = {
+    val raw = JavaRuntime.version
+    val normalized = if (raw.startsWith("1.")) raw.substring(2) else raw
+    normalized.takeWhile(_.isDigit) match {
+      case "" => 0
+      case digits => digits.toInt
+    }
+  }
+
+  /**
+   * Discovers JUnit 5 (Jupiter) tests using the JUnit Platform launcher.
+   *
+   * Bloop's regular fingerprint discovery (via Zinc analysis) cannot find Jupiter tests: the
+   * adapter reports a fake fingerprint on purpose and relies on its own discovery, which in sbt
+   * lives in a plugin. We port that step here by running `JupiterTestCollector` against the
+   * project's compiled classes, using Bloop's *bundled* JUnit Platform launcher and Jupiter
+   * engine (Bloop is built against `jupiter-interface`).
+   *
+   * The project's own `junit-platform`/`junit-jupiter` jars are deliberately kept out of the
+   * discovery classloader: if both Bloop's and the project's copies were visible, the platform's
+   * ServiceLoader would see two copies of `TestEngine`/`JupiterTestEngine` and fail with
+   * "TestEngine ... not a subtype" or duplicate-engine errors. The compiled test classes in
+   * `classDirectory` are scanned with Bloop's engine; the tests themselves are run in the forked
+   * JVM with the project's own engine.
+   *
+   * Bloop's bundled JUnit Platform launcher is compiled for Java 17, so discovery is skipped (with
+   * a clear message) when the Bloop server runs on an older JVM.
+   *
+   * @param classDirectory   Directory that directly contains the project's compiled `.class` files.
+   * @param runtimeClasspath Project runtime classpath URLs (Bloop's Jupiter jars are filtered out).
+   * @param logger           Logger for diagnostic messages.
+   * @return TaskDefs for the discovered Jupiter tests (empty if none, on failure, or on JDK < 17).
+   */
+  def discoverJUnit5Tests(
+      classDirectory: Path,
+      runtimeClasspath: Array[URL],
+      logger: Logger
+  ): List[TaskDef] = {
+    if (currentJavaMajorVersion < JUnit5MinJavaVersion) {
+      logger.warn(
+        s"JUnit 5 test discovery requires the Bloop server to run on JDK $JUnit5MinJavaVersion+ " +
+          s"(current: ${JavaRuntime.version}); skipping JUnit 5 discovery."
+      )
+      Nil
+    } else {
+      try {
+        logger.debug(s"Discovering JUnit 5 tests in ${classDirectory.toAbsolutePath}")
+        val discoveryClasspath = runtimeClasspath.filterNot(isBundledJupiterJar)
+        val collector = new JupiterTestCollector.Builder()
+          .withClassDirectory(classDirectory.toFile)
+          .withClassLoader(getClass.getClassLoader)
+          .withRuntimeClassPath(discoveryClasspath)
+          .build()
+        val discovered = collector.collectTests().getDiscoveredTests.asScala.toList
+        logger.debug(s"Discovered ${discovered.size} JUnit 5 test(s)")
+        discovered.map { item =>
+          new TaskDef(
+            item.getFullyQualifiedClassName,
+            item.getFingerprint,
+            item.isExplicit,
+            item.getSelectors
+          )
+        }
+      } catch {
+        case e: LinkageError =>
+          logger.error(
+            s"JUnit 5 support requires the Bloop server on JDK $JUnit5MinJavaVersion+ " +
+              s"(JUnit Platform 6 targets Java 17). Discovery skipped: ${e.getMessage}"
+          )
+          Nil
+        case NonFatal(t) =>
+          logger.error(s"JUnit 5 test discovery failed in ${classDirectory.toAbsolutePath}", t)
+          Nil
+      }
+    }
   }
 
   /**

--- a/frontend/src/test/scala/bloop/JUnit5TestSpec.scala
+++ b/frontend/src/test/scala/bloop/JUnit5TestSpec.scala
@@ -1,0 +1,77 @@
+package bloop
+
+import bloop.cli.Commands
+import bloop.engine.Run
+import bloop.io.AbsolutePath
+import bloop.io.Environment.lineSeparator
+import bloop.logging.RecordingLogger
+import bloop.util.TestUtil
+
+import org.junit.Assert
+import org.junit.Test
+
+class JUnit5TestSpec {
+  // A class whose only test marker is a *method-level* `@org.junit.jupiter.api.Test`.
+  // Bloop's fingerprint discovery cannot find this: the Jupiter adapter reports a fake fingerprint
+  // on purpose, so even a fully public class is invisible to fingerprint matching. It is found only
+  // via the JUnit Platform launcher (JupiterTestCollector).
+  private val jupiterTestSource =
+    """
+      |package hello
+      |
+      |import org.junit.jupiter.api.Test
+      |import org.junit.jupiter.api.Assertions.assertEquals
+      |
+      |class JupiterTest {
+      |  @Test def addition(): Unit = assertEquals(4, 2 + 2)
+      |}
+    """.stripMargin
+
+  /**
+   * Builds a one-project workspace with the given JUnit 5 stack on the classpath, runs `test`, and
+   * asserts the method-level `@Test` was discovered (started) and the run was green. Discovery
+   * always uses Bloop's bundled JUnit Platform launcher; the run uses whatever engine `jars`
+   * provides, so this exercises the discovery→run handoff for both Jupiter 6.x and 5.x.
+   */
+  private def assertDiscoversAndRuns(jars: Array[AbsolutePath]): Unit = {
+    val logger = new RecordingLogger(ansiCodesSupported = false)
+    val structure = Map("test-project" -> Map("JupiterTest.scala" -> jupiterTestSource))
+    TestUtil.testState(
+      structure,
+      Map.empty[String, Set[String]],
+      userLogger = Some(logger),
+      extraJars = jars,
+      testProjects = Set("test-project")
+    ) { state =>
+      val action = Run(Commands.Test(List("test-project"), args = List("-v", "-a")))
+      val testedState = TestUtil.blockingExecute(action, state)
+      Assert.assertTrue(
+        s"Unexpected compilation/test error:\n${logger.getMessagesAt(Some("error")).mkString(lineSeparator)}",
+        testedState.status.isOk
+      )
+      Assert.assertTrue(
+        s"JUnit 5 test was not discovered/run. Started:\n${logger.startedTestInfos.mkString(lineSeparator)}",
+        logger.startedTestInfos.exists(_.contains("hello.JupiterTest"))
+      )
+    }
+  }
+
+  @Test
+  def canDiscoverAndRunJupiterTests(): Unit = {
+    // The bundled adapter version (Jupiter 6.x), resolved on Bloop's own test classpath.
+    val jars = bloop.internal.build.BuildTestInfo.jupiterTestJars.map(AbsolutePath.apply).toArray
+    assertDiscoversAndRuns(jars)
+  }
+
+  @Test
+  def canDiscoverAndRunJupiter5xTests(): Unit = {
+    // Run a project on the JUnit Platform 1.x / Jupiter 5.x stack (jupiter-interface 0.16.0) while
+    // Bloop discovers it with its bundled 6.x launcher — proving the bundle supports 5.x projects.
+    val logger = new RecordingLogger(ansiCodesSupported = false)
+    val jars = DependencyResolution.resolve(
+      List(DependencyResolution.Artifact("com.github.sbt.junit", "jupiter-interface", "0.16.0")),
+      logger
+    )
+    assertDiscoversAndRuns(jars)
+  }
+}

--- a/frontend/src/test/scala/bloop/util/TestProject.scala
+++ b/frontend/src/test/scala/bloop/util/TestProject.scala
@@ -115,7 +115,8 @@ abstract class BaseTestProject {
       jars: Array[AbsolutePath] = Array(),
       sourcesGlobs: List[Config.SourcesGlobs] = Nil,
       sourceGenerators: List[Config.SourceGenerator] = Nil,
-      additionalResources: List[Path] = Nil
+      additionalResources: List[Path] = Nil,
+      testFrameworks: Option[List[Config.TestFramework]] = None
   ): TestProject = {
     val projectBaseDir = Files.createDirectories(baseDir.underlying.resolve(name))
     val ProjectArchetype(sourceDir, outDir, resourceDir, classes, runtimeResourceDir) =
@@ -168,7 +169,8 @@ abstract class BaseTestProject {
 
     val javacConfig = Config.Java(javacOptions)
 
-    val frameworks = if (enableTests) Config.TestFramework.DefaultFrameworks else Nil
+    val frameworks =
+      if (enableTests) testFrameworks.getOrElse(Config.TestFramework.DefaultFrameworks) else Nil
     val testConfig = Config.Test(frameworks, Config.TestOptions.empty)
     val platform = Config.Platform.Jvm(
       javaConfig,

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -400,7 +400,10 @@ object TestUtil {
     val classpath = depsTargets ++ allJars ++ extraJars
     val sourceDirectories = List(srcs)
     val testFrameworks =
-      if (classpath.exists(_.syntax.contains("junit"))) List(Config.TestFramework.JUnit) else Nil
+      if (classpath.exists(_.syntax.contains("jupiter-interface")))
+        List(Config.TestFramework(List(bloop.testing.TestInternals.JupiterFrameworkClass)))
+      else if (classpath.exists(_.syntax.contains("junit"))) List(Config.TestFramework.JUnit)
+      else Nil
 
     writeFilesToBase(srcs, sources.map(kv => RelativePath(kv._1) -> kv._2))
     Project(

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -363,12 +363,22 @@ object BuildImplementation {
               val junitJars = jars.filter(j => j.contains("junit") || j.contains("hamcrest"))
               "junitTestJars" -> junitJars
           }
+          val jupiterTestJars = BuildInfoKey.map((Test / Keys.externalDependencyClasspath)) {
+            case (_, classpath) =>
+              val jars = classpath.map(_.data.getAbsolutePath)
+              val jupiterJars = jars.filter(j =>
+                j.contains("jupiter") || j.contains("junit-platform") ||
+                  j.contains("opentest4j") || j.contains("apiguardian")
+              )
+              "jupiterTestJars" -> jupiterJars
+          }
           val sampleSourceGenerator = (Test / Keys.resourceDirectory).value / "source-generator.py"
 
           List(
             "sampleSourceGenerator" -> sampleSourceGenerator,
             "semanticdbVersion" -> Dependencies.semanticdbVersion,
             junitTestJars,
+            jupiterTestJars,
             BuildKeys.bloopCoursierJson,
             (ThisBuild / Keys.baseDirectory)
           )

--- a/project/BuildPlugin.scala
+++ b/project/BuildPlugin.scala
@@ -360,7 +360,16 @@ object BuildImplementation {
           val junitTestJars = BuildInfoKey.map((Test / Keys.externalDependencyClasspath)) {
             case (_, classpath) =>
               val jars = classpath.map(_.data.getAbsolutePath)
-              val junitJars = jars.filter(j => j.contains("junit") || j.contains("hamcrest"))
+              // JUnit 4 fixture jars only: exclude the JUnit 5 / Platform stack, which is on the
+              // test classpath via bloop's jupiter-interface dependency and would otherwise be
+              // pulled in by the loose `contains("junit")` match (e.g. the `.../junit/...` path of
+              // jupiter-interface and the `junit-jupiter`/`junit-platform` jars).
+              val junitJars = jars.filter(j =>
+                (j.contains("junit") || j.contains("hamcrest")) &&
+                  !j.contains("jupiter") && !j.contains("junit-platform") &&
+                  !j.contains("junit-vintage") && !j.contains("opentest4j") &&
+                  !j.contains("apiguardian")
+              )
               "junitTestJars" -> junitJars
           }
           val jupiterTestJars = BuildInfoKey.map((Test / Keys.externalDependencyClasspath)) {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,6 +26,7 @@ object Dependencies {
   val sbtTestInterfaceVersion = "1.0"
   val sbtTestAgentVersion = "1.12.11"
   val junitVersion = "0.13.3"
+  val jupiterInterfaceVersion = "0.19.0"
   val directoryWatcherVersion = "0.8.0+6-f651bd93"
   val monixVersion = "3.2.0"
   val jsoniterVersion = "2.13.3.2"
@@ -85,6 +86,7 @@ object Dependencies {
   val pprint = "com.lihaoyi" %% "pprint" % "0.9.6"
   val oslib = "com.lihaoyi" %% "os-lib" % "0.11.8"
   val junit = "com.github.sbt" % "junit-interface" % junitVersion
+  val jupiterInterface = "com.github.sbt.junit" % "jupiter-interface" % jupiterInterfaceVersion
   val directoryWatcher = "ch.epfl.scala" % "directory-watcher" % directoryWatcherVersion
   val difflib = "com.googlecode.java-diff-utils" % "diffutils" % difflibVersion
 


### PR DESCRIPTION
Closes #996.

Bloop discovers tests through the sbt test-interface fingerprint mechanism, but JUnit 5 can't be found that way: the `com.github.sbt.junit:jupiter-interface` adapter deliberately reports a *fake* fingerprint so fingerprint discovery finds nothing, and does its real discovery in an **sbt plugin** (via the JUnit Platform launcher) — which Bloop doesn't run. As a result, JUnit 5 tests (including method-level `@Test` and package-private classes) were never discovered.

## How

- Bundle `jupiter-interface 0.19.0` and run its `JupiterTestCollector` (the JUnit Platform launcher) to discover Jupiter tests, merging the results into Bloop's normal discovery for **both** the `test` run path and the BSP test-listing path (Metals' test explorer).
- Discovery uses Bloop's **bundled** JUnit Platform launcher/engine; the project's own platform/jupiter jars are kept out of the discovery classloader — otherwise the platform's ServiceLoader sees two `TestEngine` copies and fails with "not a subtype"/duplicate-engine.
- The tests themselves run in the forked JVM with the **project's own** engine. So a project on Jupiter 5.x is discovered by the bundled 6.x launcher and executed by its 5.x engine - one bundle, both lines.
- If a project depends on `junit-jupiter` but lacks the adapter (typical for Maven/Gradle), Bloop auto-resolves and appends `jupiter-interface`, mirroring the existing TestNG handling.

## ⚠️ Requires the build server on JDK 17+

`jupiter-interface 0.19.0` pulls JUnit Platform 6.x, whose baseline is **Java 17**. JUnit 5 *discovery* therefore requires the Bloop **server** to run on JDK 17+. This is guarded: on older JVMs discovery is skipped with a clear warning (no crash). The native CLI is unaffected, and Bloop already de-facto requires JDK 16+ (`UnixDomainSocketAddress`).

## Out of scope / follow-ups

- `scalacenter/bloop-config`: a `Config.TestFramework.Jupiter` constant + `DefaultFrameworks` entry.
- `bloop-maven-plugin` / `gradle-bloop`: emit the Jupiter framework FQN in generated config (Bloop's classpath-based auto-detect mitigates, but the generators should still emit it).
