### PR TITLE
fix: Do not let the native launcher consume -D arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: sbt/setup-sbt@v1
+      - uses: coursier/setup-action@v3
+        with:
+          apps: scala-cli
 
       - name: Publish GraalVM Native artifacts
         run: sbt "cli/graalvm-native-image:packageBin"
@@ -187,28 +190,12 @@ jobs:
       - name: Check the native binary
         shell: bash
         run: |
-          root=$(pwd)
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            bin=$root/cli/target/graalvm-native-image/bloop-cli.exe
+            bin=cli/target/graalvm-native-image/bloop-cli.exe
           else
-            bin=$root/cli/target/graalvm-native-image/bloop-cli
+            bin=cli/target/graalvm-native-image/bloop-cli
           fi
-          "$bin" about
-          # A -D before the command is a launcher property that Bloop.main must extract
-          # before command selection (see -H:-ParseRuntimeOptions in build.sbt); the
-          # command must still run. If extraction regressed, the -D would be treated as
-          # the command and the banner would not be printed.
-          "$bin" -Dbloop.smoke.marker=1 about 2>&1 | grep -F 'Maintained by'
-          # A -D after `--` must survive the native launcher and reach the server (the
-          # core of the fix); the server echoes it back as an unknown project name. The
-          # generated config path handling is awkward on Windows, so run this elsewhere.
-          if [ "${{ matrix.os }}" != "windows-latest" ]; then
-            ws=$(mktemp -d)
-            mkdir -p "$ws/.bloop" "$ws/out/classes"
-            printf '{"version":"1.4.0","project":{"name":"smoke","directory":"%s","workspaceDir":"%s","sources":[],"dependencies":[],"classpath":[],"out":"%s/out","classesDir":"%s/out/classes"}}' \
-              "$ws" "$ws" "$ws" "$ws" > "$ws/.bloop/smoke.json"
-            ( cd "$ws" && "$bin" compile -- -Dbloop.smoke.marker=1 2>&1 || true ) | grep -F -- '-Dbloop.smoke.marker=1'
-          fi
+          bin/test-native-cli.sh "$bin"
 
   release:
     name: Release version on ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
               "frontend/test:compile; \
               backend/test; \
               docs/compile; \
-              cli/compile; \
+              cli/test; \
               bloopRifle/test; \
               frontend/testOnly bloop.ScalaVersionsSpec; \
               frontend/testOnly -bloop.ScalaVersionsSpec; \
@@ -184,13 +184,31 @@ jobs:
       - name: Sanity check of the generated binary
         run: sbt publishLocal
 
-      - name: Check on windows
-        if: matrix.os == 'windows-latest'
-        run: cli/target/graalvm-native-image/bloop-cli.exe about
-      
-      - name: Check on other systems
-        if: matrix.os == 'windows-latest'
-        run: cli/target/graalvm-native-image/bloop-cli about
+      - name: Check the native binary
+        shell: bash
+        run: |
+          root=$(pwd)
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            bin=$root/cli/target/graalvm-native-image/bloop-cli.exe
+          else
+            bin=$root/cli/target/graalvm-native-image/bloop-cli
+          fi
+          "$bin" about
+          # A -D before the command is a launcher property that Bloop.main must extract
+          # before command selection (see -H:-ParseRuntimeOptions in build.sbt); the
+          # command must still run. If extraction regressed, the -D would be treated as
+          # the command and the banner would not be printed.
+          "$bin" -Dbloop.smoke.marker=1 about 2>&1 | grep -F 'Maintained by'
+          # A -D after `--` must survive the native launcher and reach the server (the
+          # core of the fix); the server echoes it back as an unknown project name. The
+          # generated config path handling is awkward on Windows, so run this elsewhere.
+          if [ "${{ matrix.os }}" != "windows-latest" ]; then
+            ws=$(mktemp -d)
+            mkdir -p "$ws/.bloop" "$ws/out/classes"
+            printf '{"version":"1.4.0","project":{"name":"smoke","directory":"%s","workspaceDir":"%s","sources":[],"dependencies":[],"classpath":[],"out":"%s/out","classesDir":"%s/out/classes"}}' \
+              "$ws" "$ws" "$ws" "$ws" > "$ws/.bloop/smoke.json"
+            ( cd "$ws" && "$bin" compile -- -Dbloop.smoke.marker=1 2>&1 || true ) | grep -F -- '-Dbloop.smoke.marker=1'
+          fi
 
   release:
     name: Release version on ${{ matrix.os }}

--- a/bin/test-native-cli.sh
+++ b/bin/test-native-cli.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Smoke-tests a freshly built native Bloop CLI binary (passed as the first argument).
+#
+# The binary is built with -H:-ParseRuntimeOptions (see build.sbt), so the native
+# launcher must not consume -D/-X/-XX: arguments at startup:
+#
+#   1. A -D before the command is a launcher property that Bloop.main extracts before
+#      command selection; the command must still run. If extraction regressed, the -D
+#      would be treated as the command and `about` would not print its banner.
+#   2. A -D after `--` must survive the launcher, cross the server, and reach the test
+#      framework. This is checked end to end: Scala CLI generates a real project (with
+#      its .bloop configuration in .scala-build) and the binary runs a ScalaTest suite
+#      that prints the ConfigMap it received.
+#
+# Requires `scala-cli` on the PATH and a Bloop server version resolvable by the binary
+# (in CI, `sbt publishLocal` runs before this script).
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "usage: $0 <path-to-bloop-cli-binary>" >&2
+  exit 1
+fi
+
+bin=$(cd "$(dirname "$1")" && pwd)/$(basename "$1")
+
+"$bin" about
+
+out=$("$bin" -Dbloop.smoke.marker=1 about 2>&1 || true)
+echo "$out"
+echo "$out" | grep -F 'Maintained by'
+
+workspace=$(mktemp -d)
+trap 'rm -rf "$workspace"' EXIT
+
+cat > "$workspace/Smoke.test.scala" <<'EOF'
+//> using dep org.scalatest::scalatest::3.2.19
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.{BeforeAndAfterAllConfigMap, ConfigMap}
+
+class SmokeTest extends AnyFunSuite with BeforeAndAfterAllConfigMap {
+  override def beforeAll(cm: ConfigMap): Unit = println(s"configMap=$cm")
+  test("ok") { assert(true) }
+}
+EOF
+
+(cd "$workspace" && scala-cli compile --test .)
+
+testProject=$(basename "$workspace"/.scala-build/.bloop/*-test.json .json)
+out=$(cd "$workspace/.scala-build" && "$bin" test "$testProject" -- -Dkey=value 2>&1 || true)
+echo "$out"
+echo "$out" | grep -F 'configMap=Map(key -> value)'

--- a/build.sbt
+++ b/build.sbt
@@ -232,6 +232,14 @@ lazy val cliSettings = Seq(
       "--add-exports=org.graalvm.nativeimage.base/com.oracle.svm.util=ALL-UNNAMED",
       "--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jni=ALL-UNNAMED",
       "--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk=ALL-UNNAMED",
+      // Do not let the native launcher consume -D/-X/-XX: options at startup, so that
+      // arguments after `--` reach the server (e.g. `bloop test foo -- -Dkey=value` for
+      // the test framework). Bloop.main re-applies the launcher's own -D properties that
+      // appear before the command (bloop.java-opts, bloop.server, ...); -X/-XX: runtime
+      // options for the client binary itself are no longer honoured (a native image
+      // cannot apply them once started).
+      // On GraalVM for JDK 21+ this needs -H:+UnlockExperimentalVMOptions before it.
+      "-H:-ParseRuntimeOptions",
       "--no-fallback",
       "--enable-url-protocols=http,https",
       "--enable-all-security-services",

--- a/cli/src/main/scala/bloop/cli/Bloop.scala
+++ b/cli/src/main/scala/bloop/cli/Bloop.scala
@@ -12,4 +12,36 @@ object Bloop extends CommandsEntryPoint {
     Status
   )
   override def defaultCommand: Option[Command[_]] = Some(Default)
+
+  override def main(args: Array[String]): Unit = {
+    val (properties, rest) = partitionLauncherProperties(args)
+    properties.foreach { case (key, value) => System.setProperty(key, value) }
+    super.main(rest)
+  }
+
+  /**
+   * The native binary is built with `-H:-ParseRuntimeOptions`, so the launcher no longer
+   * turns `-D` arguments into system properties on its own. The `-D` tokens before the
+   * first `--` are the launcher's own properties (`bloop.java-opts`, `bloop.server`, ...):
+   * they are separated out here, before the command is selected, and applied as system
+   * properties. Everything else — the command, its options, and every token from `--`
+   * onwards — is left untouched so that e.g. `bloop test foo -- -Dkey=value` reaches the
+   * test framework.
+   */
+  private[cli] def partitionLauncherProperties(
+      args: Array[String]
+  ): (Seq[(String, String)], Array[String]) = {
+    val dashDash = args.indexOf("--")
+    val (launcherScope, rest) =
+      if (dashDash < 0) (args.toSeq, Seq.empty[String])
+      else (args.take(dashDash).toSeq, args.drop(dashDash).toSeq)
+    val (rawProperties, kept) = launcherScope.partition(_.startsWith("-D"))
+    val properties = rawProperties.map { arg =>
+      arg.stripPrefix("-D").split("=", 2) match {
+        case Array(key, value) => key -> value
+        case Array(key) => key -> ""
+      }
+    }
+    (properties, (kept ++ rest).toArray)
+  }
 }

--- a/cli/src/test/scala/bloop/cli/BloopSpec.scala
+++ b/cli/src/test/scala/bloop/cli/BloopSpec.scala
@@ -1,0 +1,56 @@
+package bloop.cli
+
+import utest._
+
+object BloopSpec extends TestSuite {
+  val tests = Tests {
+    test("lifts -D before the command and keeps the command and its arguments") {
+      val (props, rest) =
+        Bloop.partitionLauncherProperties(Array("-Dbloop.java-opts=-Xmx8g", "compile", "foo"))
+      assert(props == Seq("bloop.java-opts" -> "-Xmx8g"))
+      assert(rest.toSeq == Seq("compile", "foo"))
+    }
+
+    test("keeps -D after -- untouched (the framework/program owns it)") {
+      val cases = Seq(
+        Array("test", "foo", "--", "-Dkey=value"),
+        Array("run", "app", "--", "-Da=1", "-Db=2")
+      )
+      cases.foreach { args =>
+        val (props, rest) = Bloop.partitionLauncherProperties(args)
+        assert(props.isEmpty)
+        assert(rest.toSeq == args.toSeq)
+      }
+    }
+
+    test("lifts -D even when a global option comes first") {
+      val (props, rest) =
+        Bloop.partitionLauncherProperties(Array("--verbose", "-Dbloop.server=host", "about"))
+      assert(props == Seq("bloop.server" -> "host"))
+      assert(rest.toSeq == Seq("--verbose", "about"))
+    }
+
+    test("lifts -D before a registered command") {
+      val (props, rest) = Bloop.partitionLauncherProperties(Array("-Dk=v", "status"))
+      assert(props == Seq("k" -> "v"))
+      assert(rest.toSeq == Seq("status"))
+    }
+
+    test("keeps = signs inside a property value") {
+      val (props, _) = Bloop.partitionLauncherProperties(Array("-Dk=a=b", "compile"))
+      assert(props == Seq("k" -> "a=b"))
+    }
+
+    test("handles a property without a value") {
+      val (props, rest) = Bloop.partitionLauncherProperties(Array("-Dflag", "about"))
+      assert(props == Seq("flag" -> ""))
+      assert(rest.toSeq == Seq("about"))
+    }
+
+    test("returns empty for no arguments") {
+      val (props, rest) = Bloop.partitionLauncherProperties(Array.empty[String])
+      assert(props.isEmpty)
+      assert(rest.isEmpty)
+    }
+  }
+}

--- a/frontend/src/test/resources/scala-seed-project/src/test/scala/example/HelloSpec.scala
+++ b/frontend/src/test/resources/scala-seed-project/src/test/scala/example/HelloSpec.scala
@@ -2,7 +2,10 @@ package example
 
 import org.scalatest._
 
-class HelloSpec extends FlatSpec with Matchers {
+class HelloSpec extends FlatSpec with Matchers with BeforeAndAfterAllConfigMap {
+  override def beforeAll(configMap: ConfigMap): Unit =
+    configMap.get("key").foreach(value => println(s"HelloSpec config key=$value"))
+
   "The Hello object" should "say hello" in {
     Hello.greeting shouldEqual "hello"
   }

--- a/frontend/src/test/scala/bloop/CliSpec.scala
+++ b/frontend/src/test/scala/bloop/CliSpec.scala
@@ -249,6 +249,31 @@ object CliSpec extends BaseSuite {
     }
   }
 
+  test("parse test args after -- as framework args") {
+    Cli.parse(
+      Array("test", "foo", "--only", "MySpec", "--", "-Dkey=value", "-z", "ok"),
+      CommonOptions.default
+    ) match {
+      case Run(cmd: Commands.Test, _) =>
+        assert(cmd.projects == List("foo"))
+        assert(cmd.only == List("MySpec"))
+        assert(cmd.args == List("-Dkey=value", "-z", "ok"))
+      case action => throw new AssertionError(s"Expected a test command, got $action")
+    }
+  }
+
+  test("parse run args after -- as process args") {
+    Cli.parse(
+      Array("run", "foo", "--", "-Dkey=value", "arg1"),
+      CommonOptions.default
+    ) match {
+      case Run(cmd: Commands.Run, _) =>
+        assert(cmd.projects == List("foo"))
+        assert(cmd.args == List("-Dkey=value", "arg1"))
+      case action => throw new AssertionError(s"Expected a run command, got $action")
+    }
+  }
+
   test("reject an out-of-range --jvm-debug port through the CLI") {
     checkIsCliError(
       Cli.parse(Array("run", "foo", "--jvm-debug", "70000"), CommonOptions.default),

--- a/frontend/src/test/scala/bloop/TestSpec.scala
+++ b/frontend/src/test/scala/bloop/TestSpec.scala
@@ -54,6 +54,13 @@ object SeedTestSpec extends BaseTestSpec("root-test", "scala-seed-project") {
         |All 1 test suites passed.
         |$delimiter
         |""".stripMargin
+
+  testProject("test framework receives -D arguments", runOnlyOnJava8 = false) { (build, logger) =>
+    val project = build.projectFor(projectName)
+    build.state.test(project, Nil, List("-Dkey=value"))
+    try assert(logger.infos.exists(_.contains("HelloSpec config key=value")))
+    catch { case err: AssertionError => logger.dump(); throw err }
+  }
 }
 
 object ResourcesTestSpec extends BaseTestSpec("root-test", "resources-test-project") {


### PR DESCRIPTION
Fixes #1490. `bloop test foo -- -Dkey=value` never reached the test framework (ScalaTest's ConfigMap stayed empty), though sbt handles it fine.

**Cause:** GraalVM native images consume `-D`/`-X`/`-XX:` from argv at startup by default, even after `--`, so the CLI binary ate `-Dkey=value` before Bloop ran. Broken since bloopgun became the first native client (1.4.1); the server side was always correct.

**Fix:** build with `-H:-ParseRuntimeOptions` so args reach the server verbatim. `Bloop.main` still lifts the launcher's own `-D` properties (those before the command) so `bloop.java-opts` etc. keep working; everything from the command onward, including after `--`, is forwarded untouched. Client-side `-X`/`-XX:` tuning is no longer honored (a native image can't apply it once started).
