### PR TITLE
Add opt-in portable analysis files

### DIFF
--- a/backend/src/main/scala/bloop/Compiler.scala
+++ b/backend/src/main/scala/bloop/Compiler.scala
@@ -46,6 +46,7 @@ import sbt.internal.inc.bloop.internal.BloopStamps
 import sbt.util.InterfaceUtil
 import xsbti.T2
 import xsbti.VirtualFileRef
+import xsbti.compile.analysis.ReadWriteMappers
 import xsbti.compile._
 
 case class CompileInputs(
@@ -80,7 +81,9 @@ case class CompileOutPaths(
     analysisOut: AbsolutePath,
     genericClassesDir: AbsolutePath,
     externalClassesDir: AbsolutePath,
-    internalReadOnlyClassesDir: AbsolutePath
+    internalReadOnlyClassesDir: AbsolutePath,
+    // How paths are rewritten when the analysis is persisted (see `PortableAnalysis`)
+    analysisMappers: ReadWriteMappers = ReadWriteMappers.getEmptyMappers()
 ) {
   // Don't change the internals of this method without updating how they are cleaned up
   private def createInternalNewDir(generateDirName: String => String): AbsolutePath = {
@@ -534,7 +537,8 @@ object Compiler {
 
           def persistAnalysis(analysis: CompileAnalysis, out: AbsolutePath): Task[Unit] = {
             // Important to memoize it, it's triggered by different clients
-            Task(persist(out, analysis, result.setup, tracer, logger)).memoize
+            val mappers = compileInputs.out.analysisMappers
+            Task(persist(out, analysis, result.setup, mappers, tracer, logger)).memoize
           }
 
           // .betasty files are always produced with -Ybest-effort, even when
@@ -1229,6 +1233,7 @@ object Compiler {
       storeFile: AbsolutePath,
       analysis: CompileAnalysis,
       setup: MiniSetup,
+      mappers: ReadWriteMappers,
       tracer: BraveTracer,
       logger: Logger
   ): Unit = try {
@@ -1238,7 +1243,9 @@ object Compiler {
         logger.debug(s"Skipping analysis persistence to ${storeFile.syntax}, analysis is empty")
       } else {
         logger.debug(label)
-        FileAnalysisStore.binary(storeFile.toFile).set(ConcreteAnalysisContents(analysis, setup))
+        FileAnalysisStore
+          .binary(storeFile.toFile, mappers)
+          .set(ConcreteAnalysisContents(analysis, setup))
         logger.debug(s"Wrote analysis to ${storeFile.syntax}...")
       }
     }

--- a/backend/src/main/scala/bloop/PortableAnalysis.scala
+++ b/backend/src/main/scala/bloop/PortableAnalysis.scala
@@ -1,0 +1,277 @@
+package bloop
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+import scala.util.Try
+
+import bloop.util.JavaRuntime
+
+import xsbti.VirtualFileRef
+import xsbti.compile.MiniSetup
+import xsbti.compile.analysis.ReadMapper
+import xsbti.compile.analysis.ReadWriteMappers
+import xsbti.compile.analysis.Stamp
+import xsbti.compile.analysis.WriteMapper
+
+/**
+ * Makes persisted Zinc analyses independent of absolute paths.
+ *
+ * On write, paths under a known root become `${KEY}/relative` tokens; on read, tokens resolve
+ * to the roots of the current machine. Only the persisted form changes: the in-memory analysis
+ * keeps absolute paths, so the rest of the compilation pipeline is unaffected.
+ */
+object PortableAnalysis {
+  val EnabledProperty = "bloop.analysis.portable"
+  val RootsProperty = "bloop.analysis.roots"
+
+  /** Read per call so that a long-lived server (and tests) observe property changes. */
+  def enabled: Boolean = java.lang.Boolean.getBoolean(EnabledProperty)
+
+  /** Extra roots from `bloop.analysis.roots=KEY=/path,KEY2=/path`; malformed entries are skipped. */
+  def extraRoots: List[(String, Path)] = parseRoots(sys.props.get(RootsProperty))
+
+  def parseRoots(value: Option[String]): List[(String, Path)] = {
+    value.toList.flatMap(_.split(',')).flatMap { entry =>
+      entry.split("=", 2) match {
+        case Array(rawKey, rawPath) =>
+          val key = rawKey.trim
+          val path = rawPath.trim
+          if (key.isEmpty || path.isEmpty || !isValidKey(key)) None
+          else Try(Paths.get(path)).toOption.map(p => key -> p)
+        case _ => None
+      }
+    }
+  }
+
+  private def isValidKey(key: String): Boolean =
+    key.forall(c => c.isLetterOrDigit || c == '_')
+
+  /** Mappers for persisting: tokenise on write, identity on read. Never throws. */
+  def writeMappers(roots: Roots): ReadWriteMappers =
+    new ReadWriteMappers(ReadMapper.getEmptyMapper, new TokenisingWriteMapper(roots))
+
+  /**
+   * Mappers for loading: resolve tokens on read, identity on write. A token that cannot be
+   * resolved is signalled by throwing from inside the mapper, which Zinc's store turns into an
+   * empty result; [[ReadSide.failure]] keeps the first reason so the caller can report it.
+   */
+  def readMappers(roots: Roots): ReadSide = new ReadSide(new ResolvingReadMapper(roots))
+
+  final class ReadSide private[PortableAnalysis] (reader: ResolvingReadMapper) {
+    val mappers: ReadWriteMappers = new ReadWriteMappers(reader, WriteMapper.getEmptyMapper)
+    def failure: Option[String] = reader.failure
+  }
+
+  final class UnresolvableToken(reason: String) extends RuntimeException(reason)
+
+  private final class TokenisingWriteMapper(roots: Roots) extends WriteMapper {
+    private def mapRef(ref: VirtualFileRef): VirtualFileRef =
+      roots.toTokenString(ref.id).fold(ref)(VirtualFileRef.of)
+    private def mapPath(path: Path): Path =
+      roots.toToken(path).fold(path)(token => Paths.get(token))
+
+    override def mapSourceFile(sourceFile: VirtualFileRef): VirtualFileRef = mapRef(sourceFile)
+    override def mapBinaryFile(binaryFile: VirtualFileRef): VirtualFileRef = mapRef(binaryFile)
+    override def mapProductFile(productFile: VirtualFileRef): VirtualFileRef = mapRef(productFile)
+    override def mapOutputDir(outputDir: Path): Path = mapPath(outputDir)
+    override def mapSourceDir(sourceDir: Path): Path = mapPath(sourceDir)
+    override def mapClasspathEntry(classpathEntry: Path): Path = mapPath(classpathEntry)
+    override def mapJavacOption(javacOption: String): String = roots.mapOptionString(javacOption)
+    override def mapScalacOption(scalacOption: String): String =
+      roots.mapOptionString(scalacOption)
+    override def mapProductStamp(file: VirtualFileRef, productStamp: Stamp): Stamp = productStamp
+    override def mapSourceStamp(file: VirtualFileRef, sourceStamp: Stamp): Stamp = sourceStamp
+    override def mapBinaryStamp(file: VirtualFileRef, binaryStamp: Stamp): Stamp = binaryStamp
+    // Zinc applies this hook before the per-field mappers on write and after them on read
+    override def mapMiniSetup(miniSetup: MiniSetup): MiniSetup = miniSetup
+  }
+
+  private final class ResolvingReadMapper(roots: Roots) extends ReadMapper {
+    @volatile private var firstFailure: Option[String] = None
+
+    def failure: Option[String] = firstFailure
+
+    private def reject(reason: String): Nothing = {
+      if (firstFailure.isEmpty) firstFailure = Some(reason)
+      throw new UnresolvableToken(reason)
+    }
+
+    private def mapRef(ref: VirtualFileRef): VirtualFileRef = roots.resolve(ref.id) match {
+      case NotAToken => ref
+      case Resolved(path) => VirtualFileRef.of(path.toString)
+      case Invalid(reason) => reject(reason)
+    }
+
+    // Path-typed fields arrive already parsed, so detect tokens on their string form
+    private def mapPath(path: Path): Path = roots.resolve(path.toString) match {
+      case NotAToken => path
+      case Resolved(resolved) => resolved
+      case Invalid(reason) => reject(reason)
+    }
+
+    override def mapSourceFile(sourceFile: VirtualFileRef): VirtualFileRef = mapRef(sourceFile)
+    override def mapBinaryFile(binaryFile: VirtualFileRef): VirtualFileRef = mapRef(binaryFile)
+    override def mapProductFile(productFile: VirtualFileRef): VirtualFileRef = mapRef(productFile)
+    override def mapOutputDir(outputDir: Path): Path = mapPath(outputDir)
+    override def mapSourceDir(sourceDir: Path): Path = mapPath(sourceDir)
+    override def mapClasspathEntry(classpathEntry: Path): Path = mapPath(classpathEntry)
+    override def mapJavacOption(javacOption: String): String =
+      roots.resolveOptionString(javacOption)
+    override def mapScalacOption(scalacOption: String): String =
+      roots.resolveOptionString(scalacOption)
+    override def mapProductStamp(file: VirtualFileRef, productStamp: Stamp): Stamp = productStamp
+    override def mapSourceStamp(file: VirtualFileRef, sourceStamp: Stamp): Stamp = sourceStamp
+    override def mapBinaryStamp(file: VirtualFileRef, binaryStamp: Stamp): Stamp = binaryStamp
+    override def mapMiniSetup(miniSetup: MiniSetup): MiniSetup = miniSetup
+  }
+
+  sealed trait Resolution
+  case object NotAToken extends Resolution
+  final case class Resolved(path: Path) extends Resolution
+  final case class Invalid(reason: String) extends Resolution
+
+  /**
+   * A root known by `key`. `derived` is the spelling Bloop derived it from (the one config and
+   * the compiler see); `spellings` adds the canonical spelling when it differs, so paths that
+   * were canonicalised elsewhere (e.g. `/private/var` for `/var`) still match on write.
+   */
+  final case class Root(key: String, derived: Path, spellings: List[Path]) {
+    def depth: Int = spellings.map(_.getNameCount).max
+  }
+
+  final class Roots private (val entries: List[Root]) {
+    private val byKey: Map[String, Root] = entries.map(r => r.key -> r).toMap
+
+    /** Tokenises an absolute path under a root; anything else is left for the caller unchanged. */
+    def toToken(path: Path): Option[String] = {
+      if (!path.isAbsolute) None
+      else {
+        val it = entries.iterator
+        var result: Option[String] = None
+        while (result.isEmpty && it.hasNext) {
+          val root = it.next()
+          root.spellings.find(sp => path.startsWith(sp)).foreach { sp =>
+            val rest = sp.relativize(path).toString.replace('\\', '/')
+            result = Some(token(root.key, rest))
+          }
+        }
+        result
+      }
+    }
+
+    /** Like [[toToken]] but total over strings: never throws, never touches existing tokens. */
+    def toTokenString(id: String): Option[String] =
+      if (id.isEmpty || id.startsWith("${")) None
+      else Try(Paths.get(id)).toOption.flatMap(toToken)
+
+    def resolve(id: String): Resolution = {
+      if (!id.startsWith("${")) NotAToken
+      else {
+        val close = id.indexOf('}')
+        if (close < 0) Invalid(s"malformed token '$id'")
+        else {
+          val key = id.substring(2, close)
+          val rest = id.substring(close + 1)
+          if (key.isEmpty) Invalid(s"malformed token '$id'")
+          else if (!(rest.isEmpty || rest.startsWith("/") || rest.startsWith("\\")))
+            Invalid(s"malformed token '$id'")
+          else {
+            byKey.get(key) match {
+              case None => Invalid(s"unknown root '$key' in '$id'")
+              case Some(root) =>
+                val segments = rest.replace('\\', '/').split('/').filter(_.nonEmpty)
+                if (segments.contains("..")) Invalid(s"'$id' escapes its root")
+                else {
+                  val resolved = segments.foldLeft(root.derived)(_.resolve(_))
+                  if (resolved.startsWith(root.derived)) Resolved(resolved)
+                  else Invalid(s"'$id' resolves outside its root")
+                }
+            }
+          }
+        }
+      }
+    }
+
+    /**
+     * Replaces every root spelling that is followed by a path boundary. The separator after
+     * the root is preserved so that options round-trip byte for byte on the same OS.
+     */
+    def mapOptionString(option: String): String = {
+      entries.foldLeft(option) { (acc, root) =>
+        root.spellings.foldLeft(acc) { (acc, spelling) =>
+          replaceAtBoundary(acc, spelling.toString, token(root.key, ""))
+        }
+      }
+    }
+
+    /** Replaces known `${KEY}` tokens with the derived spelling; unknown tokens are kept. */
+    def resolveOptionString(option: String): String = {
+      entries.foldLeft(option) { (acc, root) =>
+        replaceAtBoundary(acc, token(root.key, ""), root.derived.toString)
+      }
+    }
+
+    private def token(key: String, rest: String): String =
+      if (rest.isEmpty) s"$${$key}" else s"$${$key}/$rest"
+
+    private def isBoundary(c: Char): Boolean =
+      c == '/' || c == '\\' || c == ':' || c == ';' || c == ',' || c == '=' || c == '"' ||
+        c == '\'' || c.isWhitespace
+
+    private def replaceAtBoundary(in: String, target: String, replacement: String): String = {
+      if (target.isEmpty || !in.contains(target)) in
+      else {
+        val out = new java.lang.StringBuilder
+        var from = 0
+        var idx = in.indexOf(target, from)
+        while (idx >= 0) {
+          val end = idx + target.length
+          val atBoundary = end == in.length || isBoundary(in.charAt(end))
+          out.append(in, from, idx)
+          out.append(if (atBoundary) replacement else target)
+          from = end
+          idx = in.indexOf(target, from)
+        }
+        out.append(in, from, in.length)
+        out.toString
+      }
+    }
+  }
+
+  object Roots {
+
+    /**
+     * Builds the root map from `(key, path)` pairs: missing paths are dropped, a later entry
+     * for the same key wins, and deeper roots come first so a nested root beats its parent.
+     */
+    def apply(entries: List[(String, Path)]): Roots = {
+      val existing = entries.filter { case (_, p) => p.isAbsolute && Files.exists(p) }
+      val lastPerKey = existing.groupBy(_._1).map { case (key, es) => key -> es.last._2 }
+      val roots = existing.map(_._1).distinct.map { key =>
+        val derived = lastPerKey(key)
+        val canonical = Try(derived.toRealPath()).toOption.filter(_ != derived)
+        Root(key, derived, derived :: canonical.toList)
+      }
+      new Roots(roots.sortBy(r => -r.depth))
+    }
+
+    /** Roots for a build whose workspace is `base`, mirroring sbt's `rootPaths`. */
+    def derive(base: Path, extra: List[(String, Path)] = extraRoots): Roots = {
+      val home = Paths.get(sys.props("user.home"))
+      val defaults = List("BASE" -> base) ++
+        coursierCache.map("CSR_CACHE" -> _).toList ++
+        List(
+          "IVY_HOME" -> home.resolve(".ivy2"),
+          "SBT_BOOT" -> home.resolve(".sbt").resolve("boot"),
+          "JAVA_HOME" -> JavaRuntime.home.underlying
+        )
+      Roots(defaults ++ extra)
+    }
+
+    // Resolving the cache location may create directories, so do it lazily and only once
+    private lazy val coursierCache: Option[Path] =
+      Try(coursierapi.Cache.create().getLocation.toPath).toOption
+  }
+}

--- a/backend/src/test/scala/bloop/PortableAnalysisSpec.scala
+++ b/backend/src/test/scala/bloop/PortableAnalysisSpec.scala
@@ -1,0 +1,347 @@
+package bloop
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.Optional
+
+import scala.util.Properties
+
+import bloop.PortableAnalysis.Invalid
+import bloop.PortableAnalysis.NotAToken
+import bloop.PortableAnalysis.Resolved
+import bloop.PortableAnalysis.Roots
+import bloop.io.AbsolutePath
+
+import org.junit.Assert._
+import org.junit.Assume.assumeFalse
+import org.junit.Test
+import sbt.internal.inc.Analysis
+import sbt.internal.inc.Analysis.NonLocalProduct
+import sbt.internal.inc.Compilation
+import sbt.internal.inc.Compilations
+import sbt.internal.inc.CompileOutput
+import sbt.internal.inc.ConcreteAnalysisContents
+import sbt.internal.inc.FileAnalysisStore
+import sbt.internal.inc.SourceInfos
+import sbt.internal.inc.bloop.internal.BloopStamps
+import sbt.util.InterfaceUtil
+import xsbti.Position
+import xsbti.Severity
+import xsbti.T2
+import xsbti.VirtualFileRef
+import xsbti.compile.CompileOrder
+import xsbti.compile.FileHash
+import xsbti.compile.MiniOptions
+import xsbti.compile.MiniSetup
+
+class PortableAnalysisSpec {
+  private def withTempDir[T](f: Path => T): T = {
+    val dir = Files.createTempDirectory("portable-analysis")
+    try f(dir)
+    finally bloop.io.Paths.delete(AbsolutePath(dir))
+  }
+
+  private def mkdir(parent: Path, name: String): Path =
+    Files.createDirectories(parent.resolve(name))
+
+  @Test
+  def tokenisesPathsUnderRootsMostSpecificFirst(): Unit = withTempDir { dir =>
+    val base = mkdir(dir, "ws")
+    val cache = mkdir(base, "cache")
+    val roots = Roots(List("BASE" -> base, "CSR_CACHE" -> cache))
+    assertEquals(Some("${BASE}/src/A.scala"), roots.toToken(base.resolve("src").resolve("A.scala")))
+    assertEquals(Some("${CSR_CACHE}/x.jar"), roots.toToken(cache.resolve("x.jar")))
+    assertEquals(Some("${BASE}"), roots.toToken(base))
+    assertEquals(None, roots.toToken(dir.resolve("elsewhere").resolve("B.scala")))
+  }
+
+  @Test
+  def tokenMatchingIsSegmentAware(): Unit = withTempDir { dir =>
+    val base = mkdir(dir, "proj")
+    val roots = Roots(List("BASE" -> base))
+    assertEquals(None, roots.toToken(dir.resolve("proj2").resolve("A.scala")))
+    assertEquals(None, roots.toToken(Paths.get("/tmp/dummy")))
+  }
+
+  @Test
+  def relativeAndTokenInputsAreLeftAlone(): Unit = withTempDir { dir =>
+    val roots = Roots(List("BASE" -> dir))
+    assertEquals(None, roots.toToken(Paths.get("${BASE}/x")))
+    assertEquals(None, roots.toToken(Paths.get("rt.jar")))
+    assertEquals(None, roots.toTokenString("${BASE}/x"))
+    assertEquals(None, roots.toTokenString(""))
+  }
+
+  @Test
+  def resolvesTokensWithTheDerivedSpelling(): Unit = withTempDir { dir =>
+    val base = mkdir(dir, "ws")
+    val roots = Roots(List("BASE" -> base))
+    val expected = base.resolve("src").resolve("A.scala")
+    assertEquals(Resolved(expected), roots.resolve("${BASE}/src/A.scala"))
+    assertEquals(Resolved(expected), roots.resolve("${BASE}\\src\\A.scala"))
+    assertEquals(Resolved(base), roots.resolve("${BASE}"))
+    assertEquals(NotAToken, roots.resolve(expected.toString))
+    assertEquals(NotAToken, roots.resolve("rt.jar"))
+  }
+
+  @Test
+  def rejectsUnknownKeysAndParentSegments(): Unit = withTempDir { dir =>
+    val roots = Roots(List("BASE" -> dir))
+    def assertInvalid(id: String): Unit = roots.resolve(id) match {
+      case Invalid(reason) =>
+        assertTrue(s"Reason should mention the input: $reason", reason.nonEmpty)
+      case other => fail(s"Expected Invalid for '$id', got $other")
+    }
+    assertInvalid("${NOPE}/x")
+    assertInvalid("${BASE}/../x")
+    assertInvalid("${BASE}/a/../../x")
+    assertInvalid("${BASE}x")
+    assertInvalid("${}/x")
+    assertInvalid("${BASE")
+  }
+
+  @Test
+  def canonicalSpellingMatchesOnWriteAndDerivedSpellingOnRead(): Unit = withTempDir { dir =>
+    assumeFalse("symbolic links need privileges on Windows", Properties.isWin)
+    val real = mkdir(dir, "real")
+    val link = Files.createSymbolicLink(dir.resolve("link"), real)
+    val roots = Roots(List("BASE" -> link))
+    // Bloop canonicalises some paths (e.g. internal classes dirs); both spellings must tokenise
+    val canonical = real.toRealPath()
+    assertEquals(Some("${BASE}/A.scala"), roots.toToken(canonical.resolve("A.scala")))
+    assertEquals(Some("${BASE}/A.scala"), roots.toToken(link.resolve("A.scala")))
+    // ...but tokens resolve to the spelling the root was derived from
+    assertEquals(Resolved(link.resolve("A.scala")), roots.resolve("${BASE}/A.scala"))
+  }
+
+  @Test
+  def mapsOptionStringsAnywhereWithABoundary(): Unit = withTempDir { dir =>
+    val base = mkdir(dir, "ws")
+    val roots = Roots(List("BASE" -> base))
+    val javac = s"-Xplugin:semanticdb -sourceroot:$base -targetroot:javac-classes-directory"
+    assertEquals(
+      "-Xplugin:semanticdb -sourceroot:${BASE} -targetroot:javac-classes-directory",
+      roots.mapOptionString(javac)
+    )
+    assertEquals(javac, roots.resolveOptionString(roots.mapOptionString(javac)))
+    assertEquals(
+      "-P:semanticdb:sourceroot:${BASE}",
+      roots.mapOptionString(s"-P:semanticdb:sourceroot:$base")
+    )
+    val plugin = s"-Xplugin:${base.resolve("plugin.jar")}"
+    val pluginToken = "-Xplugin:${BASE}" + java.io.File.separator + "plugin.jar"
+    assertEquals(pluginToken, roots.mapOptionString(plugin))
+    assertEquals(plugin, roots.resolveOptionString(pluginToken))
+    val sibling = s"-Xplugin:${base}2/plugin.jar"
+    assertEquals(sibling, roots.mapOptionString(sibling))
+    assertEquals("-deprecation", roots.mapOptionString("-deprecation"))
+    assertEquals("-Dfoo=${HOME}/x", roots.resolveOptionString("-Dfoo=${HOME}/x"))
+    val once = roots.mapOptionString(javac)
+    assertEquals(once, roots.mapOptionString(once))
+    assertEquals(javac, roots.resolveOptionString(roots.resolveOptionString(once)))
+  }
+
+  @Test
+  def writeSideNeverThrows(): Unit = withTempDir { dir =>
+    val roots = Roots(List("BASE" -> dir))
+    val inputs = List("", "${", "${BASE", "a:b", "C:\\", "\u0000", "rt.jar", "//", " ")
+    inputs.foreach { s =>
+      val _ = (roots.toTokenString(s), roots.mapOptionString(s))
+    }
+  }
+
+  @Test
+  def parsesExtraRootsProperty(): Unit = {
+    val parsed = PortableAnalysis.parseRoots(Some("K=/a, BAD ,=/x,K2=/b,K3="))
+    assertEquals(List("K" -> Paths.get("/a"), "K2" -> Paths.get("/b")), parsed)
+    assertEquals(Nil, PortableAnalysis.parseRoots(None))
+    assertEquals(Nil, PortableAnalysis.parseRoots(Some("")))
+  }
+
+  @Test
+  def derivedRootsIncludeBaseAndSkipMissingOnes(): Unit = withTempDir { dir =>
+    val base = mkdir(dir, "ws")
+    val extra =
+      List("MISSING" -> dir.resolve("nope"), "EXTRA" -> dir, "BASE" -> dir.resolve("nope"))
+    val roots = Roots.derive(base, extra)
+    val keys = roots.entries.map(_.key)
+    assertTrue(keys.toString, keys.contains("BASE"))
+    assertTrue(keys.toString, keys.contains("EXTRA"))
+    assertTrue(keys.toString, keys.contains("JAVA_HOME"))
+    assertFalse(keys.toString, keys.contains("MISSING"))
+    // An extra root never overrides a derived one with a path that does not exist
+    assertEquals(Some("${BASE}/A.scala"), roots.toToken(base.resolve("A.scala")))
+    assertFalse(PortableAnalysis.enabled)
+  }
+
+  private def machine(dir: Path, name: String): Machine = {
+    val base = mkdir(dir, name)
+    Machine(base, mkdir(dir, s"$name-cache"), mkdir(base, "out"))
+  }
+
+  private def positionIn(path: Path): Position = new Position {
+    override def line(): Optional[Integer] = Optional.empty()
+    override def lineContent(): String = "class A"
+    override def offset(): Optional[Integer] = Optional.empty()
+    override def pointer(): Optional[Integer] = Optional.empty()
+    override def pointerSpace(): Optional[String] = Optional.empty()
+    override def sourcePath(): Optional[String] = Optional.of(path.toString)
+    override def sourceFile(): Optional[java.io.File] = Optional.of(path.toFile)
+  }
+
+  private val stamp = BloopStamps.fromBloopHashToZincHash(1234)
+
+  private def analysisFor(m: Machine): (Analysis, MiniSetup) = {
+    val problem =
+      InterfaceUtil.problem(
+        "typer",
+        positionIn(m.src),
+        "unused",
+        Severity.Warn,
+        None,
+        None,
+        Nil,
+        Nil
+      )
+    val info = SourceInfos.makeInfo(List(problem), Nil, Nil)
+    val output = CompileOutput(m.out)
+    val analysis = Analysis.empty
+      .addSource(
+        m.ref(m.src),
+        Nil,
+        stamp,
+        info,
+        List(NonLocalProduct("A", "A", m.ref(m.classFile), stamp)),
+        Nil,
+        Nil,
+        Nil,
+        List((m.ref(m.jar), "scala.Predef", stamp))
+      )
+      .copy(compilations = Compilations.empty.add(Compilation(0L, output)))
+    val options = MiniOptions.of(
+      Array(FileHash.of(m.jar, 7)),
+      m.scalacOptions.toArray,
+      m.javacOptions.toArray
+    )
+    val setup =
+      MiniSetup.of(
+        output,
+        options,
+        "2.13.18",
+        CompileOrder.Mixed,
+        true,
+        Array.empty[T2[String, String]]
+      )
+    (analysis, setup)
+  }
+
+  private def slashed(path: Path): String = path.toString.replace('\\', '/')
+
+  @Test
+  def roundTripRebasesEveryMappedFieldAndKeepsProblemPositions(): Unit = withTempDir { dir =>
+    val a = machine(dir, "a")
+    val b = machine(dir, "b")
+    val (analysis, setup) = analysisFor(a)
+    val file = dir.resolve("a-analysis.bin").toFile
+    FileAnalysisStore
+      .binary(file, PortableAnalysis.writeMappers(a.roots))
+      .set(ConcreteAnalysisContents(analysis, setup))
+
+    // The persisted form really contains tokens
+    val raw = FileAnalysisStore.binary(file).get.get
+    val rawAnalysis = raw.getAnalysis.asInstanceOf[Analysis]
+    assertEquals(Set("${BASE}/src/A.scala"), rawAnalysis.stamps.sources.keySet.map(_.id))
+    assertEquals(Set("${BASE}/out/A.class"), rawAnalysis.stamps.products.keySet.map(_.id))
+    assertEquals(Set("${CSR_CACHE}/lib.jar"), rawAnalysis.stamps.libraries.keySet.map(_.id))
+    assertEquals("${BASE}/out", slashed(raw.getMiniSetup.output.getSingleOutputAsPath.get))
+    assertEquals("${CSR_CACHE}/lib.jar", slashed(raw.getMiniSetup.options.classpathHash.head.file))
+    assertTrue(raw.getMiniSetup.options.scalacOptions.contains("-P:semanticdb:sourceroot:${BASE}"))
+
+    // Reading on "machine b" rebases everything that is mapped, exactly once
+    val readSide = PortableAnalysis.readMappers(b.roots)
+    val contents = FileAnalysisStore.binary(file, readSide.mappers).get.get
+    val read = contents.getAnalysis.asInstanceOf[Analysis]
+    assertEquals(Set(b.ref(b.src)), read.stamps.sources.keySet)
+    assertEquals(Set(b.ref(b.classFile)), read.stamps.products.keySet)
+    assertEquals(Set(b.ref(b.jar)), read.stamps.libraries.keySet)
+    assertEquals(stamp.toString, read.stamps.sources(b.ref(b.src)).toString)
+    assertEquals(Set(b.ref(b.classFile)), read.relations.products(b.ref(b.src)))
+    assertEquals(Set(b.ref(b.jar)), read.relations.libraryDeps(b.ref(b.src)))
+    assertEquals(b.out, read.compilations.allCompilations.head.getOutput.getSingleOutputAsPath.get)
+    val setupB = contents.getMiniSetup
+    assertEquals(b.out, setupB.output.getSingleOutputAsPath.get)
+    assertEquals(b.jar, setupB.options.classpathHash.head.file)
+    assertEquals(b.scalacOptions, setupB.options.scalacOptions.toList)
+    assertEquals(b.javacOptions, setupB.options.javacOptions.toList)
+    assertEquals(None, readSide.failure)
+
+    // Documented limitation: diagnostic positions are not rebased
+    val problem = read.infos.get(b.ref(b.src)).getReportedProblems.head
+    assertEquals(Optional.of(a.src.toString), problem.position.sourcePath)
+  }
+
+  @Test
+  def absoluteAnalysesPassThroughTheReadMapperUnchanged(): Unit = withTempDir { dir =>
+    val a = machine(dir, "a")
+    val b = machine(dir, "b")
+    val (analysis, setup) = analysisFor(a)
+    val file = dir.resolve("a-analysis.bin").toFile
+    FileAnalysisStore.binary(file).set(ConcreteAnalysisContents(analysis, setup))
+    val readSide = PortableAnalysis.readMappers(b.roots)
+    val contents = FileAnalysisStore.binary(file, readSide.mappers).get.get
+    val read = contents.getAnalysis.asInstanceOf[Analysis]
+    assertEquals(Set(a.ref(a.src)), read.stamps.sources.keySet)
+    assertEquals(Set(a.ref(a.jar)), read.stamps.libraries.keySet)
+    assertEquals(a.out, contents.getMiniSetup.output.getSingleOutputAsPath.get)
+    assertEquals(a.scalacOptions, contents.getMiniSetup.options.scalacOptions.toList)
+    assertEquals(None, readSide.failure)
+  }
+
+  @Test
+  def unknownRootMakesTheStoreReturnEmptyAndRecordsTheReason(): Unit = withTempDir { dir =>
+    val a = machine(dir, "a")
+    val b = machine(dir, "b")
+    val (analysis, setup) = analysisFor(a)
+    val file = dir.resolve("a-analysis.bin").toFile
+    val foreignRoots = Roots(List("NOPE" -> a.base, "CSR_CACHE" -> a.cache))
+    FileAnalysisStore
+      .binary(file, PortableAnalysis.writeMappers(foreignRoots))
+      .set(ConcreteAnalysisContents(analysis, setup))
+    val readSide = PortableAnalysis.readMappers(b.roots)
+    assertFalse(FileAnalysisStore.binary(file, readSide.mappers).get.isPresent)
+    assertTrue(readSide.failure.toString, readSide.failure.exists(_.contains("NOPE")))
+  }
+
+  @Test
+  def parentSegmentsAreRejectedByTheReadMapper(): Unit = withTempDir { dir =>
+    val a = machine(dir, "a")
+    val readSide = PortableAnalysis.readMappers(a.roots)
+    val reader = readSide.mappers.getReadMapper
+    def assertRejected(op: => Any): Unit = {
+      try { op; fail("expected UnresolvableToken") }
+      catch { case _: PortableAnalysis.UnresolvableToken => () }
+    }
+    assertRejected(reader.mapSourceFile(VirtualFileRef.of("${BASE}/../x")))
+    assertRejected(reader.mapOutputDir(Paths.get("${BASE}/../x")))
+    assertRejected(reader.mapClasspathEntry(Paths.get("${NOPE}/x.jar")))
+    assertTrue(readSide.failure.toString, readSide.failure.exists(_.contains("escapes")))
+    // Absolute inputs and unknown tokens inside option strings are left alone
+    assertEquals(a.ref(a.src), reader.mapSourceFile(a.ref(a.src)))
+    assertEquals("-Dfoo=${HOME}/x", reader.mapScalacOption("-Dfoo=${HOME}/x"))
+  }
+}
+
+// A tiny "machine" for PortableAnalysisSpec: a workspace with a source, an output dir with a class file, and a cache
+private[bloop] final case class Machine(base: Path, cache: Path, out: Path) {
+  def src: Path = base.resolve("src").resolve("A.scala")
+  def classFile: Path = out.resolve("A.class")
+  def jar: Path = cache.resolve("lib.jar")
+  def plugin: Path = cache.resolve("plugin.jar")
+  def roots: Roots = Roots(List("BASE" -> base, "CSR_CACHE" -> cache))
+  def ref(path: Path): VirtualFileRef = VirtualFileRef.of(path.toString)
+  def scalacOptions: List[String] =
+    List(s"-Xplugin:$plugin", s"-P:semanticdb:sourceroot:$base", "-deprecation")
+  def javacOptions: List[String] =
+    List(s"-Xplugin:semanticdb -sourceroot:$base -targetroot:javac-classes-directory")
+}

--- a/docs/server.md
+++ b/docs/server.md
@@ -82,6 +82,32 @@ server. For example, use this to increase the memory to Bloop.
 export BLOOP_JAVA_OPTS="-Xmx16G -XX:+UseZGC -Xss4m"
 ```
 
+### Portable analysis (opt-in)
+
+By default, the incremental compilation analysis Bloop persists next to a project's outputs
+(`<out>/<name>-analysis.bin`) contains absolute paths. Moving a workspace to a different location
+(a Docker build, a CI checkout, a `git worktree`) therefore turns the first compile there into a
+full compile, even when no source changed.
+
+Set `-Dbloop.analysis.portable=true` in `BLOOP_JAVA_OPTS` to persist analysis files with paths
+relative to well-known roots: `${BASE}` (the workspace), `${CSR_CACHE}` (the coursier cache),
+`${IVY_HOME}`, `${SBT_BOOT}` and `${JAVA_HOME}`. Reading such files is always supported, so they
+also load on the same machine with the option off, and files written without the option keep
+loading as before.
+
+To reuse a build elsewhere, ship both the analysis file and the `bloop-internal-classes`
+directory found under the project's `out` directory, keeping the same layout relative to the
+workspace. Notes and limitations:
+
+- `IVY_HOME` (`~/.ivy2`), `SBT_BOOT` (`~/.sbt/boot`) and `JAVA_HOME` (the server's JVM) are
+  heuristics. Add or override roots with `-Dbloop.analysis.roots=KEY=/path,KEY2=/path`.
+- Paths outside every root stay absolute and are not portable.
+- Sharing analysis files between different operating systems is not supported.
+- An analysis whose roots cannot be resolved on the current machine is ignored with a warning,
+  a full compile follows, and the file stays on disk until the next successful compile replaces it.
+- Positions of previously reported warnings are not rewritten, so diagnostics replayed to
+  editors can point at the old location until the affected files are recompiled.
+
 ### Custom Java home
 
 By default Bloop CLI will try to find JDK 17 and up on your system, if it's not

--- a/frontend/src/main/scala/bloop/data/Project.scala
+++ b/frontend/src/main/scala/bloop/data/Project.scala
@@ -92,6 +92,10 @@ final case class Project(
     customWorkingDirectory.orElse(workspaceDirectory).getOrElse(baseDirectory)
   }
 
+  /** The workspace this project belongs to, falling back to the parent of the config dir. */
+  def workspaceRoot: AbsolutePath =
+    workspaceDirectory.getOrElse(origin.path.getParent.getParent)
+
   /** Returns concatenated list of "sources" and expanded "sourcesGlobs". */
   def allUnmanagedSourceFilesAndDirectories: Task[List[AbsolutePath]] = Task {
     val buf = mutable.ListBuffer.empty[AbsolutePath]

--- a/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
+++ b/frontend/src/main/scala/bloop/engine/caches/ResultsCache.scala
@@ -14,6 +14,7 @@ import bloop.CompileOutPaths
 import bloop.CompileProducts
 import bloop.Compiler
 import bloop.Compiler.Result
+import bloop.PortableAnalysis
 import bloop.UniqueCompileInputs
 import bloop.data.ClientInfo
 import bloop.data.Project
@@ -242,7 +243,12 @@ object ResultsCache {
       val analysisFile = p.analysisOut
       if (analysisFile.exists) {
         Task {
-          val contents = FileAnalysisStore.binary(analysisFile.toFile).get().toOption
+          // Tokens in a portable analysis resolve against this build's roots; a token that
+          // cannot be resolved makes the store return nothing and records the reason
+          val roots = PortableAnalysis.Roots.derive(p.workspaceRoot.underlying)
+          val readSide = PortableAnalysis.readMappers(roots)
+          val contents =
+            FileAnalysisStore.binary(analysisFile.toFile, readSide.mappers).get().toOption
           contents match {
             case Some(res) =>
               logger.debug(s"Loading previous analysis for '${p.name}' from '$analysisFile'.")
@@ -294,7 +300,14 @@ object ResultsCache {
                   ResultBundle.empty -> None
               }
             case None =>
-              logger.debug(s"Analysis '$analysisFile' for '${p.name}' is empty.")
+              readSide.failure match {
+                case Some(reason) =>
+                  logger.warn(
+                    s"Ignoring persisted analysis for '${p.name}': $reason; a full compile will follow"
+                  )
+                case None =>
+                  logger.debug(s"Analysis '$analysisFile' for '${p.name}' is empty.")
+              }
               ResultBundle.empty -> None
           }
 

--- a/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
+++ b/frontend/src/main/scala/bloop/engine/tasks/compilation/CompileBundle.scala
@@ -5,6 +5,7 @@ import scala.concurrent.Promise
 import bloop.ClientClassesObserver
 import bloop.CompileOutPaths
 import bloop.Compiler
+import bloop.PortableAnalysis
 import bloop.ScalaInstance
 import bloop.UniqueCompileInputs
 import bloop.cli.CommonOptions
@@ -23,6 +24,7 @@ import bloop.task.Task
 import bloop.tracing.BraveTracer
 
 import monix.reactive.Observable
+import xsbti.compile.analysis.ReadWriteMappers
 
 sealed trait CompileBundle
 
@@ -91,12 +93,19 @@ final case class SuccessfulCompileBundle(
   val isJavaOnly: Boolean = scalaSources.isEmpty && !javaSources.isEmpty
   val out: CompileOutPaths = {
     val readOnlyClassesDir = lastSuccessful.classesDir
+    val analysisMappers =
+      if (!PortableAnalysis.enabled) ReadWriteMappers.getEmptyMappers()
+      else
+        PortableAnalysis.writeMappers(
+          PortableAnalysis.Roots.derive(project.workspaceRoot.underlying)
+        )
     CompileOutPaths(
       project.out,
       project.analysisOut,
       project.genericClassesDir,
       clientClassesObserver.classesDir,
-      readOnlyClassesDir
+      readOnlyClassesDir,
+      analysisMappers
     )
   }
 

--- a/frontend/src/test/scala/bloop/PortableAnalysisSpec.scala
+++ b/frontend/src/test/scala/bloop/PortableAnalysisSpec.scala
@@ -1,0 +1,213 @@
+package bloop
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+
+import bloop.cli.ExitStatus
+import bloop.io.AbsolutePath
+import bloop.logging.RecordingLogger
+import bloop.util.TestProject
+import bloop.util.TestUtil
+
+import sbt.internal.inc.Analysis
+import sbt.internal.inc.FileAnalysisStore
+
+object PortableAnalysisSpec extends bloop.testing.BaseSuite {
+  private val sourcesA = List(
+    """/main/scala/A.scala
+      |class A
+      |""".stripMargin
+  )
+  private val sourcesB = List(
+    """/main/scala/B.scala
+      |class B extends A
+      |""".stripMargin
+  )
+  private val bothCompiled =
+    s"""Compiling a (1 Scala source)
+       |Compiling b (1 Scala source)""".stripMargin
+
+  private def withPortableAnalysis[T](enabled: Boolean)(op: => T): T = {
+    val key = PortableAnalysis.EnabledProperty
+    val previous = sys.props.get(key)
+    sys.props.update(key, enabled.toString)
+    try op
+    finally previous.fold[Unit](sys.props.remove(key).foreach(_ => ()))(sys.props.update(key, _))
+  }
+
+  private def copyTree(from: Path, to: Path): Unit = {
+    val stream = Files.walk(from)
+    try {
+      stream.forEach { source =>
+        val target = to.resolve(from.relativize(source).toString)
+        if (Files.isDirectory(source)) Files.createDirectories(target)
+        else Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING)
+        ()
+      }
+    } finally stream.close()
+  }
+
+  private def projectsIn(workspace: AbsolutePath): List[TestProject] = {
+    val a = TestProject(workspace, "a", sourcesA)
+    val b = TestProject(workspace, "b", sourcesB, List(a))
+    List(a, b)
+  }
+
+  private def newLogger(): RecordingLogger = new RecordingLogger(ansiCodesSupported = false)
+
+  private def compiled(logger: RecordingLogger): String =
+    logger.compilingInfos.sorted.mkString(System.lineSeparator)
+
+  private def sourceIdsOf(state: TestState, project: TestProject): Set[String] = {
+    val file = state.getProjectFor(project).analysisOut
+    val contents = FileAnalysisStore.binary(file.toFile).get.get
+    contents.getAnalysis.asInstanceOf[Analysis].stamps.sources.keySet.map(_.id)
+  }
+
+  private final case class Relocated(
+      workspace: AbsolutePath,
+      state: TestState,
+      projects: List[TestProject],
+      logger: RecordingLogger
+  )
+
+  /**
+   * Compiles `a` and `b` in one workspace, then recreates the same build in a second workspace,
+   * ships the first workspace's outputs (analysis files and internal classes dirs) there, and
+   * compiles again from a fresh state. `op` runs while the second workspace still exists.
+   */
+  private def withRelocatedBuild[T](op: Relocated => T): T = {
+    TestUtil.withinWorkspace { origin =>
+      val originProjects = projectsIn(origin)
+      val originLogger = newLogger()
+      val originState = loadState(origin, originProjects, originLogger)
+      val originCompiled = originState.compile(originProjects.last)
+      assertExitStatus(originCompiled, ExitStatus.Ok)
+      assertValidCompilationState(originCompiled, originProjects)
+      assertNoDiff(compiled(originLogger), bothCompiled)
+
+      TestUtil.withinWorkspace { relocated =>
+        val relocatedProjects = projectsIn(relocated)
+        copyTree(origin.resolve("target").underlying, relocated.resolve("target").underlying)
+        val logger = newLogger()
+        val state = loadState(relocated, relocatedProjects, logger)
+        val recompiled = state.compile(relocatedProjects.last)
+        assertExitStatus(recompiled, ExitStatus.Ok)
+        assertValidCompilationState(recompiled, relocatedProjects)
+        op(Relocated(relocated, recompiled, relocatedProjects, logger))
+      }
+    }
+  }
+
+  /** Compiles in a workspace, then reloads the build from disk in the same workspace. */
+  private def compileThenReload(writeEnabled: Boolean, readEnabled: Boolean): RecordingLogger = {
+    TestUtil.withinWorkspace { workspace =>
+      val projects = projectsIn(workspace)
+      withPortableAnalysis(writeEnabled) {
+        val first = loadState(workspace, projects, newLogger()).compile(projects.last)
+        assertExitStatus(first, ExitStatus.Ok)
+      }
+      withPortableAnalysis(readEnabled) {
+        val logger = newLogger()
+        val reloaded = loadState(workspace, projects, logger).compile(projects.last)
+        assertExitStatus(reloaded, ExitStatus.Ok)
+        assertValidCompilationState(reloaded, projects)
+        logger
+      }
+    }
+  }
+
+  test("relocated workspace compiles as a no-op when portable analysis is on") {
+    withPortableAnalysis(enabled = true) {
+      withRelocatedBuild { build =>
+        assertNoDiff(compiled(build.logger), "")
+        assert(!build.logger.debugs.exists(_.contains("Classpath hash changed")))
+      }
+    }
+  }
+
+  test("relocated workspace recompiles when portable analysis is off") {
+    withPortableAnalysis(enabled = false) {
+      withRelocatedBuild(build => assertNoDiff(compiled(build.logger), bothCompiled))
+    }
+  }
+
+  test("relocated workspace stays incremental") {
+    withPortableAnalysis(enabled = true) {
+      withRelocatedBuild { build =>
+        assertNoDiff(compiled(build.logger), "")
+        val source = build.projects.head.srcFor("/main/scala/A.scala")
+        Files.write(source.underlying, "class A // touched".getBytes(StandardCharsets.UTF_8))
+        val logger = newLogger()
+        val state = build.state.withLogger(logger).compile(build.projects.last)
+        assertExitStatus(state, ExitStatus.Ok)
+        assertNoDiff(compiled(logger), "Compiling a (1 Scala source)")
+      }
+    }
+  }
+
+  test("an analysis written with absolute paths loads when portable analysis is on") {
+    assertNoDiff(compiled(compileThenReload(writeEnabled = false, readEnabled = true)), "")
+  }
+
+  test("a portable analysis loads on the same machine when portable analysis is off") {
+    assertNoDiff(compiled(compileThenReload(writeEnabled = true, readEnabled = false)), "")
+  }
+
+  test("an analysis with an unknown root is ignored with a warning and the build keeps working") {
+    withPortableAnalysis(enabled = true) {
+      withRelocatedBuild { build =>
+        val a = build.projects.head
+        val project = build.state.getProjectFor(a)
+        val analysisFile = project.analysisOut.toFile
+        // Rewrite a's analysis with a root this machine will not recognise
+        val known = PortableAnalysis.readMappers(
+          PortableAnalysis.Roots.derive(project.workspaceRoot.underlying)
+        )
+        val contents = FileAnalysisStore.binary(analysisFile, known.mappers).get.get
+        val foreign = PortableAnalysis.Roots(List("NOPE" -> build.workspace.underlying))
+        FileAnalysisStore.binary(analysisFile, PortableAnalysis.writeMappers(foreign)).set(contents)
+
+        val logger = newLogger()
+        val reloaded = loadState(build.workspace, build.projects, logger)
+        assert(
+          logger.warnings.exists(w =>
+            w.contains("Ignoring persisted analysis for 'a'") && w.contains("NOPE")
+          )
+        )
+        val recompiled = reloaded.compile(build.projects.last)
+        assertExitStatus(recompiled, ExitStatus.Ok)
+        assert(logger.compilingInfos.contains("Compiling a (1 Scala source)"))
+
+        val again = newLogger()
+        val noop = recompiled.withLogger(again).compile(build.projects.last)
+        assertExitStatus(noop, ExitStatus.Ok)
+        assertNoDiff(compiled(again), "")
+      }
+    }
+  }
+
+  test("persisted paths stay absolute unless portable analysis is on") {
+    TestUtil.withinWorkspace { workspace =>
+      val projects = projectsIn(workspace)
+      val off = withPortableAnalysis(enabled = false) {
+        loadState(workspace, projects, newLogger()).compile(projects.last)
+      }
+      assertExitStatus(off, ExitStatus.Ok)
+      val absoluteIds = sourceIdsOf(off, projects.head)
+      assert(absoluteIds.nonEmpty && absoluteIds.forall(id => Paths.get(id).isAbsolute))
+
+      // A no-op compile re-persists a missing analysis file with the current setting
+      val on = withPortableAnalysis(enabled = true) {
+        Files.delete(off.getProjectFor(projects.head).analysisOut.underlying)
+        off.compile(projects.last)
+      }
+      assertExitStatus(on, ExitStatus.Ok)
+      val tokenIds = sourceIdsOf(on, projects.head)
+      assert(tokenIds.nonEmpty && tokenIds.forall(_.startsWith("${BASE}/")))
+    }
+  }
+}


### PR DESCRIPTION
Addresses the path-portability part of #1351 as a small, opt-in change.

Persisted analysis files contain absolute paths, so moving a workspace (Docker layer, CI checkout, git worktree) forces a full recompile. With `-Dbloop.analysis.portable=true` Bloop passes a `ReadWriteMappers` pair to Zinc's `FileAnalysisStore` that rewrites paths under known roots (workspace, coursier cache, ivy, sbt boot, java home) to `${KEY}/relative` tokens on write and resolves them on read. In-memory analysis, stamps, reporters and BSP are untouched.

- Default off: on-disk format unchanged. Reading tokens is always on and is a no-op for absolute paths, so existing files keep loading.
- Unresolvable tokens fail closed: the analysis is ignored with a warning and a full compile follows.
- Extra roots via `-Dbloop.analysis.roots=KEY=/path,...`
- Known limitation: Zinc does not map diagnostic positions, so replayed warnings can point at the old path until the file recompiles.
