### PR TITLE
Support sbt internal configurations in exported project dependencies

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -559,9 +559,10 @@ object BloopDefaults {
    * Creates a project name from a classpath dependency and its configuration.
    *
    * This function uses internal sbt utils (`sbt.Classpaths`) to parse configuration
-   * dependencies like sbt does and extract them. This parsing only supports compile
-   * and test, any kind of other dependency will be assumed to be test and will be
-   * reported to the user.
+   * dependencies like sbt does and extract them. Internal configurations such as
+   * `compile-internal` are resolved like their base configuration because they only
+   * differ in publishing semantics. Any other unsupported dependency will be assumed
+   * to be test and will be reported to the user.
    *
    * Ref https://www.scala-sbt.org/1.x/docs/Library-Management.html#Configurations.
    */
@@ -574,9 +575,12 @@ object BloopDefaults {
       data: ScopeSettings,
       logger: Logger
   ): List[String] = {
-    // We only detect dependencies for those configurations that are supported
+    // We only detect dependencies for those configurations that are supported,
+    // where the hidden `*-internal` variant of a supported configuration is supported too
     def filterSupported(configurationNames: Seq[String]): Seq[String] = {
-      configurationNames.filter(conf => supportedConfigurationNames.exists(_ == conf))
+      configurationNames.filter(conf =>
+        supportedConfigurationNames.contains(conf.stripSuffix("-internal"))
+      )
     }
 
     val ref = dep.project
@@ -594,8 +598,10 @@ object BloopDefaults {
         )
 
         val mappedConfiguration = {
+          // Mappings like `compile-internal` are keyed by the hidden internal variant
+          // of the configuration, which sbt resolves classpaths from
+          var mapped = mapping(configuration.name) ++ mapping(configuration.name + "-internal")
           // We need this to make `Provided` & `Optional` mean `Compile`
-          var mapped = mapping(configuration.name)
           if (configuration == Compile) {
             if (mapped.isEmpty)
               mapped = mapping(Provided.name)
@@ -609,7 +615,9 @@ object BloopDefaults {
           case Nil => Nil
           case configurationNames =>
             val configurations = configurationNames.iterator
-              .flatMap(name => activeDependentConfigurations.find(_.name == name).toList)
+              .flatMap(name =>
+                activeDependentConfigurations.find(_.name == name.stripSuffix("-internal")).toList
+              )
               .flatMap(c => defaultSbtConfigurationMappings.getOrElse(c.name, Some(c)).toList)
               .toList
 

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/internal-dependency/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/internal-dependency/build.sbt
@@ -1,0 +1,30 @@
+import bloop.integrations.sbt.BloopDefaults
+
+val util = project
+val core = project.dependsOn(util % "compile-internal, test-internal")
+
+val checkBloopFiles = taskKey[Unit]("Check bloop file contents")
+ThisBuild / checkBloopFiles := {
+  val bloopDir = Keys.baseDirectory.value./(".bloop")
+
+  def readConfig(name: String): bloop.config.Config.File =
+    BloopDefaults.unsafeParseConfig(bloopDir./(s"$name.json").toPath)
+
+  val coreConfig = readConfig("core")
+  assert(
+    coreConfig.project.dependencies == List("util"),
+    s"Expected internal dependency util in core, found ${coreConfig.project.dependencies}"
+  )
+
+  val utilClassesDir = readConfig("util").project.classesDir
+  assert(
+    coreConfig.project.classpath.contains(utilClassesDir),
+    s"Expected util classes dir on the core classpath, found ${coreConfig.project.classpath}"
+  )
+
+  val coreTestConfig = readConfig("core-test")
+  assert(
+    coreTestConfig.project.dependencies.sorted == List("core", "util"),
+    s"Expected internal dependency util in core-test, found ${coreTestConfig.project.dependencies}"
+  )
+}

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/internal-dependency/core/src/main/scala/Core.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/internal-dependency/core/src/main/scala/Core.scala
@@ -1,0 +1,3 @@
+object Core {
+  def main(args: Array[String]): Unit = println(Util.greeting)
+}

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/internal-dependency/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/internal-dependency/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/internal-dependency/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/internal-dependency/test
@@ -1,0 +1,5 @@
+> bloopInstall
+$ exists .bloop/util.json
+$ exists .bloop/core.json
+$ exists .bloop/core-test.json
+> checkBloopFiles

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/internal-dependency/util/src/main/scala/Util.scala
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/internal-dependency/util/src/main/scala/Util.scala
@@ -1,0 +1,3 @@
+object Util {
+  def greeting: String = "hello"
+}


### PR DESCRIPTION
Fixes #1373

`bloopInstall` silently dropped inter-project dependencies declared with sbt's internal configurations, e.g. the macro-project pattern from the sbt reference manual:

```scala
val core = project.dependsOn(util % "compile-internal, test-internal")
```

The generated `core.json` had `util`'s classes directory on the classpath, but `util` was missing from `dependencies`, so bloop never compiled it first and users saw spurious "not found" errors in Metals.

sbt resolves these through hidden ivy configurations (`compile-internal` extends `compile`/`optional`/`provided`) that every project has. `projectDependencyName` filtered those names out of the lists handed to `sbt.Classpaths.mapped` and looked the parsed mapping up only by the base configuration name, never by `compile-internal` — the key it is actually stored under — so the mapping came back empty and the dependency was dropped.

Now the internal variant of a supported configuration counts as supported, the mapping is also looked up under `<configuration>-internal`, and dep-side internal names resolve to their base configuration.
