### PR TITLE
Add --jvm-debug flag to run and test for attaching a debugger

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -316,6 +316,10 @@ sidebar_label: CLI --help
   <dd><p>If set, do not color output. Defaults to false.</p></dd>
   <dt><code>--debug</code> (type: <code>"all" | "file-watching" | "compilation" | "test" | "bsp" | "link"*</code>)</dt>
   <dd><p>Debug the execution of a concrete task.</p></dd>
+  <dt><code>--jvm-debug</code> (type: <code>int?</code>)</dt>
+  <dd><p>Fork the JVM with a JDWP debug agent on this port so a debugger (IntelliJ, jdb) can attach. JVM projects only; unrelated to --debug.</p></dd>
+  <dt><code>--jvm-debug-suspend</code> (type: <code>bool</code>)</dt>
+  <dd><p>With --jvm-debug, make the JVM wait for the debugger to attach before running. By default, false.</p></dd>
 </dl>
 
 #### Examples
@@ -324,6 +328,7 @@ sidebar_label: CLI --help
   * <samp>bloop run foobar -m com.acme.Main -- -J-Xmx4g arg1 arg2</samp>
   * <samp>bloop run foobar -O debug -- arg1</samp>
   * <samp>bloop run foobar -m com.acme.Main -O release -w</samp>
+  * <samp>bloop run foobar --jvm-debug 5005</samp>
 
 ## `bloop test`
 
@@ -360,6 +365,10 @@ sidebar_label: CLI --help
   <dd><p>Debug the execution of a concrete task.</p></dd>
   <dt><code>--parallel</code> (type: <code>bool</code>)</dt>
   <dd><p>Run tests in parallel. Should be chosen at user's discretion. By default, false</p></dd>
+  <dt><code>--jvm-debug</code> (type: <code>int?</code>)</dt>
+  <dd><p>Fork the JVM with a JDWP debug agent on this port so a debugger (IntelliJ, jdb) can attach. JVM projects only; unrelated to --debug.</p></dd>
+  <dt><code>--jvm-debug-suspend</code> (type: <code>bool</code>)</dt>
+  <dd><p>With --jvm-debug, make the JVM wait for the debugger to attach before running. By default, false.</p></dd>
 </dl>
 
 #### Examples
@@ -372,3 +381,4 @@ sidebar_label: CLI --help
   * <samp>bloop test foobar --propagate -w</samp>
   * <samp>bloop test foobar --only com.acme.StringSpecification</samp>
   * <samp>bloop test foobar --only com.acme.StringSpecification -- -J-Xmx4g</samp>
+  * <samp>bloop test foobar --jvm-debug 5005</samp>

--- a/docs/cli/tutorial.md
+++ b/docs/cli/tutorial.md
@@ -286,8 +286,9 @@ All 1 test suites passed.
 ===============================================
 ```
 
-To debug our tests, we can use instead
-`-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005`.
+To debug our tests, pass `--jvm-debug 5005` so a debugger (IntelliJ, `jdb`) can attach on that port.
+The tests start immediately; add `--jvm-debug-suspend` to make the JVM wait for the debugger to
+attach first.
 
 
 ## Run an application
@@ -334,8 +335,9 @@ the forked virtual machine.
 Hello, World!
 ```
 
-To debug an application, pass the following JVM argument instead
-`-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005`.
+To debug an application, pass `--jvm-debug 5005` so a debugger (IntelliJ, `jdb`) can attach on that
+port. The application starts immediately; add `--jvm-debug-suspend` to make the JVM wait for the
+debugger to attach first.
 
 
 ## Enable file watching

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -247,30 +247,38 @@ object Cli {
                 }
               case Right(c: Commands.Test) =>
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
-                withProjectsOrAll(
-                  c.projects,
-                  remainingArgs.remaining
-                ) { ps =>
-                  run(
-                    // Infer everything after '--' as if they were execution args
-                    newCommand.copy(projects = ps, args = c.args ++ remainingArgs.unparsed),
-                    newCommand.cliOptions
-                  )
-                }
+                Validate
+                  .jvmDebug(newCommand.jvmDebug, newCommand.jvmDebugSuspend, commonOptions)
+                  .getOrElse {
+                    withProjectsOrAll(
+                      c.projects,
+                      remainingArgs.remaining
+                    ) { ps =>
+                      run(
+                        // Infer everything after '--' as if they were execution args
+                        newCommand.copy(projects = ps, args = c.args ++ remainingArgs.unparsed),
+                        newCommand.cliOptions
+                      )
+                    }
+                  }
               case Right(c: Commands.Run) =>
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
-                withNonEmptyProjects(
-                  c.projects,
-                  commandName.mkString(" "),
-                  remainingArgs.remaining,
-                  commonOptions
-                ) { ps =>
-                  run(
-                    // Infer everything after '--' as if they were execution args
-                    newCommand.copy(projects = ps, args = c.args ++ remainingArgs.unparsed),
-                    newCommand.cliOptions
-                  )
-                }
+                Validate
+                  .jvmDebug(newCommand.jvmDebug, newCommand.jvmDebugSuspend, commonOptions)
+                  .getOrElse {
+                    withNonEmptyProjects(
+                      c.projects,
+                      commandName.mkString(" "),
+                      remainingArgs.remaining,
+                      commonOptions
+                    ) { ps =>
+                      run(
+                        // Infer everything after '--' as if they were execution args
+                        newCommand.copy(projects = ps, args = c.args ++ remainingArgs.unparsed),
+                        newCommand.cliOptions
+                      )
+                    }
+                  }
               case Right(c: Commands.Clean) =>
                 // We accept no project arguments in clean
                 val potentialProjects = c.projects ++ remainingArgs.remaining

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -204,7 +204,15 @@ object Commands {
       @HelpMessage(
         "Run tests in parallel. Should be chosen at user's discretion. By default, false"
       )
-      parallel: Boolean = false
+      parallel: Boolean = false,
+      @HelpMessage(
+        "Fork the JVM with a JDWP debug agent on this port so a debugger (IntelliJ, jdb) can attach. JVM projects only; unrelated to --debug."
+      )
+      jvmDebug: Option[Int] = None,
+      @HelpMessage(
+        "With --jvm-debug, make the JVM wait for the debugger to attach before running. By default, false."
+      )
+      jvmDebugSuspend: Boolean = false
   ) extends CompilingCommand
 
   object Test {
@@ -266,6 +274,14 @@ object Commands {
         "If an optimizer is used (e.g. Scala Native or Scala.js), run it in `debug` or `release` mode. Defaults to `debug`."
       )
       optimize: Option[OptimizerConfig] = None,
+      @HelpMessage(
+        "Fork the JVM with a JDWP debug agent on this port so a debugger (IntelliJ, jdb) can attach. JVM projects only; unrelated to --debug."
+      )
+      jvmDebug: Option[Int] = None,
+      @HelpMessage(
+        "With --jvm-debug, make the JVM wait for the debugger to attach before running. By default, false."
+      )
+      jvmDebugSuspend: Boolean = false,
       @Recurse cliOptions: CliOptions = CliOptions.default
   ) extends LinkingCommand
 

--- a/frontend/src/main/scala/bloop/cli/Validate.scala
+++ b/frontend/src/main/scala/bloop/cli/Validate.scala
@@ -61,6 +61,31 @@ object Validate {
   }
 
   /**
+   * Validates the `--jvm-debug` port and `--jvm-debug-suspend` options shared by `run` and `test`.
+   *
+   * The port range mirrors the bsp port validation. The `--parallel` interaction is checked later,
+   * in the interpreter, where the resolved set of test projects (and thus the number of forked
+   * JVMs) is known.
+   *
+   * @return `Some(errorAction)` if the options are invalid, `None` if they are accepted.
+   */
+  def jvmDebug(
+      jvmDebug: Option[Int],
+      jvmDebugSuspend: Boolean,
+      commonOptions: CommonOptions
+  ): Option[Action] = {
+    jvmDebug match {
+      case None =>
+        if (jvmDebugSuspend) Some(cliError(Feedback.jvmDebugSuspendWithoutPort, commonOptions))
+        else None
+      case Some(port) if port > 0 && port <= 1023 =>
+        Some(cliError(Feedback.reservedPortNumber(port), commonOptions))
+      case Some(port) if port > 1023 && port <= 65535 => None
+      case Some(invalid) => Some(cliError(Feedback.outOfRangePort(invalid), commonOptions))
+    }
+  }
+
+  /**
    * Reports errors related to the build definition.
    *
    * The method is responsible of handling non-existing .bloop configuration directories

--- a/frontend/src/main/scala/bloop/dap/BloopDebuggee.scala
+++ b/frontend/src/main/scala/bloop/dap/BloopDebuggee.scala
@@ -85,7 +85,7 @@ private final class MainClassDebugAdapter(
       mainClass.arguments.toArray,
       jvmOptions.toArray,
       mainClass.environmentVariables.getOrElse(Nil),
-      RunMode.Debug
+      RunMode.Debug()
     )
     runState.map(_.status)
   }
@@ -127,7 +127,7 @@ private final class TestSuiteDebugAdapter(
       filter,
       testClasses,
       handler,
-      mode = RunMode.Debug
+      mode = RunMode.Debug()
     )
 
     task.map(_.status)

--- a/frontend/src/main/scala/bloop/engine/Feedback.scala
+++ b/frontend/src/main/scala/bloop/engine/Feedback.scala
@@ -92,6 +92,10 @@ object Feedback {
     s"Port number '${n}' is either negative or bigger than 65535"
   def reservedPortNumber(n: Int): String =
     s"Port number '${n}' is reserved for the operating system. Use a port number bigger than 1024"
+  val jvmDebugSuspendWithoutPort: String =
+    "`--jvm-debug-suspend` can only be used together with `--jvm-debug <port>`"
+  val jvmDebugWithParallel: String =
+    "`--jvm-debug` cannot be combined with `--parallel`: a single debug port can't back multiple JVMs at once. Debug one project at a time."
   def unknownHostName(host: String): String =
     s"Host name '$host' could not be either parsed or resolved"
 

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -357,34 +357,72 @@ object Interpreter {
     }
   }
 
+  /**
+   * A fixed `--jvm-debug` port can only back one forked JVM, so combining it with `--parallel`
+   * conflicts only when more than one JVM test project will be forked at once. Non-JVM (JS, Native)
+   * test projects don't fork a debuggable JVM, so they never collide on the port.
+   */
+  private[bloop] def debugForkCollision(
+      jvmDebug: Option[Int],
+      parallel: Boolean,
+      projectsToTest: List[Project]
+  ): Boolean =
+    jvmDebug.isDefined && parallel &&
+      projectsToTest.count(p =>
+        TestTask.isTestProject(p) && p.platform.isInstanceOf[Platform.Jvm]
+      ) > 1
+
+  private[bloop] def warnIfJvmDebugUnsupported(
+      project: Project,
+      jvmDebug: Option[Int],
+      logger: Logger
+  ): Unit = {
+    if (jvmDebug.isDefined && !project.platform.isInstanceOf[Platform.Jvm])
+      logger.warn(
+        s"Ignoring --jvm-debug for '${project.name}': it is only supported for JVM projects."
+      )
+  }
+
   private def test(cmd: Commands.Test, state: State): Task[State] = {
     import state.logger
+
+    val runMode = cmd.jvmDebug match {
+      case Some(port) => RunMode.Debug(Some(port), suspend = cmd.jvmDebugSuspend)
+      case None => RunMode.Normal
+    }
 
     def testAllProjects(
         state: State,
         projectsToCompile: List[Project],
         projectsToTest: List[Project]
     ): Task[State] = {
-      val testFilter = TestInternals.parseFilters(cmd.only)
-      compileAnd(cmd, state, projectsToCompile, cmd.cliOptions.noColor, "`test`") { state =>
-        logger.debug(
-          s"Preparing test execution for ${projectsToTest.mkString(", ")}"
-        )(DebugFilter.Test)
+      if (debugForkCollision(cmd.jvmDebug, cmd.parallel, projectsToTest)) {
+        Task.now(
+          state.withError(Feedback.jvmDebugWithParallel, ExitStatus.InvalidCommandLineOption)
+        )
+      } else {
+        projectsToTest.foreach(warnIfJvmDebugUnsupported(_, cmd.jvmDebug, logger))
+        val testFilter = TestInternals.parseFilters(cmd.only)
+        compileAnd(cmd, state, projectsToCompile, cmd.cliOptions.noColor, "`test`") { state =>
+          logger.debug(
+            s"Preparing test execution for ${projectsToTest.mkString(", ")}"
+          )(DebugFilter.Test)
 
-        val handler = new LoggingEventHandler(state.logger)
+          val handler = new LoggingEventHandler(state.logger)
 
-        Tasks
-          .test(
-            state,
-            projectsToTest,
-            cmd.args,
-            testFilter,
-            ch.epfl.scala.bsp.ScalaTestSuites(Nil, Nil, Nil),
-            handler,
-            cmd.parallel,
-            RunMode.Normal
-          )
-          .map(testRuns => state.mergeStatus(testRuns.status))
+          Tasks
+            .test(
+              state,
+              projectsToTest,
+              cmd.args,
+              testFilter,
+              ch.epfl.scala.bsp.ScalaTestSuites(Nil, Nil, Nil),
+              handler,
+              cmd.parallel,
+              runMode
+            )
+            .map(testRuns => state.mergeStatus(testRuns.status))
+        }
       }
     }
 
@@ -623,12 +661,17 @@ object Interpreter {
   }
 
   private def run(cmd: Commands.Run, state: State): Task[State] = {
+    val runMode = cmd.jvmDebug match {
+      case Some(port) => RunMode.Debug(Some(port), suspend = cmd.jvmDebugSuspend)
+      case None => RunMode.Normal
+    }
     def doRun(project: Project)(state: State): Task[State] = {
       val cwd = project.workingDirectory
       compileAnd(cmd, state, List(project), cmd.cliOptions.noColor, "`run`") { state =>
         getMainClass(state, project, cmd.main) match {
           case Left(failedState) => Task.now(failedState)
           case Right(mainClass) =>
+            warnIfJvmDebugUnsupported(project, cmd.jvmDebug, state.logger)
             project.platform match {
               case platform @ Platform.Native(config, _, _) =>
                 val target = ScalaNativeToolchain.linkTargetFrom(project, config)
@@ -678,7 +721,7 @@ object Interpreter {
                   cmd.args.toArray,
                   cmd.skipJargs,
                   envVars = Nil,
-                  RunMode.Normal
+                  runMode
                 )
             }
         }

--- a/frontend/src/main/scala/bloop/engine/tasks/RunMode.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/RunMode.scala
@@ -2,6 +2,14 @@ package bloop.engine.tasks
 
 sealed trait RunMode
 object RunMode {
-  final case object Debug extends RunMode
   final case object Normal extends RunMode
+
+  /**
+   * Run the JVM with a JDWP debug agent attached.
+   *
+   * @param address The fixed port to listen on, or `None` to let the JVM pick a free port
+   *                (the chosen port is then reported on stdout).
+   * @param suspend Whether the JVM should wait for a debugger to attach before running.
+   */
+  final case class Debug(address: Option[Int] = None, suspend: Boolean = true) extends RunMode
 }

--- a/frontend/src/main/scala/bloop/exec/JvmProcessForker.scala
+++ b/frontend/src/main/scala/bloop/exec/JvmProcessForker.scala
@@ -95,8 +95,21 @@ object JvmProcessForker {
   ): JvmProcessForker = {
     mode match {
       case RunMode.Normal => new JvmForker(config, classpath)
-      case RunMode.Debug => new JvmDebuggingForker(new JvmForker(config, classpath))
+      case debug: RunMode.Debug =>
+        new JvmDebuggingForker(new JvmForker(config, classpath), debug)
     }
+  }
+
+  /**
+   * Builds the JDWP agent argument that enables remote debugging of the forked JVM.
+   *
+   * Kept as a pure function (rather than inlined in [[JvmDebuggingForker]]) so the generated
+   * agent string is straightforward to unit-test.
+   */
+  def jdwpAgentArg(debug: RunMode.Debug): String = {
+    val suspend = if (debug.suspend) "y" else "n"
+    val address = debug.address.map(port => s",address=$port").getOrElse("")
+    s"-agentlib:jdwp=transport=dt_socket,server=y,suspend=$suspend,quiet=n$address"
   }
 }
 
@@ -232,7 +245,10 @@ final class JvmForker(config: JdkConfig, classpath: Array[AbsolutePath]) extends
   }
 }
 
-final class JvmDebuggingForker(underlying: JvmProcessForker) extends JvmProcessForker {
+final class JvmDebuggingForker(
+    underlying: JvmProcessForker,
+    debug: RunMode.Debug
+) extends JvmProcessForker {
 
   override def newClassLoader(parent: Option[ClassLoader]): ClassLoader =
     underlying.newClassLoader(parent)
@@ -246,11 +262,7 @@ final class JvmDebuggingForker(underlying: JvmProcessForker) extends JvmProcessF
       opts: CommonOptions,
       extraClasspath: Array[AbsolutePath]
   ): Task[Int] = {
-    val jargs = jargs0 :+ enableDebugInterface
+    val jargs = jargs0 :+ JvmProcessForker.jdwpAgentArg(debug)
     underlying.runMain(cwd, mainClass, args, jargs, logger, opts, extraClasspath)
-  }
-
-  private def enableDebugInterface: String = {
-    s"-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=n"
   }
 }

--- a/frontend/src/test/scala/bloop/CliSpec.scala
+++ b/frontend/src/test/scala/bloop/CliSpec.scala
@@ -20,6 +20,7 @@ import bloop.util.UUIDUtil
 object CliSpec extends BaseSuite {
   val tempDir: Path = Files.createTempDirectory("validate")
   tempDir.toFile.deleteOnExit()
+  val opts: CommonOptions = CommonOptions.default
 
   test("fail at existing socket") {
     val socketPath = tempDir.resolve("test.socket")
@@ -154,6 +155,109 @@ object CliSpec extends BaseSuite {
     checkReservedPort(127)
     checkReservedPort(21)
     checkReservedPort(23)
+  }
+
+  test("succeed at valid --jvm-debug options") {
+    assert(
+      Validate
+        .jvmDebug(Some(5005), jvmDebugSuspend = false, commonOptions = opts)
+        .isEmpty
+    )
+    assert(
+      Validate
+        .jvmDebug(Some(5005), jvmDebugSuspend = true, commonOptions = opts)
+        .isEmpty
+    )
+    assert(
+      Validate
+        .jvmDebug(None, jvmDebugSuspend = false, commonOptions = opts)
+        .isEmpty
+    )
+    // Lower and upper bounds of the accepted range.
+    assert(Validate.jvmDebug(Some(1024), jvmDebugSuspend = false, commonOptions = opts).isEmpty)
+    assert(Validate.jvmDebug(Some(65535), jvmDebugSuspend = false, commonOptions = opts).isEmpty)
+  }
+
+  test("fail at out of range --jvm-debug port") {
+    checkIsCliError(
+      Validate
+        .jvmDebug(Some(70000), jvmDebugSuspend = false, commonOptions = opts)
+        .get,
+      Feedback.outOfRangePort(70000)
+    )
+    checkIsCliError(
+      Validate
+        .jvmDebug(Some(-1), jvmDebugSuspend = false, commonOptions = opts)
+        .get,
+      Feedback.outOfRangePort(-1)
+    )
+    // Boundaries just outside the accepted range.
+    checkIsCliError(
+      Validate.jvmDebug(Some(0), jvmDebugSuspend = false, commonOptions = opts).get,
+      Feedback.outOfRangePort(0)
+    )
+    checkIsCliError(
+      Validate.jvmDebug(Some(65536), jvmDebugSuspend = false, commonOptions = opts).get,
+      Feedback.outOfRangePort(65536)
+    )
+  }
+
+  test("fail at reserved --jvm-debug port") {
+    checkIsCliError(
+      Validate
+        .jvmDebug(Some(80), jvmDebugSuspend = false, commonOptions = opts)
+        .get,
+      Feedback.reservedPortNumber(80)
+    )
+    // Highest reserved port.
+    checkIsCliError(
+      Validate.jvmDebug(Some(1023), jvmDebugSuspend = false, commonOptions = opts).get,
+      Feedback.reservedPortNumber(1023)
+    )
+  }
+
+  test("fail at --jvm-debug-suspend without --jvm-debug") {
+    checkIsCliError(
+      Validate.jvmDebug(None, jvmDebugSuspend = true, commonOptions = opts).get,
+      Feedback.jvmDebugSuspendWithoutPort
+    )
+  }
+
+  test("parse --jvm-debug and --jvm-debug-suspend on run") {
+    Cli.parse(Array("run", "foo", "--jvm-debug", "5005"), CommonOptions.default) match {
+      case Run(cmd: Commands.Run, _) =>
+        assert(cmd.jvmDebug == Some(5005))
+        assert(!cmd.jvmDebugSuspend)
+      case action => throw new AssertionError(s"Expected a run command, got $action")
+    }
+    Cli.parse(
+      Array("run", "foo", "--jvm-debug", "5005", "--jvm-debug-suspend"),
+      CommonOptions.default
+    ) match {
+      case Run(cmd: Commands.Run, _) =>
+        assert(cmd.jvmDebug == Some(5005))
+        assert(cmd.jvmDebugSuspend)
+      case action => throw new AssertionError(s"Expected a run command, got $action")
+    }
+  }
+
+  test("parse --jvm-debug on test") {
+    Cli.parse(Array("test", "foo", "--jvm-debug", "5005"), CommonOptions.default) match {
+      case Run(cmd: Commands.Test, _) =>
+        assert(cmd.jvmDebug == Some(5005))
+      case action => throw new AssertionError(s"Expected a test command, got $action")
+    }
+  }
+
+  test("reject an out-of-range --jvm-debug port through the CLI") {
+    checkIsCliError(
+      Cli.parse(Array("run", "foo", "--jvm-debug", "70000"), CommonOptions.default),
+      Feedback.outOfRangePort(70000)
+    )
+    checkIsCliError(
+      Cli.parse(Array("test", "foo", "--jvm-debug", "70000"), CommonOptions.default),
+      Feedback.outOfRangePort(70000)
+    )
   }
 
   test("print about info when `--version` is passed without a command") {

--- a/frontend/src/test/scala/bloop/ForkerSpec.scala
+++ b/frontend/src/test/scala/bloop/ForkerSpec.scala
@@ -9,6 +9,7 @@ import scala.concurrent.duration.Duration
 import bloop.cli.CommonOptions
 import bloop.cli.ExitStatus
 import bloop.data.JdkConfig
+import bloop.engine.tasks.RunMode
 import bloop.exec.Forker
 import bloop.exec.JvmProcessForker
 import bloop.io.AbsolutePath
@@ -220,5 +221,27 @@ class ForkerSpec {
         assertEquals(0, exitCode.toLong)
         assert(messages.contains(expected), s"$messages did not contain $expected")
     }
+  }
+
+  @Test
+  def jdwpAgentArgKeepsDapDefaults(): Unit = {
+    // The default debug mode (no fixed address, suspend) is what the DAP/Metals path relies on:
+    // the JVM picks a free port and reports it on stdout. This string must not change.
+    assertEquals(
+      "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=n",
+      JvmProcessForker.jdwpAgentArg(RunMode.Debug())
+    )
+  }
+
+  @Test
+  def jdwpAgentArgUsesFixedAddressAndSuspend(): Unit = {
+    assertEquals(
+      "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,quiet=n,address=5005",
+      JvmProcessForker.jdwpAgentArg(RunMode.Debug(Some(5005), suspend = false))
+    )
+    assertEquals(
+      "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=n,address=5005",
+      JvmProcessForker.jdwpAgentArg(RunMode.Debug(Some(5005), suspend = true))
+    )
   }
 }

--- a/frontend/src/test/scala/bloop/GenericTestSpec.scala
+++ b/frontend/src/test/scala/bloop/GenericTestSpec.scala
@@ -1,6 +1,10 @@
 package bloop
 
 import bloop.cli.Commands
+import bloop.cli.ExitStatus
+import bloop.config.Config
+import bloop.data.Platform
+import bloop.engine.Interpreter
 import bloop.engine.Run
 import bloop.io.AbsolutePath
 import bloop.io.Environment.lineSeparator
@@ -208,6 +212,146 @@ class GenericTestSpec {
         """.stripMargin,
         logger.startedTestInfos.sorted.mkString(lineSeparator)
       )
+    }
+  }
+
+  @Test
+  def jvmDebugRejectedWhenParallelForksManyJvms(): Unit = {
+    // Two test projects + --parallel would fork two JVMs that can't share one debug port.
+    object Sources {
+      val `F.scala` =
+        """
+          |package p0
+          |import org.junit.Test
+          |class F { @Test def testF(): Unit = () }
+        """.stripMargin
+      val `G.scala` =
+        """
+          |package p4
+          |import org.junit.Test
+          |class G { @Test def testG(): Unit = () }
+        """.stripMargin
+    }
+    val structure = Map(
+      "F" -> Map("F.scala" -> Sources.`F.scala`),
+      "G" -> Map("G.scala" -> Sources.`G.scala`)
+    )
+    val logger = new RecordingLogger(ansiCodesSupported = false)
+    val junitJars = bloop.internal.build.BuildTestInfo.junitTestJars.map(AbsolutePath.apply).toArray
+    TestUtil.testState(
+      structure,
+      Map.empty[String, Set[String]],
+      userLogger = Some(logger),
+      extraJars = junitJars,
+      testProjects = Set("F", "G")
+    ) { state =>
+      val action = Run(Commands.Test(List("F", "G"), parallel = true, jvmDebug = Some(5005)))
+      val resultState = TestUtil.blockingExecute(action, state)
+      Assert.assertEquals(ExitStatus.InvalidCommandLineOption, resultState.status)
+      Assert.assertTrue(
+        s"Expected an error mentioning --jvm-debug, got: ${logger.errors}",
+        logger.errors.exists(_.contains("--jvm-debug"))
+      )
+    }
+  }
+
+  @Test
+  def jvmDebugAllowedForSingleProjectEvenWithParallel(): Unit = {
+    // A single test project forks one JVM, so --parallel is a no-op and debugging is fine.
+    object Sources {
+      val `F.scala` =
+        """
+          |package p0
+          |import org.junit.Test
+          |class F { @Test def testF(): Unit = () }
+        """.stripMargin
+    }
+    val structure = Map("F" -> Map("F.scala" -> Sources.`F.scala`))
+    val logger = new RecordingLogger(ansiCodesSupported = false)
+    val junitJars = bloop.internal.build.BuildTestInfo.junitTestJars.map(AbsolutePath.apply).toArray
+    val port = {
+      val socket = new java.net.ServerSocket(0)
+      try socket.getLocalPort
+      finally socket.close()
+    }
+    TestUtil.testState(
+      structure,
+      Map.empty[String, Set[String]],
+      userLogger = Some(logger),
+      extraJars = junitJars,
+      testProjects = Set("F")
+    ) { state =>
+      val action = Run(Commands.Test(List("F"), parallel = true, jvmDebug = Some(port)))
+      val resultState = TestUtil.blockingExecute(action, state)
+      Assert.assertTrue(
+        s"Single-project debug + parallel should not be rejected, got: ${resultState.status}",
+        resultState.status.isOk
+      )
+    }
+  }
+
+  @Test
+  def debugForkCollisionCountsOnlyJvmTestProjects(): Unit = {
+    object Sources {
+      val `F.scala` =
+        """
+          |package p0
+          |import org.junit.Test
+          |class F { @Test def testF(): Unit = () }
+        """.stripMargin
+    }
+    val structure = Map("F" -> Map("F.scala" -> Sources.`F.scala`))
+    val logger = new RecordingLogger(ansiCodesSupported = false)
+    val junitJars = bloop.internal.build.BuildTestInfo.junitTestJars.map(AbsolutePath.apply).toArray
+    TestUtil.testState(
+      structure,
+      Map.empty[String, Set[String]],
+      userLogger = Some(logger),
+      extraJars = junitJars,
+      testProjects = Set("F")
+    ) { state =>
+      val jvm = state.build.getProjectFor("F").get
+      val jvm2 = jvm.copy(name = "F2")
+      // A Scala.js test project carries the Test tag but forks no debuggable JVM.
+      val js = jvm.copy(name = "Fjs", platform = Platform.Js(Config.JsConfig.empty, None, None))
+
+      // Two JVM test projects would fork two JVMs that can't share one debug port.
+      Assert.assertTrue(
+        Interpreter.debugForkCollision(Some(5005), parallel = true, List(jvm, jvm2))
+      )
+      // A JVM test project alongside a Scala.js one: only one JVM forks, so no collision.
+      Assert.assertFalse(Interpreter.debugForkCollision(Some(5005), parallel = true, List(jvm, js)))
+      // A single JVM test project: `--parallel` is a no-op.
+      Assert.assertFalse(Interpreter.debugForkCollision(Some(5005), parallel = true, List(jvm)))
+      // No conflict without `--jvm-debug` or without `--parallel`.
+      Assert.assertFalse(Interpreter.debugForkCollision(None, parallel = true, List(jvm, jvm2)))
+      Assert.assertFalse(
+        Interpreter.debugForkCollision(Some(5005), parallel = false, List(jvm, jvm2))
+      )
+    }
+  }
+
+  @Test
+  def warnsAboutJvmDebugOnNonJvmProject(): Unit = {
+    val structure = Map("F" -> Map("F.scala" -> "package p0\nclass F"))
+    TestUtil.testState(structure, Map.empty[String, Set[String]]) { state =>
+      val jvm = state.build.getProjectFor("F").get
+      val js = jvm.copy(name = "Fjs", platform = Platform.Js(Config.JsConfig.empty, None, None))
+
+      val jsLog = new RecordingLogger(ansiCodesSupported = false)
+      Interpreter.warnIfJvmDebugUnsupported(js, Some(5005), jsLog)
+      Assert.assertTrue(
+        s"Expected a warning for the non-JVM project, got: ${jsLog.warnings}",
+        jsLog.warnings.exists(_.contains("--jvm-debug"))
+      )
+
+      val jvmLog = new RecordingLogger(ansiCodesSupported = false)
+      Interpreter.warnIfJvmDebugUnsupported(jvm, Some(5005), jvmLog)
+      Assert.assertTrue("A JVM project must not warn", jvmLog.warnings.isEmpty)
+
+      val noFlagLog = new RecordingLogger(ansiCodesSupported = false)
+      Interpreter.warnIfJvmDebugUnsupported(js, None, noFlagLog)
+      Assert.assertTrue("Without --jvm-debug there must be no warning", noFlagLog.warnings.isEmpty)
     }
   }
 }

--- a/frontend/src/test/scala/bloop/RunSpec.scala
+++ b/frontend/src/test/scala/bloop/RunSpec.scala
@@ -767,4 +767,36 @@ class RunSpec extends BloopHelpers {
       assert(logOutput.contains("BTest"))
     }
   }
+
+  @Test
+  def runForksJvmWithDebugAgent(): Unit = {
+    val port = freePort()
+    val projectName = "test-project"
+    // The main prints the JVM's own input arguments so we can assert the debug agent was injected.
+    val source =
+      s"""package $packageName
+         |object DebugMain {
+         |  def main(args: Array[String]): Unit = {
+         |    val jvmArgs = java.lang.management.ManagementFactory.getRuntimeMXBean.getInputArguments
+         |    println("JVM-ARGS: " + jvmArgs)
+         |  }
+         |}""".stripMargin
+    // suspend defaults to false, so the JVM runs (and exits) without waiting for a debugger.
+    val command =
+      Commands.Run(List(projectName), Some(s"$packageName.DebugMain"), jvmDebug = Some(port))
+    runAndCheck(projectName, List(source), command) { messages =>
+      val expectedAgent =
+        s"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,quiet=n,address=$port"
+      assert(
+        messages.exists { case (level, msg) => level == "info" && msg.contains(expectedAgent) },
+        s"Forked JVM args did not contain debug agent '$expectedAgent'.\nMessages: $messages"
+      )
+    }
+  }
+
+  private def freePort(): Int = {
+    val socket = new java.net.ServerSocket(0)
+    try socket.getLocalPort
+    finally socket.close()
+  }
 }

--- a/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
+++ b/frontend/src/test/scala/bloop/dap/DebugServerSpec.scala
@@ -1076,7 +1076,7 @@ object DebugServerSpec extends DebugBspBaseSuite {
       Array.empty,
       skipJargs = false,
       envVars = List.empty,
-      RunMode.Debug
+      RunMode.Debug()
     )
 
     remoteProcess.runAsync(defaultScheduler)


### PR DESCRIPTION
Closes #1457.

`bloop run` / `bloop test` can now fork the JVM with a JDWP agent via `--jvm-debug <port>`, so a debugger (IntelliJ, jdb) can attach. Add `--jvm-debug-suspend` to make the JVM wait for the debugger before running (default: don't wait, matching sbt's `-jvm-debug`).

### Notes
- Reuses the existing `RunMode.Debug` / `JvmDebuggingForker` machinery that was previously only reachable through BSP/DAP; `RunMode.Debug` now carries the debug address + suspend flag. The DAP agent string is unchanged.
- Port range and a dangling `--jvm-debug-suspend` are validated at the CLI layer (like the bsp port validation). `--jvm-debug` with `--parallel` is rejected only when more than one JVM test project would fork at once; it's a no-op (ignored with a warning) for non-JVM projects.
- Docs: `reference.md` gets the flag entries; `tutorial.md` now points to `--jvm-debug` instead of the raw `-J-agentlib:jdwp=...` workaround.
