### PR TITLE
Fix NullPointerException for relative paths in sbt unmanagedResources

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -1396,6 +1396,15 @@ object BloopDefaults {
   }
 
   /**
+   * Delegate to `ConfigUtil.pathsOutsideRoots` after normalizing both roots and
+   * candidate paths to absolute. A relative single-segment path has a null
+   * parent, which makes the upstream utility NPE; normalizing both sides also
+   * avoids misclassifying in-root resources when the roots are relative.
+   */
+  private def resourcesOutsideRoots(roots: Seq[Path], paths: Seq[Path]): Seq[Path] =
+    ConfigUtil.pathsOutsideRoots(roots.map(_.toAbsolutePath), paths.map(_.toAbsolutePath))
+
+  /**
    * This task is triggered by `bloopGenerate` and does stuff which is
    * sometimes dangerous because it can incur on cyclic dependencies, such as:
    *
@@ -1430,7 +1439,7 @@ object BloopDefaults {
             val currentResourceDirs = currentResources.filter(Files.isDirectory(_))
             val allResourceFiles = (configuration / Keys.resources).value
             val additionalResources =
-              ConfigUtil.pathsOutsideRoots(currentResourceDirs, allResourceFiles.map(_.toPath))
+              resourcesOutsideRoots(currentResourceDirs, allResourceFiles.map(_.toPath))
 
             val newGeneratedProject = {
               val sbt = computeSbtMetadata.value.map(_.config)
@@ -1485,7 +1494,7 @@ object BloopDefaults {
 
         val unmanagedResourceFiles = (configKey / Keys.unmanagedResources).value
         val additionalResources =
-          ConfigUtil.pathsOutsideRoots(resourceDirs, unmanagedResourceFiles.map(_.toPath))
+          resourcesOutsideRoots(resourceDirs, unmanagedResourceFiles.map(_.toPath))
         (resourceDirs ++ additionalResources).toList
       }
     }

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/unmanaged-resources/app/src/main/resources/nested/in-root.txt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/unmanaged-resources/app/src/main/resources/nested/in-root.txt
@@ -1,0 +1,1 @@
+in-root resource

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/unmanaged-resources/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/unmanaged-resources/build.sbt
@@ -1,0 +1,43 @@
+import bloop.integrations.sbt.BloopDefaults
+
+// `app` is a subproject in app/, but it exports a resource that lives outside
+// its module root (file1.yml sits at the build root). It is a relative
+// single-segment path, which used to make pathsOutsideRoots NPE on the null
+// parent, and it exercises the "resource outside the resource roots" path.
+val app = project
+  .in(file("app"))
+  .settings(
+    Compile / Keys.unmanagedResources += file("file1.yml")
+  )
+
+val bloopConfigFile = settingKey[File]("Config file to test")
+bloopConfigFile := {
+  val bloopDir = Keys.baseDirectory.value./(".bloop")
+  bloopDir./("app.json")
+}
+
+val checkBloopFiles = taskKey[Unit]("Check bloop file contents")
+checkBloopFiles := {
+  val configContents = BloopDefaults.unsafeParseConfig(bloopConfigFile.value.toPath)
+  val resources = configContents.project.resources.toList.flatten
+
+  // The resource outside the module root is exported as a standalone, absolute path.
+  val externalResource = resources.filter(_.getFileName.toString == "file1.yml")
+  assert(
+    externalResource.nonEmpty && externalResource.forall(_.isAbsolute),
+    s"file1.yml (resource outside the module root) should be a standalone absolute resource: $resources"
+  )
+
+  // The module's own resource directory is exported as a directory...
+  assert(
+    resources.exists(_.endsWith(java.nio.file.Paths.get("app", "src", "main", "resources"))),
+    s"app resource directory not found in resources: $resources"
+  )
+
+  // ...and a file inside it stays covered by that directory instead of being
+  // misclassified as a standalone resource.
+  assert(
+    !resources.exists(_.getFileName.toString == "in-root.txt"),
+    s"in-root resource was wrongly exported as a standalone file: $resources"
+  )
+}

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/unmanaged-resources/file1.yml
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/unmanaged-resources/file1.yml
@@ -1,0 +1,1 @@
+key: value

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/unmanaged-resources/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/unmanaged-resources/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/unmanaged-resources/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/unmanaged-resources/test
@@ -1,0 +1,3 @@
+$ exists file1.yml
+> bloopInstall
+> checkBloopFiles


### PR DESCRIPTION
Fixes #1360.

Normalize the resource paths to absolute before calling `pathsOutsideRoots`.