### PR TITLE
Combine --cascade with --include-dependencies in test and clean

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -401,7 +401,16 @@ object Interpreter {
           (userSelectedProjects, projectsToTest)
         } else {
           val result = Dag.inverseDependencies(state.build.dags, userSelectedProjects)
-          (result.reduced, result.allCascaded)
+          val cascaded = result.allCascaded
+          val projectsToTest =
+            if (!cmd.includeDependencies) cascaded
+            else {
+              val dependencies = userSelectedProjects.flatMap { p =>
+                Dag.dfs(state.build.getDagFor(p), mode = Dag.PreOrder)
+              }
+              (cascaded ++ dependencies).distinct
+            }
+          (result.reduced, projectsToTest)
         }
       }
 
@@ -535,18 +544,22 @@ object Interpreter {
   }
 
   private def clean(cmd: Commands.Clean, state: State): Task[State] = {
-    if (cmd.projects.isEmpty) {
-      val projects = state.build.loadedProjects.map(_.project)
-      Tasks.clean(state, projects, cmd.includeDependencies).map(_.mergeStatus(ExitStatus.Ok))
-    } else {
+    def doClean(projects: List[Project]): Task[State] = {
+      val cascaded =
+        if (!cmd.cascade) Nil
+        else Dag.inverseDependencies(state.build.dags, projects).allCascaded
+      val downward =
+        if (!cmd.includeDependencies) Nil
+        else projects.flatMap(p => Dag.dfs(state.build.getDagFor(p), mode = Dag.PreOrder))
+      val targets = (projects ++ cascaded ++ downward).distinct
+      Tasks.clean(state, targets, includeDeps = false).map(_.mergeStatus(ExitStatus.Ok))
+    }
+
+    if (cmd.projects.isEmpty) doClean(state.build.loadedProjects.map(_.project))
+    else {
       val lookup = lookupProjects(cmd.projects, state.build.getProjectFor(_))
-      if (!lookup.missing.isEmpty)
-        Task.now(reportMissing(lookup.missing, state))
-      else {
-        Tasks
-          .clean(state, lookup.found, cmd.includeDependencies)
-          .map(_.mergeStatus(ExitStatus.Ok))
-      }
+      if (lookup.missing.nonEmpty) Task.now(reportMissing(lookup.missing, state))
+      else doClean(lookup.found)
     }
   }
 

--- a/frontend/src/test/scala/bloop/CleanSpec.scala
+++ b/frontend/src/test/scala/bloop/CleanSpec.scala
@@ -1,0 +1,79 @@
+package bloop
+
+import bloop.cli.Commands
+import bloop.data.Project
+import bloop.engine.Run
+import bloop.engine.State
+import bloop.logging.RecordingLogger
+import bloop.util.TestUtil
+
+import org.junit.Assert
+import org.junit.Test
+
+class CleanSpec {
+  /*
+   *    I
+   *    |\
+   *    | \
+   *    H  G
+   *    |
+   *    F
+   */
+  private val structure = Map(
+    "F" -> Map("F.scala" -> "package p0\nclass F"),
+    "H" -> Map("H.scala" -> "package p1\nclass H"),
+    "G" -> Map("G.scala" -> "package p4\nclass G"),
+    "I" -> Map("I.scala" -> "package p3\nclass I")
+  )
+  private val deps = Map("I" -> Set("H", "G", "F"), "H" -> Set("F"))
+
+  private def hasResult(name: String, state: State): Boolean =
+    TestUtil.hasPreviousResult(project(name, state), state)
+
+  private def project(name: String, state: State): Project =
+    state.build.getProjectFor(name).getOrElse(sys.error(s"Missing project $name"))
+
+  @Test
+  def cleanCascadesToDependents(): Unit = {
+    val logger = new RecordingLogger(ansiCodesSupported = false)
+    TestUtil.testState(structure, deps, userLogger = Some(logger)) { state =>
+      // Compiling `I` compiles the whole build (I -> H, G, F).
+      val compiled = TestUtil.blockingExecute(Run(Commands.Compile(List("I"))), state)
+      Assert.assertTrue("Unexpected compilation error", compiled.status.isOk)
+      List("F", "H", "G", "I").foreach { p =>
+        Assert.assertTrue(s"$p should have compiled", hasResult(p, compiled))
+      }
+
+      // Cleaning `F` with `--cascade` must also clean its dependents `H` and `I`, but not `G`.
+      val cleaned =
+        TestUtil.blockingExecute(Run(Commands.Clean(List("F"), cascade = true)), compiled)
+      Assert.assertTrue("Unexpected clean error", cleaned.status.isOk)
+      Assert.assertFalse("F should be cleaned", hasResult("F", cleaned))
+      Assert.assertFalse("H should be cleaned (depends on F)", hasResult("H", cleaned))
+      Assert.assertFalse("I should be cleaned (depends on F)", hasResult("I", cleaned))
+      Assert.assertTrue("G should NOT be cleaned", hasResult("G", cleaned))
+    }
+  }
+
+  @Test
+  def cleanIncludesDependencies(): Unit = {
+    val logger = new RecordingLogger(ansiCodesSupported = false)
+    TestUtil.testState(structure, deps, userLogger = Some(logger)) { state =>
+      val compiled = TestUtil.blockingExecute(Run(Commands.Compile(List("I"))), state)
+      Assert.assertTrue("Unexpected compilation error", compiled.status.isOk)
+
+      // Cleaning `H` with `--include-dependencies` must also clean its dependency `F`,
+      // but not its dependent `I` nor the unrelated `G`.
+      val cleaned =
+        TestUtil.blockingExecute(
+          Run(Commands.Clean(List("H"), includeDependencies = true)),
+          compiled
+        )
+      Assert.assertTrue("Unexpected clean error", cleaned.status.isOk)
+      Assert.assertFalse("H should be cleaned", hasResult("H", cleaned))
+      Assert.assertFalse("F should be cleaned (dependency of H)", hasResult("F", cleaned))
+      Assert.assertTrue("I should NOT be cleaned", hasResult("I", cleaned))
+      Assert.assertTrue("G should NOT be cleaned", hasResult("G", cleaned))
+    }
+  }
+}

--- a/frontend/src/test/scala/bloop/GenericTestSpec.scala
+++ b/frontend/src/test/scala/bloop/GenericTestSpec.scala
@@ -102,4 +102,112 @@ class GenericTestSpec {
       )
     }
   }
+
+  @Test
+  def canCombineCascadingAndDependencies(): Unit = {
+    /*
+     *    I
+     *    |\
+     *    | \
+     *    H  G
+     *    |
+     *    F
+     *
+     *  where `F`, `H`, `G` and `I` all define tests.
+     *
+     *  Testing `H` with both `--cascade` and `--include-dependencies` should run tests for:
+     *    - `H` itself
+     *    - `I` (cascades up: `I` depends on `H`)
+     *    - `F` (includes dependencies: `H` depends on `F`)
+     *  but NOT `G`, which is neither a dependent nor a dependency of `H`.
+     */
+
+    object Sources {
+      val `F.scala` =
+        """
+          |package p0
+          |
+          |import org.junit.Test
+          |
+          |class F {
+          |  @Test def testF(): Unit = ()
+          |}
+        """.stripMargin
+
+      val `H.scala` =
+        """
+          |package p1
+          |
+          |import org.junit.Test
+          |
+          |class H {
+          |  @Test def testH(): Unit = ()
+          |}
+        """.stripMargin
+
+      val `G.scala` =
+        """
+          |package p4
+          |
+          |import org.junit.Test
+          |
+          |class G {
+          |  @Test def testG(): Unit = ()
+          |}
+        """.stripMargin
+
+      val `I.scala` =
+        """
+          |package p3
+          |
+          |import org.junit.Test
+          |
+          |class I {
+          |  @Test def testI(): Unit = ()
+          |}
+        """.stripMargin
+    }
+
+    val structure = Map(
+      "F" -> Map("F.scala" -> Sources.`F.scala`),
+      "H" -> Map("H.scala" -> Sources.`H.scala`),
+      "I" -> Map("I.scala" -> Sources.`I.scala`),
+      "G" -> Map("G.scala" -> Sources.`G.scala`)
+    )
+
+    val logger = new RecordingLogger(ansiCodesSupported = false)
+    val deps = Map("I" -> Set("H", "G", "F"), "H" -> Set("F"))
+    val testProjects = Set("F", "G", "H", "I")
+    val junitJars = bloop.internal.build.BuildTestInfo.junitTestJars.map(AbsolutePath.apply).toArray
+    TestUtil.testState(
+      structure,
+      deps,
+      userLogger = Some(logger),
+      extraJars = junitJars,
+      testProjects = testProjects
+    ) { state =>
+      val action = Run(
+        Commands.Test(
+          List("H"),
+          cascade = true,
+          includeDependencies = true,
+          args = List("-v", "-a")
+        )
+      )
+      val compiledState = TestUtil.blockingExecute(action, state)
+      Assert.assertTrue("Unexpected compilation error", compiledState.status.isOk)
+      // Cascade pulls in I (depends on H); include-dependencies pulls in F (H depends on F).
+      TestUtil.assertNoDiff(
+        """
+          |Test p0.F.testF started
+          |Test p1.H.testH started
+          |Test p3.I.testI started
+          |Test run p0.F started
+          |Test run p1.H started
+          |Test run p3.I started
+        """.stripMargin,
+        logger.startedTestInfos.sorted.mkString(lineSeparator)
+      )
+    }
+  }
 }


### PR DESCRIPTION
Fixes #1229.

- `--cascade` adds reverse dependencies — projects depending on the target.
- `--include-dependencies` adds forward dependencies — projects the target depends on.
- Neither flag implicitly enables the other.