### PR TITLE
Add regression test for the Ammonite console on JDK > 8

### DIFF
--- a/frontend/src/test/scala/bloop/ConsoleSpec.scala
+++ b/frontend/src/test/scala/bloop/ConsoleSpec.scala
@@ -55,6 +55,68 @@ object ConsoleSpec extends BaseSuite {
             |$expectedCommand
             |""".stripMargin
       )
+
+      // The generated command must use a current Ammonite (`latest.release`, which supports
+      // JDK > 8) and must not emit a `--scala-version` flag; together those previously broke
+      // the console with a MissingRequirementError on JDK > 8.
+      val ammoniteCommand = logger.infos
+        .find(_.startsWith("coursier"))
+        .getOrElse(sys.error(s"No coursier command logged: ${logger.infos}"))
+      assert(ammoniteCommand.contains("latest.release"))
+      assert(!ammoniteCommand.contains("--scala-version"))
     }
+  }
+
+  // On JDK > 8 the Ammonite console used to fail with
+  //   MissingRequirementError: object java.lang.Object in compiler mirror not found
+  // Actually launching the command bloop generates must initialize Ammonite's compiler on the
+  // running JDK without that error. Skipped when the `coursier` launcher is not on the PATH.
+  private val launchTestName =
+    "ammonite console launches without MissingRequirementError"
+  if (TestUtil.hasCoursier) {
+    test(launchTestName) {
+      TestUtil.withinWorkspace { workspace =>
+        val aSource =
+          """/A.scala
+            |class A
+          """.stripMargin
+
+        val logger = new RecordingLogger(ansiCodesSupported = false)
+        val `A` = TestProject(workspace, "a", List(aSource))
+        val projects = List(`A`)
+        val state = loadState(workspace, projects, logger)
+
+        // Run Ammonite headlessly: evaluate code and exit instead of waiting for a terminal.
+        val marker = "bloop-1226-ok"
+        val ammArgs = List("--no-home-predef", "-c", s"""println("$marker")""")
+        val consoleState = state.console(`A`, ammArgs)
+        assert(consoleState.status == ExitStatus.Ok)
+
+        // The server prints the `coursier launch ...` command (newline-joined) as an info message.
+        val command = logger.infos
+          .find(_.startsWith("coursier"))
+          .getOrElse(sys.error(s"No coursier command logged: ${logger.infos}"))
+        val tokens = command.split("\n").toIndexedSeq
+
+        val output = new StringBuilder
+        val procLogger = scala.sys.process.ProcessLogger { line =>
+          output.append(line).append(lineSeparator)
+          ()
+        }
+        val exit = scala.sys.process.Process(tokens, workspace.toFile).!(procLogger)
+
+        Predef.assert(
+          !output.toString.contains("MissingRequirementError"),
+          s"Ammonite failed with MissingRequirementError:\n$output"
+        )
+        Predef.assert(exit == 0, s"Ammonite exited with $exit:\n$output")
+        Predef.assert(
+          output.toString.contains(marker),
+          s"Expected '$marker' in Ammonite output:\n$output"
+        )
+      }
+    }
+  } else {
+    ignore(launchTestName, "IGNORED (coursier not on PATH)")(())
   }
 }

--- a/frontend/src/test/scala/bloop/util/TestUtil.scala
+++ b/frontend/src/test/scala/bloop/util/TestUtil.scala
@@ -654,6 +654,15 @@ object TestUtil {
   private lazy val hasPython3 = hasPythonNamed("python3")
   private lazy val hasPython2 = hasPythonNamed("python")
 
+  /** Whether the `coursier` launcher is on the PATH (the binary `bloop console` shells out to). */
+  lazy val hasCoursier: Boolean = try {
+    scala.sys.process
+      .Process(Seq("coursier", "version"))
+      .!(scala.sys.process.ProcessLogger(_ => (), _ => ())) == 0
+  } catch {
+    case NonFatal(_) => false
+  }
+
   lazy val generator: List[String] =
     if (hasPython3) List("python3", BuildTestInfo.sampleSourceGenerator.getAbsolutePath)
     else if (hasPython2) List("python", BuildTestInfo.sampleSourceGenerator.getAbsolutePath)


### PR DESCRIPTION
Closes #1226

## Summary

`bloop console <project>` historically failed on JDK > 8 with:

```
scala.reflect.internal.MissingRequirementError: object java.lang.Object in compiler mirror not found
```

This was an upstream Ammonite / JDK 9+ issue (com-lihaoyi/Ammonite#1035): on JDK > 8 the Scala compiler can't locate the platform classes (`rt.jar` / `sun.boot.class.path` were removed). It was never bloop-specific — even a direct `coursier launch com.lihaoyi:ammonite_2.13.3:2.3.8` failed identically.

It no longer reproduces on current `main`: the console emits a `coursier launch …` command that the CLI runs with the user's own coursier (#2856 / #2568), defaults to a `latest.release` Ammonite that supports JDK > 8, and no longer passes the old `--scala-version` flag.

Verified on JDK 17.

