### PR TITLE
Print the about banner for `bloop --version` and `bloop version`

### DIFF
--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -204,9 +204,9 @@ object Cli {
             Print(commandUsageAsked(commandName.mkString(" ")), commonOptions, Exit(ExitStatus.Ok))
           case Right((commandName, WithHelp(_, _, command), remainingArgs)) =>
             // Override common options depending who's the caller of parse (whether nailgun or main)
-            def run(command: Commands.RawCommand, cliOptions: CliOptions): Run = {
+            def run(command: Commands.RawCommand, cliOptions: CliOptions): Action = {
               if (!cliOptions.version) Run(command, Exit(ExitStatus.Ok))
-              else Run(Commands.About(cliOptions), Run(command, Exit(ExitStatus.Ok)))
+              else Print(aboutAsked, commonOptions, Run(command, Exit(ExitStatus.Ok)))
             }
 
             command match {
@@ -214,6 +214,8 @@ object Cli {
               case Right(_: Commands.Help) =>
                 Print(helpAsked, commonOptions, Exit(ExitStatus.Ok))
               case Right(_: Commands.About) =>
+                Print(aboutAsked, commonOptions, Exit(ExitStatus.Ok))
+              case Right(_: Commands.Version) =>
                 Print(aboutAsked, commonOptions, Exit(ExitStatus.Ok))
               case Right(c: Commands.Bsp) =>
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
@@ -295,9 +297,8 @@ object Cli {
         newAction.getOrElse {
           userOptions match {
             case Left(err) => printErrorAndExit(err.message, commonOptions)
-            case Right(cliOptions0) =>
-              val cliOptions = cliOptions0.copy(common = commonOptions)
-              if (cliOptions.version) Run(Commands.About(cliOptions), Exit(ExitStatus.Ok))
+            case Right(cliOptions) =>
+              if (cliOptions.version) Print(aboutAsked, commonOptions, Exit(ExitStatus.Ok))
               else {
                 val msg = "These flags can only go together with commands!"
                 Print(msg, commonOptions, Exit(ExitStatus.InvalidCommandLineOption))

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -80,6 +80,15 @@ object Commands {
     implicit lazy val help: CaseAppHelp[About] = CaseAppHelp.derive
   }
 
+  case class Version(
+      @Recurse cliOptions: CliOptions = CliOptions.default
+  ) extends RawCommand
+
+  object Version {
+    implicit lazy val parser: Parser[Version] = Parser.derive
+    implicit lazy val help: CaseAppHelp[Version] = CaseAppHelp.derive
+  }
+
   case class Projects(
       @HelpMessage("Print out a dot graph you can pipe into `dot`. By default, false.")
       dotGraph: Boolean = false,

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -57,6 +57,8 @@ object Interpreter {
             execute(next, runBsp(cmd, state))
           case Run(cmd: Commands.About, _) =>
             notHandled("about", cmd.cliOptions, state)
+          case Run(cmd: Commands.Version, _) =>
+            notHandled("version", cmd.cliOptions, state)
           case Run(cmd: Commands.Help, _) =>
             notHandled("help", cmd.cliOptions, state)
           case Run(cmd: Commands.Command, next) =>

--- a/frontend/src/test/scala/bloop/AutoCompleteSpec.scala
+++ b/frontend/src/test/scala/bloop/AutoCompleteSpec.scala
@@ -29,6 +29,7 @@ class AutoCompleteSpec {
         |projects
         |run
         |test
+        |version
         |clean compile console link run test
         |A
         |B
@@ -65,6 +66,7 @@ class AutoCompleteSpec {
         |projects
         |run
         |test
+        |version
         |clean compile console link run test
         |A
         |B
@@ -101,6 +103,7 @@ class AutoCompleteSpec {
         |projects
         |run
         |test
+        |version
         |clean compile console link run test
         |A
         |B

--- a/frontend/src/test/scala/bloop/CliSpec.scala
+++ b/frontend/src/test/scala/bloop/CliSpec.scala
@@ -5,6 +5,7 @@ import java.nio.file.Path
 
 import bloop.cli.BspProtocol
 import bloop.cli.Commands
+import bloop.cli.CommonOptions
 import bloop.cli.ExitStatus
 import bloop.cli.Validate
 import bloop.engine.Action
@@ -12,6 +13,7 @@ import bloop.engine.Exit
 import bloop.engine.Feedback
 import bloop.engine.Print
 import bloop.engine.Run
+import bloop.internal.build.BuildInfo
 import bloop.testing.BaseSuite
 import bloop.util.UUIDUtil
 
@@ -152,6 +154,34 @@ object CliSpec extends BaseSuite {
     checkReservedPort(127)
     checkReservedPort(21)
     checkReservedPort(23)
+  }
+
+  test("print about info when `--version` is passed without a command") {
+    checkPrintsAbout(Cli.parse(Array("--version"), CommonOptions.default))
+  }
+
+  test("print about info when the `version` command is used") {
+    checkPrintsAbout(Cli.parse(Array("version"), CommonOptions.default))
+  }
+
+  test("print about info before running a command when `--version` is passed") {
+    val action = Cli.parse(Array("compile", "foo", "--version"), CommonOptions.default)
+    checkPrintsAbout(
+      action,
+      alsoRuns = { case Run(_: Commands.Compile, Exit(ExitStatus.Ok)) => () }
+    )
+  }
+
+  def checkPrintsAbout(
+      action: Action,
+      alsoRuns: PartialFunction[Action, Unit] = { case Exit(ExitStatus.Ok) => () }
+  ): Unit = {
+    action match {
+      case Print(msg, _, next) if msg.contains(BuildInfo.version) && alsoRuns.isDefinedAt(next) =>
+        ()
+      case _ =>
+        throw new AssertionError(s"Expected about info to be printed, got ${action}.")
+    }
   }
 
   def uniqueId: String = UUIDUtil.randomUUID.take(8)


### PR DESCRIPTION
Closes #1283

`bloop --version` printed an internal error instead of version info. Now `bloop --version`, `bloop -v`, `bloop version`, and `bloop about` all print the same banner.
