### PR TITLE
Add reload command to pick up externally modified analysis files

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -109,6 +109,38 @@ to it.
 You can exit the server by running `bloop exit` from the CLI. You can also kill
 it with `kill`, the Activity Monitor in your machine or `htop`.
 
+## Reload compilation state from disk
+
+The server reads the compilation state it persists for each project once and
+then keeps it in memory, so a server that is already running does not notice
+when that state changes on disk. Reloading makes the server read it again:
+
+- CLI: `bloop reload` reloads the compilation state of all projects, or a
+  selection with `--project`.
+- BSP: the `bloop/reloadAnalysis` request does the same, for the given build
+  targets, or for all of them when the request carries no target list. (The
+  standard `workspace/reload` request reloads the *build configuration* only —
+  Bloop already does that on every request.)
+
+When a reload does not happen, the BSP request fails with a machine-readable
+reason and a `retryable` flag in the error data: a build that is busy compiling
+or being cleaned settles on its own, whereas state that cannot be used needs the
+caller to fix what is on disk.
+
+A reload either replaces the state of every requested project or changes
+nothing at all. It fails, leaving the server exactly as it was, when a
+requested project is compiling, when its state changes while the reload is in
+progress, or when the state on disk cannot be used. Projects with no persisted
+state simply start their next compilation from scratch.
+
+Two limits are worth knowing before building on this. Compilation state records
+absolute paths, so state produced under a different workspace path — on another
+machine, or in another checkout — is not usable: the reload is rejected and
+the state the server already had is kept. And Bloop only re-reads what it wrote itself; it does not
+define an interchange format, so producing state elsewhere and placing it in
+Bloop's output directories relies on internals that are free to change between
+versions.
+
 ## Ignore exceptions in server logs
 
 Bloop uses Nailgun, which sometimes prints exceptions in your server logs such

--- a/frontend/src/main/scala/bloop/Bloop.scala
+++ b/frontend/src/main/scala/bloop/Bloop.scala
@@ -12,6 +12,7 @@ import bloop.engine.BuildLoader
 import bloop.engine.Exit
 import bloop.engine.Interpreter
 import bloop.engine.NoPool
+import bloop.engine.tasks.compilation.CompileGatekeeper
 import bloop.engine.Run
 import bloop.engine.State
 import bloop.io.AbsolutePath
@@ -49,7 +50,10 @@ object Bloop extends CaseApp[CliOptions] {
     def waitForState(t: Task[State]): State = {
       // Ignore the exit status here, all we want is the task to finish execution or fail.
       Cli.waitUntilEndOfWorld(options, state.pool, config, state.logger) {
-        t.map(s => { State.stateCache.updateBuild(s.copy(status = ExitStatus.Ok)); s.status })
+        t.map { s =>
+          CompileGatekeeper.commitState(state, s.copy(status = ExitStatus.Ok))
+          s.status
+        }
       }
 
       // Recover the state if the previous task has been successful.

--- a/frontend/src/main/scala/bloop/BloopServer.scala
+++ b/frontend/src/main/scala/bloop/BloopServer.scala
@@ -269,6 +269,9 @@ object BloopServer {
     val aliasManager = server.getAliasManager
     aliasManager.addAlias(new Alias("about", "Show bloop information.", classOf[Cli]))
     aliasManager.addAlias(new Alias("clean", "Clean project(s) in the build.", classOf[Cli]))
+    aliasManager.addAlias(
+      new Alias("reload", "Reload the compilation state of project(s) from disk.", classOf[Cli])
+    )
     aliasManager.addAlias(new Alias("compile", "Compile project(s) in the build.", classOf[Cli]))
     aliasManager.addAlias(new Alias("test", "Run project(s)' tests in the build.", classOf[Cli]))
     aliasManager.addAlias(

--- a/frontend/src/main/scala/bloop/Cli.scala
+++ b/frontend/src/main/scala/bloop/Cli.scala
@@ -15,6 +15,7 @@ import bloop.cli.ExitStatus
 import bloop.cli.Validate
 import bloop.data.ClientInfo.CliClientInfo
 import bloop.engine._
+import bloop.engine.tasks.compilation.CompileGatekeeper
 import bloop.io.AbsolutePath
 import bloop.io.Paths
 import bloop.logging.BloopLogger
@@ -290,6 +291,11 @@ object Cli {
                 val potentialProjects = c.projects ++ remainingArgs.remaining
                 val cliOptions = c.cliOptions.copy(common = commonOptions)
                 run(c.copy(projects = potentialProjects, cliOptions = cliOptions), c.cliOptions)
+              case Right(c: Commands.Reload) =>
+                // We accept no project arguments in reload
+                val potentialProjects = c.projects ++ remainingArgs.remaining
+                val cliOptions = c.cliOptions.copy(common = commonOptions)
+                run(c.copy(projects = potentialProjects, cliOptions = cliOptions), c.cliOptions)
               case Right(c: Commands.Projects) =>
                 val newCommand = c.copy(cliOptions = c.cliOptions.copy(common = commonOptions))
                 run(newCommand, newCommand.cliOptions)
@@ -389,15 +395,21 @@ object Cli {
     val configDir = configDirectory.underlying
     waitUntilEndOfWorld(cliOptions, pool, configDir, logger, cancel) {
       val taskToInterpret = { (cli: CliClientInfo) =>
-        val state = State.loadActiveStateFor(configDirectory, cli, pool, cliOptions.common, logger)
-        Interpreter.execute(action, state).map { newState =>
-          action match {
-            case Run(_: Commands.ValidatedBsp, _) =>
-              () // Ignore, BSP services auto-update the build
-            case _ => State.stateCache.updateBuild(newState.copy(status = ExitStatus.Ok))
-          }
+        val stateTask =
+          State.loadActiveStateFor(configDirectory, cli, pool, cliOptions.common, logger)
+        stateTask.flatMap { initialState =>
+          Interpreter.execute(action, Task.now(initialState)).map { newState =>
+            action match {
+              case Run(_: Commands.ValidatedBsp, _) =>
+                () // Ignore, BSP services auto-update the build
+              case _ =>
+                // Publish what this action changed, so an action that ran concurrently with
+                // another keeps both sets of results
+                CompileGatekeeper.commitState(initialState, newState.copy(status = ExitStatus.Ok))
+            }
 
-          newState
+            newState
+          }
         }
       }
 

--- a/frontend/src/main/scala/bloop/bsp/BloopBspDefinitions.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspDefinitions.scala
@@ -1,5 +1,6 @@
 package bloop.bsp
 
+import ch.epfl.scala.bsp
 import ch.epfl.scala.bsp.Uri
 
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
@@ -52,6 +53,32 @@ object BloopBspDefinitions {
   object stopClientCaching
       extends Endpoint[StopClientCachingParams, Unit]("bloop/stopClientCaching")(
         StopClientCachingParams.codec,
+        Endpoint.unitCodec
+      )
+
+  /**
+   * Why a reload did not happen, reported as data so clients decide from `retryable` instead of
+   * matching on the message.
+   */
+  final case class ReloadAnalysisError(reason: String, retryable: Boolean)
+  object ReloadAnalysisError {
+    implicit val codec: JsonValueCodec[ReloadAnalysisError] =
+      JsonCodecMaker.makeWithRequiredCollectionFields
+  }
+
+  final case class ReloadAnalysisParams(targets: Option[List[bsp.BuildTargetIdentifier]])
+  object ReloadAnalysisParams {
+    implicit val codec: JsonValueCodec[ReloadAnalysisParams] =
+      JsonCodecMaker.makeWithRequiredCollectionFields
+  }
+
+  /**
+   * Re-reads the compilation state persisted on disk, which `workspace/reload` does not: that
+   * request must keep working while the build compiles, whereas importing state needs it idle.
+   */
+  object reloadAnalysis
+      extends Endpoint[ReloadAnalysisParams, Unit]("bloop/reloadAnalysis")(
+        ReloadAnalysisParams.codec,
         Endpoint.unitCodec
       )
 }

--- a/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
+++ b/frontend/src/main/scala/bloop/bsp/BloopBspServices.scala
@@ -31,6 +31,8 @@ import ch.epfl.scala.debugadapter.Debuggee
 import bloop.Compiler
 import bloop.ScalaInstance
 import bloop.bsp.BloopBspDefinitions.BloopExtraBuildParams
+import bloop.bsp.BloopBspDefinitions.ReloadAnalysisError
+import bloop.bsp.BloopBspDefinitions.ReloadAnalysisParams
 import bloop.bsp.BloopBspDefinitions.ScalaCompileReport
 import bloop.bsp.BloopBspDefinitions.ScalaCompileReportKind
 import bloop.cli.Commands
@@ -57,6 +59,8 @@ import bloop.engine.State
 import bloop.engine.tasks.CompileTask
 import bloop.engine.tasks.RunMode
 import bloop.engine.tasks.Tasks
+import bloop.engine.tasks.compilation.CompileGatekeeper
+import bloop.engine.tasks.compilation.ReloadFailure
 import bloop.engine.tasks.TestTask
 import bloop.engine.tasks.compilation.CompileClientStore
 import bloop.engine.tasks.toolchains.ScalaJsToolchain
@@ -136,6 +140,7 @@ final class BloopBspServices(
     .request(endpoints.Build.shutdown)(_ => shutdown())
     .notificationAsync(endpoints.Build.exit)(_ => exit())
     .requestAsync(endpoints.Workspace.buildTargets)(_ => schedule(buildTargets()))
+    .requestAsync(endpoints.Workspace.reload)(_ => schedule(reload()))
     .requestAsync(endpoints.BuildTarget.sources)(p => schedule(sources(p)))
     .requestAsync(endpoints.BuildTarget.inverseSources)(p => schedule(inverseSources(p)))
     .requestAsync(endpoints.BuildTarget.resources)(p => schedule(resources(p)))
@@ -154,6 +159,7 @@ final class BloopBspServices(
     .requestAsync(endpoints.BuildTarget.jvmTestEnvironment)(p => schedule(jvmTestEnvironment(p)))
     .requestAsync(endpoints.BuildTarget.jvmRunEnvironment)(p => schedule(jvmRunEnvironment(p)))
     .notificationAsync(BloopBspDefinitions.stopClientCaching)(p => stopClientCaching(p))
+    .requestAsync(BloopBspDefinitions.reloadAnalysis)(p => schedule(reloadAnalysis(p)))
 
   // Internal state, initial value defaults to
   @volatile private var currentState: State = callSiteState
@@ -200,12 +206,17 @@ final class BloopBspServices(
       }
   }
 
-  private def saveState(state: State, bspLogger: BspServerLogger): Task[Unit] = {
+  private def saveState(
+      previous: State,
+      state: State,
+      bspLogger: BspServerLogger
+  ): Task[Unit] = {
     Task {
       val configDir = state.build.origin
       bspLogger.debug(s"Saving bsp state for ${configDir.syntax}")
-      // Save the state globally so that it can be accessed by other clients
-      State.stateCache.updateBuild(state)
+      // Save what this request changed so that other clients see it, without overwriting what
+      // they published while it ran
+      CompileGatekeeper.commitState(previous, state)
       publishStateInObserver(state)
     }.flatten
   }
@@ -327,7 +338,7 @@ final class BloopBspServices(
               buildTargetChangedProvider = Some(false),
               jvmTestEnvironmentProvider = Some(true),
               jvmRunEnvironmentProvider = Some(true),
-              canReload = Some(false)
+              canReload = Some(true)
             ),
             None,
             None
@@ -381,7 +392,7 @@ final class BloopBspServices(
         case Right(clientInfo) =>
           reloadState(currentState.build.origin, clientInfo, None, bspLogger).flatMap { state =>
             compute(state, bspLogger).flatMap {
-              case (state, e) => saveState(state, bspLogger).map(_ => e)
+              case (newState, e) => saveState(state, newState, bspLogger).map(_ => e)
             }
           }
       }
@@ -696,6 +707,63 @@ final class BloopBspServices(
           }
       }
     }
+  }
+
+  /** Reloads the build configuration only; `bloop/reloadAnalysis` imports compilation state. */
+  def reload(): BspEndpointResponse[Unit] = {
+    ifInitialized(None) { (state: State, _: BspServerLogger) =>
+      Task.now((state, Right(())))
+    }
+  }
+
+  /**
+   * Re-reads the compilation state persisted on disk. Nothing is replaced unless the whole
+   * import succeeds, so an error leaves clients the state the server already had.
+   */
+  def reloadAnalysis(params: ReloadAnalysisParams): BspEndpointResponse[Unit] = {
+    ifInitialized(None) { (state: State, logger: BspServerLogger) =>
+      // An absent selection means every project, but an empty one asks for nothing and is far
+      // more likely to be a mistake than a request to reload the whole build
+      val targets: Either[ReloadFailure, List[Project]] = params.targets match {
+        case None => Right(state.build.loadedProjects.map(_.project))
+        case Some(Nil) =>
+          Left(ReloadFailure.UnknownTargets("No build targets to reload were given"))
+        case Some(requested) =>
+          mapToProjects(requested, state) match {
+            case Right(mappings) => Right(mappings.map(_._2).toList)
+            case Left(error) => Left(ReloadFailure.UnknownTargets(error))
+          }
+      }
+
+      // A failed reload leaves the state exactly as it found it, so nothing is published
+      def fail(state: State, failure: ReloadFailure): (State, BspResponse[Unit]) = {
+        logger.error(failure.message)
+        (state, Left(reloadError(failure)))
+      }
+
+      targets match {
+        case Left(failure) => Task.now(fail(state, failure))
+        case Right(projects) =>
+          Tasks.reloadAnalysis(state, projects).map {
+            case Right(newState) => (newState, Right(()))
+            case Left(failure) => fail(state, failure)
+          }
+      }
+    }
+  }
+
+  private def reloadError(failure: ReloadFailure): Response.Error = {
+    val code = failure match {
+      case _: ReloadFailure.UnknownTargets => ErrorCode.InvalidParams
+      // The request itself is well formed, the server just could not carry it out, so this
+      // belongs in the range reserved for implementation-defined server errors
+      case _ => ErrorCode.Unknown(BloopBspServices.ReloadFailedErrorCode)
+    }
+    val data = ReloadAnalysisError(failure.reason, failure.retryable)
+    Response.Error(
+      ErrorObject(code, failure.message, Some(RawJson(writeToArray(data)))),
+      RequestId.Null
+    )
   }
 
   def scalaTestClasses(
@@ -1615,6 +1683,10 @@ final class BloopBspServices(
 }
 
 object BloopBspServices {
+
+  /** Server error code, from the range JSON-RPC reserves for implementation-defined errors. */
+  private[bloop] final val ReloadFailedErrorCode: Int = -32001
+
   private[bloop] val counter: AtomicInteger = new AtomicInteger(0)
   private[bloop] val DefaultLanguages = List("scala", "java")
   private[bloop] val JavaOnly = List("java")

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -130,6 +130,21 @@ object Commands {
     implicit lazy val help: CaseAppHelp[Clean] = CaseAppHelp.derive
   }
 
+  case class Reload(
+      @ExtraName("p")
+      @ExtraName("project")
+      @HelpMessage(
+        "The projects whose compilation state to reload from disk (you can specify multiple). If none, all are reloaded."
+      )
+      projects: List[String] = Nil,
+      @Recurse cliOptions: CliOptions = CliOptions.default
+  ) extends RawCommand
+
+  object Reload {
+    implicit lazy val parser: Parser[Reload] = Parser.derive
+    implicit lazy val help: CaseAppHelp[Reload] = CaseAppHelp.derive
+  }
+
   @CommandName("bsp")
   case class Bsp(
       @HelpMessage("The connection protocol for the bsp server. By default, local.")

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -20,6 +20,7 @@ import bloop.data.Platform
 import bloop.data.Project
 import bloop.engine.Feedback.XMessageString
 import bloop.engine.tasks.CompileTask
+import bloop.engine.tasks.compilation.CompileGatekeeper
 import bloop.engine.tasks.LinkTask
 import bloop.engine.tasks.RunMode
 import bloop.engine.tasks.Tasks
@@ -74,6 +75,8 @@ object Interpreter {
                 cmd match {
                   case cmd: Commands.Clean =>
                     execute(next, clean(cmd, state))
+                  case cmd: Commands.Reload =>
+                    execute(next, reload(cmd, state))
                   case cmd: Commands.Compile =>
                     execute(next, compile(cmd, state))
                   case cmd: Commands.Console =>
@@ -157,7 +160,9 @@ object Interpreter {
           val newState = State.stateCache.getUpdatedStateFrom(state).getOrElse(state)
           f(newState).map { state =>
             watcher.notifyWatch()
-            State.stateCache.updateBuild(state)
+            // Commit what this iteration changed: a whole-snapshot write would undo anything
+            // published while it compiled, such as a reload of another target
+            CompileGatekeeper.commitState(newState, state)
           }
         }
 
@@ -766,6 +771,23 @@ object Interpreter {
       val lookup = lookupProjects(cmd.projects, state.build.getProjectFor(_))
       if (lookup.missing.nonEmpty) Task.now(reportMissing(lookup.missing, state))
       else doClean(lookup.found)
+    }
+  }
+
+  private def reload(cmd: Commands.Reload, state: State): Task[State] = {
+    def doReload(projects: List[Project]): Task[State] = {
+      Tasks.reloadAnalysis(state, projects).map {
+        case Right(newState) => newState.mergeStatus(ExitStatus.Ok)
+        // Nothing was changed, so the state is returned as it was and never published
+        case Left(failure) => state.withError(failure.message, ExitStatus.RunError)
+      }
+    }
+
+    if (cmd.projects.isEmpty) doReload(state.build.loadedProjects.map(_.project))
+    else {
+      val lookup = lookupProjects(cmd.projects, state.build.getProjectFor(_))
+      if (lookup.missing.nonEmpty) Task.now(reportMissing(lookup.missing, state))
+      else doReload(lookup.found)
     }
   }
 

--- a/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
@@ -22,6 +22,7 @@ import bloop.engine.ExecutionContext
 import bloop.engine.tasks.compilation.FinalCompileResult
 import bloop.engine.tasks.compilation.FinalEmptyResult
 import bloop.engine.tasks.compilation.FinalNormalCompileResult
+import bloop.engine.tasks.compilation.ReloadFailure
 import bloop.engine.tasks.compilation.ResultBundle
 import bloop.io.AbsolutePath
 import bloop.io.Paths
@@ -135,6 +136,63 @@ final case class ResultsCache private (
     }
   }
 
+  /**
+   * Replaces the in-memory results of `reloaded`. A project mapped to `None` had no persisted
+   * analysis and is dropped, so its next compilation starts from a clean slate.
+   */
+  def replaceWithReloaded(reloaded: Map[Project, Option[ResultBundle]]): ResultsCache = {
+    val projects = reloaded.keys
+    val base = new ResultsCache(all -- projects, successful -- projects)
+    reloaded.foldLeft(base) {
+      case (rs, (_, None)) => rs
+      case (rs, (p, Some(bundle))) => rs.addResult(p, bundle)
+    }
+  }
+
+  /** Applies what this cache changed against `base` on top of `latest`, keeping concurrent work. */
+  def mergeOnto(base: ResultsCache, latest: ResultsCache): ResultsCache = {
+    def merge[T <: AnyRef](
+        baseEntries: Map[Project, T],
+        ourEntries: Map[Project, T],
+        latestEntries: Map[Project, T]
+    ): Map[Project, T] = {
+      val changed = (baseEntries.keySet ++ ourEntries.keySet).filter { project =>
+        baseEntries.get(project) match {
+          case Some(before) => !ourEntries.get(project).exists(_ eq before)
+          case None => ourEntries.contains(project)
+        }
+      }
+
+      changed.foldLeft(latestEntries) {
+        case (entries, project) =>
+          ourEntries.get(project) match {
+            case Some(ours) => entries + (project -> ours)
+            case None => entries - project
+          }
+      }
+    }
+
+    new ResultsCache(
+      merge(base.all, all, latest.all),
+      merge(base.successful, successful, latest.successful)
+    )
+  }
+
+  /** Sets the successful result of a single project. */
+  private[bloop] def replaceSuccessful(
+      project: Project,
+      result: Option[LastSuccessfulResult]
+  ): ResultsCache = {
+    result match {
+      case Some(value) => new ResultsCache(all, successful + (project -> value))
+      case None => new ResultsCache(all, successful - project)
+    }
+  }
+
+  /** Drops everything known about a project, as if it had never compiled. */
+  private[bloop] def forget(project: Project): ResultsCache =
+    new ResultsCache(all - project, successful - project)
+
   override def toString: String = {
     case class PrettyPrintedResultsCache(
         all: Map[String, Compiler.Result],
@@ -171,144 +229,9 @@ object ResultsCache {
       cleanOrphanedInternalDirs: Boolean,
       logger: Logger
   ): Task[ResultsCache] = {
-    import bloop.util.JavaCompat.EnrichOptional
-
-    /**
-     * Orphaned internal directories are directories that are not used by any
-     * client and that are currently not the internal classes directory of any project.
-     *
-     * These are usually deleted by Bloop right away, but in some cases there might be left,
-     * which means it's safe to delete them.
-     *
-     * An example path cleaned up by this method is:
-     * .bloop/mtest/bloop-internal-classes/classes-Metals-12MpgYmRSGOOK5fxouxTqg==-iWRxh-luRTOxk3bOx9UAfg==
-     */
-    def cleanUpOrphanedInternalDirs(
-        project: Project,
-        analysisClassesDir: AbsolutePath
-    ): Task[Unit] = {
-      if (!cleanOrphanedInternalDirs) Task.unit
-      else {
-        val internalClassesDir =
-          CompileOutPaths.createInternalClassesRootDir(project.out)
-        // This is a surprise, skip any cleanup if internal analysis dir doesn't
-        // live under the internal classes dir root assigned to the project
-        if (internalClassesDir != analysisClassesDir.getParent) Task.unit
-        else {
-          ClientInfo.toGenericClassesDir(analysisClassesDir) match {
-            case Some(genericClassesName) =>
-              val deleteOrphans = Task {
-                val orphanInternalDirs = new mutable.ListBuffer[Path]()
-                Paths.list(internalClassesDir).foreach { absPath =>
-                  val path = absPath.underlying
-                  val fileName = path.getFileName().toString
-                  /*
-                   * An internal classes directory is orphan if it's mapped to
-                   * the same project and it's not the analysis classes
-                   * directory from which we're loading the compile analysis.
-                   */
-                  val isOrphan =
-                    fileName.startsWith(genericClassesName) &&
-                      path != analysisClassesDir.underlying
-                  if (isOrphan) {
-                    logger.debug(
-                      s"Discovered orphan directory $path"
-                    )(DebugFilter.All)
-                    orphanInternalDirs.+=(path)
-                  }
-                }
-
-                orphanInternalDirs.foreach { orphanDir =>
-                  try {
-                    Paths.delete(AbsolutePath(orphanDir))
-                  } catch {
-                    case _: NoSuchFileException => ()
-                    case NonFatal(t) =>
-                      logger.debug(
-                        s"Unexpected error when pruning internal classes dir $orphanDir"
-                      )(DebugFilter.All)
-                      logger.trace(t)
-                  }
-                }
-              }
-              deleteOrphans.materialize.map(_ => ())
-            case None => Task.unit
-          }
-        }
-      }
-    }
-
-    def fetchPreviousResult(p: Project): Task[(ResultBundle, Option[Task[Unit]])] = {
-      val analysisFile = p.analysisOut
-      if (analysisFile.exists) {
-        Task {
-          val contents = FileAnalysisStore.binary(analysisFile.toFile).get().toOption
-          contents match {
-            case Some(res) =>
-              logger.debug(s"Loading previous analysis for '${p.name}' from '$analysisFile'.")
-              val r = PreviousResult.of(Optional.of(res.getAnalysis), Optional.of(res.getMiniSetup))
-              res.getAnalysis.readCompilations.getAllCompilations.lastOption match {
-                case Some(lastCompilation) =>
-                  lastCompilation.getOutput.getSingleOutputAsPath.toOption match {
-                    case Some(classesDir) =>
-                      val originPath = p.origin.path.syntax
-                      val inputs = UniqueCompileInputs.emptyFor(originPath)
-                      val dummyTasks = bloop.CompileBackgroundTasks.empty
-                      val dummy = ObservedLogger.dummy(logger, ExecutionContext.ioScheduler)
-                      val reporter = new LogReporter(p, dummy, cwd, ReporterConfig.defaultFormat)
-
-                      val products =
-                        CompileProducts(classesDir, classesDir, r, r, Set.empty, Map.empty)
-                      val bundle = ResultBundle(
-                        Result.Success(reporter, products, 0L, dummyTasks, false, false, None),
-                        Some(LastSuccessfulResult(inputs, products, Task.now(()))),
-                        None
-                      )
-
-                      // Compute a cleanup task if this is the first time loading this project
-                      // It's fine to rerun this task whenever the classes directory changes
-                      val cleanupTask = {
-                        var cleanupTask0: Task[Unit] = Task.unit
-                        val cleanupKey = AbsolutePath(classesDir)
-                        cleanedOrphanDirsInBuild.computeIfAbsent(
-                          cleanupKey,
-                          (_: AbsolutePath) => {
-                            cleanupTask0 = cleanUpOrphanedInternalDirs(p, cleanupKey)
-                            true
-                          }
-                        )
-                        cleanupTask0
-                      }
-
-                      bundle -> Some(cleanupTask)
-                    case None =>
-                      logger.debug(
-                        s"Analysis '$analysisFile' last compilation for '${p.name}' didn't contain classes dir."
-                      )
-                      ResultBundle.empty -> None
-                  }
-                case None =>
-                  logger.debug(
-                    s"Analysis '$analysisFile' for '${p.name}' didn't contain last compilation."
-                  )
-                  ResultBundle.empty -> None
-              }
-            case None =>
-              logger.debug(s"Analysis '$analysisFile' for '${p.name}' is empty.")
-              ResultBundle.empty -> None
-          }
-
-        }
-      } else {
-        Task.now {
-          logger.debug(s"Missing analysis file for project '${p.name}'")
-          ResultBundle.empty -> None
-        }
-      }
-    }
-
     val projects = build.loadedProjects.map(_.project)
-    val all = projects.map(p => fetchPreviousResult(p).map(r => p -> r))
+    val all =
+      projects.map(p => fetchPreviousResult(p, cwd, cleanOrphanedInternalDirs, logger).map(p -> _))
     Task.gatherUnordered(all).executeOn(ExecutionContext.ioScheduler).map { projectResults =>
       val newCache = new ResultsCache(Map.empty, Map.empty)
       val cleanupTasks = new mutable.ListBuffer[Task[Unit]]()
@@ -323,6 +246,221 @@ object ResultsCache {
 
       // Return the collected results per project
       results
+    }
+  }
+
+  /**
+   * Orphaned internal directories are directories that are not used by any
+   * client and that are currently not the internal classes directory of any project.
+   *
+   * These are usually deleted by Bloop right away, but in some cases there might be left,
+   * which means it's safe to delete them.
+   *
+   * An example path cleaned up by this method is:
+   * .bloop/mtest/bloop-internal-classes/classes-Metals-12MpgYmRSGOOK5fxouxTqg==-iWRxh-luRTOxk3bOx9UAfg==
+   */
+  private def cleanUpOrphanedInternalDirs(
+      project: Project,
+      analysisClassesDir: AbsolutePath,
+      logger: Logger
+  ): Task[Unit] = {
+    val internalClassesDir =
+      CompileOutPaths.createInternalClassesRootDir(project.out)
+    // This is a surprise, skip any cleanup if internal analysis dir doesn't
+    // live under the internal classes dir root assigned to the project
+    if (internalClassesDir != analysisClassesDir.getParent) Task.unit
+    else {
+      ClientInfo.toGenericClassesDir(analysisClassesDir) match {
+        case Some(genericClassesName) =>
+          val deleteOrphans = Task {
+            val orphanInternalDirs = new mutable.ListBuffer[Path]()
+            Paths.list(internalClassesDir).foreach { absPath =>
+              val path = absPath.underlying
+              val fileName = path.getFileName().toString
+              /*
+               * An internal classes directory is orphan if it's mapped to
+               * the same project and it's not the analysis classes
+               * directory from which we're loading the compile analysis.
+               */
+              val isOrphan =
+                fileName.startsWith(genericClassesName) &&
+                  path != analysisClassesDir.underlying
+              if (isOrphan) {
+                logger.debug(
+                  s"Discovered orphan directory $path"
+                )(DebugFilter.All)
+                orphanInternalDirs.+=(path)
+              }
+            }
+
+            orphanInternalDirs.foreach { orphanDir =>
+              try {
+                Paths.delete(AbsolutePath(orphanDir))
+              } catch {
+                case _: NoSuchFileException => ()
+                case NonFatal(t) =>
+                  logger.debug(
+                    s"Unexpected error when pruning internal classes dir $orphanDir"
+                  )(DebugFilter.All)
+                  logger.trace(t)
+              }
+            }
+          }
+          deleteOrphans.materialize.map(_ => ())
+        case None => Task.unit
+      }
+    }
+  }
+
+  /** Outcome of reading a persisted analysis: missing means no state, invalid means untrusted. */
+  private[bloop] sealed trait PersistedResult
+  private[bloop] object PersistedResult {
+    final case class Loaded(bundle: ResultBundle, cleanup: Option[Task[Unit]])
+        extends PersistedResult
+    case object Missing extends PersistedResult
+    final case class Invalid(reason: String) extends PersistedResult
+  }
+
+  private def fetchPreviousResult(
+      p: Project,
+      cwd: AbsolutePath,
+      cleanOrphanedInternalDirs: Boolean,
+      logger: Logger
+  ): Task[(ResultBundle, Option[Task[Unit]])] = {
+    Task(loadPersistedResult(p, cwd, cleanOrphanedInternalDirs, logger)).map {
+      case PersistedResult.Loaded(bundle, cleanup) => bundle -> cleanup
+      case PersistedResult.Missing => ResultBundle.empty -> None
+      case PersistedResult.Invalid(reason) =>
+        // A build must still load when a single analysis is unusable, so degrade to no state
+        logger.warn(s"Ignoring persisted analysis for '${p.name}': $reason")
+        ResultBundle.empty -> None
+    }
+  }
+
+  /**
+   * Reads the analysis persisted for `p`. Its recorded output directory is accepted only when
+   * Bloop manages it, because compilation later deletes that directory once superseded.
+   */
+  private[bloop] def loadPersistedResult(
+      p: Project,
+      cwd: AbsolutePath,
+      cleanOrphanedInternalDirs: Boolean,
+      logger: Logger
+  ): PersistedResult = {
+    import bloop.util.JavaCompat.EnrichOptional
+    val analysisFile = p.analysisOut
+    if (!analysisFile.exists) {
+      logger.debug(s"Missing analysis file for project '${p.name}'")
+      PersistedResult.Missing
+    } else {
+      try {
+        val contents = FileAnalysisStore.binary(analysisFile.toFile).get().toOption
+        contents match {
+          // Zinc reports content it cannot deserialize as no contents at all
+          case None => PersistedResult.Invalid(s"analysis '$analysisFile' could not be read")
+          case Some(res) =>
+            logger.debug(s"Loading previous analysis for '${p.name}' from '$analysisFile'.")
+            val r = PreviousResult.of(Optional.of(res.getAnalysis), Optional.of(res.getMiniSetup))
+            val classesDirOrNone = for {
+              lastCompilation <- res.getAnalysis.readCompilations.getAllCompilations.lastOption
+              classesDir <- lastCompilation.getOutput.getSingleOutputAsPath.toOption
+            } yield classesDir
+
+            classesDirOrNone match {
+              case None =>
+                PersistedResult.Invalid(
+                  s"analysis '$analysisFile' has no output directory for its last compilation"
+                )
+              case Some(classesDir) if !isInternalClassesDirOf(AbsolutePath(classesDir), p) =>
+                PersistedResult.Invalid(
+                  s"output directory '$classesDir' recorded in '$analysisFile' is not an internal " +
+                    s"classes directory of '${p.name}'"
+                )
+              case Some(classesDir) if !AbsolutePath(classesDir).isDirectory =>
+                PersistedResult.Invalid(
+                  s"output directory '$classesDir' recorded in '$analysisFile' no longer exists"
+                )
+              case Some(classesDir) =>
+                val originPath = p.origin.path.syntax
+                val inputs = UniqueCompileInputs.emptyFor(originPath)
+                val dummyTasks = bloop.CompileBackgroundTasks.empty
+                val dummy = ObservedLogger.dummy(logger, ExecutionContext.ioScheduler)
+                val reporter = new LogReporter(p, dummy, cwd, ReporterConfig.defaultFormat)
+
+                val products = CompileProducts(classesDir, classesDir, r, r, Set.empty, Map.empty)
+                val bundle = ResultBundle(
+                  Result.Success(reporter, products, 0L, dummyTasks, false, false, None),
+                  Some(LastSuccessfulResult(inputs, products, Task.now(()))),
+                  None
+                )
+
+                // Compute a cleanup task if this is the first time loading this project
+                // It's fine to rerun this task whenever the classes directory changes
+                val cleanupTask = {
+                  if (!cleanOrphanedInternalDirs) None
+                  else {
+                    var cleanupTask0: Task[Unit] = Task.unit
+                    val cleanupKey = AbsolutePath(classesDir)
+                    cleanedOrphanDirsInBuild.computeIfAbsent(
+                      cleanupKey,
+                      (_: AbsolutePath) => {
+                        cleanupTask0 = cleanUpOrphanedInternalDirs(p, cleanupKey, logger)
+                        true
+                      }
+                    )
+                    Some(cleanupTask0)
+                  }
+                }
+
+                PersistedResult.Loaded(bundle, cleanupTask)
+            }
+        }
+      } catch {
+        case NonFatal(t) =>
+          logger.trace(t)
+          PersistedResult.Invalid(s"analysis '$analysisFile' could not be read: ${t.getMessage}")
+      }
+    }
+  }
+
+  /**
+   * Tells whether `classesDir` is an internal classes directory Bloop made for `project`.
+   * Compilation deletes it once superseded, so no foreign path may take its place.
+   */
+  private def isInternalClassesDirOf(classesDir: AbsolutePath, project: Project): Boolean = {
+    val internalClassesRoot = CompileOutPaths.createInternalClassesRootDir(project.out)
+    val dir = classesDir.underlying.normalize()
+    dir.getParent == internalClassesRoot.underlying.normalize() &&
+    ClientInfo.toGenericClassesDir(classesDir).isDefined
+  }
+
+  /**
+   * Reads the analysis persisted for every project, failing if any exists but cannot be used:
+   * callers replace state with the result, so a bad file must not destroy what Bloop holds.
+   */
+  private[bloop] def loadPersistedResults(
+      projects: List[Project],
+      cwd: AbsolutePath,
+      logger: Logger
+  ): Either[ReloadFailure, Map[Project, Option[ResultBundle]]] = {
+    val loaded = projects.map { p =>
+      // Pruning here would delete directories the state being replaced still points at
+      p -> loadPersistedResult(p, cwd, cleanOrphanedInternalDirs = false, logger)
+    }
+
+    val invalid = loaded.collect {
+      case (p, PersistedResult.Invalid(reason)) => s"'${p.name}': $reason"
+    }
+
+    if (invalid.nonEmpty) {
+      Left(
+        ReloadFailure.UnusableState(s"Cannot reload compilation state, ${invalid.mkString("; ")}")
+      )
+    } else {
+      Right(loaded.map {
+        case (p, PersistedResult.Loaded(bundle, _)) => p -> Some(bundle)
+        case (p, _) => p -> None
+      }.toMap)
     }
   }
 }

--- a/frontend/src/main/scala/bloop/engine/caches/StateCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/StateCache.scala
@@ -66,15 +66,51 @@ final class StateCache(cache: ConcurrentHashMap[AbsolutePath, StateCache.CachedS
     getStateFor(state.build.origin, state.client, state.pool, state.commonOptions, state.logger)
   }
 
-  /**
-   * Updates the cache with `state`.
-   *
-   * @param state The state to put in the cache.
-   * @return The updated `State`.
-   */
-  def updateBuild(state: State): State = {
+  /** Replaces everything cached for this build. Requests publish with [[commit]] instead. */
+  private[bloop] def updateBuild(state: State): State = {
     cache.put(state.build.origin, StateCache.CachedState.fromState(state))
     state
+  }
+
+  /**
+   * Publishes what `next` changed with respect to `previous`, as one atomic step. Publish
+   * through `CompileGatekeeper.commitState`, which holds the coordinator lock this needs.
+   */
+  private[bloop] def commit(previous: State, next: State)(
+      reconcile: ResultsCache => ResultsCache
+  ): State = {
+    cache.compute(
+      next.build.origin,
+      (_: AbsolutePath, cached: StateCache.CachedState) => {
+        if (cached == null)
+          StateCache.CachedState.fromState(next).copy(results = reconcile(next.results))
+        else {
+          StateCache.CachedState(
+            if (previous.build eq next.build) cached.build else next.build,
+            reconcile(next.results.mergeOnto(previous.results, cached.results)),
+            if (previous.compilerCache eq next.compilerCache) cached.compilerCache
+            else next.compilerCache,
+            if (previous.sourceGeneratorCache eq next.sourceGeneratorCache)
+              cached.sourceGeneratorCache
+            else next.sourceGeneratorCache
+          )
+        }
+      }
+    )
+    next
+  }
+
+  /** Applies `f` to the results cached for `state` as one atomic read-modify-write. */
+  private[bloop] def transformResults(state: State)(f: ResultsCache => ResultsCache): Unit = {
+    cache.compute(
+      state.build.origin,
+      (_: AbsolutePath, cached: StateCache.CachedState) => {
+        // Seed from the caller when this build has never been cached, so the change is not lost
+        val base = if (cached == null) StateCache.CachedState.fromState(state) else cached
+        base.copy(results = f(base.results))
+      }
+    )
+    ()
   }
 
   /**
@@ -118,7 +154,7 @@ final class StateCache(cache: ConcurrentHashMap[AbsolutePath, StateCache.CachedS
         BuildLoader
           .loadBuildIncrementally(from, createdOrModified, changed, settings, logger)
           .map { newProjects =>
-            val newState = previousState match {
+            val newStateOrSeed = previousState match {
               case Some(state) =>
                 // Update the build incrementally and then create a new updated state
                 val currentProjects = state.build.loadedProjects
@@ -132,8 +168,24 @@ final class StateCache(cache: ConcurrentHashMap[AbsolutePath, StateCache.CachedS
               // Create a new state since there was no previous one
               case None => createState(Build(from, newProjects, settings))
             }
-            cache.put(from, StateCache.CachedState.fromState(newState))
-            newState
+            previousState match {
+              // Only the build definition changed here, so committing the difference keeps
+              // results that were published while the configuration files were read
+              case Some(previous) =>
+                bloop.engine.tasks.compilation.CompileGatekeeper
+                  .commitState(previous, newStateOrSeed)
+              case None =>
+                // Another caller may have seeded this build and had state imported into it
+                // already, so keep those results and adopt only the definition loaded here
+                cache.compute(
+                  from,
+                  (_: AbsolutePath, cached: StateCache.CachedState) => {
+                    if (cached == null) StateCache.CachedState.fromState(newStateOrSeed)
+                    else cached.copy(build = newStateOrSeed.build)
+                  }
+                )
+                newStateOrSeed
+            }
           }
     }
   }

--- a/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/Tasks.scala
@@ -10,9 +10,12 @@ import bloop.cli.ExitStatus
 import bloop.data.JdkConfig
 import bloop.data.Project
 import bloop.engine.Dag
+import bloop.engine.ExecutionContext
 import bloop.engine.State
 import bloop.engine.caches.LastSuccessfulResult
+import bloop.engine.caches.ResultsCache
 import bloop.engine.tasks.compilation.CompileGatekeeper
+import bloop.engine.tasks.compilation.ReloadFailure
 import bloop.exec.Forker
 import bloop.exec.JvmProcessForker
 import bloop.io.AbsolutePath
@@ -44,12 +47,29 @@ object Tasks {
     val allTargetsToClean =
       if (!includeDeps) targets
       else targets.flatMap(t => Dag.dfs(state.build.getDagFor(t), mode = Dag.PreOrder)).distinct
-    // Drop the cross-client in-memory last successful results so the next compile can't reuse them.
-    Task(allTargetsToClean.foreach(CompileGatekeeper.clearSuccessfulResult))
-      .flatMap { _ =>
+    // Drop the cross-client in-memory last successful results so the next compile can't reuse
+    // them, and keep the projects reserved until their products are gone
+    CompileGatekeeper
+      .cleaning(allTargetsToClean) {
         state.results.cleanSuccessful(allTargetsToClean.toSet, state.client, state.logger)
       }
       .map(newResults => state.copy(results = newResults))
+  }
+
+  /**
+   * Reloads the persisted compilation state of `targets`, so analysis written by an external
+   * tool becomes visible without a restart. Publishes it or fails without changing anything.
+   */
+  def reloadAnalysis(state: State, targets: List[Project]): Task[Either[ReloadFailure, State]] = {
+    val cwd = state.commonOptions.workingPath
+    Task {
+      CompileGatekeeper.reloadSuccessfulResults(targets) { () =>
+        ResultsCache.loadPersistedResults(targets, cwd, state.logger)
+      } { reloaded =>
+        State.stateCache.transformResults(state)(_.replaceWithReloaded(reloaded))
+      }
+    }.executeOn(ExecutionContext.ioScheduler)
+      .map(_.map(_ => state))
   }
 
   /**

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGatekeeper.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileGatekeeper.scala
@@ -1,13 +1,16 @@
 package bloop.engine.tasks.compilation
 
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
 
 import bloop.Compiler
 import bloop.UniqueCompileInputs
 import bloop.data.ClientInfo
 import bloop.data.Project
 import bloop.engine.Dag
+import bloop.engine.State
 import bloop.engine.caches.LastSuccessfulResult
+import bloop.engine.caches.ResultsCache
 import bloop.logging.DebugFilter
 import bloop.logging.Logger
 import bloop.logging.LoggerAction
@@ -33,7 +36,40 @@ object CompileGatekeeper {
   /* -------------------------------------------------------------------------------------------- */
 
   private val runningCompilations = new ConcurrentHashMap[UniqueCompileInputs, RunningCompilation]()
-  private val lastSuccessfulResults = new ConcurrentHashMap[ProjectId, LastSuccessfulResult]()
+
+  /**
+   * What this module knows about a project. A tombstone is not the same as knowing nothing: it
+   * stops a client that still carries the removed result from bringing it back.
+   */
+  private[bloop] sealed trait CompilationEntry
+  private[bloop] object CompilationEntry {
+
+    /** The successful state compilation builds on. Its absence is a [[Tombstone]]. */
+    final case class Present(successful: LastSuccessfulResult) extends CompilationEntry
+    case object Tombstone extends CompilationEntry
+  }
+
+  private val lastSuccessfulResults = new ConcurrentHashMap[ProjectId, CompilationEntry]()
+
+  /**
+   * Counts the events that changed a project's state, so a reload can tell whether anything
+   * happened while it read from disk. Entries cannot: a clean leaves tombstone over tombstone.
+   */
+  private val generations = new ConcurrentHashMap[ProjectId, java.lang.Long]()
+
+  private def bumpGeneration(id: ProjectId): Unit = {
+    generations.merge(id, java.lang.Long.valueOf(1L), (a, b) => a + b)
+    ()
+  }
+
+  private def generationOf(id: ProjectId): Long =
+    Option(generations.get(id)).map(_.longValue).getOrElse(0L)
+
+  /**
+   * Serializes admitting a compilation, registering its result and reloading, which read and
+   * write both maps as a unit. Always taken before any map lock, never the other way around.
+   */
+  private val stateLock = new Object
 
   /* -------------------------------------------------------------------------------------------- */
 
@@ -48,29 +84,37 @@ object CompileGatekeeper {
       import bundle.logger
       var deduplicate = true
 
-      val running = runningCompilations.compute(
-        bundle.uniqueInputs,
-        (_: UniqueCompileInputs, running: RunningCompilation) => {
-          if (running == null) {
-            tracer.trace(
-              "no running compilation found starting new one",
-              ("uniqueInputs", bundle.uniqueInputs.toString)
-            ) { tracer =>
-              logger.debug(s"no running compilation found starting new one:${bundle.uniqueInputs}")
-              deduplicate = false
-              scheduleCompilation(inputs, bundle, client, compile, tracer)
-            }
-          } else {
-            tracer.trace(
-              "Found matching compilation",
-              ("uniqueInputs", bundle.uniqueInputs.toString)
-            ) { tracer =>
-              if (deduplicate) running
-              else scheduleCompilation(inputs, bundle, client, compile, tracer)
+      // Admitting a compilation reads the last successful result, so it cannot interleave with
+      // a reload replacing it
+      val running = stateLock.synchronized {
+        runningCompilations.compute(
+          bundle.uniqueInputs,
+          (_: UniqueCompileInputs, running: RunningCompilation) => {
+            // A disconnected compilation keeps running, so it still reserves its project even
+            // though no new client may deduplicate onto it
+            if (running == null || running.isUnsubscribed.get) {
+              tracer.trace(
+                "no running compilation found starting new one",
+                ("uniqueInputs", bundle.uniqueInputs.toString)
+              ) { tracer =>
+                logger.debug(
+                  s"no running compilation found starting new one:${bundle.uniqueInputs}"
+                )
+                deduplicate = false
+                scheduleCompilation(inputs, bundle, client, compile, tracer)
+              }
+            } else {
+              tracer.trace(
+                "Found matching compilation",
+                ("uniqueInputs", bundle.uniqueInputs.toString)
+              ) { tracer =>
+                if (deduplicate) running
+                else scheduleCompilation(inputs, bundle, client, compile, tracer)
+              }
             }
           }
-        }
-      )
+        )
+      }
 
       (running, deduplicate)
     }
@@ -86,8 +130,10 @@ object CompileGatekeeper {
       ("uniqueInputs", inputs.toString)
     ) { _ =>
       logger.debug(s"Disconnected deduplication from running compilation:${inputs}")
+      // Cancellation is cooperative, so the compilation may run for a while yet. It stays in
+      // the map, where it reserves its project against a reload, until it terminally completes
       runningCompilation.isUnsubscribed.compareAndSet(false, true)
-      runningCompilations.remove(inputs, runningCompilation); ()
+      ()
     }
   }
 
@@ -109,15 +155,27 @@ object CompileGatekeeper {
       import bundle.logger
       import inputs.project
 
-      def initializeLastSuccessful(previousOrNull: LastSuccessfulResult): LastSuccessfulResult =
+      def initializeLastSuccessful(previousOrNull: CompilationEntry): LastSuccessfulResult =
         tracer.trace(s"initialize last successful") { _ =>
-          val result = Option(previousOrNull).getOrElse(bundle.lastSuccessful)
+          // Whether the coordinator knows the state, or this client is the only one who does
+          val isAuthoritative = previousOrNull != null
+          val result = previousOrNull match {
+            case CompilationEntry.Present(previous) => previous
+            case CompilationEntry.Tombstone =>
+              // The state was removed on purpose, so the one this client carries is obsolete
+              logger.debug(s"Ignoring analysis for ${project.name}, its state was removed")
+              LastSuccessfulResult.empty(inputs.project)
+            case null => bundle.lastSuccessful
+          }
           if (!result.classesDir.exists) {
             logger.debug(
               s"Ignoring analysis for ${project.name}, directory ${result.classesDir} is missing"
             )
             LastSuccessfulResult.empty(inputs.project)
-          } else if (bundle.latestResult == Compiler.Result.Empty) {
+          } else if (!isAuthoritative && bundle.latestResult == Compiler.Result.Empty) {
+            // Only this client's own leftover state is dropped for having no last result. State
+            // the coordinator holds is newer than anything the client knows, which is exactly
+            // the case after state was imported into a server that had not compiled yet
             logger.debug(s"Ignoring existing analysis for ${project.name}, last result was empty")
             LastSuccessfulResult
               .empty(inputs.project)
@@ -136,24 +194,30 @@ object CompileGatekeeper {
 
       def getMostRecentSuccessfulResultAtomically =
         tracer.trace("get most recent successful result atomically") { _ =>
-          lastSuccessfulResults.compute(
-            project.uniqueId,
-            (_: String, previousResultOrNull: LastSuccessfulResult) => {
-              logger.debug(
-                s"Return previous result or the initial last successful coming from the bundle:${project.uniqueId}"
-              )
-              // Return previous result or the initial last successful coming from the bundle
-              initializeLastSuccessful(previousResultOrNull)
-            }
-          )
+          lastSuccessfulResults
+            .compute(
+              project.uniqueId,
+              (_: String, previousResultOrNull: CompilationEntry) => {
+                logger.debug(
+                  s"Return previous result or the initial last successful coming from the bundle:${project.uniqueId}"
+                )
+                // Return previous result or the initial last successful coming from the bundle
+                CompilationEntry.Present(initializeLastSuccessful(previousResultOrNull))
+              }
+            ) match {
+            case CompilationEntry.Present(result) => result
+            case _ => LastSuccessfulResult.empty(project)
+          }
         }
 
       logger.debug(s"Scheduling compilation for ${project.name}...")
+      bumpGeneration(project.uniqueId)
 
       // Replace client-specific last successful with the most recent result
       val mostRecentSuccessful = getMostRecentSuccessfulResultAtomically
 
       val isUnsubscribed = AtomicBoolean(false)
+      val runningRef = new AtomicReference[RunningCompilation]()
       val newBundle = bundle.copy(lastSuccessful = mostRecentSuccessful)
       val compileAndUnsubscribe = tracer.trace("compile and unsubscribe") { _ =>
         compile(newBundle)
@@ -165,7 +229,7 @@ object CompileGatekeeper {
                 result,
                 project,
                 bundle.uniqueInputs,
-                isUnsubscribed,
+                runningRef,
                 logger,
                 tracer
               )
@@ -174,34 +238,33 @@ object CompileGatekeeper {
           .memoize
       }
 
-      RunningCompilation(
+      val runningCompilation = RunningCompilation(
         compileAndUnsubscribe,
         mostRecentSuccessful,
         isUnsubscribed,
         bundle.mirror,
         client
       )
+
+      runningRef.set(runningCompilation)
+      runningCompilation
     }
 
   private def processResultAtomically(
       resultDag: Dag[PartialCompileResult],
       project: Project,
       oinputs: UniqueCompileInputs,
-      isAlreadyUnsubscribed: AtomicBoolean,
+      running: AtomicReference[RunningCompilation],
       logger: Logger,
       tracer: BraveTracer
   ): Dag[PartialCompileResult] = {
 
     def cleanUpAfterCompilationError[T](result: T): T =
       tracer.trace("cleaning after compilation error") { _ =>
-        if (!isAlreadyUnsubscribed.get) {
-          // Remove running compilation if host compilation hasn't unsubscribed (maybe it's blocked)
-          logger.debug(
-            s"Remove running compilation if host compilation hasn't unsubscribed (maybe it's blocked):${oinputs}"
-          )
-          runningCompilations.remove(oinputs)
-        }
-
+        logger.debug(s"Remove running compilation that finished without a result:${oinputs}")
+        // Only this compilation may be retired: a disconnected one can have been replaced by a
+        // newer compilation registered under the same inputs
+        runningCompilations.remove(oinputs, running.get)
         result
       }
 
@@ -216,7 +279,7 @@ object CompileGatekeeper {
               }
             case Some(res) =>
               tracer.trace("unregister deduplication and register successful") { _ =>
-                unregisterDeduplicationAndRegisterSuccessful(project, oinputs, res, logger)
+                unregisterDeduplicationAndRegisterSuccessful(project, oinputs, running, res, logger)
               }
           }
           result
@@ -245,17 +308,25 @@ object CompileGatekeeper {
   private def unregisterDeduplicationAndRegisterSuccessful(
       project: Project,
       oracleInputs: UniqueCompileInputs,
+      running: AtomicReference[RunningCompilation],
       successful: LastSuccessfulResult,
       logger: Logger
   ): Unit = {
-    runningCompilations.compute(
-      oracleInputs,
-      (_: UniqueCompileInputs, _: RunningCompilation) => {
-        logger.debug("Unregister deduplication and registered successfully")
-        lastSuccessfulResults.compute(project.uniqueId, (_, _) => successful)
-        null
-      }
-    )
+    // Retiring the compilation and publishing its result is one step for a concurrent reload,
+    // which must never observe the project as idle before its result is registered
+    stateLock.synchronized {
+      runningCompilations.compute(
+        oracleInputs,
+        (_: UniqueCompileInputs, current: RunningCompilation) => {
+          logger.debug("Unregister deduplication and registered successfully")
+          lastSuccessfulResults
+            .compute(project.uniqueId, (_, _) => CompilationEntry.Present(successful))
+          bumpGeneration(project.uniqueId)
+          // Retire this compilation only, leaving any newer one that replaced it in place
+          if (current == null || (current eq running.get)) null else current
+        }
+      )
+    }
 
     logger.debug(
       s"Recording new last successful request for ${project.name} associated with ${successful.classesDir}"
@@ -271,18 +342,150 @@ object CompileGatekeeper {
    * state (which only observes new results at the end of the compile request).
    */
   def latestSuccessfulResult(project: Project): Option[LastSuccessfulResult] =
-    Option(lastSuccessfulResults.get(project.uniqueId))
+    Option(lastSuccessfulResults.get(project.uniqueId)).collect {
+      case CompilationEntry.Present(result) => result
+    }
+
+  /** Tells whether any of `projects` has a compilation in flight. */
+  private def isCompilingAnyOf(projects: List[Project]): Boolean = {
+    import scala.collection.JavaConverters._
+    val origins = projects.iterator.map(_.origin.path.syntax).toSet
+    runningCompilations.keys().asScala.exists(inputs => origins.contains(inputs.originProjectPath))
+  }
+
+  private[bloop] final val BusyProjectsError =
+    "Cannot reload compilation state while projects compile, retry when the build is idle"
+  private[bloop] final val ConcurrentChangeError =
+    "Compilation state changed while it was being reloaded, retry when the build is idle"
+  private[bloop] final val CleaningProjectsError =
+    "Cannot reload compilation state while projects are cleaned, retry when the build is idle"
+
+  private val cleaningProjects = new java.util.HashSet[ProjectId]()
+
+  /**
+   * Runs `clean` with `projects` reserved against reloads. The reservation lasts until it
+   * finishes because its deletions do, and a reload in between would publish vanishing state.
+   */
+  private[bloop] def cleaning[T](projects: List[Project])(clean: Task[T]): Task[T] = {
+    val ids = projects.map(_.uniqueId)
+    val reserve = Task {
+      stateLock.synchronized {
+        ids.foreach { id =>
+          lastSuccessfulResults.put(id, CompilationEntry.Tombstone)
+          bumpGeneration(id)
+        }
+        ids.foreach(id => cleaningProjects.add(id))
+      }
+    }
+
+    val release = Task {
+      stateLock.synchronized(ids.foreach(id => cleaningProjects.remove(id)))
+      ()
+    }
+
+    reserve.flatMap(_ => clean).doOnFinish(_ => release)
+  }
+
+  private def isCleaningAnyOf(projects: List[Project]): Boolean =
+    projects.exists(p => cleaningProjects.contains(p.uniqueId))
+
+  /**
+   * Replaces the last successful result of `projects` with what `loadFromDisk` reads, provided
+   * nothing happened to them meanwhile. `publish` runs in the same critical section.
+   */
+  private[bloop] def reloadSuccessfulResults(
+      projects: List[Project]
+  )(
+      loadFromDisk: () => Either[ReloadFailure, Map[Project, Option[ResultBundle]]]
+  )(
+      publish: Map[Project, Option[ResultBundle]] => Unit
+  ): Either[ReloadFailure, Map[Project, Option[ResultBundle]]] = {
+    def generationsOf(ps: List[Project]): Map[ProjectId, Long] =
+      ps.map(p => p.uniqueId -> generationOf(p.uniqueId)).toMap
+
+    // Deciding that the build is idle and recording where it stood must be one step: anything
+    // starting afterwards has to take this lock to bump a generation, so the final check sees it
+    val baseline = stateLock.synchronized {
+      if (isCleaningAnyOf(projects)) Left(ReloadFailure.Cleaning(CleaningProjectsError))
+      else if (isCompilingAnyOf(projects)) Left(ReloadFailure.Busy(BusyProjectsError))
+      else Right(generationsOf(projects))
+    }
+
+    baseline.flatMap { generationsBeforeRead =>
+      loadFromDisk().flatMap { reloaded =>
+        stateLock.synchronized {
+          val changed = projects.exists { p =>
+            generationOf(p.uniqueId) != generationsBeforeRead(p.uniqueId)
+          }
+
+          if (isCleaningAnyOf(projects)) Left(ReloadFailure.Cleaning(CleaningProjectsError))
+          else if (isCompilingAnyOf(projects)) Left(ReloadFailure.Busy(BusyProjectsError))
+          else if (changed) Left(ReloadFailure.ConcurrentChange(ConcurrentChangeError))
+          else {
+            reloaded.foreach {
+              case (p, bundle) =>
+                bumpGeneration(p.uniqueId)
+                val entry = bundle.flatMap(_.successful) match {
+                  case Some(successful) => CompilationEntry.Present(successful)
+                  // Record that there is no state rather than forgetting the project, so a
+                  // client still holding the replaced result cannot reinstate it
+                  case None => CompilationEntry.Tombstone
+                }
+                lastSuccessfulResults.put(p.uniqueId, entry)
+            }
+            // Both stores are updated here, while compilations are held out, so no compilation
+            // can land between them and be overwritten by the second write
+            publish(reloaded)
+            Right(reloaded)
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Publishes `next` on behalf of a request that started from `previous`, under this module's
+   * lock. Taking it before the cache's is also the order a reload uses, so neither can wait.
+   */
+  private[bloop] def commitState(previous: State, next: State): State = {
+    stateLock.synchronized {
+      State.stateCache.commit(previous, next)(reconcile(next))
+    }
+  }
+
+  /**
+   * Replaces every project's successful result with the one this module holds, so a request
+   * publishing later than it ran cannot reinstate what it knew. Requires the state lock.
+   */
+  private def reconcile(state: State)(results: ResultsCache): ResultsCache = {
+    state.build.loadedProjects.foldLeft(results) {
+      case (reconciled, loaded) =>
+        val project = loaded.project
+        Option(lastSuccessfulResults.get(project.uniqueId)) match {
+          case Some(CompilationEntry.Present(successful)) =>
+            reconciled.replaceSuccessful(project, Some(successful))
+          // State that was removed on purpose leaves no result of any kind behind, as a clean
+          // and a reload that found nothing on disk both do
+          case Some(CompilationEntry.Tombstone) => reconciled.forget(project)
+          case None => reconciled
+        }
+    }
+  }
 
   // Expose clearing mechanism so that it can be invoked in the tests and community build runner
   private[bloop] def clearSuccessfulResults(): Unit = {
-    lastSuccessfulResults.synchronized {
+    stateLock.synchronized {
       lastSuccessfulResults.clear()
+      generations.clear()
     }
   }
 
   // Drop the cached last successful result for a single project so a clean fully resets it.
   private[bloop] def clearSuccessfulResult(project: Project): Unit = {
-    lastSuccessfulResults.remove(project.uniqueId)
+    stateLock.synchronized {
+      lastSuccessfulResults.put(project.uniqueId, CompilationEntry.Tombstone)
+      bumpGeneration(project.uniqueId)
+    }
     ()
   }
 }

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/ReloadFailure.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/ReloadFailure.scala
@@ -1,0 +1,51 @@
+package bloop.engine.tasks.compilation
+
+/**
+ * Why a reload did not happen. Clients branch on `retryable`: a busy build settles on its own,
+ * whereas unusable state needs the caller to fix what is on disk.
+ */
+sealed trait ReloadFailure {
+  def message: String
+
+  /** Stable identifier for clients, independent of the names used in this source. */
+  def reason: String
+  def retryable: Boolean
+}
+
+object ReloadFailure {
+
+  /** Projects are compiling, so their state is about to change. */
+  final case class Busy(message: String) extends ReloadFailure {
+    val reason: String = "busy"
+
+    val retryable: Boolean = true
+  }
+
+  /** Projects are being cleaned, so the state to replace is being removed. */
+  final case class Cleaning(message: String) extends ReloadFailure {
+    val reason: String = "cleaning"
+
+    val retryable: Boolean = true
+  }
+
+  /** The state of the projects changed while it was read from disk. */
+  final case class ConcurrentChange(message: String) extends ReloadFailure {
+    val reason: String = "concurrent-change"
+
+    val retryable: Boolean = true
+  }
+
+  /** The state persisted on disk exists but cannot be used. */
+  final case class UnusableState(message: String) extends ReloadFailure {
+    val reason: String = "unusable-state"
+
+    val retryable: Boolean = false
+  }
+
+  /** The requested targets do not name projects of this build. */
+  final case class UnknownTargets(message: String) extends ReloadFailure {
+    val reason: String = "unknown-targets"
+
+    val retryable: Boolean = false
+  }
+}

--- a/frontend/src/main/scala/bloop/util/CommandsDocGenerator.scala
+++ b/frontend/src/main/scala/bloop/util/CommandsDocGenerator.scala
@@ -33,7 +33,7 @@ object CommandsDocGenerator {
           val progName = "bloop"
           val b = new StringBuilder
           b ++= NL
-          b ++= s"## `$progName $commandName$argsOption`"
+          b ++= s"## `$progName ${commandName.mkString(" ")}$argsOption`"
           b ++= NL
           b ++= NL
           b ++= "#### Usage"
@@ -123,6 +123,8 @@ object CommandsDocGenerator {
       s"bloop clean $ExampleProjectName",
       s"bloop clean $ExampleProjectName $ExampleProjectName2",
       s"bloop clean $ExampleProjectName --propagate",
+      "bloop reload",
+      s"bloop reload $ExampleProjectName",
       s"bloop bsp --protocol local --socket ${tmp.resolve("socket").toString} --pipe-name \\\\.\\pipe\\my-name-pipe",
       "bloop bsp --protocol tcp --host 127.0.0.1 --port 5101",
       s"bloop compile $ExampleProjectName",
@@ -158,6 +160,7 @@ object CommandsDocGenerator {
       case _: Commands.About => Some("about")
       case _: Commands.Projects => Some("projects")
       case _: Commands.Clean => Some("clean")
+      case _: Commands.Reload => Some("reload")
       case _: Commands.Bsp => Some("bsp")
       case _: Commands.Compile => Some("compile")
       case _: Commands.Test => Some("test")

--- a/frontend/src/test/scala/bloop/AutoCompleteSpec.scala
+++ b/frontend/src/test/scala/bloop/AutoCompleteSpec.scala
@@ -27,10 +27,11 @@ class AutoCompleteSpec {
         |help
         |link
         |projects
+        |reload
         |run
         |test
         |version
-        |clean compile console link run test
+        |clean compile console link reload run test
         |A
         |B
         |A
@@ -65,10 +66,11 @@ class AutoCompleteSpec {
         |help
         |link
         |projects
+        |reload
         |run
         |test
         |version
-        |clean compile console link run test
+        |clean compile console link reload run test
         |A
         |B
         |A
@@ -103,10 +105,11 @@ class AutoCompleteSpec {
         |help
         |link
         |projects
+        |reload
         |run
         |test
         |version
-        |clean compile console link run test
+        |clean compile console link reload run test
         |A
         |B
         |A

--- a/frontend/src/test/scala/bloop/ReloadAnalysisSpec.scala
+++ b/frontend/src/test/scala/bloop/ReloadAnalysisSpec.scala
@@ -1,0 +1,519 @@
+package bloop
+
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.Await
+import scala.concurrent.duration.FiniteDuration
+
+import bloop.cli.ExitStatus
+import bloop.engine.ExecutionContext
+import bloop.engine.State
+import bloop.engine.caches.ResultsCache
+import bloop.engine.tasks.compilation.CompileGatekeeper
+import bloop.io.AbsolutePath
+import bloop.io.ParallelOps
+import bloop.io.ParallelOps.CopyMode
+import bloop.logging.NoopLogger
+import bloop.logging.RecordingLogger
+import bloop.task.Task
+import bloop.util.TestProject
+import bloop.util.TestUtil
+
+object ReloadAnalysisSpec extends bloop.testing.BaseSuite {
+
+  object Sources {
+    val `A.scala` =
+      """/A.scala
+        |class A
+      """.stripMargin
+    val `B.scala` =
+      """/B.scala
+        |class B extends A
+      """.stripMargin
+    val `B2.scala` =
+      """/B.scala
+        |class B extends A { def foo: Int = 1 }
+      """.stripMargin
+  }
+
+  test("reload makes an externally restored analysis visible without a restart") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(Sources.`A.scala`, Sources.`B.scala`))
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.compile(`A`)
+      assertExitStatus(compiledState, ExitStatus.Ok)
+      assertValidCompilationState(compiledState, projects)
+
+      val project = compiledState.getProjectFor(`A`)
+      val analysisFile = project.analysisOut
+      assert(analysisFile.exists)
+      val lastSuccessful = compiledState.state.results.lastSuccessfulResult(project) match {
+        case Some(result) => result
+        case None => fail("Missing last successful result for 'a'")
+      }
+
+      // Snapshot the analysis and the classes directory it references, as an external
+      // save/restore tool would do before handing the state back to a running server
+      TestUtil.await(FiniteDuration(30, TimeUnit.SECONDS))(lastSuccessful.populatingProducts)
+      val classesDir = lastSuccessful.classesDir
+      val backupAnalysis = workspace.resolve("backup-analysis.bin")
+      val backupClasses = workspace.resolve("backup-classes")
+      Files.copy(
+        analysisFile.underlying,
+        backupAnalysis.underlying,
+        StandardCopyOption.REPLACE_EXISTING
+      )
+      copyDirectory(classesDir, backupClasses)
+
+      // Diverge the in-memory and persisted state from the snapshot with a semantic change
+      assertIsFile(writeFile(`A`.srcFor("B.scala"), Sources.`B2.scala`))
+      val secondCompiledState = compiledState.compile(`A`)
+      assertExitStatus(secondCompiledState, ExitStatus.Ok)
+      assertNoDiff(
+        logger.compilingInfos.mkString(System.lineSeparator),
+        """Compiling a (2 Scala sources)
+          |Compiling a (1 Scala source)
+        """.stripMargin
+      )
+
+      // The non-noop compile schedules a background deletion of the superseded classes
+      // directory; wait for it so that restoring the directory afterwards cannot race it
+      waitUntilDeleted(classesDir)
+
+      // Restore the snapshot on disk while the "server" (test state) is still running
+      Files.copy(
+        backupAnalysis.underlying,
+        analysisFile.underlying,
+        StandardCopyOption.REPLACE_EXISTING
+      )
+      copyDirectory(backupClasses, classesDir)
+      assertIsFile(writeFile(`A`.srcFor("B.scala"), Sources.`B.scala`))
+
+      val reloadedState = secondCompiledState.reloadAnalysis(`A`)
+      assertExitStatus(reloadedState, ExitStatus.Ok)
+
+      // The restored analysis matches the reverted sources, so compilation must be a no-op
+      val finalState = reloadedState.compile(`A`)
+      assertExitStatus(finalState, ExitStatus.Ok)
+      assertSuccessfulCompilation(finalState, projects, isNoOp = true)
+      assertNoDiff(
+        logger.compilingInfos.mkString(System.lineSeparator),
+        """Compiling a (2 Scala sources)
+          |Compiling a (1 Scala source)
+        """.stripMargin
+      )
+    }
+  }
+
+  test("reload drops in-memory results when the analysis file is missing") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(Sources.`A.scala`, Sources.`B.scala`))
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.compile(`A`)
+      assertExitStatus(compiledState, ExitStatus.Ok)
+      assertValidCompilationState(compiledState, projects)
+
+      val analysisFile = compiledState.getProjectFor(`A`).analysisOut
+      assert(analysisFile.exists)
+      Files.delete(analysisFile.underlying)
+
+      val reloadedState = compiledState.reloadAnalysis(`A`)
+      assertExitStatus(reloadedState, ExitStatus.Ok)
+
+      // Without the reload the in-memory analysis would make this compile a no-op
+      val secondCompiledState = reloadedState.compile(`A`)
+      assertExitStatus(secondCompiledState, ExitStatus.Ok)
+      assertSuccessfulCompilation(secondCompiledState, projects, isNoOp = false)
+      assertNoDiff(
+        logger.compilingInfos.mkString(System.lineSeparator),
+        """Compiling a (2 Scala sources)
+          |Compiling a (2 Scala sources)
+        """.stripMargin
+      )
+    }
+  }
+
+  test("reload preserves the current state when the analysis file is corrupt") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(Sources.`A.scala`, Sources.`B.scala`))
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.compile(`A`)
+      assertExitStatus(compiledState, ExitStatus.Ok)
+
+      val analysisFile = compiledState.getProjectFor(`A`).analysisOut
+      assert(analysisFile.exists)
+      Files.write(analysisFile.underlying, "not a valid analysis file".getBytes())
+
+      val reloadedState = compiledState.reloadAnalysis(`A`)
+      assertExitStatus(reloadedState, ExitStatus.RunError)
+      assert(logger.errors.exists(_.contains("could not be read")))
+
+      // An unusable analysis must not cost the state the server already had
+      val secondCompiledState = reloadedState.compile(`A`)
+      assertExitStatus(secondCompiledState, ExitStatus.Ok)
+      assertSuccessfulCompilation(secondCompiledState, projects, isNoOp = true)
+      assertNoDiff(
+        logger.compilingInfos.mkString(System.lineSeparator),
+        """Compiling a (2 Scala sources)
+        """.stripMargin
+      )
+    }
+  }
+
+  test("reload rejects an analysis whose output directory belongs to another project") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(Sources.`A.scala`, Sources.`B.scala`))
+      val `B` = TestProject(workspace, "b", List(Sources.`A.scala`))
+      val projects = List(`A`, `B`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.compile(`A`).compile(`B`)
+      assertExitStatus(compiledState, ExitStatus.Ok)
+
+      // Restoring state that was persisted for a different project records an output directory
+      // Bloop does not manage for this one, and following it would later delete a foreign path
+      val analysisOfA = compiledState.getProjectFor(`A`).analysisOut
+      val analysisOfB = compiledState.getProjectFor(`B`).analysisOut
+      Files.copy(
+        analysisOfB.underlying,
+        analysisOfA.underlying,
+        StandardCopyOption.REPLACE_EXISTING
+      )
+
+      val reloadedState = compiledState.reloadAnalysis(`A`)
+      assertExitStatus(reloadedState, ExitStatus.RunError)
+      assert(logger.errors.exists(_.contains("is not an internal classes directory")))
+
+      val secondCompiledState = reloadedState.compile(`A`)
+      assertExitStatus(secondCompiledState, ExitStatus.Ok)
+      assertSuccessfulCompilation(secondCompiledState, List(`A`), isNoOp = true)
+    }
+  }
+
+  test("reload fails when the restored analysis references a missing classes directory") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(Sources.`A.scala`, Sources.`B.scala`))
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.compile(`A`)
+      assertExitStatus(compiledState, ExitStatus.Ok)
+
+      val project = compiledState.getProjectFor(`A`)
+      val analysisFile = project.analysisOut
+      val lastSuccessful = compiledState.state.results.lastSuccessfulResult(project) match {
+        case Some(result) => result
+        case None => fail("Missing last successful result for 'a'")
+      }
+      TestUtil.await(FiniteDuration(30, TimeUnit.SECONDS))(lastSuccessful.populatingProducts)
+      val backupAnalysis = workspace.resolve("backup-analysis.bin")
+      Files.copy(
+        analysisFile.underlying,
+        backupAnalysis.underlying,
+        StandardCopyOption.REPLACE_EXISTING
+      )
+
+      assertIsFile(writeFile(`A`.srcFor("B.scala"), Sources.`B2.scala`))
+      val secondCompiledState = compiledState.compile(`A`)
+      assertExitStatus(secondCompiledState, ExitStatus.Ok)
+
+      // Restore the analysis but not the classes directory it points to, which the non-noop
+      // compile above schedules for background deletion
+      waitUntilDeleted(lastSuccessful.classesDir)
+      Files.copy(
+        backupAnalysis.underlying,
+        analysisFile.underlying,
+        StandardCopyOption.REPLACE_EXISTING
+      )
+      val reloadedState = secondCompiledState.reloadAnalysis(`A`)
+      assertExitStatus(reloadedState, ExitStatus.RunError)
+      assert(logger.errors.exists(_.contains("no longer exists")))
+
+      // A restore that left the products behind must be reported rather than silently
+      // costing a rebuild, and the state the server had must survive it
+      val finalState = reloadedState.compile(`A`)
+      assertExitStatus(finalState, ExitStatus.Ok)
+      assertSuccessfulCompilation(finalState, projects, isNoOp = true)
+      assertNoDiff(
+        logger.compilingInfos.mkString(System.lineSeparator),
+        """Compiling a (2 Scala sources)
+          |Compiling a (1 Scala source)
+        """.stripMargin
+      )
+    }
+  }
+
+  test("reload is refused while a clean is removing the state it would replace") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(Sources.`A.scala`, Sources.`B.scala`))
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.compile(`A`)
+      assertExitStatus(compiledState, ExitStatus.Ok)
+
+      val project = compiledState.getProjectFor(`A`)
+      val cleanedState = CompileGatekeeper.cleaning(List(project)) {
+        Task {
+          val reloadedState = compiledState.reloadAnalysis(`A`)
+          assertExitStatus(reloadedState, ExitStatus.RunError)
+          assert(logger.errors.exists(_.contains("while projects are cleaned")))
+        }
+      }
+      TestUtil.await(FiniteDuration(30, TimeUnit.SECONDS))(cleanedState)
+
+      // The reservation is released once the clean finishes, so reloads work again
+      val reloadedState = compiledState.reloadAnalysis(`A`)
+      assertExitStatus(reloadedState, ExitStatus.Ok)
+    }
+  }
+
+  test("reload is refused while a compilation is in flight") {
+    TestUtil.withinWorkspace { workspace =>
+      object SlowSources {
+        val `Macros.scala` =
+          """/Macros.scala
+            |package macros
+            |
+            |import scala.reflect.macros.blackbox.Context
+            |import scala.language.experimental.macros
+            |
+            |object SleepMacro {
+            |  def sleep(): Unit = macro sleepImpl
+            |  def sleepImpl(c: Context)(): c.Expr[Unit] = {
+            |    import c.universe._
+            |    Thread.sleep(2000)
+            |    reify { () }
+            |  }
+            |}""".stripMargin
+
+        val `User.scala` =
+          """/User.scala
+            |object User {
+            |  macros.SleepMacro.sleep()
+            |}
+          """.stripMargin
+      }
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `Macros` = TestProject(workspace, "macros", List(SlowSources.`Macros.scala`))
+      val `User` = TestProject(workspace, "user", List(SlowSources.`User.scala`), List(`Macros`))
+      val projects = List(`Macros`, `User`)
+      val state = loadState(workspace, projects, logger)
+      val compiledMacros = state.compile(`Macros`)
+      assertExitStatus(compiledMacros, ExitStatus.Ok)
+
+      val runningCompilation = compiledMacros.compileHandle(`User`)
+      val deadline = System.currentTimeMillis() + 20000
+      while (
+        !logger.compilingInfos.exists(_.contains("Compiling user")) &&
+        System.currentTimeMillis() < deadline
+      ) Thread.sleep(50)
+      assert(logger.compilingInfos.exists(_.contains("Compiling user")))
+
+      val reloadedState = compiledMacros.reloadAnalysis()
+      assertExitStatus(reloadedState, ExitStatus.RunError)
+      assert(logger.errors.exists(_.contains("Cannot reload compilation state")))
+
+      val compiledUser = Await.result(runningCompilation, FiniteDuration(60, TimeUnit.SECONDS))
+      assertExitStatus(compiledUser, ExitStatus.Ok)
+    }
+  }
+
+  test("a client holding older state cannot reinstate state a reload removed") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(Sources.`A.scala`, Sources.`B.scala`))
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.compile(`A`)
+      assertExitStatus(compiledState, ExitStatus.Ok)
+
+      val analysisFile = compiledState.getProjectFor(`A`).analysisOut
+      Files.delete(analysisFile.underlying)
+      val reloadedState = compiledState.reloadAnalysis(`A`)
+      assertExitStatus(reloadedState, ExitStatus.Ok)
+
+      // `compiledState` predates the reload and still carries the removed result. Compiling from
+      // it must not bring that result back, so the compile has to rebuild from scratch
+      val staleCompiledState = compiledState.compile(`A`)
+      assertExitStatus(staleCompiledState, ExitStatus.Ok)
+      assertSuccessfulCompilation(staleCompiledState, projects, isNoOp = false)
+      assertNoDiff(
+        logger.compilingInfos.mkString(System.lineSeparator),
+        """Compiling a (2 Scala sources)
+          |Compiling a (2 Scala sources)
+        """.stripMargin
+      )
+    }
+  }
+
+  test("imported state is used by a client that has not compiled anything yet") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(Sources.`A.scala`, Sources.`B.scala`))
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.compile(`A`)
+      assertExitStatus(compiledState, ExitStatus.Ok)
+
+      val project = compiledState.getProjectFor(`A`)
+      val analysisFile = project.analysisOut
+      val lastSuccessful = compiledState.state.results.lastSuccessfulResult(project) match {
+        case Some(result) => result
+        case None => fail("Missing last successful result for 'a'")
+      }
+      TestUtil.await(FiniteDuration(30, TimeUnit.SECONDS))(lastSuccessful.populatingProducts)
+      val backupAnalysis = workspace.resolve("backup-analysis.bin")
+      Files.copy(
+        analysisFile.underlying,
+        backupAnalysis.underlying,
+        StandardCopyOption.REPLACE_EXISTING
+      )
+
+      // A state loaded without an analysis has no compilation result of its own, which is the
+      // position a server is in when a cache is restored into it before it has compiled
+      Files.delete(analysisFile.underlying)
+      val freshLogger = new RecordingLogger(ansiCodesSupported = false)
+      val freshState = loadState(workspace, projects, freshLogger)
+      Files.copy(
+        backupAnalysis.underlying,
+        analysisFile.underlying,
+        StandardCopyOption.REPLACE_EXISTING
+      )
+
+      val reloadedState = freshState.reloadAnalysis(`A`)
+      assertExitStatus(reloadedState, ExitStatus.Ok)
+
+      // Compiling from the state that predates the import must still use what was imported
+      val compiledFromStale = freshState.compile(`A`)
+      assertExitStatus(compiledFromStale, ExitStatus.Ok)
+      assertSuccessfulCompilation(compiledFromStale, projects, isNoOp = true)
+      assertNoDiff(freshLogger.compilingInfos.mkString(System.lineSeparator), "")
+    }
+  }
+
+  test("an imported result survives a request that started before the reload") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(Sources.`A.scala`, Sources.`B.scala`))
+      val `B` = TestProject(workspace, "b", List(Sources.`A.scala`))
+      val projects = List(`A`, `B`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.compile(`A`).compile(`B`)
+      assertExitStatus(compiledState, ExitStatus.Ok)
+
+      val projectA = compiledState.getProjectFor(`A`)
+      CompileGatekeeper.commitState(state.state, compiledState.state)
+
+      // A request that acted on B only, holding the results from before A was reloaded
+      val staleRequest = compiledState.state
+
+      Files.delete(projectA.analysisOut.underlying)
+      assertExitStatus(compiledState.reloadAnalysis(`A`), ExitStatus.Ok)
+      assert(cachedResults(staleRequest).lastSuccessfulResult(projectA).isEmpty)
+
+      // Publishing a change of its own must not carry the result it still holds for A along
+      // with it. B is only here so that the commit has something to publish
+      val projectB = compiledState.getProjectFor(`B`)
+      val requestResult = staleRequest.copy(
+        results = staleRequest.results.replaceWithReloaded(Map(projectB -> None))
+      )
+      CompileGatekeeper.commitState(staleRequest, requestResult)
+
+      assert(cachedResults(staleRequest).lastSuccessfulResult(projectA).isEmpty)
+    }
+  }
+
+  test("reload fails when a clean removes the state it read, even over an earlier removal") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(Sources.`A.scala`, Sources.`B.scala`))
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.compile(`A`)
+      assertExitStatus(compiledState, ExitStatus.Ok)
+
+      val project = compiledState.getProjectFor(`A`)
+      // Leave a removal behind, so a second one writes the same marker the reload would compare
+      CompileGatekeeper.clearSuccessfulResult(project)
+
+      val reloaded = CompileGatekeeper.reloadSuccessfulResults(List(project)) { () =>
+        // Another removal lands while the state is being read from disk
+        CompileGatekeeper.clearSuccessfulResult(project)
+        ResultsCache.loadPersistedResults(List(project), workspace, logger)
+      }(_ => ())
+
+      reloaded match {
+        case Left(failure) => assert(failure.reason == "concurrent-change")
+        case Right(_) => fail("Reload reported success although the state it read was removed")
+      }
+    }
+  }
+
+  test("a delayed commit cannot reverse a reload of the same project") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(Sources.`A.scala`, Sources.`B.scala`))
+      val projects = List(`A`)
+      val state = loadState(workspace, projects, logger)
+      val compiledState = state.compile(`A`)
+      assertExitStatus(compiledState, ExitStatus.Ok)
+
+      val project = compiledState.getProjectFor(`A`)
+      CompileGatekeeper.commitState(state.state, compiledState.state)
+
+      // A request that ran before the reload and is about to publish its own result for A
+      val delayedRequest = compiledState.state
+
+      val analysisFile = project.analysisOut
+      Files.delete(analysisFile.underlying)
+      val reloadedState = compiledState.reloadAnalysis(`A`)
+      assertExitStatus(reloadedState, ExitStatus.Ok)
+
+      // Committing it must adopt the state the reload left behind, not reinstate its own
+      CompileGatekeeper.commitState(state.state, delayedRequest)
+      assert(cachedResults(delayedRequest).lastSuccessfulResult(project).isEmpty)
+    }
+  }
+
+  private def cachedResults(state: State) = {
+    State.stateCache
+      .getStateFor(
+        state.build.origin,
+        state.client,
+        state.pool,
+        state.commonOptions,
+        state.logger
+      )
+      .map(_.results)
+      .getOrElse(fail("Build is not cached"))
+  }
+
+  private def waitUntilDeleted(dir: AbsolutePath): Unit = {
+    val deadline = System.currentTimeMillis() + 30000
+    while (dir.exists && System.currentTimeMillis() < deadline) Thread.sleep(50)
+    assert(!dir.exists)
+  }
+
+  private def copyDirectory(from: AbsolutePath, to: AbsolutePath): Unit = {
+    val config = ParallelOps.CopyConfiguration(2, CopyMode.ReplaceExisting, Set.empty, Set.empty)
+    val copyTask = ParallelOps.copyDirectories(config)(
+      from.underlying,
+      to.underlying,
+      ExecutionContext.ioScheduler,
+      enableCancellation = false,
+      NoopLogger
+    )
+    TestUtil.await(FiniteDuration(30, TimeUnit.SECONDS))(copyTask)
+    ()
+  }
+}

--- a/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspBaseSuite.scala
@@ -18,6 +18,7 @@ import ch.epfl.scala.bsp.endpoints
 
 import bloop.TestSchedulers
 import bloop.bsp.BloopBspDefinitions.BloopExtraBuildParams
+import bloop.bsp.BloopBspDefinitions.ReloadAnalysisParams
 import bloop.cli.BspProtocol
 import bloop.cli.Commands
 import bloop.cli.ExitStatus
@@ -295,6 +296,42 @@ abstract class BspBaseSuite extends BaseSuite with BspClientTest {
       // Use a default timeout of 5 seconds for every clean operation
       TestUtil.await(FiniteDuration(5, "s")) {
         cleanTask(project)
+      }
+    }
+
+    def reloadAnalysisTask(projects: List[TestProject]): Task[ManagedBspTestState] = {
+      val targets = if (projects.isEmpty) None else Some(projects.map(_.bspId))
+      rpcRequest(BloopBspDefinitions.reloadAnalysis, ReloadAnalysisParams(targets)).flatMap { _ =>
+        // `headL` returns latest saved state from bsp because source is behavior subject
+        Task
+          .liftMonixTaskUncancellable(
+            serverStates.headL
+          )
+          .map { state =>
+            new ManagedBspTestState(
+              state,
+              bsp.StatusCode.Ok,
+              None,
+              None,
+              currentCompileIteration,
+              diagnostics,
+              client0,
+              serverStates
+            )
+          }
+      }
+    }
+
+    def reloadAnalysis(projects: TestProject*): ManagedBspTestState = {
+      // Use a default timeout of 5 seconds for every reload operation
+      TestUtil.await(FiniteDuration(5, "s")) {
+        reloadAnalysisTask(projects.toList)
+      }
+    }
+
+    def workspaceReload(): Unit = {
+      TestUtil.await(FiniteDuration(5, "s")) {
+        rpcRequest(Workspace.reload, None)
       }
     }
 

--- a/frontend/src/test/scala/bloop/bsp/BspReloadSpec.scala
+++ b/frontend/src/test/scala/bloop/bsp/BspReloadSpec.scala
@@ -1,0 +1,244 @@
+package bloop.bsp
+
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.FiniteDuration
+
+import bloop.cli.BspProtocol
+import bloop.cli.ExitStatus
+import bloop.engine.ExecutionContext
+import bloop.io.AbsolutePath
+import bloop.io.ParallelOps
+import bloop.io.ParallelOps.CopyMode
+import bloop.logging.NoopLogger
+import bloop.logging.RecordingLogger
+import bloop.util.TestProject
+import bloop.util.TestUtil
+
+object TcpBspReloadSpec extends BspReloadSpec(BspProtocol.Tcp)
+object LocalBspReloadSpec extends BspReloadSpec(BspProtocol.Local)
+
+abstract class BspReloadSpec(
+    override val protocol: BspProtocol
+) extends BspBaseSuite {
+
+  object Sources {
+    val `A.scala` =
+      """/A.scala
+        |class A
+      """.stripMargin
+    val `B.scala` =
+      """/B.scala
+        |class B extends A
+      """.stripMargin
+    val `B2.scala` =
+      """/B.scala
+        |class B extends A { def foo: Int = 1 }
+      """.stripMargin
+  }
+
+  test("bloop/reloadAnalysis makes an externally restored analysis visible") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(Sources.`A.scala`, Sources.`B.scala`))
+      val projects = List(`A`)
+      loadBspState(workspace, projects, logger) { state =>
+        val compiledState = state.compile(`A`)
+        assertExitStatus(compiledState, ExitStatus.Ok)
+        assertValidCompilationState(compiledState, projects)
+
+        val project = compiledState.toTestState.getProjectFor(`A`)
+        val analysisFile = project.analysisOut
+        assert(analysisFile.exists)
+        val lastSuccessful = compiledState.toTestState.state.results
+          .lastSuccessfulResult(project) match {
+          case Some(result) => result
+          case None => fail("Missing last successful result for 'a'")
+        }
+
+        // Snapshot the analysis and the classes directory it references, as an external
+        // save/restore tool would do before handing the state back to a running server
+        TestUtil.await(FiniteDuration(30, TimeUnit.SECONDS))(lastSuccessful.populatingProducts)
+        val classesDir = lastSuccessful.classesDir
+        val backupAnalysis = workspace.resolve("backup-analysis.bin")
+        val backupClasses = workspace.resolve("backup-classes")
+        Files.copy(
+          analysisFile.underlying,
+          backupAnalysis.underlying,
+          StandardCopyOption.REPLACE_EXISTING
+        )
+        copyDirectory(classesDir, backupClasses)
+
+        // Diverge the in-memory and persisted state from the snapshot
+        writeFile(`A`.srcFor("B.scala"), Sources.`B2.scala`)
+        val secondCompiledState = compiledState.compile(`A`)
+        assertExitStatus(secondCompiledState, ExitStatus.Ok)
+
+        // The non-noop compile schedules a background deletion of the superseded classes
+        // directory; wait for it so that restoring the directory afterwards cannot race it
+        waitUntilDeleted(classesDir)
+
+        // Restore the snapshot on disk and reload while the server is running
+        Files.copy(
+          backupAnalysis.underlying,
+          analysisFile.underlying,
+          StandardCopyOption.REPLACE_EXISTING
+        )
+        copyDirectory(backupClasses, classesDir)
+        writeFile(`A`.srcFor("B.scala"), Sources.`B.scala`)
+
+        val reloadedState = secondCompiledState.reloadAnalysis(`A`)
+
+        // The restored analysis matches the reverted sources, so this compile is a no-op
+        val finalState = reloadedState.compile(`A`)
+        assertExitStatus(finalState, ExitStatus.Ok)
+        assertNoDiff(finalState.lastDiagnostics(`A`), "")
+      }
+    }
+  }
+
+  test("compile diagnostics are still reset after an analysis reload") {
+    TestUtil.withinWorkspace { workspace =>
+      object FailingSources {
+        val `Foo.scala` =
+          """/Foo.scala
+            |object Foo {
+            |  val x: String = 1
+            |}
+          """.stripMargin
+        val `Foo2.scala` =
+          """/Foo.scala
+            |object Foo {
+            |  val x: String = "1"
+            |}
+          """.stripMargin
+      }
+
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(FailingSources.`Foo.scala`))
+      val projects = List(`A`)
+      loadBspState(workspace, projects, logger) { state =>
+        val compiledState = state.compile(`A`)
+        assertExitStatus(compiledState, ExitStatus.CompilationError)
+        assertNoDiff(
+          compiledState.lastDiagnostics(`A`),
+          """#1: task start 1
+            |  -> Msg: Compiling a (1 Scala source)
+            |  -> Data kind: compile-task
+            |#1: a/src/Foo.scala
+            |  -> List(Diagnostic(Range(Position(1,18),Position(1,18)),Some(Error),Some(_),Some(_),type mismatch;  found   : Int(1)  required: String,None,None,Some({"actions":[]})))
+            |  -> reset = true
+            |#1: task finish 1
+            |  -> errors 1, warnings 0, noop false
+            |  -> Msg: Compiled 'a'
+            |  -> Data kind: compile-report
+            """.stripMargin
+        )
+
+        val reloadedState = compiledState.reloadAnalysis(`A`)
+
+        // The per-client failed-compilation state must survive the reload so that the next
+        // successful compile still resets the previously published diagnostics
+        writeFile(`A`.srcFor("Foo.scala"), FailingSources.`Foo2.scala`)
+        val secondCompiledState = reloadedState.compile(`A`)
+        assertExitStatus(secondCompiledState, ExitStatus.Ok)
+        assertNoDiff(
+          secondCompiledState.lastDiagnostics(`A`),
+          """#2: task start 2
+            |  -> Msg: Compiling a (1 Scala source)
+            |  -> Data kind: compile-task
+            |#2: a/src/Foo.scala
+            |  -> List()
+            |  -> reset = true
+            |#2: task finish 2
+            |  -> errors 0, warnings 0, noop false
+            |  -> Msg: Compiled 'a'
+            |  -> Data kind: compile-report
+            """.stripMargin
+        )
+      }
+    }
+  }
+
+  test("workspace/reload does not import compilation state") {
+    TestUtil.withinWorkspace { workspace =>
+      val logger = new RecordingLogger(ansiCodesSupported = false)
+      val `A` = TestProject(workspace, "a", List(Sources.`A.scala`, Sources.`B.scala`))
+      val projects = List(`A`)
+      loadBspState(workspace, projects, logger) { state =>
+        val compiledState = state.compile(`A`)
+        assertExitStatus(compiledState, ExitStatus.Ok)
+
+        val project = compiledState.toTestState.getProjectFor(`A`)
+        val analysisFile = project.analysisOut
+        val lastSuccessful = compiledState.toTestState.state.results
+          .lastSuccessfulResult(project) match {
+          case Some(result) => result
+          case None => fail("Missing last successful result for 'a'")
+        }
+        TestUtil.await(FiniteDuration(30, TimeUnit.SECONDS))(lastSuccessful.populatingProducts)
+        val classesDir = lastSuccessful.classesDir
+        val backupAnalysis = workspace.resolve("backup-analysis.bin")
+        val backupClasses = workspace.resolve("backup-classes")
+        Files.copy(
+          analysisFile.underlying,
+          backupAnalysis.underlying,
+          StandardCopyOption.REPLACE_EXISTING
+        )
+        copyDirectory(classesDir, backupClasses)
+
+        writeFile(`A`.srcFor("B.scala"), Sources.`B2.scala`)
+        val secondCompiledState = compiledState.compile(`A`)
+        assertExitStatus(secondCompiledState, ExitStatus.Ok)
+        waitUntilDeleted(classesDir)
+
+        Files.copy(
+          backupAnalysis.underlying,
+          analysisFile.underlying,
+          StandardCopyOption.REPLACE_EXISTING
+        )
+        copyDirectory(backupClasses, classesDir)
+        writeFile(`A`.srcFor("B.scala"), Sources.`B.scala`)
+
+        // Reloading the build configuration must leave compilation state alone, so the
+        // restored analysis stays invisible until it is imported explicitly
+        secondCompiledState.workspaceReload()
+
+        val thirdCompiledState = secondCompiledState.compile(`A`)
+        assertExitStatus(thirdCompiledState, ExitStatus.Ok)
+        assertNoDiff(
+          thirdCompiledState.lastDiagnostics(`A`),
+          """#3: task start 3
+            |  -> Msg: Compiling a (1 Scala source)
+            |  -> Data kind: compile-task
+            |#3: task finish 3
+            |  -> errors 0, warnings 0, noop false
+            |  -> Msg: Compiled 'a'
+            |  -> Data kind: compile-report
+            """.stripMargin
+        )
+      }
+    }
+  }
+
+  private def waitUntilDeleted(dir: AbsolutePath): Unit = {
+    val deadline = System.currentTimeMillis() + 30000
+    while (dir.exists && System.currentTimeMillis() < deadline) Thread.sleep(50)
+    assert(!dir.exists)
+  }
+
+  private def copyDirectory(from: AbsolutePath, to: AbsolutePath): Unit = {
+    val config = ParallelOps.CopyConfiguration(2, CopyMode.ReplaceExisting, Set.empty, Set.empty)
+    val copyTask = ParallelOps.copyDirectories(config)(
+      from.underlying,
+      to.underlying,
+      ExecutionContext.ioScheduler,
+      enableCancellation = false,
+      NoopLogger
+    )
+    TestUtil.await(FiniteDuration(30, TimeUnit.SECONDS))(copyTask)
+    ()
+  }
+}

--- a/frontend/src/test/scala/bloop/bsp/TestConstants.scala
+++ b/frontend/src/test/scala/bloop/bsp/TestConstants.scala
@@ -22,7 +22,7 @@ object TestConstants {
         "buildTargetChangedProvider": false,
         "jvmRunEnvironmentProvider": true,
         "jvmTestEnvironmentProvider": true,
-        "canReload": false
+        "canReload": true
       }
     },
     "id": 2,

--- a/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
+++ b/frontend/src/test/scala/bloop/testing/BloopHelpers.scala
@@ -227,6 +227,11 @@ trait BloopHelpers {
       new TestState(TestUtil.blockingExecute(cleanTask, state))
     }
 
+    def reloadAnalysis(projects: TestProject*): TestState = {
+      val reloadTask = Run(Commands.Reload(projects.map(_.config.name).toList))
+      new TestState(TestUtil.blockingExecute(reloadTask, state))
+    }
+
     def testTask(project: TestProject, only: List[String], args: List[String]): Task[TestState] = {
       val testTask = Run(Commands.Test(List(project.config.name), only = only, args = args))
       TestUtil.interpreterTask(testTask, state).map(new TestState(_))


### PR DESCRIPTION
Bloop reads each project's persisted compilation state once and keeps it in memory, so state replaced on disk — restoring a cache saved from an earlier run, say — is invisible until a restart.

Adds a way to re-read it:

- **CLI:** `bloop reload`, all projects or `--project`
- **BSP:** `bloop/reloadAnalysis`, given targets or all

A reload replaces every requested project or nothing. It fails, untouched, while a project compiles or is cleaned, if state changes mid-read, or if what's on disk can't be used; BSP errors carry a stable `reason` and `retryable` flag. Persisted state is only adopted when the output directory it names is one Bloop manages for that project — compilation later deletes that directory, so an unvalidated path would eventually be removed recursively.

`workspace/reload` is implemented as configuration-only (Bloop already reloads config per request) and never imports state, so it can't fail for unrelated reasons.

**Closes #1091.** The remaining half of that discussion — sharing state across machines or checkouts — is blocked by absolute paths in the persisted state and is tracked in #1351.

**Known issue:** after a reload, an earlier-started request can leave a stale *latest* result, affecting BSP diagnostic carry-over only — the successful result compilation builds on is authoritative.

Tests: `ReloadAnalysisSpec` (12) and `BspReloadSpec` (3 per transport).
