### PR TITLE
Detect JSDOMNodeJSEnv when generating Scala.js configs

### DIFF
--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/Compat.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/Compat.scala
@@ -7,6 +7,7 @@ import sbt.Def
 import sbt.Exec
 import sbt.Keys
 import sbt.SettingKey
+import sbt.TaskKey
 import sbt.io.syntax.File
 import sbt.librarymanagement.ScalaModuleInfo
 import sbt.util.CacheStore
@@ -42,6 +43,12 @@ object Compat extends CompatPlatform {
   def toAnyRefSettingKey(id: String, m: Manifest[AnyRef]): SettingKey[AnyRef] = {
     implicit val manifest: Manifest[AnyRef] = m
     SettingKey(id)
+  }
+
+  // sbt 1 requires a Manifest and sbt 2 a ClassTag; a Manifest satisfies both
+  def toAnyRefTaskKey(id: String, m: Manifest[AnyRef]): TaskKey[AnyRef] = {
+    implicit val manifest: Manifest[AnyRef] = m
+    TaskKey(id)
   }
 
   val bloopCompatSettings: Seq[Def.Setting[?]] = List(

--- a/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
+++ b/integrations/sbt-bloop/src/main/scala/bloop/integrations/sbt/SbtBloop.scala
@@ -103,6 +103,8 @@ object BloopKeys {
     settingKey("Proxy for Scala.js definition of `scalajsLinkerConfig#sourceMap`")
   val bloopScalaJSUseWebAssembly: SettingKey[Option[Boolean]] =
     settingKey("Proxy for Scala.js definition of `scalajsLinkerConfig#experimentalUseWebAssembly`")
+  val bloopScalaJSJsdom: TaskKey[Option[Boolean]] =
+    taskKey[Option[Boolean]]("Proxy for Scala.js `jsEnv`: whether the configured env uses jsdom")
   val bloopMainClass: SettingKey[Option[String]] =
     settingKey[Option[String]]("The main class to run a bloop target")
   val bloopSupportedConfigurations: SettingKey[Seq[Configuration]] =
@@ -241,6 +243,8 @@ object BloopDefaults {
         if (Keys.bspEnabled.value) bloopGenerate.value else Value(None)
       },
       BloopKeys.bloopPostGenerate := bloopPostGenerate.value,
+      // Config-scoped, unlike the other Scala.js proxies, so that `Test / jsEnv` is honored
+      BloopKeys.bloopScalaJSJsdom := findOutScalaJsJsdom.value,
       BloopKeys.bloopMainClass := None,
       Keys.run / BloopKeys.bloopMainClass := BloopKeys.bloopMainClass.value
     ) ++ discoveredSbtPluginsSettings
@@ -294,6 +298,8 @@ object BloopDefaults {
   private final val NoJSModule = "NoModule"
   private final val CommonJSModule = "CommonJSModule"
   private final val ESModule = "ESModule"
+
+  private final val JsdomEnvClassName = "org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv"
 
   /**
    * Create a "proxy" for a setting that will allow us to inspect its value even though
@@ -377,6 +383,36 @@ object BloopDefaults {
     } catch {
       case _: ClassNotFoundException => Def.setting(None)
       case _: NoSuchMethodException => Def.setting(None)
+    }
+  }
+
+  /** Like `proxyForSetting` but for keys that Scala.js defines as tasks, e.g. `jsEnv`. */
+  def proxyForTask(id: String, `class`: Class[?]): Def.Initialize[Task[Option[AnyRef]]] = {
+    val taskManifest = new Manifest[AnyRef] { override def runtimeClass = `class` }
+    Compat.toAnyRefTaskKey(id, taskManifest).?
+  }
+
+  /**
+   * Detects whether the `jsEnv` configured in this scope needs the DOM. Must be
+   * evaluated in the configuration scope of `bloopGenerate` so that `Test / jsEnv`
+   * is honored through regular sbt delegation.
+   */
+  def findOutScalaJsJsdom: Def.Initialize[Task[Option[Boolean]]] = Def.taskDyn {
+    try {
+      val jsEnvClass = Class.forName("org.scalajs.jsenv.JSEnv")
+      val jsEnvTask = proxyForTask("jsEnv", jsEnvClass)
+      Def.task {
+        jsEnvTask.value.map { env =>
+          // If the jsdom env class isn't loadable here, no instance of it can exist;
+          // the name check covers shaded or otherwise classloader-isolated copies
+          val isJsdomInstance =
+            try Class.forName(JsdomEnvClassName).isInstance(env)
+            catch { case _: ClassNotFoundException => false }
+          isJsdomInstance || env.getClass.getName.contains("JSDOMNodeJSEnv")
+        }
+      }
+    } catch {
+      case _: ClassNotFoundException => Compat.inlinedTask[Option[Boolean]](None)
     }
   }
 
@@ -880,7 +916,7 @@ object BloopDefaults {
 
         val scalaJsEmitSourceMaps = BloopKeys.bloopScalaJSSourceMap.value.getOrElse(false)
         val scalaJsUseWebAssembly = BloopKeys.bloopScalaJSUseWebAssembly.value.getOrElse(false)
-        val jsdom = Some(false)
+        val jsdom = BloopKeys.bloopScalaJSJsdom.value.orElse(Some(false))
         val jsConfig = Config.JsConfig(scalaJsVersion, scalaJsStage, scalaJsModule, scalaJsEmitSourceMaps, jsdom, None, None, Nil,
             /* moduleSplitStyle*/ None, scalaJsUseWebAssembly)
         Config.Platform.Js(jsConfig, mainClass)

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/build.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/build.sbt
@@ -1,12 +1,41 @@
+def checkSettings = List(
+  InputKey[Unit]("check") := {
+    val args = complete.DefaultParsers.spaceDelimited("").parsed
+    val expectedPlatform = args(0)
+    val expectedMainJsdom = args(1)
+    val expectedTestJsdom = args(2)
+    val id = thisProject.value.id
+    def stripped(file: File): String = IO.read(file).replaceAll("\\s", "")
+    val mainConfig = stripped(bloopConfigDir.value / s"$id.json")
+    val testConfig = stripped(bloopConfigDir.value / s"$id-test.json")
+    assert(mainConfig.contains(s""""platform":{"name":"$expectedPlatform""""))
+    assert(mainConfig.contains(s""""mode":"debug""""))
+    assert(mainConfig.contains(s""""version":"1.22.0""""))
+    assert(
+      mainConfig.contains(s""""jsdom":$expectedMainJsdom"""),
+      s"expected jsdom=$expectedMainJsdom in $id.json"
+    )
+    assert(
+      testConfig.contains(s""""jsdom":$expectedTestJsdom"""),
+      s"expected jsdom=$expectedTestJsdom in $id-test.json"
+    )
+  }
+)
+
 val jsProject = project
   .enablePlugins(ScalaJSPlugin)
+  .settings(checkSettings)
+
+val jsdomProject = project
+  .enablePlugins(ScalaJSPlugin)
+  .settings(checkSettings)
   .settings(
-    InputKey[Unit]("check") := {
-      val expected = complete.DefaultParsers.spaceDelimited("").parsed.head
-      val config = bloopConfigDir.value / s"${thisProject.value.id}.json"
-      val lines = IO.read(config).replaceAll("\\s", "")
-      assert(lines.contains(s""""platform":{"name":"$expected""""))
-      assert(lines.contains(s""""mode":"debug""""))
-      assert(lines.contains(s""""version":"1.22.0""""))
-    }
+    Test / jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv()
+  )
+
+val jsdomAllProject = project
+  .enablePlugins(ScalaJSPlugin)
+  .settings(checkSettings)
+  .settings(
+    jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv()
   )

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/project/plugins.sbt
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % sys.props.apply("plugin.version"))
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
+libraryDependencies += "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.1"

--- a/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/test
+++ b/integrations/sbt-bloop/src/sbt-test/sbt-bloop/scala-js/test
@@ -1,2 +1,4 @@
 > bloopInstall
-> jsProject/check js
+> jsProject/check js false false
+> jsdomProject/check js false true
+> jsdomAllProject/check js true true


### PR DESCRIPTION
Closes #1489. The plugin hardcoded `jsdom = false`, ignoring a project's `jsEnv := new JSDOMNodeJSEnv()`. Now detected reflectively and set accordingly.

Notable: `jsEnv` is a `TaskKey` in Scala.js 1.x, so this adds a task proxy (`toAnyRefTaskKey`) alongside the existing setting proxies; wired in `configSettings` so `Test / jsEnv` is honored. Detects `JSDOMNodeJSEnv` only — other DOM envs can force it via `Test / bloopScalaJSJsdom := Some(true)`.
