### PR TITLE
Report a crash from the compiler instead of hanging the compilation

### DIFF
--- a/backend/src/main/scala/bloop/CompileExceptions.scala
+++ b/backend/src/main/scala/bloop/CompileExceptions.scala
@@ -2,6 +2,13 @@ package bloop
 
 import scala.util.control.NoStackTrace
 
+/**
+ * A fatal error thrown by the compiler, wrapped in a non-fatal exception so that it can
+ * be turned into a failed compilation result and reported back to the client.
+ */
+final class CompilerCrash(message: String, cause: Throwable)
+    extends RuntimeException(message, cause)
+
 private[bloop] object CompileExceptions {
   abstract class CompileException(msg: String) extends RuntimeException(msg) with NoStackTrace
   object FailedOrCancelledPromise

--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -1,8 +1,6 @@
 package bloop
 
 import java.io.File
-import java.io.PrintWriter
-import java.io.StringWriter
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
@@ -782,10 +780,7 @@ object Compiler {
                 toBackgroundTasks(backgroundTasksForFailedCompilation.toList)
               Result.Failed(failedProblems, None, elapsed, backgroundTasks, None)
             case t: Throwable =>
-              t.printStackTrace()
-              val sw = new StringWriter()
-              t.printStackTrace(new PrintWriter(sw))
-              logger.error(sw.toString())
+              // The full stack trace is reported by the consumer of this failed result
               val backgroundTasks =
                 toBackgroundTasks(backgroundTasksForFailedCompilation.toList)
               val failedProblems = findFailedProblems(reporter, None)

--- a/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopHighLevelCompiler.scala
+++ b/backend/src/main/scala/sbt/internal/inc/bloop/internal/BloopHighLevelCompiler.scala
@@ -8,6 +8,7 @@ import java.util.Optional
 import scala.concurrent.Promise
 import scala.util.control.NonFatal
 
+import bloop.CompilerCrash
 import bloop.logging.ObservedLogger
 import bloop.logging.TeeOutputStream
 import bloop.reporter.ZincReporter
@@ -134,6 +135,14 @@ final class BloopHighLevelCompiler(
             _.addListener(baos)
           }
 
+          // Wrap a fatal error in a non-fatal crash: fatal errors escape the task that runs
+          // the compilation, so they would never complete it and clients would wait forever.
+          // The consumer of the failed compilation result reports the full stack trace.
+          def compilerCrash(cause: Throwable, advice: String): CompilerCrash = {
+            JavaCompleted.tryFailure(cause)
+            new CompilerCrash(s"The compiler crashed with a ${cause.getClass().getSimpleName()}. $advice", cause)
+          }
+
           try {
             scalac.compile(
               sources.toArray,
@@ -149,13 +158,11 @@ final class BloopHighLevelCompiler(
             )
           } catch {
             case t: StackOverflowError =>
-              val msg = "Encountered a StackOverflowError coming from the compiler. You might need to restart your Bloop build server"
-              logger.error(s"${msg}:\n${t.getStackTrace().mkString("\n")}")
-              throw new CompileFailed(new Array(0), msg, new Array(0), None, t)
+              throw compilerCrash(t, "You might need to restart your Bloop build server")
             case t: NoClassDefFoundError =>
-              val msg = "Encountered a NoClassDefFoundError coming from the compiler. You might need to clean compile your workspace"
-              logger.error(s"${msg}:\n${t.getStackTrace().mkString("\n")}")
-              throw new CompileFailed(new Array(0), msg, new Array(0), None, t)
+              throw compilerCrash(t, "You might need to clean compile your workspace")
+            case t: LinkageError =>
+              throw compilerCrash(t, "A compiler plugin or something else on the compiler classpath may be incompatible with the used Scala version")
             case NonFatal(t) =>
               // If scala compilation happens, complete the java promise so that it doesn't block
               JavaCompleted.tryFailure(t)

--- a/frontend/src/test/scala/bloop/BaseCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/BaseCompileSpec.scala
@@ -1454,6 +1454,78 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
     }
   }
 
+  test("report the full stack trace once when a compiler plugin crashes the compiler") {
+    TestUtil.withinWorkspace { workspace =>
+      val pluginSources = List(
+        """/CrashingPlugin.scala
+          |package crash
+          |
+          |import scala.tools.nsc.Global
+          |import scala.tools.nsc.Phase
+          |import scala.tools.nsc.plugins.Plugin
+          |import scala.tools.nsc.plugins.PluginComponent
+          |
+          |class CrashingPlugin(val global: Global) extends Plugin {
+          |  val name = "crash"
+          |  val description = "Crashes the compiler after typer"
+          |  val components = List[PluginComponent](Component)
+          |
+          |  object Component extends PluginComponent {
+          |    val global: CrashingPlugin.this.global.type = CrashingPlugin.this.global
+          |    val phaseName = "crash"
+          |    val runsAfter = List("typer")
+          |    def newPhase(prev: Phase): Phase = new StdPhase(prev) {
+          |      def apply(unit: global.CompilationUnit): Unit =
+          |        throw new NoSuchMethodError("boom")
+          |    }
+          |  }
+          |}
+          """.stripMargin
+      )
+
+      val appSources = List(
+        """/App.scala
+          |object App
+          """.stripMargin
+      )
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", pluginSources)
+      // Scalac accepts an exploded plugin archive, so point -Xplugin at the classes directory
+      val `B` = TestProject(
+        workspace,
+        "b",
+        appSources,
+        scalacOptions = List(s"-Xplugin:${`A`.externalClassesDir}", "-Xplugin-require:crash")
+      )
+
+      val projects = List(`A`, `B`)
+      val state = loadState(workspace, projects, logger)
+      val compiledPlugin = state.compile(`A`)
+      assertExitStatus(compiledPlugin, ExitStatus.Ok)
+      writeFile(
+        `A`.externalClassesDir.resolve("scalac-plugin.xml"),
+        """<plugin>
+          |  <name>crash</name>
+          |  <classname>crash.CrashingPlugin</classname>
+          |</plugin>
+          """.stripMargin
+      )
+
+      val compiledState = compiledPlugin.compile(`B`)
+      assertExitStatus(compiledState, ExitStatus.CompilationError)
+
+      val crashReports =
+        logger.errors.filter(_.startsWith("Unexpected error when compiling b"))
+      assert(crashReports.size == 1)
+      assert(crashReports.head.contains("The compiler crashed with a NoSuchMethodError"))
+      assert(crashReports.head.contains("java.lang.NoSuchMethodError: boom"))
+      assert(crashReports.head.contains("at crash.CrashingPlugin"))
+      // The trace must be reported exactly once, not echoed again from the compiler backend
+      assert(logger.errors.count(_.contains("java.lang.NoSuchMethodError: boom")) == 1)
+    }
+  }
+
   test("cascade compilation compiles only a strict subset of targets") {
     TestUtil.withinWorkspace { workspace =>
       /*


### PR DESCRIPTION
Fixes #1434

The original report asked for the complete stack trace when a compiler plugin crashes the compiler with a `NoSuchMethodError`. The reporting side was largely fixed in the meantime (since v1.5.12 the consumer of a failed compile result prints the whole trace), but reproducing the scenario revealed something worse: the compilation never finishes at all.

`NoSuchMethodError` is a `LinkageError`, which `NonFatal` treats as fatal: it escapes the monix task running the compilation and the result is never completed, leaving the client waiting forever. `StackOverflowError` and `NoClassDefFoundError` were already special-cased in `BloopHighLevelCompiler`, but every other `LinkageError` fell through, and the crash reporting was split between the catch sites and the consumer of the result, which printed the trace twice.

Now all fatal compiler crashes are wrapped in a new non-fatal `bloop.CompilerCrash` carrying type-specific advice, so the compilation fails normally through `Result.Failed(..., Some(t))` and the consumer of the result reports the full stack trace exactly once:

```
Unexpected error when compiling b: bloop.CompilerCrash: The compiler crashed with a NoSuchMethodError. A compiler plugin or something else on the compiler classpath may be incompatible with the used Scala version
	at sbt.internal.inc.bloop.internal.BloopHighLevelCompiler.compileSources$1(...)
	...
Caused by: java.lang.NoSuchMethodError: boom
	at crash.CrashingPlugin$Component$$anon$1.apply(CrashingPlugin.scala:19)
	at scala.tools.nsc.Global$GlobalPhase.applyPhase(Global.scala:465)
	...
```

### Notes

`CompilerCrash` is deliberately public in the `bloop` package even though it is just a transport between the compiler integration and the result reporting: the only instantiation site lives in `sbt.internal.inc.bloop.internal`, outside the `bloop` package hierarchy, so `private[bloop]` would not compile, and the class's fully-qualified name is the first line of the user-visible report, where `bloop.CompilerCrash` reads better than a `sbt.internal.inc.*` name.
