### PR TITLE
Support multi-jvm source directories in sbt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
             sbt-bloop/bsp-enabled \
             sbt-bloop/meta-builds \
             sbt-bloop/no-compile-incremental \
+            sbt-bloop/multi-jvm-configuration \
             sbt-bloop/non-compiling"
         shell: bash
 

--- a/docs/build-tools/sbt.md
+++ b/docs/build-tools/sbt.md
@@ -131,8 +131,13 @@ $ sbt bloopInstall
 ### Enable custom configurations
 
 By default, `bloopInstall` exports projects for the standard `Compile`,
-`Test` and `IntegrationTest` sbt configurations. If your build defines
-additional configurations in a project, such as [your own sbt custom
+`Test` and `IntegrationTest` sbt configurations, as well as the `multi-jvm`
+configuration used by Akka's [sbt-multi-jvm](https://doc.akka.io/docs/akka/current/multi-jvm-testing.html)
+plugin. The latter is exported automatically whenever a project enables the
+plugin, so its `src/multi-jvm` sources are compiled with no extra setup.
+
+If your build defines other additional configurations in a project, such as
+[your own sbt custom
 configuration](https://www.scala-sbt.org/1.0/docs/offline/Testing.html#Custom+test+configuration),
 you might want to export these configurations to Bloop projects too.
 

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -174,6 +174,7 @@ object BloopDefaults {
       Compile,
       Test,
       IntegrationTest,
+      MultiJvm,
       Provided,
       Optional
     )
@@ -229,10 +230,20 @@ object BloopDefaults {
       Keys.run / BloopKeys.bloopMainClass := BloopKeys.bloopMainClass.value
     ) ++ discoveredSbtPluginsSettings
 
+  /**
+   * The configuration used by Akka's sbt-multi-jvm plugin for its `src/multi-jvm`
+   * sources. Bloop matches it by name so that multi-jvm targets are exported
+   * automatically, without users having to wire `configSettings` in their build.
+   * Projects that don't enable the plugin define no products for it, so
+   * `bloopGenerate` short-circuits and no target is produced.
+   */
+  val MultiJvm: Configuration = Configuration.of("MultiJvm", "multi-jvm")
+
   lazy val projectSettings: Seq[Def.Setting[?]] = {
     sbt.inConfig(Compile)(configSettings) ++
       sbt.inConfig(Test)(configSettings) ++
       sbt.inConfig(IntegrationTest)(configSettings) ++
+      sbt.inConfig(MultiJvm)(configSettings) ++
       List(
         BloopKeys.bloopScalaJSStage := findOutScalaJsStage.value,
         BloopKeys.bloopScalaJSModuleKind := findOutScalaJsModuleKind.value,
@@ -809,7 +820,10 @@ object BloopDefaults {
       }
     } else {
       Def.task {
-        val isForkedExecution = if (configuration == Test || configuration == IntegrationTest) {
+        val isTestLike =
+          configuration == Test || configuration == IntegrationTest ||
+            configuration.name == MultiJvm.name
+        val isForkedExecution = if (isTestLike) {
           (Test / Keys.test / Keys.fork).value
         } else {
           (Compile / Keys.run / Keys.fork).value
@@ -908,6 +922,8 @@ object BloopDefaults {
     val tags = configuration match {
       case IntegrationTest => List(Tag.IntegrationTest)
       case Test => List(Tag.Test)
+      // multi-jvm extends Test, so its target holds test code
+      case c if c.name == MultiJvm.name => List(Tag.Test)
       case _ => List(Tag.Library)
     }
 

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/multi-jvm-configuration/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/multi-jvm-configuration/build.sbt
@@ -1,0 +1,51 @@
+import java.nio.file.Files
+
+// Mirrors how Akka's sbt-multi-jvm plugin declares its configuration.
+val MultiJvm = config("multi-jvm").extend(Test)
+
+val foo = project
+  .in(file("foo"))
+  .configs(MultiJvm)
+  .settings(
+    // Set up the standard sbt settings for the multi-jvm configuration (sources,
+    // products, compile) just like sbt-multi-jvm does. Crucially we do NOT wire
+    // any bloop settings here: bloop must export this configuration automatically.
+    inConfig(MultiJvm)(Defaults.testSettings)
+  )
+
+val checkBloopFile = taskKey[Unit]("Check bloop file contents")
+ThisBuild / checkBloopFile := {
+  val bloopDir = (ThisBuild / baseDirectory).value / ".bloop"
+  val fooConfig = bloopDir / "foo.json"
+  val fooTestConfig = bloopDir / "foo-test.json"
+  val fooMultiJvmConfig = bloopDir / "foo-multi-jvm.json"
+
+  List(fooConfig, fooTestConfig, fooMultiJvmConfig).foreach { f =>
+    assert(Files.exists(f.toPath), s"Missing config file for $f.")
+  }
+
+  def readBareFile(p: java.nio.file.Path): String =
+    new String(Files.readAllBytes(p)).replaceAll("\\s", "")
+
+  val contents = readBareFile(fooMultiJvmConfig.toPath)
+
+  // multi-jvm extends Test, so its target depends on foo (compile) and foo-test
+  assert(
+    contents.contains(""""dependencies":["foo","foo-test"]"""),
+    s"Unexpected dependencies in foo-multi-jvm.json: $contents"
+  )
+
+  // multi-jvm holds test code, so the target is tagged as test
+  assert(
+    contents.contains(""""tags":["test"]"""),
+    s"foo-multi-jvm.json should be tagged as test: $contents"
+  )
+
+  // The multi-jvm source directory must be exported. Normalize Windows
+  // separators so the check is platform independent.
+  val normalized = contents.replace("\\\\", "/")
+  assert(
+    normalized.contains("src/multi-jvm/scala"),
+    s"multi-jvm source directory missing in foo-multi-jvm.json: $contents"
+  )
+}

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/multi-jvm-configuration/foo/src/multi-jvm/scala/SampleMultiJvm.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/multi-jvm-configuration/foo/src/multi-jvm/scala/SampleMultiJvm.scala
@@ -1,0 +1,3 @@
+object SampleMultiJvm {
+  def greeting: String = "hello from multi-jvm"
+}

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/multi-jvm-configuration/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/multi-jvm-configuration/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/multi-jvm-configuration/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/multi-jvm-configuration/test
@@ -1,0 +1,6 @@
+# The multi-jvm sources must compile through sbt's own multi-jvm configuration
+> foo / MultiJvm / compile
+# Bloop must export the multi-jvm configuration without any extra build setup
+> bloopInstall
+$ exists .bloop/foo-multi-jvm.json
+> checkBloopFile


### PR DESCRIPTION
Closes #1280.

Builds using Akka's [sbt-multi-jvm](https://doc.akka.io/docs/akka/current/multi-jvm-testing.html) plugin keep their sources under a custom `multi-jvm` configuration (`config("multi-jvm") extend Test`). sbt-bloop only wired its settings into `Compile`, `Test` and `IntegrationTest`, so `multi-jvm` had no `bloopGenerate` task and was invisible to `bloopInstall` — those sources were never exported or compiled, and IDEs couldn't see them.

This scopes bloop's `configSettings` into a `multi-jvm` configuration matched by name, so the plugin's config is exported automatically with no `build.sbt` changes — mirroring the existing special-casing of Scala.js / Scala Native. Projects that don't enable the plugin define no products for it, so `bloopGenerate` short-circuits and no target is produced.
