### PR TITLE
Source globs watcher

### DIFF
--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -136,11 +136,23 @@ object Interpreter {
     }
     val groupTasks =
       projectsSourcesAndDirs.grouped(8).map(group => Task.gatherUnordered(group)).toList
+    val watchedPlainSources = reachable.flatMap(_.sources.map(_.underlying))
+    val watchedProjectGlobs = reachable.flatMap(_.sourcesGlobs)
+    val watchedSourceGeneratorGlobs = reachable.flatMap { project =>
+      project.sourceGenerators.flatMap(_.sourcesGlobs)
+    }
     Task
       .sequence(groupTasks)
       .map(fp => fp.flatten.flatten.map(_.underlying))
       .flatMap { allSources =>
-        val watcher = SourceWatcher(projects.map(_.name), allSources, state.logger)
+        val watcher = SourceWatcher(
+          projects.map(_.name),
+          allSources,
+          watchedPlainSources,
+          watchedProjectGlobs,
+          watchedSourceGeneratorGlobs,
+          state.logger
+        )
         val fg = (state: State) => {
           val newState = State.stateCache.getUpdatedStateFrom(state).getOrElse(state)
           f(newState).map { state =>

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -126,10 +126,13 @@ object Interpreter {
     val projectsSourcesAndDirs = reachable.map { project =>
       for {
         unmanaged <- project.allUnmanagedSourceFilesAndDirectories
+        // Globs expand to the files existing now; watch their directories so
+        // that creating a new matching file also triggers an iteration
+        globDirectories = project.sourcesGlobs.map(_.directory)
         generatorSourceDirs = project.sourceGenerators.flatMap(gen =>
           gen.sourcesGlobs.map(_.directory) ++ gen.unmangedInputs
         )
-      } yield unmanaged ++ generatorSourceDirs
+      } yield unmanaged ++ globDirectories ++ generatorSourceDirs
     }
     val groupTasks =
       projectsSourcesAndDirs.grouped(8).map(group => Task.gatherUnordered(group)).toList

--- a/frontend/src/main/scala/bloop/io/SourceWatcher.scala
+++ b/frontend/src/main/scala/bloop/io/SourceWatcher.scala
@@ -31,6 +31,9 @@ final class SourceWatcher private (
     projectNames: List[String],
     dirs: Seq[Path],
     files: Seq[Path],
+    plainSources: Seq[Path],
+    projectGlobs: Seq[SourcesGlobs],
+    sourceGeneratorGlobs: Seq[SourcesGlobs],
     logger: Logger
 ) {
   import java.nio.file.Files
@@ -54,18 +57,9 @@ final class SourceWatcher private (
       )
 
     var watchingEnabled: Boolean = true
-    val isSourceFile: Path => Boolean = {
-      val projects = state0.build.loadedProjects.map(_.project)
-      val plainSources = projects.flatMap(_.sources.map(_.underlying))
-      val projectGlobs = projects.flatMap(_.sourcesGlobs)
-      val sourceGeneratorGlobs = for {
-        project <- projects
-        sourceGenerator <- project.sourceGenerators
-        glob <- sourceGenerator.sourcesGlobs
-      } yield glob
+    val isSourceFile: Path => Boolean =
       path =>
         SourceWatcher.isWatchedSourceFile(plainSources, projectGlobs, sourceGeneratorGlobs, path)
-    }
     val listener = new DirectoryChangeListener {
       override def isWatching: Boolean = watchingEnabled
 
@@ -232,27 +226,52 @@ object SourceWatcher {
       sourceGeneratorGlobs: Seq[SourcesGlobs],
       path: Path
   ): Boolean = {
+    val normalizedPath = path.toAbsolutePath.normalize
+    val normalizedPlainSources = plainSources.map(_.toAbsolutePath.normalize)
+
     // `SourcesGlobs.matches` relativizes against its own directory, and Java glob semantics let a
     // `**` pattern match the resulting `../` path. Only globs whose directory contains the path
     // may decide whether it is a source.
-    def enclosesPath(glob: SourcesGlobs): Boolean = path.startsWith(glob.directory.underlying)
+    def globDirectory(glob: SourcesGlobs): Path = glob.directory.underlying.toAbsolutePath.normalize
+    def enclosesPath(glob: SourcesGlobs): Boolean = normalizedPath.startsWith(globDirectory(glob))
+    def withinWalkDepth(glob: SourcesGlobs): Boolean =
+      globDirectory(glob).relativize(normalizedPath).getNameCount <= glob.walkDepth
     def matchedBy(globs: Seq[SourcesGlobs]): Boolean =
-      globs.exists(glob => enclosesPath(glob) && glob.matches(path))
-    def underPlainSource = plainSources.exists(source => path.startsWith(source))
+      globs.exists(glob =>
+        enclosesPath(glob) && withinWalkDepth(glob) && glob.matches(normalizedPath)
+      )
+    def underPlainSource =
+      normalizedPlainSources.exists(source => normalizedPath.startsWith(source))
 
     // A non-hidden Scala/Java file is a source unless it sits inside a sources-glob directory
     // that filters it out and no plain source directory covers it.
     def isDefaultSource =
-      SourceHasher.matchSourceFile(path) && (!projectGlobs.exists(enclosesPath) || underPlainSource)
+      SourceHasher.matchSourceFile(normalizedPath) &&
+        (!projectGlobs.exists(enclosesPath) || underPlainSource)
 
     matchedBy(projectGlobs) || matchedBy(sourceGeneratorGlobs) || isDefaultSource
   }
 
-  def apply(projectNames: List[String], paths0: Seq[Path], logger: Logger): SourceWatcher = {
+  def apply(
+      projectNames: List[String],
+      paths0: Seq[Path],
+      plainSources: Seq[Path],
+      projectGlobs: Seq[SourcesGlobs],
+      sourceGeneratorGlobs: Seq[SourcesGlobs],
+      logger: Logger
+  ): SourceWatcher = {
     val existingPaths = paths0.distinct.filter(p => Files.exists(p))
     val dirs = existingPaths.filter(p => Files.isDirectory(p))
     val files = existingPaths.filter(p => Files.isRegularFile(p))
-    new SourceWatcher(projectNames, dirs, files, logger)
+    new SourceWatcher(
+      projectNames,
+      dirs,
+      files,
+      plainSources,
+      projectGlobs,
+      sourceGeneratorGlobs,
+      logger
+    )
   }
 
   sealed trait EventStream

--- a/frontend/src/main/scala/bloop/io/SourceWatcher.scala
+++ b/frontend/src/main/scala/bloop/io/SourceWatcher.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.FiniteDuration
 
+import bloop.data.SourcesGlobs
 import bloop.engine.ExecutionContext
 import bloop.engine.State
 import bloop.logging.DebugFilter
@@ -54,12 +55,16 @@ final class SourceWatcher private (
 
     var watchingEnabled: Boolean = true
     val isSourceFile: Path => Boolean = {
+      val projects = state0.build.loadedProjects.map(_.project)
+      val plainSources = projects.flatMap(_.sources.map(_.underlying))
+      val projectGlobs = projects.flatMap(_.sourcesGlobs)
       val sourceGeneratorGlobs = for {
-        loadedProject <- state0.build.loadedProjects
-        sourceGenerator <- loadedProject.project.sourceGenerators
+        project <- projects
+        sourceGenerator <- project.sourceGenerators
         glob <- sourceGenerator.sourcesGlobs
       } yield glob
-      path => SourceHasher.matchSourceFile(path) || sourceGeneratorGlobs.exists(_.matches(path))
+      path =>
+        SourceWatcher.isWatchedSourceFile(plainSources, projectGlobs, sourceGeneratorGlobs, path)
     }
     val listener = new DirectoryChangeListener {
       override def isWatching: Boolean = watchingEnabled
@@ -213,6 +218,36 @@ final class SourceWatcher private (
 }
 
 object SourceWatcher {
+
+  /**
+   * Decides whether a file watching event should trigger a new compilation iteration.
+   *
+   * A file inside a sources-glob directory is a source only if some glob matches it; otherwise
+   * it is filtered out and must not wake compilation, unless a plain source directory also
+   * covers it. Files outside glob directories keep the default non-hidden source-file rule.
+   */
+  def isWatchedSourceFile(
+      plainSources: Seq[Path],
+      projectGlobs: Seq[SourcesGlobs],
+      sourceGeneratorGlobs: Seq[SourcesGlobs],
+      path: Path
+  ): Boolean = {
+    // `SourcesGlobs.matches` relativizes against its own directory, and Java glob semantics let a
+    // `**` pattern match the resulting `../` path. Only globs whose directory contains the path
+    // may decide whether it is a source.
+    def enclosesPath(glob: SourcesGlobs): Boolean = path.startsWith(glob.directory.underlying)
+    def matchedBy(globs: Seq[SourcesGlobs]): Boolean =
+      globs.exists(glob => enclosesPath(glob) && glob.matches(path))
+    def underPlainSource = plainSources.exists(source => path.startsWith(source))
+
+    // A non-hidden Scala/Java file is a source unless it sits inside a sources-glob directory
+    // that filters it out and no plain source directory covers it.
+    def isDefaultSource =
+      SourceHasher.matchSourceFile(path) && (!projectGlobs.exists(enclosesPath) || underPlainSource)
+
+    matchedBy(projectGlobs) || matchedBy(sourceGeneratorGlobs) || isDefaultSource
+  }
+
   def apply(projectNames: List[String], paths0: Seq[Path], logger: Logger): SourceWatcher = {
     val existingPaths = paths0.distinct.filter(p => Files.exists(p))
     val dirs = existingPaths.filter(p => Files.isDirectory(p))

--- a/frontend/src/test/scala/bloop/FileWatchingSpec.scala
+++ b/frontend/src/test/scala/bloop/FileWatchingSpec.scala
@@ -401,6 +401,68 @@ object FileWatchingSpec extends BaseSuite {
     }
   }
 
+  flakyTest("watcher picks up new files in sources globs directories", 3) {
+    TestUtil.withinWorkspace { workspace =>
+      import ExecutionContext.ioScheduler
+      val source =
+        """/A.scala
+          |object A
+          |""".stripMargin
+
+      val baseProject = TestProject(workspace, "a", List(source))
+      val globDirectory = baseProject.config.directory.resolve("glob-sources")
+      java.nio.file.Files.createDirectories(globDirectory)
+      val `A` = baseProject.copy(
+        config = baseProject.config.copy(
+          sourcesGlobs = Some(
+            List(
+              Config.SourcesGlobs(
+                globDirectory,
+                walkDepth = None,
+                includes = List("glob:*.scala"),
+                excludes = Nil
+              )
+            )
+          )
+        )
+      )
+      val projects = List(`A`)
+      val initialState = loadState(workspace, projects, new RecordingLogger())
+      val compiledState = initialState.compile(`A`)
+      assert(compiledState.status == ExitStatus.Ok)
+      assertValidCompilationState(compiledState, projects)
+
+      val (logObserver, logsObservable) =
+        Observable.multicast[(String, String)](MulticastStrategy.replay)(ioScheduler)
+      val logger = new PublisherLogger(logObserver, DebugFilter.All)
+
+      compiledState.withLogger(logger).compileHandle(`A`, watch = true)
+
+      // The empty glob directory contributes no expanded files, so watching it
+      // is the only way new files can trigger an iteration
+      val HasIterationStoppedMsg = s"Watching 2"
+      def waitUntilIteration(totalIterations: Int, duration: Option[Long] = None): Task[Unit] =
+        waitUntilWatchIteration(logsObservable, totalIterations, HasIterationStoppedMsg, duration)
+
+      def testValidLatestState: TestState = {
+        val state = compiledState.getLatestSavedStateGlobally()
+        assert(state.status == ExitStatus.Ok)
+        assertValidCompilationState(state, projects)
+        state
+      }
+
+      TestUtil.await(FiniteDuration(20, TimeUnit.SECONDS), ExecutionContext.ioScheduler) {
+        for {
+          _ <- waitUntilIteration(1)
+          _ <- Task(testValidLatestState)
+          _ <- Task(writeFile(AbsolutePath(globDirectory.resolve("B.scala")), "object B"))
+          _ <- waitUntilIteration(2, Some(6000L))
+          _ <- Task(testValidLatestState)
+        } yield ()
+      }
+    }
+  }
+
   def waitUntilWatchIteration(
       logsObservable: Observable[(String, String)],
       totalIterations: Int,
@@ -486,7 +548,10 @@ object FileWatchingSpec extends BaseSuite {
 
   private def numberDirsOf(dag: Dag[Project]): Int = {
     val reachable = Dag.dfs(dag, mode = Dag.PreOrder)
-    val allSources = reachable.iterator.flatMap(_.sources.toList).map(_.underlying).toList
+    val allSources = reachable.iterator
+      .flatMap(p => p.sources.toList ++ p.sourcesGlobs.map(_.directory))
+      .map(_.underlying)
+      .toList
     allSources.filter { p =>
       val s = p.toString
       java.nio.file.Files.exists(p) && !s.endsWith(".scala") && !s.endsWith(".java")

--- a/frontend/src/test/scala/bloop/io/SourceWatcherSpec.scala
+++ b/frontend/src/test/scala/bloop/io/SourceWatcherSpec.scala
@@ -13,9 +13,10 @@ object SourceWatcherSpec extends bloop.testing.BaseSuite {
   private def globs(
       directory: AbsolutePath,
       includes: List[String],
-      excludes: List[String]
+      excludes: List[String],
+      walkDepth: Option[Int] = None
   ): List[SourcesGlobs] =
-    SourcesGlobs.fromStrings("test", directory, None, includes, excludes, logger)
+    SourcesGlobs.fromStrings("test", directory, walkDepth, includes, excludes, logger)
 
   private def isWatched(
       plainSources: Seq[Path],
@@ -73,6 +74,15 @@ object SourceWatcherSpec extends bloop.testing.BaseSuite {
     }
   }
 
+  test("source globs obey walkDepth when matching watcher events") {
+    TestUtil.withinWorkspace { workspace =>
+      val globDir = workspace.resolve("globbed")
+      val projectGlobs = globs(globDir, List("glob:**.scala"), Nil, Some(1))
+      assert(isWatched(Nil, projectGlobs, Nil, globDir.resolve("Foo.scala")))
+      assert(!isWatched(Nil, projectGlobs, Nil, globDir.resolve("nested").resolve("Foo.scala")))
+    }
+  }
+
   test("source generator inputs are watched even outside glob and plain directories") {
     TestUtil.withinWorkspace { workspace =>
       val inputsDir = workspace.resolve("generator-inputs")
@@ -80,6 +90,15 @@ object SourceWatcherSpec extends bloop.testing.BaseSuite {
       assert(isWatched(Nil, Nil, generatorGlobs, inputsDir.resolve("data.in")))
       // a stray source file in a generator input directory keeps the default rule
       assert(isWatched(Nil, Nil, generatorGlobs, inputsDir.resolve("Stray.scala")))
+    }
+  }
+
+  test("source generator globs obey walkDepth when matching watcher events") {
+    TestUtil.withinWorkspace { workspace =>
+      val inputsDir = workspace.resolve("generator-inputs")
+      val generatorGlobs = globs(inputsDir, List("glob:**.in"), Nil, Some(1))
+      assert(isWatched(Nil, Nil, generatorGlobs, inputsDir.resolve("data.in")))
+      assert(!isWatched(Nil, Nil, generatorGlobs, inputsDir.resolve("sub").resolve("data.in")))
     }
   }
 

--- a/frontend/src/test/scala/bloop/io/SourceWatcherSpec.scala
+++ b/frontend/src/test/scala/bloop/io/SourceWatcherSpec.scala
@@ -1,0 +1,96 @@
+package bloop.io
+
+import java.nio.file.Path
+
+import bloop.data.SourcesGlobs
+import bloop.logging.RecordingLogger
+import bloop.util.TestUtil
+
+object SourceWatcherSpec extends bloop.testing.BaseSuite {
+
+  private val logger = new RecordingLogger(ansiCodesSupported = false)
+
+  private def globs(
+      directory: AbsolutePath,
+      includes: List[String],
+      excludes: List[String]
+  ): List[SourcesGlobs] =
+    SourcesGlobs.fromStrings("test", directory, None, includes, excludes, logger)
+
+  private def isWatched(
+      plainSources: Seq[Path],
+      projectGlobs: Seq[SourcesGlobs],
+      generatorGlobs: Seq[SourcesGlobs],
+      path: AbsolutePath
+  ): Boolean =
+    SourceWatcher.isWatchedSourceFile(plainSources, projectGlobs, generatorGlobs, path.underlying)
+
+  test("plain source files keep the default non-hidden source-file rule") {
+    TestUtil.withinWorkspace { workspace =>
+      val srcDir = workspace.resolve("src")
+      val plain = List(srcDir.underlying)
+      assert(isWatched(plain, Nil, Nil, srcDir.resolve("Foo.scala")))
+      assert(isWatched(plain, Nil, Nil, srcDir.resolve("nested").resolve("Bar.java")))
+      // hidden and non-source files are never watched
+      assert(!isWatched(plain, Nil, Nil, srcDir.resolve(".Hidden.scala")))
+      assert(!isWatched(plain, Nil, Nil, srcDir.resolve("notes.txt")))
+    }
+  }
+
+  test("files in a sources-glob directory follow the glob includes and excludes") {
+    TestUtil.withinWorkspace { workspace =>
+      val globDir = workspace.resolve("globbed")
+      val projectGlobs = globs(globDir, List("glob:*.scala"), List("glob:*Excluded.scala"))
+      assert(isWatched(Nil, projectGlobs, Nil, globDir.resolve("Foo.scala")))
+      // a glob-excluded file must not wake compilation (the fix)
+      assert(!isWatched(Nil, projectGlobs, Nil, globDir.resolve("FooExcluded.scala")))
+      // an extension the glob does not include is ignored even though it is a source file
+      assert(!isWatched(Nil, projectGlobs, Nil, globDir.resolve("Legacy.java")))
+    }
+  }
+
+  test("a plain source directory rescues a file excluded by an overlapping glob") {
+    TestUtil.withinWorkspace { workspace =>
+      val sharedDir = workspace.resolve("shared")
+      val projectGlobs = globs(sharedDir, List("glob:*.scala"), List("glob:Excluded.scala"))
+      val plain = List(sharedDir.underlying)
+      // the glob excludes it, but another project compiles the directory as a plain source
+      assert(isWatched(plain, projectGlobs, Nil, sharedDir.resolve("Excluded.scala")))
+    }
+  }
+
+  test("a broad glob does not match files outside its own directory") {
+    TestUtil.withinWorkspace { workspace =>
+      val dirA = workspace.resolve("a")
+      val dirB = workspace.resolve("b")
+      // a recursive glob in one project must not wake compilation for files that live in another
+      // project's directory and are excluded there
+      val projectGlobs =
+        globs(dirA, List("glob:**/*.scala"), Nil) ++
+          globs(dirB, List("glob:*.scala"), List("glob:*Excluded.scala"))
+      assert(isWatched(Nil, projectGlobs, Nil, dirB.resolve("Foo.scala")))
+      assert(!isWatched(Nil, projectGlobs, Nil, dirB.resolve("FooExcluded.scala")))
+    }
+  }
+
+  test("source generator inputs are watched even outside glob and plain directories") {
+    TestUtil.withinWorkspace { workspace =>
+      val inputsDir = workspace.resolve("generator-inputs")
+      val generatorGlobs = globs(inputsDir, List("glob:*.in"), Nil)
+      assert(isWatched(Nil, Nil, generatorGlobs, inputsDir.resolve("data.in")))
+      // a stray source file in a generator input directory keeps the default rule
+      assert(isWatched(Nil, Nil, generatorGlobs, inputsDir.resolve("Stray.scala")))
+    }
+  }
+
+  test("a broad generator glob does not match files outside its own directory") {
+    TestUtil.withinWorkspace { workspace =>
+      val inputsDir = workspace.resolve("generator-inputs")
+      val otherDir = workspace.resolve("other")
+      val generatorGlobs = globs(inputsDir, List("glob:**/*.in"), Nil)
+      assert(isWatched(Nil, Nil, generatorGlobs, inputsDir.resolve("sub").resolve("data.in")))
+      // a like-named file in an unrelated directory must not be claimed by the generator glob
+      assert(!isWatched(Nil, Nil, generatorGlobs, otherDir.resolve("data.in")))
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Improve file watching for projects that use `sourcesGlobs`.

This makes `bloop compile -w` watch source-glob directories themselves, so newly-created matching files can trigger a new compile iteration. It also tightens event matching so watched files follow the same glob semantics as source discovery: globs only apply inside their configured directory and respect `walkDepth`.

## Details

- Watches `sourcesGlobs` directories in addition to already-expanded source files.
- Uses only the reachable watched project closure when deciding whether an event is a source event.
- Prevents unrelated loaded projects' globs from influencing the active watcher.
- Respects `sourcesGlobs.walkDepth` for both project source globs and source-generator input globs.
- Adds unit coverage for glob include/exclude matching, directory containment, and walk-depth behavior.
- Adds a file-watching regression test for creating a new matching file inside a `sourcesGlobs` directory.

## Notes

This was split out from the sbt source filter fix (#2973) because issue #1440 is now handled by exporting filtered sbt sources as explicit files. This PR keeps only the independent watcher improvement for existing `sourcesGlobs` support.