### PR TITLE
Fully reset incremental state on clean

### DIFF
--- a/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
@@ -79,7 +79,7 @@ final case class ResultsCache private (
       logger: Logger
   ): Task[ResultsCache] = {
     def delete(path: AbsolutePath): Task[Unit] = Task {
-      logger.debug(s"Deleting classes directory: $path")(DebugFilter.All)
+      logger.debug(s"Deleting $path")(DebugFilter.All)
       Paths.delete(path)
     }
     // Remove all the successful results from the cache.
@@ -92,8 +92,11 @@ final case class ResultsCache private (
           delete(client.getUniqueClassesDirFor(project, forceGeneration = false))
         )
     }
+    // The persisted analysis is deleted for every target, not only those with an in-memory
+    // result, so a clean fully resets incremental state and is reloaded fresh after a restart.
+    val deleteAnalysisFiles = projects.iterator.map(p => delete(p.analysisOut)).toList
 
-    Task.gatherUnordered(deleteClassesDirs).map { _ =>
+    Task.gatherUnordered(deleteClassesDirs.toList ++ deleteAnalysisFiles).map { _ =>
       new ResultsCache(newAll, newSuccessful)
     }
   }

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -44,10 +44,12 @@ object Tasks {
     val allTargetsToClean =
       if (!includeDeps) targets
       else targets.flatMap(t => Dag.dfs(state.build.getDagFor(t), mode = Dag.PreOrder)).distinct
-    state.results.cleanSuccessful(allTargetsToClean.toSet, state.client, state.logger).map {
-      newResults =>
-        state.copy(results = newResults)
-    }
+    // Drop the cross-client in-memory last successful results so the next compile can't reuse them.
+    Task(allTargetsToClean.foreach(CompileGatekeeper.clearSuccessfulResult))
+      .flatMap { _ =>
+        state.results.cleanSuccessful(allTargetsToClean.toSet, state.client, state.logger)
+      }
+      .map(newResults => state.copy(results = newResults))
   }
 
   /**

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGatekeeper.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGatekeeper.scala
@@ -279,4 +279,10 @@ object CompileGatekeeper {
       lastSuccessfulResults.clear()
     }
   }
+
+  // Drop the cached last successful result for a single project so a clean fully resets it.
+  private[bloop] def clearSuccessfulResult(project: Project): Unit = {
+    lastSuccessfulResults.remove(project.uniqueId)
+    ()
+  }
 }

--- a/frontend/src/test/scala/bloop/BaseCompileSpec.scala
+++ b/frontend/src/test/scala/bloop/BaseCompileSpec.scala
@@ -335,6 +335,62 @@ abstract class BaseCompileSpec extends bloop.testing.BaseSuite {
     }
   }
 
+  test("clean fully resets analysis when a package becomes an object") {
+    TestUtil.withinWorkspace { workspace =>
+      object Sources {
+        // A `foo.bar` package containing an object.
+        val `Foo.scala` =
+          """/main/scala/Foo.scala
+            |package foo.bar
+            |
+            |object Bar {
+            |  val myFooBar: Int = 1
+            |}
+          """.stripMargin
+
+        // The same FQN, but `bar` is now a top-level object instead of a package.
+        val `Foo2.scala` =
+          """/main/scala/Foo.scala
+            |package foo
+            |
+            |object bar {
+            |  object Bar {
+            |    val myFooBar: Int = 1
+            |  }
+            |}
+          """.stripMargin
+      }
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(Sources.`Foo.scala`))
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.compile(`A`)
+      assertExitStatus(compiledState, ExitStatus.Ok)
+      assertValidCompilationState(compiledState, projects)
+
+      val analysisFile = compiledState.getProjectFor(`A`).analysisOut
+      assert(analysisFile.exists)
+
+      // Turn the `foo.bar` package into a top-level `object bar` with the same FQN.
+      assertIsFile(writeFile(`A`.srcFor("main/scala/Foo.scala"), Sources.`Foo2.scala`))
+
+      // A clean must also delete the persisted analysis, otherwise it is reloaded after a
+      // restart and the next compile runs incrementally against the stale package definition.
+      val _ = compiledState.clean(`A`)
+      assertNotFile(analysisFile)
+
+      // Compile from a freshly loaded state with no intervening recompile, so the test exercises
+      // a server restart at the point where the stale analysis would otherwise still be present.
+      val restartedLogger = new RecordingLogger(ansiCodesSupported = false)
+      val restartedState = loadState(workspace, projects, restartedLogger)
+      val restartedCompile = restartedState.compile(`A`)
+      assertExitStatus(restartedCompile, ExitStatus.Ok)
+      assertValidCompilationState(restartedCompile, projects)
+      assert(!restartedLogger.renderErrors().contains("already defined as package"))
+    }
+  }
+
   test("simulate an incremental compiler session") {
     TestUtil.withinWorkspace { workspace =>
       object Sources {


### PR DESCRIPTION
Fixes #1466.

Converting a `package foo.bar` declaration into a top-level `object bar` of the same name reported `bar is already defined as package bar`. The error survived "Clean compiling workspace", restarting the build server, and reimporting the build — only `rm -rf .bloop` cleared it.

### Cause

`clean` deleted the class directories but kept two pieces of incremental state:
- the persisted Zinc analysis file (`<project.out>/<name>-analysis.bin`), and
- the in-memory `CompileGatekeeper` last-successful result.

After a restart the stale analysis was reloaded and the next compile ran incrementally against it, so the old `package foo.bar` definition kept colliding with the new `object bar`. `rm -rf .bloop` was the only fix because it also removes the analysis file.

> **Note for reviewers:** the analysis file is now deleted for *all* cleaned targets, not only those with an in-memory successful result — the file can exist on disk even when the in-memory cache has none (e.g. right after a restart), so it can't reuse the existing `successful`-keyed deletion loop.