### PR TITLE
Add --reverse-order flag to control CLI error output order

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -117,6 +117,8 @@ sidebar_label: CLI --help
   <dd><p>Pipeline the compilation of modules in your build. By default, false.</p></dd>
   <dt><code>--reporter</code> (type: <code>reporter</code>)</dt>
   <dd><p>Pick reporter to show compilation messages. By default, bloop's used.</p></dd>
+  <dt><code>--reverse-order</code> (type: <code>bool?</code>)</dt>
+  <dd><p>Print errors newest-first. Pass --reverse-order=false to print them as the compiler reports them. By default, bloop reverses and scalac does not.</p></dd>
   <dt><code>--watch</code> or <code>-w</code> (type: <code>bool</code>)</dt>
   <dd><p>Run the command when projects' source files change. By default, false.</p></dd>
   <dt><code>--cascade</code> (type: <code>bool</code>)</dt>
@@ -175,6 +177,8 @@ sidebar_label: CLI --help
   <dd><p>Pipeline the compilation of modules in your build. By default, false.</p></dd>
   <dt><code>--reporter</code> (type: <code>reporter</code>)</dt>
   <dd><p>Pick reporter to show compilation messages. By default, bloop's used.</p></dd>
+  <dt><code>--reverse-order</code> (type: <code>bool?</code>)</dt>
+  <dd><p>Print errors newest-first. Pass --reverse-order=false to print them as the compiler reports them. By default, bloop reverses and scalac does not.</p></dd>
   <dt><code>--exclude-root</code> (type: <code>bool</code>)</dt>
   <dd><p>Start up the console compiling only the target project's dependencies.</p></dd>
   <dt><code>--repl</code> (type: <code>repl</code>)</dt>
@@ -235,6 +239,8 @@ sidebar_label: CLI --help
   <dd><p>Pipeline the compilation of modules in your build. By default, false.</p></dd>
   <dt><code>--reporter</code> (type: <code>reporter</code>)</dt>
   <dd><p>Pick reporter to show compilation messages. By default, bloop's used.</p></dd>
+  <dt><code>--reverse-order</code> (type: <code>bool?</code>)</dt>
+  <dd><p>Print errors newest-first. Pass --reverse-order=false to print them as the compiler reports them. By default, bloop reverses and scalac does not.</p></dd>
   <dt><code>--watch</code> or <code>-w</code> (type: <code>bool</code>)</dt>
   <dd><p>If set, run the command whenever projects' source files change.</p></dd>
   <dt><code>--optimize</code> or <code>-O</code> (type: <code>"debug" | "release"?</code>)</dt>
@@ -298,6 +304,8 @@ sidebar_label: CLI --help
   <dd><p>Pipeline the compilation of modules in your build. By default, false.</p></dd>
   <dt><code>--reporter</code> (type: <code>reporter</code>)</dt>
   <dd><p>Pick reporter to show compilation messages. By default, bloop's used.</p></dd>
+  <dt><code>--reverse-order</code> (type: <code>bool?</code>)</dt>
+  <dd><p>Print errors newest-first. Pass --reverse-order=false to print them as the compiler reports them. By default, bloop reverses and scalac does not.</p></dd>
   <dt><code>--args</code> (type: <code>string*</code>)</dt>
   <dd><p>The arguments to pass in to the main class.</p></dd>
   <dt><code>--watch</code> or <code>-w</code> (type: <code>bool</code>)</dt>
@@ -351,6 +359,8 @@ sidebar_label: CLI --help
   <dd><p>The arguments to pass in to the test framework.</p></dd>
   <dt><code>--reporter</code> (type: <code>reporter</code>)</dt>
   <dd><p>Pick reporter to show compilation messages. By default, bloop's used.</p></dd>
+  <dt><code>--reverse-order</code> (type: <code>bool?</code>)</dt>
+  <dd><p>Print errors newest-first. Pass --reverse-order=false to print them as the compiler reports them. By default, bloop reverses and scalac does not.</p></dd>
   <dt><code>--watch</code> or <code>-w</code> (type: <code>bool</code>)</dt>
   <dd><p>Run the command when projects' source files change. By default, false.</p></dd>
   <dt><code>--config-dir</code> or <code>-c</code> (type: <code>path?</code>)</dt>

--- a/frontend/src/main/scala/bloop/cli/Commands.scala
+++ b/frontend/src/main/scala/bloop/cli/Commands.scala
@@ -40,6 +40,7 @@ object Commands {
   sealed trait CompilingCommand extends RawCommand {
     def projects: List[String]
     def reporter: ReporterKind
+    def reverseOrder: Option[Boolean]
     def incremental: Boolean
     def pipeline: Boolean
   }
@@ -163,6 +164,10 @@ object Commands {
       pipeline: Boolean = false,
       @HelpMessage("Pick reporter to show compilation messages. By default, bloop's used.")
       reporter: ReporterKind = BloopReporter,
+      @HelpMessage(
+        "Print errors newest-first. Pass --reverse-order=false to print them as the compiler reports them. By default, bloop reverses and scalac does not."
+      )
+      reverseOrder: Option[Boolean] = None,
       @ExtraName("w")
       @HelpMessage("Run the command when projects' source files change. By default, false.")
       watch: Boolean = false,
@@ -201,6 +206,10 @@ object Commands {
       args: List[String] = Nil,
       @HelpMessage("Pick reporter to show compilation messages. By default, bloop's used.")
       reporter: ReporterKind = BloopReporter,
+      @HelpMessage(
+        "Print errors newest-first. Pass --reverse-order=false to print them as the compiler reports them. By default, bloop reverses and scalac does not."
+      )
+      reverseOrder: Option[Boolean] = None,
       @ExtraName("w")
       @HelpMessage("Run the command when projects' source files change. By default, false.")
       watch: Boolean = false,
@@ -235,6 +244,10 @@ object Commands {
       pipeline: Boolean = false,
       @HelpMessage("Pick reporter to show compilation messages. By default, bloop's used.")
       reporter: ReporterKind = BloopReporter,
+      @HelpMessage(
+        "Print errors newest-first. Pass --reverse-order=false to print them as the compiler reports them. By default, bloop reverses and scalac does not."
+      )
+      reverseOrder: Option[Boolean] = None,
       @HelpMessage("Start up the console compiling only the target project's dependencies.")
       excludeRoot: Boolean = false,
       @HelpMessage(
@@ -266,6 +279,10 @@ object Commands {
       pipeline: Boolean = false,
       @HelpMessage("Pick reporter to show compilation messages. By default, bloop's used.")
       reporter: ReporterKind = BloopReporter,
+      @HelpMessage(
+        "Print errors newest-first. Pass --reverse-order=false to print them as the compiler reports them. By default, bloop reverses and scalac does not."
+      )
+      reverseOrder: Option[Boolean] = None,
       @HelpMessage("The arguments to pass in to the main class.")
       args: List[String] = Nil,
       @ExtraName("w")
@@ -308,6 +325,10 @@ object Commands {
       pipeline: Boolean = false,
       @HelpMessage("Pick reporter to show compilation messages. By default, bloop's used.")
       reporter: ReporterKind = BloopReporter,
+      @HelpMessage(
+        "Print errors newest-first. Pass --reverse-order=false to print them as the compiler reports them. By default, bloop reverses and scalac does not."
+      )
+      reverseOrder: Option[Boolean] = None,
       @ExtraName("w")
       @HelpMessage("If set, run the command whenever projects' source files change.")
       watch: Boolean = false,

--- a/frontend/src/main/scala/bloop/engine/Interpreter.scala
+++ b/frontend/src/main/scala/bloop/engine/Interpreter.scala
@@ -187,7 +187,11 @@ object Interpreter {
     }
 
     val compileTask = state.flatMap { state =>
-      val config = ReporterKind.toReporterConfig(cmd.reporter).copy(colors = !noColor)
+      val baseConfig = ReporterKind.toReporterConfig(cmd.reporter)
+      val config = baseConfig.copy(
+        colors = !noColor,
+        reverseOrder = cmd.reverseOrder.getOrElse(baseConfig.reverseOrder)
+      )
       val dag = getProjectsDag(projects, state)
       val createReporter = (inputs: ReporterInputs[Logger]) =>
         new LogReporter(inputs.project, inputs.logger, inputs.cwd, config)

--- a/frontend/src/test/scala/bloop/AutoCompleteSpec.scala
+++ b/frontend/src/test/scala/bloop/AutoCompleteSpec.scala
@@ -39,6 +39,7 @@ class AutoCompleteSpec {
         |--incremental=-[Compile the project incrementally. By default, true.]:incremental:(true false)
         |--pipeline=-[Pipeline the compilation of modules in your build. By default, false.]:pipeline:(true false)
         |--reporter[Pick reporter to show compilation messages. By default, bloop's used.]:reporter:_reporters
+        |--reverse-order=-[Print errors newest-first. Pass --reverse-order=false to print them as the compiler reports them. By default, bloop reverses and scalac does not.]:reverse-order:(true false)
         |--watch=-[Run the command when projects' source files change. By default, false.]:watch:(true false)
         |--cascade=-[Compile a project and all projects depending on it. By default, false.]:cascade:(true false)
         |--summary=-[Print a summary of project compile times, blocked projects and totals. By default, false.]:summary:(true false)
@@ -77,6 +78,7 @@ class AutoCompleteSpec {
         |incremental#'Compile the project incrementally. By default, true.'#(_boolean)
         |pipeline#'Pipeline the compilation of modules in your build. By default, false.'#(_boolean)
         |reporter#'Pick reporter to show compilation messages. By default, bloop's used.'#(_reporters)
+        |reverse-order#'Print errors newest-first. Pass --reverse-order=false to print them as the compiler reports them. By default, bloop reverses and scalac does not.'#(_boolean)
         |watch#'Run the command when projects' source files change. By default, false.'#(_boolean)
         |cascade#'Compile a project and all projects depending on it. By default, false.'#(_boolean)
         |summary#'Print a summary of project compile times, blocked projects and totals. By default, false.'#(_boolean)
@@ -115,6 +117,7 @@ class AutoCompleteSpec {
         |--incremental
         |--pipeline
         |--reporter _reporters
+        |--reverse-order
         |--watch
         |--cascade
         |--summary

--- a/frontend/src/test/scala/bloop/CliSpec.scala
+++ b/frontend/src/test/scala/bloop/CliSpec.scala
@@ -249,6 +249,37 @@ object CliSpec extends BaseSuite {
     }
   }
 
+  test("parse --reverse-order on compile") {
+    Cli.parse(Array("compile", "foo"), CommonOptions.default) match {
+      case Run(cmd: Commands.Compile, _) =>
+        assert(cmd.reverseOrder.isEmpty)
+      case action => throw new AssertionError(s"Expected a compile command, got $action")
+    }
+    Cli.parse(Array("compile", "foo", "--reverse-order=false"), CommonOptions.default) match {
+      case Run(cmd: Commands.Compile, _) =>
+        assert(cmd.reverseOrder == Some(false))
+      case action => throw new AssertionError(s"Expected a compile command, got $action")
+    }
+    Cli.parse(Array("compile", "foo", "--reverse-order"), CommonOptions.default) match {
+      case Run(cmd: Commands.Compile, _) =>
+        assert(cmd.reverseOrder == Some(true))
+      case action => throw new AssertionError(s"Expected a compile command, got $action")
+    }
+  }
+
+  test("parse --reverse-order on test and run") {
+    Cli.parse(Array("test", "foo", "--reverse-order=false"), CommonOptions.default) match {
+      case Run(cmd: Commands.Test, _) =>
+        assert(cmd.reverseOrder == Some(false))
+      case action => throw new AssertionError(s"Expected a test command, got $action")
+    }
+    Cli.parse(Array("run", "foo", "--reverse-order=false"), CommonOptions.default) match {
+      case Run(cmd: Commands.Run, _) =>
+        assert(cmd.reverseOrder == Some(false))
+      case action => throw new AssertionError(s"Expected a run command, got $action")
+    }
+  }
+
   test("parse test args after -- as framework args") {
     Cli.parse(
       Array("test", "foo", "--only", "MySpec", "--", "-Dkey=value", "-z", "ok"),

--- a/frontend/src/test/scala/bloop/ReporterOrderSpec.scala
+++ b/frontend/src/test/scala/bloop/ReporterOrderSpec.scala
@@ -1,0 +1,81 @@
+package bloop
+
+import bloop.cli.Commands
+import bloop.cli.ScalacReporter
+import bloop.util.TestUtil
+
+import org.junit.Assert
+import org.junit.Test
+
+class ReporterOrderSpec {
+  // Two independent type errors in source order: the first requires a `String`,
+  // the second requires an `Int`, so each error is identifiable by its message.
+  private val structure = Map(
+    "A" -> Map(
+      "A.scala" ->
+        """package p
+          |object A {
+          |  val first: String = 1
+          |  val second: Int = "s"
+          |}
+          |""".stripMargin
+    )
+  )
+  private val deps = Map.empty[String, Set[String]]
+
+  private def indexOfError(messages: List[(String, String)], snippet: String): Int = {
+    val errors = messages.collect { case ("error", msg) => msg }
+    val index = errors.indexWhere(_.contains(snippet))
+    Assert.assertTrue(
+      s"Missing error containing '$snippet' in:\n${errors.mkString("\n")}",
+      index >= 0
+    )
+    index
+  }
+
+  @Test
+  def defaultReporterPrintsErrorsInReverseOrder(): Unit = {
+    TestUtil.testState(structure, deps) { state =>
+      TestUtil.runAndCheck(state, Commands.Compile(List("A"))) { messages =>
+        val firstError = indexOfError(messages, "required: String")
+        val secondError = indexOfError(messages, "required: Int")
+        Assert.assertTrue(
+          "Expected errors in reverse order of occurrence by default",
+          secondError < firstError
+        )
+      }
+    }
+  }
+
+  @Test
+  def reverseOrderFalsePrintsErrorsInOccurrenceOrder(): Unit = {
+    TestUtil.testState(structure, deps) { state =>
+      val compile = Commands.Compile(List("A"), reverseOrder = Some(false))
+      TestUtil.runAndCheck(state, compile) { messages =>
+        val firstError = indexOfError(messages, "required: String")
+        val secondError = indexOfError(messages, "required: Int")
+        Assert.assertTrue(
+          "Expected errors in order of occurrence with --reverse-order=false",
+          firstError < secondError
+        )
+      }
+    }
+  }
+
+  // Without the flag the reporter's own order must win. The bloop reporter reverses, so only the
+  // scalac reporter can catch a default that is hardcoded instead of read from the reporter.
+  @Test
+  def absentFlagKeepsTheScalacReporterOrder(): Unit = {
+    TestUtil.testState(structure, deps) { state =>
+      val compile = Commands.Compile(List("A"), reporter = ScalacReporter)
+      TestUtil.runAndCheck(state, compile) { messages =>
+        val firstError = indexOfError(messages, "required: String")
+        val secondError = indexOfError(messages, "required: Int")
+        Assert.assertTrue(
+          "Expected the scalac reporter to keep its own occurrence order when the flag is absent",
+          firstError < secondError
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1502.

Bloop's default CLI reporter buffers compiler diagnostics and prints them last-to-first. That is good interactive UX — the first error lands nearest the prompt — but it breaks piping output into consumers that expect the traditional order.

This adds `--reverse-order` to every compiling command (`compile`, `test`, `run`, `console`, `link`):

- **unset** — current behavior, unchanged. The reporter decides: bloop reverses, scalac does not.
- **`--reverse-order=false`** — diagnostics stream first-to-last, as the compiler reports them.
- **`--reverse-order`** — forces the reversed summary, including under `--reporter scalac`.

### Why a flag rather than changing the default

`ReporterConfig.reverseOrder` already existed but was welded to the reporter choice: picking `--reporter scalac` got you first-to-last order *and* a different output format. This decouples the two axes, so you can keep bloop's format and choose the order. Unset is byte-identical to the previous expression, so no existing output changes.

### Scope

Implemented at a single site. `Interpreter.runCompile` is the only place the CLI builds a `LogReporter` config, and all five commands reach it — `compile` directly, the rest through `compileAnd`:

```scala
val baseConfig = ReporterKind.toReporterConfig(cmd.reporter)
val config = baseConfig.copy(
  colors = !noColor,
  reverseOrder = cmd.reverseOrder.getOrElse(baseConfig.reverseOrder)
)
```

`reverseOrder` is declared on the sealed `CompilingCommand` trait, so the compiler enforces that no command silently omits it. BSP is untouched — it builds its own config and already forces first-to-last.

The `docs/cli/reference.md` entries are hand-written rather than regenerated, because running `CommandsDocGenerator` on current `main` corrupts the file (#3024). The added entries follow the file's existing style, including the `?` suffix it uses for optional types.

### One caveat, stated plainly

The issue's motivation was vim's quickfix list, and this flag only fixes the ordering half of that. Bloop's default format is multi-line with source snippets and error IDs, and diagnostics go to stderr — so a quickfix workflow still wants `2>&1` and realistically `--reporter scalac` for a one-line-per-error format. Ordering is the part users could not work around on their own; the format axis stays where it was.
