### PR TITLE
Recompile retained sources when a re-added source reintroduces a package object

### DIFF
--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopNameHashing.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopNameHashing.scala
@@ -115,13 +115,23 @@ private final class BloopNameHashing(
               current.apis.internalAPI
             )
           debug("\nChanges:\n" + newApiChanges)
+
+          // Zinc invalidates dependents through recorded dependency edges, but a
+          // source removed from the build and later re-added with unchanged
+          // contents has no such edges from retained sources: they were erased
+          // when it was removed. When a (re-)added source reintroduces a package
+          // object, invalidate the retained sources that reference that package
+          // so their implicit resolution is recomputed against it.
+          val readdedPackageObjectInvalidations =
+            invalidationsFromAddedPackageObjects(invalidatedSources, previous, current)
+
           val nextInvalidations = invalidateAfterInternalCompilation(
             current,
             newApiChanges,
             recompiledClasses,
             cycleNum >= options.transitiveStep,
             IncrementalCommon.comesFromScalaSource(previous.relations, Some(current.relations))
-          )
+          ) ++ readdedPackageObjectInvalidations
           debug(s"Next invalidations: $nextInvalidations")
 
           val continue = lookup.shouldDoIncrementalCompilation(nextInvalidations, current)
@@ -265,6 +275,67 @@ private final class BloopNameHashing(
       val merged = pruned ++ fresh
       debug("********* Merged: \n" + merged.relations + "\n*********")
       merged
+    }
+  }
+
+  /**
+   * Computes extra invalidations for package objects that were just (re-)added.
+   *
+   * This is a Bloop-specific workaround for source-set churn (sources removed
+   * and re-added through build/config changes), not a general precision
+   * improvement — those belong in Zinc, per the note on [[BloopNameHashing]].
+   * When a source is removed, the dependency edges from retained sources onto
+   * its symbols are erased, and re-adding it does not restore them, so Zinc's
+   * edge-based invalidation leaves those retained sources compiled against the
+   * stale state. A package object is the common trigger because it contributes
+   * implicits to the implicit scope of its whole package.
+   *
+   * When a recompiled source produces a `*.package` class absent from the
+   * previous analysis, we invalidate every class in that package (each has the
+   * package object in its implicit scope) and every class that references one of
+   * those classes. This is deliberately conservative — re-adding a package
+   * object recompiles its whole package — which is an acceptable tradeoff
+   * because source-set churn is rare and correctness outweighs incrementality
+   * here. It only fires for added package objects, so ordinary and clean
+   * compiles are unaffected.
+   *
+   * Coverage is bounded by recorded dependency edges. A retained source that
+   * imports the package solely for package-object members (without referencing
+   * any of the package's classes) holds no such edge in the stale analysis and
+   * is therefore not detected; catching it would require import/used-name
+   * information that the erased analysis no longer carries.
+   */
+  private def invalidationsFromAddedPackageObjects(
+      recompiledSources: Set[VirtualFile],
+      previous: Analysis,
+      current: Analysis
+  ): Set[String] = {
+    def packageOf(className: String): String = {
+      val i = className.lastIndexOf('.')
+      if (i < 0) "" else className.substring(0, i)
+    }
+
+    val knownClasses = previous.relations.classes._2s
+    val addedPackageObjects = recompiledSources
+      .flatMap(src => current.relations.classNames(src))
+      .filter(name => name.endsWith(".package") && !knownClasses.contains(name))
+
+    if (addedPackageObjects.isEmpty) Set.empty
+    else {
+      val allClasses = current.relations.classes._2s
+      addedPackageObjects.flatMap { packageObject =>
+        val pkg = packageOf(packageObject)
+        // Every class in the package has the package object in its implicit
+        // scope, so any of them may now resolve implicits differently.
+        val classesInPackage =
+          allClasses.filter(name => name != packageObject && packageOf(name) == pkg)
+        // Classes that reference one of the package's classes (e.g. importers
+        // that use its types). This is the most we can detect from recorded
+        // edges — see the method doc for the bound on coverage.
+        val packageClassUsers =
+          classesInPackage.flatMap(name => current.relations.usesInternalClass(name))
+        classesInPackage ++ packageClassUsers
+      }
     }
   }
 }

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopNameHashing.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopNameHashing.scala
@@ -116,13 +116,7 @@ private final class BloopNameHashing(
             )
           debug("\nChanges:\n" + newApiChanges)
 
-          // Zinc invalidates dependents through recorded dependency edges, but a
-          // source removed from the build and later re-added with unchanged
-          // contents has no such edges from retained sources: they were erased
-          // when it was removed. When a (re-)added source reintroduces a package
-          // object, invalidate the retained sources that reference that package
-          // so their implicit resolution is recomputed against it.
-          val readdedPackageObjectInvalidations =
+          val addedPackageObjectInvalidations =
             invalidationsFromAddedPackageObjects(invalidatedSources, previous, current)
 
           val nextInvalidations = invalidateAfterInternalCompilation(
@@ -131,7 +125,7 @@ private final class BloopNameHashing(
             recompiledClasses,
             cycleNum >= options.transitiveStep,
             IncrementalCommon.comesFromScalaSource(previous.relations, Some(current.relations))
-          ) ++ readdedPackageObjectInvalidations
+          ) ++ addedPackageObjectInvalidations
           debug(s"Next invalidations: $nextInvalidations")
 
           val continue = lookup.shouldDoIncrementalCompilation(nextInvalidations, current)
@@ -281,29 +275,19 @@ private final class BloopNameHashing(
   /**
    * Computes extra invalidations for package objects that were just (re-)added.
    *
-   * This is a Bloop-specific workaround for source-set churn (sources removed
-   * and re-added through build/config changes), not a general precision
-   * improvement — those belong in Zinc, per the note on [[BloopNameHashing]].
-   * When a source is removed, the dependency edges from retained sources onto
-   * its symbols are erased, and re-adding it does not restore them, so Zinc's
-   * edge-based invalidation leaves those retained sources compiled against the
-   * stale state. A package object is the common trigger because it contributes
-   * implicits to the implicit scope of its whole package.
+   * A Bloop-specific workaround for source-set churn: a removed-then-re-added
+   * source loses the dependency edges from retained sources, so Zinc's
+   * edge-based invalidation leaves them compiled against the stale state (the
+   * precise fix belongs in Zinc, per the note on [[BloopNameHashing]]). Package
+   * objects are the common trigger since they contribute implicits to the whole
+   * package's implicit scope.
    *
    * When a recompiled source produces a `*.package` class absent from the
-   * previous analysis, we invalidate every class in that package (each has the
-   * package object in its implicit scope) and every class that references one of
-   * those classes. This is deliberately conservative — re-adding a package
-   * object recompiles its whole package — which is an acceptable tradeoff
-   * because source-set churn is rare and correctness outweighs incrementality
-   * here. It only fires for added package objects, so ordinary and clean
-   * compiles are unaffected.
-   *
-   * Coverage is bounded by recorded dependency edges. A retained source that
-   * imports the package solely for package-object members (without referencing
-   * any of the package's classes) holds no such edge in the stale analysis and
-   * is therefore not detected; catching it would require import/used-name
-   * information that the erased analysis no longer carries.
+   * previous analysis, we invalidate every class in that package and everything
+   * referencing one of them. Deliberately conservative and fires only for added
+   * package objects, so ordinary and clean compiles are unaffected. Coverage is
+   * bounded by recorded edges: a source that imports only package-object members
+   * (without referencing any of the package's classes) has no edge to detect.
    */
   private def invalidationsFromAddedPackageObjects(
       recompiledSources: Set[VirtualFile],

--- a/frontend/src/test/scala/bloop/BaseCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/BaseCompileSpec.scala
@@ -2108,6 +2108,97 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
     }
   }
 
+  // Removing a source from the build and later re-adding it with unchanged
+  // contents must recompile the retained sources whose implicit resolution
+  // depends on it. This mirrors the original report: a package object `p` lives
+  // in a togglable source root and the implicit it provides changes how code in
+  // package `p` and importers of `p` resolve `implicitly[Level]`.
+  test("recompiles a source directory removed from and then re-added to the project") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+
+      // `p.A` (same package as the togglable package object) and `q.Main` (an
+      // importer of `p`) both resolve `implicitly[Level]` at COMPILE TIME:
+      //   - to `Level.fallback` (5) when the package object is absent, or
+      //   - to the package object's `boosted` (14) when it is present.
+      // Package `p` stays alive via `Level.scala`/`A.scala`, so both keep
+      // compiling either way. Re-adding the package object must recompile BOTH
+      // `p.A` (same package) and `q.Main` (importer); leaving either stale is
+      // observable in the printed sum. Exercises Scala compilation semantics,
+      // not merely the presence of a class file on the runtime classpath.
+      val base = TestProject(
+        workspace,
+        "a",
+        List(
+          """/p/Level.scala
+            |package p
+            |final case class Level(n: Int)
+            |object Level {
+            |  implicit val fallback: Level = Level(5)
+            |}
+          """.stripMargin,
+          """/p/A.scala
+            |package p
+            |object A {
+            |  def value: Int = implicitly[Level].n
+            |}
+          """.stripMargin,
+          """/q/Main.scala
+            |package q
+            |import p._
+            |object Main {
+            |  def main(args: Array[String]): Unit =
+            |    println("RESULT=" + (A.value + implicitly[Level].n))
+            |}
+          """.stripMargin
+        )
+      )
+
+      // A second source root whose package object `p` supplies the
+      // higher-priority implicit resolved by `p.A` and `q.Main` when present.
+      val secondSrcDir = workspace.resolve("a-extra-src")
+      Files.createDirectories(secondSrcDir.underlying)
+      writeFile(
+        secondSrcDir.resolve("package.scala"),
+        """package object p {
+          |  implicit val boosted: Level = Level(14)
+          |}
+          """.stripMargin
+      )
+
+      val withBoth =
+        base.copy(
+          config = base.config.copy(sources = base.config.sources :+ secondSrcDir.underlying)
+        )
+      // `base` already lists only the default source root
+      val withoutSecond = base
+
+      // Runs the app and returns its `RESULT=` line, the user-visible output.
+      def runResult(state: TestState, project: bloop.util.TestProject): String = {
+        logger.clear()
+        val runState = state.run(project)
+        assertExitStatus(runState, ExitStatus.Ok)
+        logger.infos
+          .find(_.startsWith("RESULT="))
+          .map(_.stripPrefix("RESULT="))
+          .getOrElse(sys.error(s"Run printed no RESULT line; infos: ${logger.infos}"))
+      }
+
+      // 1. Both present: `p.A` and `q.Main` resolve the boosted implicit (14 + 14).
+      val state1 = loadState(workspace, List(withBoth), logger)
+      assertNoDiff(runResult(state1, withBoth), "28")
+
+      // 2. Remove the package object: both fall back (5 + 5).
+      val state2 = reloadWithNewProject(withoutSecond, state1)
+      assertNoDiff(runResult(state2, withoutSecond), "10")
+
+      // 3. Re-add it: both `p.A` and `q.Main` must recompile to the boosted
+      //    implicit again (14 + 14) — the #1347 regression.
+      val state3 = reloadWithNewProject(withBoth, state2)
+      assertNoDiff(runResult(state3, withBoth), "28")
+    }
+  }
+
   test("fail compilation when using wildcard import from empty package - after package rename") {
     TestUtil.withinWorkspace { workspace =>
       object Sources {


### PR DESCRIPTION
Fixes #1347.

## Root cause
Zinc's incremental invalidation is edge-based. When a source is removed, the dependency edges from retained sources onto its symbols are erased, and those retained sources recompile against a fallback. Re-adding the source does **not** restore those edges, so nothing reinvalidates the retained sources — they keep the stale compilation.

This reproduces with stock Zinc in a plain sbt project (delete a `package.scala`, compile, restore it, compile), so the underlying gap is in Zinc. `BloopNameHashing` delegates invalidation precision to Zinc by policy, so a precise fix belongs upstream; this PR is a pragmatic Bloop-side guard for the source-set-churn case #1347 reports.

## Fix
When a recompiled source reintroduces a **package object** absent from the previous analysis, invalidate every class in that package (each has the package object in its implicit scope) and every class that references one of them. Guarded to fire only for added package objects, so ordinary and clean compiles are unaffected.

### Tradeoffs / limitations (documented in code)
- **Conservative:** re-adding a package object recompiles its whole package. Acceptable — source-set churn is rare and correctness outweighs incrementality here.
- **Scala 2 package objects only:** keyed on the `*.package` class name; Scala 3 top-level `$package` wrappers are not matched.
- **Edge-bounded coverage:** a source that imports the package solely for package-object members (without referencing any of the package's classes) holds no recorded edge in the stale analysis and is not detected.

## Test
Adds a regression test mirroring the original report: package `p` with retained `p.A` (same package as the togglable package object `p`) plus a cross-package importer `q.Main`. It runs the app and asserts the user-visible output **28 → 10 → 28** across compile / remove-root / re-add-root. Verified to fail without the fix (**28 → 10 → 10**), so it cannot silently pass while the bug persists.
