### PR TITLE
bugfix: Catch interrupted exception when thread is finished

### DIFF
--- a/bloop-rifle/src/main/scala/bloop/rifle/internal/nailgun/Nailgun.scala
+++ b/bloop-rifle/src/main/scala/bloop/rifle/internal/nailgun/Nailgun.scala
@@ -343,6 +343,9 @@ final class Protocol(
                 }
             }
           }
+        } catch {
+          case exception: InterruptedException =>
+            logger.debug("Stdin thread interrupted", exception)
         } finally reader.close()
       }
       (thread, sendStdinSemaphore)


### PR DESCRIPTION
Fixes https://github.com/scalacenter/bloop/issues/3025